### PR TITLE
Fixing issue 33

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -230,6 +230,7 @@ func isEmpty(object interface{}) bool {
 	}
 
 	objValue := reflect.ValueOf(object)
+
 	switch objValue.Kind() {
 	case reflect.Map:
 		fallthrough
@@ -237,10 +238,17 @@ func isEmpty(object interface{}) bool {
 		{
 			return (objValue.Len() == 0)
 		}
+	case reflect.Ptr:
+		{
+			switch object.(type) {
+			case *time.Time:
+				return object.(*time.Time).IsZero()
+			default:
+				return false
+			}
+		}
 	}
-
 	return false
-
 }
 
 // Empty asserts that the specified object is empty.  I.e. nil, "", false, 0 or a

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -335,6 +335,7 @@ func Test_isEmpty(t *testing.T) {
 	True(t, isEmpty(0))
 	True(t, isEmpty(false))
 	True(t, isEmpty(map[string]string{}))
+	True(t, isEmpty(new(time.Time)))
 
 	False(t, isEmpty("something"))
 	False(t, isEmpty(errors.New("something")))


### PR DESCRIPTION
Very simplistic fix for issue #33 (checking for empty time.Time).

Would be very interested in seeing how this could be done using pure reflection to avoid the the type assertion and type switch, if that's at all possible.
