### PR TITLE
Added Repeatability Statements to Expectations

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -242,11 +242,15 @@ func (m *Mock) AssertExpectations(t *testing.T) bool {
 
 	// iterate through each expectation
 	for _, expectedCall := range m.ExpectedCalls {
-		if !m.methodWasCalled(expectedCall.Method, expectedCall.Arguments) {
+		switch {
+		case !m.methodWasCalled(expectedCall.Method, expectedCall.Arguments):
 			somethingMissing = true
 			failedExpectations++
 			t.Logf("\u274C\t%s(%s)", expectedCall.Method, expectedCall.Arguments.String())
-		} else {
+		case expectedCall.Repeatability > 0:
+			somethingMissing = true
+			failedExpectations++
+		default:
 			t.Logf("\u2705\t%s(%s)", expectedCall.Method, expectedCall.Arguments.String())
 		}
 	}

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -387,12 +387,16 @@ func Test_Mock_AssertExpectations_With_Repeatability(t *testing.T) {
 
 	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
 
-	mockedService.Mock.On("Test_Mock_AssertExpectations_With_Repeatability", 1, 2, 3).Return(5, 6, 7).Once()
+	mockedService.Mock.On("Test_Mock_AssertExpectations_With_Repeatability", 1, 2, 3).Return(5, 6, 7).Twice()
 
 	tt := new(testing.T)
 	assert.False(t, mockedService.AssertExpectations(tt))
 
 	// make the call now
+	mockedService.Mock.Called(1, 2, 3)
+
+	assert.False(t, mockedService.AssertExpectations(tt))
+
 	mockedService.Mock.Called(1, 2, 3)
 
 	// now assert expectations


### PR DESCRIPTION
**Fully backward-compatible addition**

I use testify in all of my Go programming. I need some "repeat-bounding" semantics to continue using it in realistschuckle/gohaml. This pull request adds the following capability without changing the expectations of existing testify/mock code:

``` go
func Test_My_Mock_Returns_Different_Values(t *testing.T) {
    mock := &myMock{}
    mock.On("ExpectedMethod", 1).Return("Hello").Once()
    mock.On("ExpectedMethod", 1).Return("Good-bye").Twice()

    assert.Equal(t, "Hello", mock.ExpectedMethod(1))
    assert.Equal(t, "Good-bye", mock.ExpectedMethod(1))

    tt = new(testing.T)
    assert.False(mock.AssertExpectations(tt))

    assert.Equal(t, "Good-bye", mock.ExpectedMethod(1))
    mock.AssertExpectations(t)

    assert.Panics(t, func() {
        mock.ExpectedMethod(1)
    })
}
```

All of your tests still exist in their unchanged form with the exception of Test_Mock_findExpectedCall which should bother no one since you do not export that method.
