### PR TITLE
Allow Contains and NotContains to check slices and arrays

### DIFF
--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -200,6 +200,7 @@ func TestNotEqual(t *testing.T) {
 func TestContains(t *testing.T) {
 
 	mockT := new(testing.T)
+	list := []string{"Foo", "Bar"}
 
 	if !Contains(mockT, "Hello World", "Hello") {
 		t.Error("Contains should return true: \"Hello World\" contains \"Hello\"")
@@ -208,11 +209,19 @@ func TestContains(t *testing.T) {
 		t.Error("Contains should return false: \"Hello World\" does not contain \"Salut\"")
 	}
 
+	if !Contains(mockT, list, "Bar") {
+		t.Error("Contains should return true: \"[\"Foo\", \"Bar\"]\" contains \"Bar\"")
+	}
+	if Contains(mockT, list, "Salut") {
+		t.Error("Contains should return false: \"[\"Foo\", \"Bar\"]\" does not contain \"Salut\"")
+	}
+
 }
 
 func TestNotContains(t *testing.T) {
 
 	mockT := new(testing.T)
+	list := []string{"Foo", "Bar"}
 
 	if !NotContains(mockT, "Hello World", "Hello!") {
 		t.Error("NotContains should return true: \"Hello World\" does not contain \"Hello!\"")
@@ -220,6 +229,56 @@ func TestNotContains(t *testing.T) {
 	if NotContains(mockT, "Hello World", "Hello") {
 		t.Error("NotContains should return false: \"Hello World\" contains \"Hello\"")
 	}
+
+	if !NotContains(mockT, list, "Foo!") {
+		t.Error("NotContains should return true: \"[\"Foo\", \"Bar\"]\" does not contain \"Foo!\"")
+	}
+	if NotContains(mockT, list, "Foo") {
+		t.Error("NotContains should return false: \"[\"Foo\", \"Bar\"]\" contains \"Foo\"")
+	}
+
+}
+
+func Test_includeElement(t *testing.T) {
+
+	list1 := []string{"Foo", "Bar"}
+	list2 := []int{1, 2}
+
+	ok, found := includeElement("Hello World", "World")
+	True(t, ok)
+	True(t, found)
+
+	ok, found = includeElement(list1, "Foo")
+	True(t, ok)
+	True(t, found)
+
+	ok, found = includeElement(list1, "Bar")
+	True(t, ok)
+	True(t, found)
+
+	ok, found = includeElement(list2, 1)
+	True(t, ok)
+	True(t, found)
+
+	ok, found = includeElement(list2, 2)
+	True(t, ok)
+	True(t, found)
+
+	ok, found = includeElement(list1, "Foo!")
+	True(t, ok)
+	False(t, found)
+
+	ok, found = includeElement(list2, 3)
+	True(t, ok)
+	False(t, found)
+
+	ok, found = includeElement(list2, "1")
+	True(t, ok)
+	False(t, found)
+
+	ok, found = includeElement(1433, "1")
+	False(t, ok)
+	False(t, found)
 
 }
 

--- a/assert/doc.go
+++ b/assert/doc.go
@@ -73,9 +73,9 @@
 //
 //    assert.IsType(t, expectedObject, actualObject [, message [, format-args]])
 //
-//    assert.Contains(t, string, substring [, message [, format-args]])
+//    assert.Contains(t, stringOrSlice, substringOrElement [, message [, format-args]])
 //
-//    assert.NotContains(t, string, substring [, message [, format-args]])
+//    assert.NotContains(t, stringOrSlice, substringOrElement [, message [, format-args]])
 //
 //    assert.Panics(t, func(){
 //
@@ -126,9 +126,9 @@
 //
 //    assert.IsType(expectedObject, actualObject [, message [, format-args]])
 //
-//    assert.Contains(string, substring [, message [, format-args]])
+//    assert.Contains(stringOrSlice, substringOrElement [, message [, format-args]])
 //
-//    assert.NotContains(string, substring [, message [, format-args]])
+//    assert.NotContains(stringOrSlice, substringOrElement [, message [, format-args]])
 //
 //    assert.Panics(func(){
 //

--- a/assert/forward_assertions.go
+++ b/assert/forward_assertions.go
@@ -129,7 +129,7 @@ func (a *Assertions) NotEqual(expected, actual interface{}, msgAndArgs ...interf
 //    assert.Contains("Hello World", "World", "But 'Hello World' does contain 'World'")
 //
 // Returns whether the assertion was successful (true) or not (false).
-func (a *Assertions) Contains(s, contains string, msgAndArgs ...interface{}) bool {
+func (a *Assertions) Contains(s, contains interface{}, msgAndArgs ...interface{}) bool {
 	return Contains(a.t, s, contains, msgAndArgs...)
 }
 
@@ -138,7 +138,7 @@ func (a *Assertions) Contains(s, contains string, msgAndArgs ...interface{}) boo
 //    assert.NotContains("Hello World", "Earth", "But 'Hello World' does NOT contain 'Earth'")
 //
 // Returns whether the assertion was successful (true) or not (false).
-func (a *Assertions) NotContains(s, contains string, msgAndArgs ...interface{}) bool {
+func (a *Assertions) NotContains(s, contains interface{}, msgAndArgs ...interface{}) bool {
 	return NotContains(a.t, s, contains, msgAndArgs...)
 }
 

--- a/assert/forward_assertions_test.go
+++ b/assert/forward_assertions_test.go
@@ -148,6 +148,7 @@ func TestNotEqualWrapper(t *testing.T) {
 func TestContainsWrapper(t *testing.T) {
 
 	assert := New(new(testing.T))
+	list := []string{"Foo", "Bar"}
 
 	if !assert.Contains("Hello World", "Hello") {
 		t.Error("Contains should return true: \"Hello World\" contains \"Hello\"")
@@ -156,17 +157,32 @@ func TestContainsWrapper(t *testing.T) {
 		t.Error("Contains should return false: \"Hello World\" does not contain \"Salut\"")
 	}
 
+	if !assert.Contains(list, "Foo") {
+		t.Error("Contains should return true: \"[\"Foo\", \"Bar\"]\" contains \"Foo\"")
+	}
+	if assert.Contains(list, "Salut") {
+		t.Error("Contains should return false: \"[\"Foo\", \"Bar\"]\" does not contain \"Salut\"")
+	}
+
 }
 
 func TestNotContainsWrapper(t *testing.T) {
 
 	assert := New(new(testing.T))
+	list := []string{"Foo", "Bar"}
 
 	if !assert.NotContains("Hello World", "Hello!") {
 		t.Error("NotContains should return true: \"Hello World\" does not contain \"Hello!\"")
 	}
 	if assert.NotContains("Hello World", "Hello") {
 		t.Error("NotContains should return false: \"Hello World\" contains \"Hello\"")
+	}
+
+	if !assert.NotContains(list, "Foo!") {
+		t.Error("NotContains should return true: \"[\"Foo\", \"Bar\"]\" does not contain \"Foo!\"")
+	}
+	if assert.NotContains(list, "Foo") {
+		t.Error("NotContains should return false: \"[\"Foo\", \"Bar\"]\" contains \"Foo\"")
 	}
 
 }


### PR DESCRIPTION
Added `assert.Includes(t, someIterable, element)` which try to iterate over the iterable's elements to check if element is included on it.

It tries to iterate over an generic "list" like an slice, array... So I think it is an useful assert if you need to check if an "list" includes an specific element.
