### PR TITLE
Add test for logging capture.

### DIFF
--- a/suite/suite_test.go
+++ b/suite/suite_test.go
@@ -1,12 +1,12 @@
 package suite
 
 import (
-	"testing"
-	"github.com/stretchr/testify/assert"
-	"os"
-	"io/ioutil"
 	"errors"
 	"fmt"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"os"
+	"testing"
 )
 
 // This suite is intended to store values to make sure that only
@@ -120,11 +120,10 @@ func (s *SuiteLoggingTester) TestLoggingFail() {
 
 type StdoutCapture struct {
 	oldStdout *os.File
-	readPipe	*os.File
+	readPipe  *os.File
 }
 
 func (sc *StdoutCapture) StartCapture() {
-	fmt.Println("Starting capture1!")
 	sc.oldStdout = os.Stdout
 	sc.readPipe, os.Stdout, _ = os.Pipe()
 }


### PR DESCRIPTION
@matryer How does this look? I originally went the route you suggested and changed Run and all the suite methods to us testing.TB (the interface for both testing.T[est] and testing.B[enchmark]), but because I had to fail a test in there, there was still failure-looking output printed to stdout, so I just went with capturing stdout.
