### PR TITLE
Have testing.RunTests run the tests we find with their setup methods.

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -12,7 +12,7 @@
 package testify
 
 import (
-    _ "github.com/stretchr/testify/assert"
-    _ "github.com/stretchr/testify/http"
-    _ "github.com/stretchr/testify/mock"
+	_ "github.com/stretchr/testify/assert"
+	_ "github.com/stretchr/testify/http"
+	_ "github.com/stretchr/testify/mock"
 )

--- a/suite/suite.go
+++ b/suite/suite.go
@@ -39,6 +39,7 @@ func Run(t *testing.T, suite TestingSuite) {
 			test := testing.InternalTest{
 				Name: method.Name,
 				F: func(t *testing.T) {
+					parentT := suite.T()
 					suite.SetT(t)
 					if setupTestSuite, ok := suite.(SetupTestSuite); ok {
 						setupTestSuite.SetupTest()
@@ -47,15 +48,15 @@ func Run(t *testing.T, suite TestingSuite) {
 					if tearDownTestSuite, ok := suite.(TearDownTestSuite); ok {
 						tearDownTestSuite.TearDownTest()
 					}
+					suite.SetT(parentT)
 				},
 			}
 			tests = append(tests, test)
 		}
 	}
 
-	if !testing.RunTests(func(pat, str string) (bool, error) {
-		return true, nil
-	}, tests) {
+	if !testing.RunTests(func(_, _ string) (bool, error) {return true, nil},
+		tests) {
 		t.Fail()
 	}
 


### PR DESCRIPTION
Hi,

This patch fixes logging with T().Logf et al by running each test with their own T in testing.RunTests. This has a few benefits, chief among them that if a suite or suite generating test function fails, output from all suites is not printed - only the failed individual tests, complete with nice test names and everything :) Makes my life much better! If I can do anything to help this get merged so I can use it at work, please let me know.

Thanks,
Sean
