### PR TITLE
mock: fix use of AnythingOfType with AssertCalled

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -296,11 +296,11 @@ func (m *Mock) AssertNotCalled(t TestingT, methodName string, arguments ...inter
 	return true
 }
 
-func (m *Mock) methodWasCalled(methodName string, arguments []interface{}) bool {
+func (m *Mock) methodWasCalled(methodName string, expected []interface{}) bool {
 	for _, call := range m.Calls {
 		if call.Method == methodName {
 
-			_, differences := call.Arguments.Diff(arguments)
+			_, differences := Arguments(expected).Diff(call.Arguments)
 
 			if differences == 0 {
 				// found the expected call

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -473,6 +473,18 @@ func Test_Mock_AssertCalled(t *testing.T) {
 
 }
 
+func Test_Mock_AssertCalled_WithAnythingOfTypeArgument(t *testing.T) {
+
+	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+
+	mockedService.Mock.On("Test_Mock_AssertCalled_WithAnythingOfTypeArgument", Anything, Anything, Anything).Return()
+
+	mockedService.Mock.Called(1, "two", []uint8("three"))
+
+	assert.True(t, mockedService.AssertCalled(t, "Test_Mock_AssertCalled_WithAnythingOfTypeArgument", AnythingOfType("int"), AnythingOfType("string"), AnythingOfType("[]uint8")))
+
+}
+
 func Test_Mock_AssertCalled_WithArguments(t *testing.T) {
 
 	var mockedService *TestExampleImplementation = new(TestExampleImplementation)


### PR DESCRIPTION
This allows you to use AnythingOfType in AssertCalled. Without this fix you can only pass literal arguments, because of the ordering of argument slices in `methodWasCalled`.
