### PR TITLE
Implement assert.AlmostEqual() for Floating Point Values

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -175,8 +175,13 @@ func sameType(t TestingT, expected, actual interface{}, msgAndArgs ...interface{
 	return true
 }
 
-// Checks if floating point values are almost equal by rounding to 7 decimal places.
-func AlmostEqual(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool {
+// AlmostEqualFloat asserts that two floats are equal by rounding
+// them both to 7 decimal places before comparing.
+//
+//    assert.AlmostEqualFloat(t, 2.00000001, 2.00000003, "2.00000001 and 2.00000003 should be equal")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func AlmostEqualFloat(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool {
 	same := sameType(t, expected, actual, msgAndArgs...)
 	if !same {
 		return same

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -96,46 +96,46 @@ func TestEqual(t *testing.T) {
 
 }
 
-func TestAlmostEqual(t *testing.T) {
+func TestAlmostEqualFloat(t *testing.T) {
 	mockT := new(testing.T)
-	if !AlmostEqual(mockT, 2.0, 2.0) {
-		t.Errorf("AlmostEqual should return true")
+	if !AlmostEqualFloat(mockT, 2.0, 2.0) {
+		t.Errorf("AlmostEqualFloat should return true")
 	}
 
-	if !AlmostEqual(mockT, 2.1, 2.1) {
-		t.Errorf("AlmostEqual should return true")
+	if !AlmostEqualFloat(mockT, 2.1, 2.1) {
+		t.Errorf("AlmostEqualFloat should return true")
 	}
 
-	if !AlmostEqual(mockT, 5.55, 5.55) {
-		t.Errorf("AlmostEqual should return true")
+	if !AlmostEqualFloat(mockT, 5.55, 5.55) {
+		t.Errorf("AlmostEqualFloat should return true")
 	}
 
-	if AlmostEqual(mockT, 2.1, 2.0) {
-		t.Errorf("AlmostEqual should return false")
+	if AlmostEqualFloat(mockT, 2.1, 2.0) {
+		t.Errorf("AlmostEqualFloat should return false")
 	}
 
-	if AlmostEqual(mockT, 3.0, 2.0) {
-		t.Errorf("AlmostEqual should return false")
+	if AlmostEqualFloat(mockT, 3.0, 2.0) {
+		t.Errorf("AlmostEqualFloat should return false")
 	}
 
-	if AlmostEqual(mockT, 5.67, 5.0) {
-		t.Errorf("AlmostEqual should return false")
+	if AlmostEqualFloat(mockT, 5.67, 5.0) {
+		t.Errorf("AlmostEqualFloat should return false")
 	}
 
-	if AlmostEqual(mockT, 5.67, int(5)) {
-		t.Errorf("AlmostEqual should return false")
+	if AlmostEqualFloat(mockT, 5.67, int(5)) {
+		t.Errorf("AlmostEqualFloat should return false")
 	}
 
-	if !AlmostEqual(mockT, 2.00000001, 2.00000003) {
-		t.Errorf("AlmostEqual should return true")
+	if !AlmostEqualFloat(mockT, 2.00000001, 2.00000003) {
+		t.Errorf("AlmostEqualFloat should return true")
 	}
 
-	if !AlmostEqual(mockT, float32(2.00000001), float32(2.00000003)) {
-		t.Errorf("AlmostEqual should return true")
+	if !AlmostEqualFloat(mockT, float32(2.00000001), float32(2.00000003)) {
+		t.Errorf("AlmostEqualFloat should return true")
 	}
 
-	if AlmostEqual(mockT, float32(3.67), float32(7.2)) {
-		t.Errorf("AlmostEqual should return false")
+	if AlmostEqualFloat(mockT, float32(3.67), float32(7.2)) {
+		t.Errorf("AlmostEqualFloat should return false")
 	}
 
 }


### PR DESCRIPTION
Implemented function that asserts 2 floating point numbers are "almost" equal by rounding them to 7 decimal places.

e.g. AlmostEqual(mockT, 2.00000001, 2.00000003)

PR includes related unit tests
