### PR TITLE
Fix dependencies for 'go get'.

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -8,3 +8,9 @@
 //
 // The mock package provides a system by which it is possible to mock your objects and verify calls are happening as expected.
 package testify
+
+import (
+    _ "github.com/stretchr/testify/assert"
+    _ "github.com/stretchr/testify/http"
+    _ "github.com/stretchr/testify/mock"
+)


### PR DESCRIPTION
@stretchr The `objx` packages wasn't getting picked up when running:

```
$ go get -u github.com/stretchr/testify
```

I added the dependencies to the subpackages in the `doc.go` so that they'd get picked up automatically.
