### PR TITLE
Attempt type conversion in assert.Equal

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -25,11 +25,22 @@ type Comparison func() (success bool)
 // This function does no assertion of any kind.
 func ObjectsAreEqual(expected, actual interface{}) bool {
 
+	if expected == nil || actual == nil {
+		return expected == actual
+	}
+
 	if reflect.DeepEqual(expected, actual) {
 		return true
 	}
 
-	if reflect.ValueOf(expected) == reflect.ValueOf(actual) {
+	expectedValue := reflect.ValueOf(expected)
+	actualValue := reflect.ValueOf(actual)
+	if expectedValue == actualValue {
+		return true
+	}
+
+	// Attempt comparison after type conversion
+	if actualValue.Type().ConvertibleTo(expectedValue.Type()) && expectedValue == actualValue.Convert(expectedValue.Type()) {
 		return true
 	}
 

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -87,6 +87,12 @@ func TestEqual(t *testing.T) {
 	if !Equal(mockT, nil, nil) {
 		t.Error("Equal should return true")
 	}
+	if !Equal(mockT, int32(123), int64(123)) {
+		t.Error("Equal should return true")
+	}
+	if !Equal(mockT, int64(123), uint64(123)) {
+		t.Error("Equal should return true")
+	}
 
 }
 


### PR DESCRIPTION
If the two values being tested are of compatible types, convert one
value to the other's type before comparing them. This allows
`assert.Equal(int64(123), uint64(123))` to pass.
