### PR TITLE
Add feature: more entries of the call stack could be printed out on assert failure

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1,25 +1,25 @@
 package assert
 
 import (
-	"bufio"
-	"bytes"
-	"fmt"
-	"reflect"
-	"runtime"
-	"strings"
-	"time"
+    "bufio"
+    "bytes"
+    "fmt"
+    "reflect"
+    "runtime"
+    "strings"
+    "time"
 )
 
 // TestingT is an interface wrapper around *testing.T
 type TestingT interface {
-	Errorf(format string, args ...interface{})
+    Errorf(format string, args ...interface{})
 }
 
 // Comparison a custom function that returns true on success and false on failure
 type Comparison func() (success bool)
 
 /*
-	Helper functions
+    Helper functions
 */
 
 // ObjectsAreEqual determines if two objects are considered equal.
@@ -27,31 +27,31 @@ type Comparison func() (success bool)
 // This function does no assertion of any kind.
 func ObjectsAreEqual(expected, actual interface{}) bool {
 
-	if expected == nil || actual == nil {
-		return expected == actual
-	}
+    if expected == nil || actual == nil {
+        return expected == actual
+    }
 
-	if reflect.DeepEqual(expected, actual) {
-		return true
-	}
+    if reflect.DeepEqual(expected, actual) {
+        return true
+    }
 
-	expectedValue := reflect.ValueOf(expected)
-	actualValue := reflect.ValueOf(actual)
-	if expectedValue == actualValue {
-		return true
-	}
+    expectedValue := reflect.ValueOf(expected)
+    actualValue := reflect.ValueOf(actual)
+    if expectedValue == actualValue {
+        return true
+    }
 
-	// Attempt comparison after type conversion
-	if actualValue.Type().ConvertibleTo(expectedValue.Type()) && expectedValue == actualValue.Convert(expectedValue.Type()) {
-		return true
-	}
+    // Attempt comparison after type conversion
+    if actualValue.Type().ConvertibleTo(expectedValue.Type()) && expectedValue == actualValue.Convert(expectedValue.Type()) {
+        return true
+    }
 
-	// Last ditch effort
-	if fmt.Sprintf("%#v", expected) == fmt.Sprintf("%#v", actual) {
-		return true
-	}
+    // Last ditch effort
+    if fmt.Sprintf("%#v", expected) == fmt.Sprintf("%#v", actual) {
+        return true
+    }
 
-	return false
+    return false
 
 }
 
@@ -63,99 +63,99 @@ the problem actually occured in calling code.*/
 // that failed.
 func CallerInfo() string {
 
-	file := ""
-	line := 0
-	ok := false
+    file := ""
+    line := 0
+    ok := false
 
-	for i := 0; ; i++ {
-		_, file, line, ok = runtime.Caller(i)
-		if !ok {
-			return ""
-		}
-		parts := strings.Split(file, "/")
-		dir := parts[len(parts)-2]
-		file = parts[len(parts)-1]
-		if (dir != "assert" && dir != "mock" && dir != "require") || file == "mock_test.go" {
-			break
-		}
-	}
+    for i := 0; ; i++ {
+        _, file, line, ok = runtime.Caller(i)
+        if !ok {
+            return ""
+        }
+        parts := strings.Split(file, "/")
+        dir := parts[len(parts)-2]
+        file = parts[len(parts)-1]
+        if (dir != "assert" && dir != "mock" && dir != "require") || file == "mock_test.go" {
+            break
+        }
+    }
 
-	return fmt.Sprintf("%s:%d", file, line)
+    return fmt.Sprintf("%s:%d", file, line)
 }
 
 // getWhitespaceString returns a string that is long enough to overwrite the default
 // output from the go testing framework.
 func getWhitespaceString() string {
 
-	_, file, line, ok := runtime.Caller(1)
-	if !ok {
-		return ""
-	}
-	parts := strings.Split(file, "/")
-	file = parts[len(parts)-1]
+    _, file, line, ok := runtime.Caller(1)
+    if !ok {
+        return ""
+    }
+    parts := strings.Split(file, "/")
+    file = parts[len(parts)-1]
 
-	return strings.Repeat(" ", len(fmt.Sprintf("%s:%d:      ", file, line)))
+    return strings.Repeat(" ", len(fmt.Sprintf("%s:%d:      ", file, line)))
 
 }
 
 func messageFromMsgAndArgs(msgAndArgs ...interface{}) string {
-	if len(msgAndArgs) == 0 || msgAndArgs == nil {
-		return ""
-	}
-	if len(msgAndArgs) == 1 {
-		return msgAndArgs[0].(string)
-	}
-	if len(msgAndArgs) > 1 {
-		return fmt.Sprintf(msgAndArgs[0].(string), msgAndArgs[1:]...)
-	}
-	return ""
+    if len(msgAndArgs) == 0 || msgAndArgs == nil {
+        return ""
+    }
+    if len(msgAndArgs) == 1 {
+        return msgAndArgs[0].(string)
+    }
+    if len(msgAndArgs) > 1 {
+        return fmt.Sprintf(msgAndArgs[0].(string), msgAndArgs[1:]...)
+    }
+    return ""
 }
 
 // Indents all lines of the message by appending a number of tabs to each line, in an output format compatible with Go's
 // test printing (see inner comment for specifics)
 func indentMessageLines(message string, tabs int) string {
-	outBuf := new(bytes.Buffer)
+    outBuf := new(bytes.Buffer)
 
-	for i, scanner := 0, bufio.NewScanner(strings.NewReader(message)); scanner.Scan(); i++ {
-		if i != 0 {
-			outBuf.WriteRune('\n')
-		}
-		for ii := 0; ii < tabs; ii++ {
-			outBuf.WriteRune('\t')
-			// Bizarrely, all lines except the first need one fewer tabs prepended, so deliberately advance the counter
-			// by 1 prematurely.
-			if ii == 0 && i > 0 {
-				ii++
-			}
-		}
-		outBuf.WriteString(scanner.Text())
-	}
+    for i, scanner := 0, bufio.NewScanner(strings.NewReader(message)); scanner.Scan(); i++ {
+        if i != 0 {
+            outBuf.WriteRune('\n')
+        }
+        for ii := 0; ii < tabs; ii++ {
+            outBuf.WriteRune('\t')
+            // Bizarrely, all lines except the first need one fewer tabs prepended, so deliberately advance the counter
+            // by 1 prematurely.
+            if ii == 0 && i > 0 {
+                ii++
+            }
+        }
+        outBuf.WriteString(scanner.Text())
+    }
 
-	return outBuf.String()
+    return outBuf.String()
 }
 
 // Fail reports a failure through
 func Fail(t TestingT, failureMessage string, msgAndArgs ...interface{}) bool {
 
-	message := messageFromMsgAndArgs(msgAndArgs...)
+    message := messageFromMsgAndArgs(msgAndArgs...)
 
-	if len(message) > 0 {
-		t.Errorf("\r%s\r\tLocation:\t%s\n"+
-			"\r\tError:%s\n"+
-			"\r\tMessages:\t%s\n\r",
-			getWhitespaceString(),
-			CallerInfo(),
-			indentMessageLines(failureMessage, 2),
-			message)
-	} else {
-		t.Errorf("\r%s\r\tLocation:\t%s\n"+
-			"\r\tError:%s\n\r",
-			getWhitespaceString(),
-			CallerInfo(),
-			indentMessageLines(failureMessage, 2))
-	}
+    if len(message) > 0 {
+        t.Errorf("\r%s\r\tLocation:\t%s\n"+
+            "\r\tError:%s\n"+
+            "\r\tMessages:\t%s\n\r",
+            getWhitespaceString(),
+            CallerInfo(),
+            indentMessageLines(failureMessage, 2),
+            message)
+    } else {
+        t.Errorf("\r%s\r\tLocation:\t%s\n"+
+            "\r\tError:%s\n\r",
+            getWhitespaceString(),
+            CallerInfo(),
+            indentMessageLines(failureMessage, 2))
+    }
 
-	return false
+    return false
 }
 
 // Implements asserts that an object is implemented by the specified interface.
@@ -163,24 +163,24 @@ func Fail(t TestingT, failureMessage string, msgAndArgs ...interface{}) bool {
 //    assert.Implements(t, (*MyInterface)(nil), new(MyObject), "MyObject")
 func Implements(t TestingT, interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) bool {
 
-	interfaceType := reflect.TypeOf(interfaceObject).Elem()
+    interfaceType := reflect.TypeOf(interfaceObject).Elem()
 
-	if !reflect.TypeOf(object).Implements(interfaceType) {
-		return Fail(t, fmt.Sprintf("Object must implement %v", interfaceType), msgAndArgs...)
-	}
+    if !reflect.TypeOf(object).Implements(interfaceType) {
+        return Fail(t, fmt.Sprintf("Object must implement %v", interfaceType), msgAndArgs...)
+    }
 
-	return true
+    return true
 
 }
 
 // IsType asserts that the specified objects are of the same type.
 func IsType(t TestingT, expectedType interface{}, object interface{}, msgAndArgs ...interface{}) bool {
 
-	if !ObjectsAreEqual(reflect.TypeOf(object), reflect.TypeOf(expectedType)) {
-		return Fail(t, fmt.Sprintf("Object expected to be of type %v, but was %v", reflect.TypeOf(expectedType), reflect.TypeOf(object)), msgAndArgs...)
-	}
+    if !ObjectsAreEqual(reflect.TypeOf(object), reflect.TypeOf(expectedType)) {
+        return Fail(t, fmt.Sprintf("Object expected to be of type %v, but was %v", reflect.TypeOf(expectedType), reflect.TypeOf(object)), msgAndArgs...)
+    }
 
-	return true
+    return true
 }
 
 // Equal asserts that two objects are equal.
@@ -190,12 +190,12 @@ func IsType(t TestingT, expectedType interface{}, object interface{}, msgAndArgs
 // Returns whether the assertion was successful (true) or not (false).
 func Equal(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool {
 
-	if !ObjectsAreEqual(expected, actual) {
-		return Fail(t, fmt.Sprintf("Not equal: %#v (expected)\n"+
-			"        != %#v (actual)", expected, actual), msgAndArgs...)
-	}
+    if !ObjectsAreEqual(expected, actual) {
+        return Fail(t, fmt.Sprintf("Not equal: %#v (expected)\n"+
+            "        != %#v (actual)", expected, actual), msgAndArgs...)
+    }
 
-	return true
+    return true
 
 }
 
@@ -206,14 +206,14 @@ func Equal(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) 
 // Returns whether the assertion was successful (true) or not (false).
 func Exactly(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool {
 
-	aType := reflect.TypeOf(expected)
-	bType := reflect.TypeOf(actual)
+    aType := reflect.TypeOf(expected)
+    bType := reflect.TypeOf(actual)
 
-	if aType != bType {
-		return Fail(t, "Types expected to match exactly", "%v != %v", aType, bType)
-	}
+    if aType != bType {
+        return Fail(t, "Types expected to match exactly", "%v != %v", aType, bType)
+    }
 
-	return Equal(t, expected, actual, msgAndArgs...)
+    return Equal(t, expected, actual, msgAndArgs...)
 
 }
 
@@ -224,38 +224,38 @@ func Exactly(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}
 // Returns whether the assertion was successful (true) or not (false).
 func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
 
-	success := true
+    success := true
 
-	if object == nil {
-		success = false
-	} else {
-		value := reflect.ValueOf(object)
-		kind := value.Kind()
-		if kind >= reflect.Chan && kind <= reflect.Slice && value.IsNil() {
-			success = false
-		}
-	}
+    if object == nil {
+        success = false
+    } else {
+        value := reflect.ValueOf(object)
+        kind := value.Kind()
+        if kind >= reflect.Chan && kind <= reflect.Slice && value.IsNil() {
+            success = false
+        }
+    }
 
-	if !success {
-		Fail(t, "Expected not to be nil.", msgAndArgs...)
-	}
+    if !success {
+        Fail(t, "Expected not to be nil.", msgAndArgs...)
+    }
 
-	return success
+    return success
 }
 
 // isNil checks if a specified object is nil or not, without Failing.
 func isNil(object interface{}) bool {
-	if object == nil {
-		return true
-	}
+    if object == nil {
+        return true
+    }
 
-	value := reflect.ValueOf(object)
-	kind := value.Kind()
-	if kind >= reflect.Chan && kind <= reflect.Slice && value.IsNil() {
-		return true
-	}
+    value := reflect.ValueOf(object)
+    kind := value.Kind()
+    if kind >= reflect.Chan && kind <= reflect.Slice && value.IsNil() {
+        return true
+    }
 
-	return false
+    return false
 }
 
 // Nil asserts that the specified object is nil.
@@ -264,64 +264,64 @@ func isNil(object interface{}) bool {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
-	if isNil(object) {
-		return true
-	}
-	return Fail(t, fmt.Sprintf("Expected nil, but got: %#v", object), msgAndArgs...)
+    if isNil(object) {
+        return true
+    }
+    return Fail(t, fmt.Sprintf("Expected nil, but got: %#v", object), msgAndArgs...)
 }
 
 var zeros = []interface{}{
-	int(0),
-	int8(0),
-	int16(0),
-	int32(0),
-	int64(0),
-	uint(0),
-	uint8(0),
-	uint16(0),
-	uint32(0),
-	uint64(0),
-	float32(0),
-	float64(0),
+    int(0),
+    int8(0),
+    int16(0),
+    int32(0),
+    int64(0),
+    uint(0),
+    uint8(0),
+    uint16(0),
+    uint32(0),
+    uint64(0),
+    float32(0),
+    float64(0),
 }
 
 // isEmpty gets whether the specified object is considered empty or not.
 func isEmpty(object interface{}) bool {
 
-	if object == nil {
-		return true
-	} else if object == "" {
-		return true
-	} else if object == false {
-		return true
-	}
+    if object == nil {
+        return true
+    } else if object == "" {
+        return true
+    } else if object == false {
+        return true
+    }
 
-	for _, v := range zeros {
-		if object == v {
-			return true
-		}
-	}
+    for _, v := range zeros {
+        if object == v {
+            return true
+        }
+    }
 
-	objValue := reflect.ValueOf(object)
+    objValue := reflect.ValueOf(object)
 
-	switch objValue.Kind() {
-	case reflect.Map:
-		fallthrough
-	case reflect.Slice, reflect.Chan:
-		{
-			return (objValue.Len() == 0)
-		}
-	case reflect.Ptr:
-		{
-			switch object.(type) {
-			case *time.Time:
-				return object.(*time.Time).IsZero()
-			default:
-				return false
-			}
-		}
-	}
-	return false
+    switch objValue.Kind() {
+    case reflect.Map:
+        fallthrough
+    case reflect.Slice, reflect.Chan:
+        {
+            return (objValue.Len() == 0)
+        }
+    case reflect.Ptr:
+        {
+            switch object.(type) {
+            case *time.Time:
+                return object.(*time.Time).IsZero()
+            default:
+                return false
+            }
+        }
+    }
+    return false
 }
 
 // Empty asserts that the specified object is empty.  I.e. nil, "", false, 0 or either
@@ -332,12 +332,12 @@ func isEmpty(object interface{}) bool {
 // Returns whether the assertion was successful (true) or not (false).
 func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
 
-	pass := isEmpty(object)
-	if !pass {
-		Fail(t, fmt.Sprintf("Should be empty, but was %v", object), msgAndArgs...)
-	}
+    pass := isEmpty(object)
+    if !pass {
+        Fail(t, fmt.Sprintf("Should be empty, but was %v", object), msgAndArgs...)
+    }
 
-	return pass
+    return pass
 
 }
 
@@ -351,25 +351,25 @@ func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
 // Returns whether the assertion was successful (true) or not (false).
 func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
 
-	pass := !isEmpty(object)
-	if !pass {
-		Fail(t, fmt.Sprintf("Should NOT be empty, but was %v", object), msgAndArgs...)
-	}
+    pass := !isEmpty(object)
+    if !pass {
+        Fail(t, fmt.Sprintf("Should NOT be empty, but was %v", object), msgAndArgs...)
+    }
 
-	return pass
+    return pass
 
 }
 
 // getLen try to get length of object.
 // return (false, 0) if impossible.
 func getLen(x interface{}) (ok bool, length int) {
-	v := reflect.ValueOf(x)
-	defer func() {
-		if e := recover(); e != nil {
-			ok = false
-		}
-	}()
-	return true, v.Len()
+    v := reflect.ValueOf(x)
+    defer func() {
+        if e := recover(); e != nil {
+            ok = false
+        }
+    }()
+    return true, v.Len()
 }
 
 // Len asserts that the specified object has specific length.
@@ -379,15 +379,15 @@ func getLen(x interface{}) (ok bool, length int) {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) bool {
-	ok, l := getLen(object)
-	if !ok {
-		return Fail(t, fmt.Sprintf("\"%s\" could not be applied builtin len()", object), msgAndArgs...)
-	}
+    ok, l := getLen(object)
+    if !ok {
+        return Fail(t, fmt.Sprintf("\"%s\" could not be applied builtin len()", object), msgAndArgs...)
+    }
 
-	if l != length {
-		return Fail(t, fmt.Sprintf("\"%s\" should have %d item(s), but have %d", object, length, l), msgAndArgs...)
-	}
-	return true
+    if l != length {
+        return Fail(t, fmt.Sprintf("\"%s\" should have %d item(s), but have %d", object, length, l), msgAndArgs...)
+    }
+    return true
 }
 
 // True asserts that the specified value is true.
@@ -397,11 +397,11 @@ func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) 
 // Returns whether the assertion was successful (true) or not (false).
 func True(t TestingT, value bool, msgAndArgs ...interface{}) bool {
 
-	if value != true {
-		return Fail(t, "Should be true", msgAndArgs...)
-	}
+    if value != true {
+        return Fail(t, "Should be true", msgAndArgs...)
+    }
 
-	return true
+    return true
 
 }
 
@@ -412,11 +412,11 @@ func True(t TestingT, value bool, msgAndArgs ...interface{}) bool {
 // Returns whether the assertion was successful (true) or not (false).
 func False(t TestingT, value bool, msgAndArgs ...interface{}) bool {
 
-	if value != false {
-		return Fail(t, "Should be false", msgAndArgs...)
-	}
+    if value != false {
+        return Fail(t, "Should be false", msgAndArgs...)
+    }
 
-	return true
+    return true
 
 }
 
@@ -427,11 +427,11 @@ func False(t TestingT, value bool, msgAndArgs ...interface{}) bool {
 // Returns whether the assertion was successful (true) or not (false).
 func NotEqual(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool {
 
-	if ObjectsAreEqual(expected, actual) {
-		return Fail(t, "Should not be equal", msgAndArgs...)
-	}
+    if ObjectsAreEqual(expected, actual) {
+        return Fail(t, "Should not be equal", msgAndArgs...)
+    }
 
-	return true
+    return true
 
 }
 
@@ -442,11 +442,11 @@ func NotEqual(t TestingT, expected, actual interface{}, msgAndArgs ...interface{
 // Returns whether the assertion was successful (true) or not (false).
 func Contains(t TestingT, s, contains string, msgAndArgs ...interface{}) bool {
 
-	if !strings.Contains(s, contains) {
-		return Fail(t, fmt.Sprintf("\"%s\" does not contain \"%s\"", s, contains), msgAndArgs...)
-	}
+    if !strings.Contains(s, contains) {
+        return Fail(t, fmt.Sprintf("\"%s\" does not contain \"%s\"", s, contains), msgAndArgs...)
+    }
 
-	return true
+    return true
 
 }
 
@@ -457,21 +457,21 @@ func Contains(t TestingT, s, contains string, msgAndArgs ...interface{}) bool {
 // Returns whether the assertion was successful (true) or not (false).
 func NotContains(t TestingT, s, contains string, msgAndArgs ...interface{}) bool {
 
-	if strings.Contains(s, contains) {
-		return Fail(t, fmt.Sprintf("\"%s\" should not contain \"%s\"", s, contains), msgAndArgs...)
-	}
+    if strings.Contains(s, contains) {
+        return Fail(t, fmt.Sprintf("\"%s\" should not contain \"%s\"", s, contains), msgAndArgs...)
+    }
 
-	return true
+    return true
 
 }
 
 // Condition uses a Comparison to assert a complex condition.
 func Condition(t TestingT, comp Comparison, msgAndArgs ...interface{}) bool {
-	result := comp()
-	if !result {
-		Fail(t, "Condition failed!", msgAndArgs...)
-	}
-	return result
+    result := comp()
+    if !result {
+        Fail(t, "Condition failed!", msgAndArgs...)
+    }
+    return result
 }
 
 // PanicTestFunc defines a func that should be passed to the assert.Panics and assert.NotPanics
@@ -481,22 +481,22 @@ type PanicTestFunc func()
 // didPanic returns true if the function passed to it panics. Otherwise, it returns false.
 func didPanic(f PanicTestFunc) (bool, interface{}) {
 
-	didPanic := false
-	var message interface{}
-	func() {
+    didPanic := false
+    var message interface{}
+    func() {
 
-		defer func() {
-			if message = recover(); message != nil {
-				didPanic = true
-			}
-		}()
+        defer func() {
+            if message = recover(); message != nil {
+                didPanic = true
+            }
+        }()
 
-		// call the target function
-		f()
+        // call the target function
+        f()
 
-	}()
+    }()
 
-	return didPanic, message
+    return didPanic, message
 
 }
 
@@ -509,11 +509,11 @@ func didPanic(f PanicTestFunc) (bool, interface{}) {
 // Returns whether the assertion was successful (true) or not (false).
 func Panics(t TestingT, f PanicTestFunc, msgAndArgs ...interface{}) bool {
 
-	if funcDidPanic, panicValue := didPanic(f); !funcDidPanic {
-		return Fail(t, fmt.Sprintf("func %#v should panic\n\r\tPanic value:\t%v", f, panicValue), msgAndArgs...)
-	}
+    if funcDidPanic, panicValue := didPanic(f); !funcDidPanic {
+        return Fail(t, fmt.Sprintf("func %#v should panic\n\r\tPanic value:\t%v", f, panicValue), msgAndArgs...)
+    }
 
-	return true
+    return true
 }
 
 // NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
@@ -525,11 +525,11 @@ func Panics(t TestingT, f PanicTestFunc, msgAndArgs ...interface{}) bool {
 // Returns whether the assertion was successful (true) or not (false).
 func NotPanics(t TestingT, f PanicTestFunc, msgAndArgs ...interface{}) bool {
 
-	if funcDidPanic, panicValue := didPanic(f); funcDidPanic {
-		return Fail(t, fmt.Sprintf("func %#v should not panic\n\r\tPanic value:\t%v", f, panicValue), msgAndArgs...)
-	}
+    if funcDidPanic, panicValue := didPanic(f); funcDidPanic {
+        return Fail(t, fmt.Sprintf("func %#v should not panic\n\r\tPanic value:\t%v", f, panicValue), msgAndArgs...)
+    }
 
-	return true
+    return true
 }
 
 // WithinDuration asserts that the two times are within duration delta of each other.
@@ -539,136 +539,136 @@ func NotPanics(t TestingT, f PanicTestFunc, msgAndArgs ...interface{}) bool {
 // Returns whether the assertion was successful (true) or not (false).
 func WithinDuration(t TestingT, expected, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) bool {
 
-	dt := expected.Sub(actual)
-	if dt < -delta || dt > delta {
-		return Fail(t, fmt.Sprintf("Max difference between %v and %v allowed is %v, but difference was %v", expected, actual, delta, dt), msgAndArgs...)
-	}
+    dt := expected.Sub(actual)
+    if dt < -delta || dt > delta {
+        return Fail(t, fmt.Sprintf("Max difference between %v and %v allowed is %v, but difference was %v", expected, actual, delta, dt), msgAndArgs...)
+    }
 
-	return true
+    return true
 }
 
 func toFloat(x interface{}) (float64, bool) {
-	var xf float64
-	xok := true
+    var xf float64
+    xok := true
 
-	switch xn := x.(type) {
-	case uint8:
-		xf = float64(xn)
-	case uint16:
-		xf = float64(xn)
-	case uint32:
-		xf = float64(xn)
-	case uint64:
-		xf = float64(xn)
-	case int:
-		xf = float64(xn)
-	case int8:
-		xf = float64(xn)
-	case int16:
-		xf = float64(xn)
-	case int32:
-		xf = float64(xn)
-	case int64:
-		xf = float64(xn)
-	case float32:
-		xf = float64(xn)
-	case float64:
-		xf = float64(xn)
-	default:
-		xok = false
-	}
+    switch xn := x.(type) {
+    case uint8:
+        xf = float64(xn)
+    case uint16:
+        xf = float64(xn)
+    case uint32:
+        xf = float64(xn)
+    case uint64:
+        xf = float64(xn)
+    case int:
+        xf = float64(xn)
+    case int8:
+        xf = float64(xn)
+    case int16:
+        xf = float64(xn)
+    case int32:
+        xf = float64(xn)
+    case int64:
+        xf = float64(xn)
+    case float32:
+        xf = float64(xn)
+    case float64:
+        xf = float64(xn)
+    default:
+        xok = false
+    }
 
-	return xf, xok
+    return xf, xok
 }
 
 // InDelta asserts that the two numerals are within delta of each other.
 //
-// 	 assert.InDelta(t, math.Pi, (22 / 7.0), 0.01)
+//   assert.InDelta(t, math.Pi, (22 / 7.0), 0.01)
 //
 // Returns whether the assertion was successful (true) or not (false).
 func InDelta(t TestingT, expected, actual interface{}, delta float64, msgAndArgs ...interface{}) bool {
 
-	af, aok := toFloat(expected)
-	bf, bok := toFloat(actual)
+    af, aok := toFloat(expected)
+    bf, bok := toFloat(actual)
 
-	if !aok || !bok {
-		return Fail(t, fmt.Sprintf("Parameters must be numerical"), msgAndArgs...)
-	}
+    if !aok || !bok {
+        return Fail(t, fmt.Sprintf("Parameters must be numerical"), msgAndArgs...)
+    }
 
-	dt := af - bf
-	if dt < -delta || dt > delta {
-		return Fail(t, fmt.Sprintf("Max difference between %v and %v allowed is %v, but difference was %v", expected, actual, delta, dt), msgAndArgs...)
-	}
+    dt := af - bf
+    if dt < -delta || dt > delta {
+        return Fail(t, fmt.Sprintf("Max difference between %v and %v allowed is %v, but difference was %v", expected, actual, delta, dt), msgAndArgs...)
+    }
 
-	return true
+    return true
 }
 
 // min(|expected|, |actual|) * epsilon
 func calcEpsilonDelta(expected, actual interface{}, epsilon float64) float64 {
-	af, aok := toFloat(expected)
-	bf, bok := toFloat(actual)
+    af, aok := toFloat(expected)
+    bf, bok := toFloat(actual)
 
-	if !aok || !bok {
-		// invalid input
-		return 0
-	}
+    if !aok || !bok {
+        // invalid input
+        return 0
+    }
 
-	if af < 0 {
-		af = -af
-	}
-	if bf < 0 {
-		bf = -bf
-	}
-	var delta float64
-	if af < bf {
-		delta = af * epsilon
-	} else {
-		delta = bf * epsilon
-	}
-	return delta
+    if af < 0 {
+        af = -af
+    }
+    if bf < 0 {
+        bf = -bf
+    }
+    var delta float64
+    if af < bf {
+        delta = af * epsilon
+    } else {
+        delta = bf * epsilon
+    }
+    return delta
 }
 
 // InEpsilon asserts that expected and actual have a relative error less than epsilon
 //
 // Returns whether the assertion was successful (true) or not (false).
 func InEpsilon(t TestingT, expected, actual interface{}, epsilon float64, msgAndArgs ...interface{}) bool {
-	delta := calcEpsilonDelta(expected, actual, epsilon)
+    delta := calcEpsilonDelta(expected, actual, epsilon)
 
-	return InDelta(t, expected, actual, delta, msgAndArgs...)
+    return InDelta(t, expected, actual, delta, msgAndArgs...)
 }
 
 /*
-	Errors
+    Errors
 */
 
 // NoError asserts that a function returned no error (i.e. `nil`).
 //
 //   actualObj, err := SomeFunction()
 //   if assert.NoError(t, err) {
-//	   assert.Equal(t, actualObj, expectedObj)
+//     assert.Equal(t, actualObj, expectedObj)
 //   }
 //
 // Returns whether the assertion was successful (true) or not (false).
 func NoError(t TestingT, err error, msgAndArgs ...interface{}) bool {
-	if isNil(err) {
-		return true
-	}
+    if isNil(err) {
+        return true
+    }
 
-	return Fail(t, fmt.Sprintf("No error is expected but got %v", err), msgAndArgs...)
+    return Fail(t, fmt.Sprintf("No error is expected but got %v", err), msgAndArgs...)
 }
 
 // Error asserts that a function returned an error (i.e. not `nil`).
 //
 //   actualObj, err := SomeFunction()
 //   if assert.Error(t, err, "An error was expected") {
-//	   assert.Equal(t, err, expectedError)
+//     assert.Equal(t, err, expectedError)
 //   }
 //
 // Returns whether the assertion was successful (true) or not (false).
 func Error(t TestingT, err error, msgAndArgs ...interface{}) bool {
 
-	message := messageFromMsgAndArgs(msgAndArgs...)
-	return NotNil(t, err, "An error is expected but got nil. %s", message)
+    message := messageFromMsgAndArgs(msgAndArgs...)
+    return NotNil(t, err, "An error is expected but got nil. %s", message)
 
 }
 
@@ -677,17 +677,17 @@ func Error(t TestingT, err error, msgAndArgs ...interface{}) bool {
 //
 //   actualObj, err := SomeFunction()
 //   if assert.Error(t, err, "An error was expected") {
-//	   assert.Equal(t, err, expectedError)
+//     assert.Equal(t, err, expectedError)
 //   }
 //
 // Returns whether the assertion was successful (true) or not (false).
 func EqualError(t TestingT, theError error, errString string, msgAndArgs ...interface{}) bool {
 
-	message := messageFromMsgAndArgs(msgAndArgs...)
-	if !NotNil(t, theError, "An error is expected but got nil. %s", message) {
-		return false
-	}
-	s := "An error with value \"%s\" is expected but got \"%s\". %s"
-	return Equal(t, theError.Error(), errString,
-		s, errString, theError.Error(), message)
+    message := messageFromMsgAndArgs(msgAndArgs...)
+    if !NotNil(t, theError, "An error is expected but got nil. %s", message) {
+        return false
+    }
+    s := "An error with value \"%s\" is expected but got \"%s\". %s"
+    return Equal(t, theError.Error(), errString,
+        s, errString, theError.Error(), message)
 }

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -1,14 +1,14 @@
 package assert
 
 import (
-	"errors"
-	"testing"
-	"time"
+    "errors"
+    "testing"
+    "time"
 )
 
 // AssertionTesterInterface defines an interface to be used for testing assertion methods
 type AssertionTesterInterface interface {
-	TestMethod()
+    TestMethod()
 }
 
 // AssertionTesterConformingObject is an object that conforms to the AssertionTesterInterface interface
@@ -24,515 +24,515 @@ type AssertionTesterNonConformingObject struct {
 
 func TestObjectsAreEqual(t *testing.T) {
 
-	if !ObjectsAreEqual("Hello World", "Hello World") {
-		t.Error("objectsAreEqual should return true")
-	}
-	if !ObjectsAreEqual(123, 123) {
-		t.Error("objectsAreEqual should return true")
-	}
-	if !ObjectsAreEqual(123.5, 123.5) {
-		t.Error("objectsAreEqual should return true")
-	}
-	if !ObjectsAreEqual([]byte("Hello World"), []byte("Hello World")) {
-		t.Error("objectsAreEqual should return true")
-	}
-	if !ObjectsAreEqual(nil, nil) {
-		t.Error("objectsAreEqual should return true")
-	}
+    if !ObjectsAreEqual("Hello World", "Hello World") {
+        t.Error("objectsAreEqual should return true")
+    }
+    if !ObjectsAreEqual(123, 123) {
+        t.Error("objectsAreEqual should return true")
+    }
+    if !ObjectsAreEqual(123.5, 123.5) {
+        t.Error("objectsAreEqual should return true")
+    }
+    if !ObjectsAreEqual([]byte("Hello World"), []byte("Hello World")) {
+        t.Error("objectsAreEqual should return true")
+    }
+    if !ObjectsAreEqual(nil, nil) {
+        t.Error("objectsAreEqual should return true")
+    }
 
 }
 
 func TestImplements(t *testing.T) {
 
-	mockT := new(testing.T)
+    mockT := new(testing.T)
 
-	if !Implements(mockT, (*AssertionTesterInterface)(nil), new(AssertionTesterConformingObject)) {
-		t.Error("Implements method should return true: AssertionTesterConformingObject implements AssertionTesterInterface")
-	}
-	if Implements(mockT, (*AssertionTesterInterface)(nil), new(AssertionTesterNonConformingObject)) {
-		t.Error("Implements method should return false: AssertionTesterNonConformingObject does not implements AssertionTesterInterface")
-	}
+    if !Implements(mockT, (*AssertionTesterInterface)(nil), new(AssertionTesterConformingObject)) {
+        t.Error("Implements method should return true: AssertionTesterConformingObject implements AssertionTesterInterface")
+    }
+    if Implements(mockT, (*AssertionTesterInterface)(nil), new(AssertionTesterNonConformingObject)) {
+        t.Error("Implements method should return false: AssertionTesterNonConformingObject does not implements AssertionTesterInterface")
+    }
 
 }
 
 func TestIsType(t *testing.T) {
 
-	mockT := new(testing.T)
+    mockT := new(testing.T)
 
-	if !IsType(mockT, new(AssertionTesterConformingObject), new(AssertionTesterConformingObject)) {
-		t.Error("IsType should return true: AssertionTesterConformingObject is the same type as AssertionTesterConformingObject")
-	}
-	if IsType(mockT, new(AssertionTesterConformingObject), new(AssertionTesterNonConformingObject)) {
-		t.Error("IsType should return false: AssertionTesterConformingObject is not the same type as AssertionTesterNonConformingObject")
-	}
+    if !IsType(mockT, new(AssertionTesterConformingObject), new(AssertionTesterConformingObject)) {
+        t.Error("IsType should return true: AssertionTesterConformingObject is the same type as AssertionTesterConformingObject")
+    }
+    if IsType(mockT, new(AssertionTesterConformingObject), new(AssertionTesterNonConformingObject)) {
+        t.Error("IsType should return false: AssertionTesterConformingObject is not the same type as AssertionTesterNonConformingObject")
+    }
 
 }
 
 func TestEqual(t *testing.T) {
 
-	mockT := new(testing.T)
+    mockT := new(testing.T)
 
-	if !Equal(mockT, "Hello World", "Hello World") {
-		t.Error("Equal should return true")
-	}
-	if !Equal(mockT, 123, 123) {
-		t.Error("Equal should return true")
-	}
-	if !Equal(mockT, 123.5, 123.5) {
-		t.Error("Equal should return true")
-	}
-	if !Equal(mockT, []byte("Hello World"), []byte("Hello World")) {
-		t.Error("Equal should return true")
-	}
-	if !Equal(mockT, nil, nil) {
-		t.Error("Equal should return true")
-	}
-	if !Equal(mockT, int32(123), int64(123)) {
-		t.Error("Equal should return true")
-	}
-	if !Equal(mockT, int64(123), uint64(123)) {
-		t.Error("Equal should return true")
-	}
+    if !Equal(mockT, "Hello World", "Hello World") {
+        t.Error("Equal should return true")
+    }
+    if !Equal(mockT, 123, 123) {
+        t.Error("Equal should return true")
+    }
+    if !Equal(mockT, 123.5, 123.5) {
+        t.Error("Equal should return true")
+    }
+    if !Equal(mockT, []byte("Hello World"), []byte("Hello World")) {
+        t.Error("Equal should return true")
+    }
+    if !Equal(mockT, nil, nil) {
+        t.Error("Equal should return true")
+    }
+    if !Equal(mockT, int32(123), int64(123)) {
+        t.Error("Equal should return true")
+    }
+    if !Equal(mockT, int64(123), uint64(123)) {
+        t.Error("Equal should return true")
+    }
 
 }
 
 func TestNotNil(t *testing.T) {
 
-	mockT := new(testing.T)
+    mockT := new(testing.T)
 
-	if !NotNil(mockT, new(AssertionTesterConformingObject)) {
-		t.Error("NotNil should return true: object is not nil")
-	}
-	if NotNil(mockT, nil) {
-		t.Error("NotNil should return false: object is nil")
-	}
+    if !NotNil(mockT, new(AssertionTesterConformingObject)) {
+        t.Error("NotNil should return true: object is not nil")
+    }
+    if NotNil(mockT, nil) {
+        t.Error("NotNil should return false: object is nil")
+    }
 
 }
 
 func TestNil(t *testing.T) {
 
-	mockT := new(testing.T)
+    mockT := new(testing.T)
 
-	if !Nil(mockT, nil) {
-		t.Error("Nil should return true: object is nil")
-	}
-	if Nil(mockT, new(AssertionTesterConformingObject)) {
-		t.Error("Nil should return false: object is not nil")
-	}
+    if !Nil(mockT, nil) {
+        t.Error("Nil should return true: object is nil")
+    }
+    if Nil(mockT, new(AssertionTesterConformingObject)) {
+        t.Error("Nil should return false: object is not nil")
+    }
 
 }
 
 func TestTrue(t *testing.T) {
 
-	mockT := new(testing.T)
+    mockT := new(testing.T)
 
-	if !True(mockT, true) {
-		t.Error("True should return true")
-	}
-	if True(mockT, false) {
-		t.Error("True should return false")
-	}
+    if !True(mockT, true) {
+        t.Error("True should return true")
+    }
+    if True(mockT, false) {
+        t.Error("True should return false")
+    }
 
 }
 
 func TestFalse(t *testing.T) {
 
-	mockT := new(testing.T)
+    mockT := new(testing.T)
 
-	if !False(mockT, false) {
-		t.Error("False should return true")
-	}
-	if False(mockT, true) {
-		t.Error("False should return false")
-	}
+    if !False(mockT, false) {
+        t.Error("False should return true")
+    }
+    if False(mockT, true) {
+        t.Error("False should return false")
+    }
 
 }
 
 func TestExactly(t *testing.T) {
 
-	mockT := new(testing.T)
+    mockT := new(testing.T)
 
-	a := float32(1)
-	b := float64(1)
-	c := float32(1)
-	d := float32(2)
+    a := float32(1)
+    b := float64(1)
+    c := float32(1)
+    d := float32(2)
 
-	if Exactly(mockT, a, b) {
-		t.Error("Exactly should return false")
-	}
-	if Exactly(mockT, a, d) {
-		t.Error("Exactly should return false")
-	}
-	if !Exactly(mockT, a, c) {
-		t.Error("Exactly should return true")
-	}
+    if Exactly(mockT, a, b) {
+        t.Error("Exactly should return false")
+    }
+    if Exactly(mockT, a, d) {
+        t.Error("Exactly should return false")
+    }
+    if !Exactly(mockT, a, c) {
+        t.Error("Exactly should return true")
+    }
 
-	if Exactly(mockT, nil, a) {
-		t.Error("Exactly should return false")
-	}
-	if Exactly(mockT, a, nil) {
-		t.Error("Exactly should return false")
-	}
+    if Exactly(mockT, nil, a) {
+        t.Error("Exactly should return false")
+    }
+    if Exactly(mockT, a, nil) {
+        t.Error("Exactly should return false")
+    }
 
 }
 
 func TestNotEqual(t *testing.T) {
 
-	mockT := new(testing.T)
+    mockT := new(testing.T)
 
-	if !NotEqual(mockT, "Hello World", "Hello World!") {
-		t.Error("NotEqual should return true")
-	}
-	if !NotEqual(mockT, 123, 1234) {
-		t.Error("NotEqual should return true")
-	}
-	if !NotEqual(mockT, 123.5, 123.55) {
-		t.Error("NotEqual should return true")
-	}
-	if !NotEqual(mockT, []byte("Hello World"), []byte("Hello World!")) {
-		t.Error("NotEqual should return true")
-	}
-	if !NotEqual(mockT, nil, new(AssertionTesterConformingObject)) {
-		t.Error("NotEqual should return true")
-	}
+    if !NotEqual(mockT, "Hello World", "Hello World!") {
+        t.Error("NotEqual should return true")
+    }
+    if !NotEqual(mockT, 123, 1234) {
+        t.Error("NotEqual should return true")
+    }
+    if !NotEqual(mockT, 123.5, 123.55) {
+        t.Error("NotEqual should return true")
+    }
+    if !NotEqual(mockT, []byte("Hello World"), []byte("Hello World!")) {
+        t.Error("NotEqual should return true")
+    }
+    if !NotEqual(mockT, nil, new(AssertionTesterConformingObject)) {
+        t.Error("NotEqual should return true")
+    }
 }
 
 func TestContains(t *testing.T) {
 
-	mockT := new(testing.T)
+    mockT := new(testing.T)
 
-	if !Contains(mockT, "Hello World", "Hello") {
-		t.Error("Contains should return true: \"Hello World\" contains \"Hello\"")
-	}
-	if Contains(mockT, "Hello World", "Salut") {
-		t.Error("Contains should return false: \"Hello World\" does not contain \"Salut\"")
-	}
+    if !Contains(mockT, "Hello World", "Hello") {
+        t.Error("Contains should return true: \"Hello World\" contains \"Hello\"")
+    }
+    if Contains(mockT, "Hello World", "Salut") {
+        t.Error("Contains should return false: \"Hello World\" does not contain \"Salut\"")
+    }
 
 }
 
 func TestNotContains(t *testing.T) {
 
-	mockT := new(testing.T)
+    mockT := new(testing.T)
 
-	if !NotContains(mockT, "Hello World", "Hello!") {
-		t.Error("NotContains should return true: \"Hello World\" does not contain \"Hello!\"")
-	}
-	if NotContains(mockT, "Hello World", "Hello") {
-		t.Error("NotContains should return false: \"Hello World\" contains \"Hello\"")
-	}
+    if !NotContains(mockT, "Hello World", "Hello!") {
+        t.Error("NotContains should return true: \"Hello World\" does not contain \"Hello!\"")
+    }
+    if NotContains(mockT, "Hello World", "Hello") {
+        t.Error("NotContains should return false: \"Hello World\" contains \"Hello\"")
+    }
 
 }
 
 func TestDidPanic(t *testing.T) {
 
-	if funcDidPanic, _ := didPanic(func() {
-		panic("Panic!")
-	}); !funcDidPanic {
-		t.Error("didPanic should return true")
-	}
+    if funcDidPanic, _ := didPanic(func() {
+        panic("Panic!")
+    }); !funcDidPanic {
+        t.Error("didPanic should return true")
+    }
 
-	if funcDidPanic, _ := didPanic(func() {
-	}); funcDidPanic {
-		t.Error("didPanic should return false")
-	}
+    if funcDidPanic, _ := didPanic(func() {
+    }); funcDidPanic {
+        t.Error("didPanic should return false")
+    }
 
 }
 
 func TestPanics(t *testing.T) {
 
-	mockT := new(testing.T)
+    mockT := new(testing.T)
 
-	if !Panics(mockT, func() {
-		panic("Panic!")
-	}) {
-		t.Error("Panics should return true")
-	}
+    if !Panics(mockT, func() {
+        panic("Panic!")
+    }) {
+        t.Error("Panics should return true")
+    }
 
-	if Panics(mockT, func() {
-	}) {
-		t.Error("Panics should return false")
-	}
+    if Panics(mockT, func() {
+    }) {
+        t.Error("Panics should return false")
+    }
 
 }
 
 func TestNotPanics(t *testing.T) {
 
-	mockT := new(testing.T)
+    mockT := new(testing.T)
 
-	if !NotPanics(mockT, func() {
-	}) {
-		t.Error("NotPanics should return true")
-	}
+    if !NotPanics(mockT, func() {
+    }) {
+        t.Error("NotPanics should return true")
+    }
 
-	if NotPanics(mockT, func() {
-		panic("Panic!")
-	}) {
-		t.Error("NotPanics should return false")
-	}
+    if NotPanics(mockT, func() {
+        panic("Panic!")
+    }) {
+        t.Error("NotPanics should return false")
+    }
 
 }
 
 func TestEqual_Funcs(t *testing.T) {
 
-	type f func() int
-	f1 := func() int { return 1 }
-	f2 := func() int { return 2 }
+    type f func() int
+    f1 := func() int { return 1 }
+    f2 := func() int { return 2 }
 
-	f1Copy := f1
+    f1Copy := f1
 
-	Equal(t, f1Copy, f1, "Funcs are the same and should be considered equal")
-	NotEqual(t, f1, f2, "f1 and f2 are different")
+    Equal(t, f1Copy, f1, "Funcs are the same and should be considered equal")
+    NotEqual(t, f1, f2, "f1 and f2 are different")
 
 }
 
 func TestNoError(t *testing.T) {
 
-	mockT := new(testing.T)
+    mockT := new(testing.T)
 
-	// start with a nil error
-	var err error
+    // start with a nil error
+    var err error
 
-	True(t, NoError(mockT, err), "NoError should return True for nil arg")
+    True(t, NoError(mockT, err), "NoError should return True for nil arg")
 
-	// now set an error
-	err = errors.New("some error")
+    // now set an error
+    err = errors.New("some error")
 
-	False(t, NoError(mockT, err), "NoError with error should return False")
+    False(t, NoError(mockT, err), "NoError with error should return False")
 
 }
 
 func TestError(t *testing.T) {
 
-	mockT := new(testing.T)
+    mockT := new(testing.T)
 
-	// start with a nil error
-	var err error
+    // start with a nil error
+    var err error
 
-	False(t, Error(mockT, err), "Error should return False for nil arg")
+    False(t, Error(mockT, err), "Error should return False for nil arg")
 
-	// now set an error
-	err = errors.New("some error")
+    // now set an error
+    err = errors.New("some error")
 
-	True(t, Error(mockT, err), "Error with error should return True")
+    True(t, Error(mockT, err), "Error with error should return True")
 
 }
 
 func TestEqualError(t *testing.T) {
-	mockT := new(testing.T)
+    mockT := new(testing.T)
 
-	// start with a nil error
-	var err error
-	False(t, EqualError(mockT, err, ""),
-		"EqualError should return false for nil arg")
+    // start with a nil error
+    var err error
+    False(t, EqualError(mockT, err, ""),
+        "EqualError should return false for nil arg")
 
-	// now set an error
-	err = errors.New("some error")
-	False(t, EqualError(mockT, err, "Not some error"),
-		"EqualError should return false for different error string")
-	True(t, EqualError(mockT, err, "some error"),
-		"EqualError should return true")
+    // now set an error
+    err = errors.New("some error")
+    False(t, EqualError(mockT, err, "Not some error"),
+        "EqualError should return false for different error string")
+    True(t, EqualError(mockT, err, "some error"),
+        "EqualError should return true")
 }
 
 func Test_isEmpty(t *testing.T) {
 
-	chWithValue := make(chan struct{}, 1)
-	chWithValue <- struct{}{}
+    chWithValue := make(chan struct{}, 1)
+    chWithValue <- struct{}{}
 
-	True(t, isEmpty(""))
-	True(t, isEmpty(nil))
-	True(t, isEmpty([]string{}))
-	True(t, isEmpty(0))
-	True(t, isEmpty(int32(0)))
-	True(t, isEmpty(int64(0)))
-	True(t, isEmpty(false))
-	True(t, isEmpty(map[string]string{}))
-	True(t, isEmpty(new(time.Time)))
-	True(t, isEmpty(make(chan struct{})))
-	False(t, isEmpty("something"))
-	False(t, isEmpty(errors.New("something")))
-	False(t, isEmpty([]string{"something"}))
-	False(t, isEmpty(1))
-	False(t, isEmpty(true))
-	False(t, isEmpty(map[string]string{"Hello": "World"}))
-	False(t, isEmpty(chWithValue))
+    True(t, isEmpty(""))
+    True(t, isEmpty(nil))
+    True(t, isEmpty([]string{}))
+    True(t, isEmpty(0))
+    True(t, isEmpty(int32(0)))
+    True(t, isEmpty(int64(0)))
+    True(t, isEmpty(false))
+    True(t, isEmpty(map[string]string{}))
+    True(t, isEmpty(new(time.Time)))
+    True(t, isEmpty(make(chan struct{})))
+    False(t, isEmpty("something"))
+    False(t, isEmpty(errors.New("something")))
+    False(t, isEmpty([]string{"something"}))
+    False(t, isEmpty(1))
+    False(t, isEmpty(true))
+    False(t, isEmpty(map[string]string{"Hello": "World"}))
+    False(t, isEmpty(chWithValue))
 
 }
 
 func TestEmpty(t *testing.T) {
 
-	mockT := new(testing.T)
-	chWithValue := make(chan struct{}, 1)
-	chWithValue <- struct{}{}
+    mockT := new(testing.T)
+    chWithValue := make(chan struct{}, 1)
+    chWithValue <- struct{}{}
 
-	True(t, Empty(mockT, ""), "Empty string is empty")
-	True(t, Empty(mockT, nil), "Nil is empty")
-	True(t, Empty(mockT, []string{}), "Empty string array is empty")
-	True(t, Empty(mockT, 0), "Zero int value is empty")
-	True(t, Empty(mockT, false), "False value is empty")
-	True(t, Empty(mockT, make(chan struct{})), "Channel without values is empty")
+    True(t, Empty(mockT, ""), "Empty string is empty")
+    True(t, Empty(mockT, nil), "Nil is empty")
+    True(t, Empty(mockT, []string{}), "Empty string array is empty")
+    True(t, Empty(mockT, 0), "Zero int value is empty")
+    True(t, Empty(mockT, false), "False value is empty")
+    True(t, Empty(mockT, make(chan struct{})), "Channel without values is empty")
 
-	False(t, Empty(mockT, "something"), "Non Empty string is not empty")
-	False(t, Empty(mockT, errors.New("something")), "Non nil object is not empty")
-	False(t, Empty(mockT, []string{"something"}), "Non empty string array is not empty")
-	False(t, Empty(mockT, 1), "Non-zero int value is not empty")
-	False(t, Empty(mockT, true), "True value is not empty")
-	False(t, Empty(mockT, chWithValue), "Channel with values is not empty")
+    False(t, Empty(mockT, "something"), "Non Empty string is not empty")
+    False(t, Empty(mockT, errors.New("something")), "Non nil object is not empty")
+    False(t, Empty(mockT, []string{"something"}), "Non empty string array is not empty")
+    False(t, Empty(mockT, 1), "Non-zero int value is not empty")
+    False(t, Empty(mockT, true), "True value is not empty")
+    False(t, Empty(mockT, chWithValue), "Channel with values is not empty")
 }
 
 func TestNotEmpty(t *testing.T) {
 
-	mockT := new(testing.T)
-	chWithValue := make(chan struct{}, 1)
-	chWithValue <- struct{}{}
+    mockT := new(testing.T)
+    chWithValue := make(chan struct{}, 1)
+    chWithValue <- struct{}{}
 
-	False(t, NotEmpty(mockT, ""), "Empty string is empty")
-	False(t, NotEmpty(mockT, nil), "Nil is empty")
-	False(t, NotEmpty(mockT, []string{}), "Empty string array is empty")
-	False(t, NotEmpty(mockT, 0), "Zero int value is empty")
-	False(t, NotEmpty(mockT, false), "False value is empty")
-	False(t, NotEmpty(mockT, make(chan struct{})), "Channel without values is empty")
+    False(t, NotEmpty(mockT, ""), "Empty string is empty")
+    False(t, NotEmpty(mockT, nil), "Nil is empty")
+    False(t, NotEmpty(mockT, []string{}), "Empty string array is empty")
+    False(t, NotEmpty(mockT, 0), "Zero int value is empty")
+    False(t, NotEmpty(mockT, false), "False value is empty")
+    False(t, NotEmpty(mockT, make(chan struct{})), "Channel without values is empty")
 
-	True(t, NotEmpty(mockT, "something"), "Non Empty string is not empty")
-	True(t, NotEmpty(mockT, errors.New("something")), "Non nil object is not empty")
-	True(t, NotEmpty(mockT, []string{"something"}), "Non empty string array is not empty")
-	True(t, NotEmpty(mockT, 1), "Non-zero int value is not empty")
-	True(t, NotEmpty(mockT, true), "True value is not empty")
-	True(t, NotEmpty(mockT, chWithValue), "Channel with values is not empty")
+    True(t, NotEmpty(mockT, "something"), "Non Empty string is not empty")
+    True(t, NotEmpty(mockT, errors.New("something")), "Non nil object is not empty")
+    True(t, NotEmpty(mockT, []string{"something"}), "Non empty string array is not empty")
+    True(t, NotEmpty(mockT, 1), "Non-zero int value is not empty")
+    True(t, NotEmpty(mockT, true), "True value is not empty")
+    True(t, NotEmpty(mockT, chWithValue), "Channel with values is not empty")
 }
 
 func Test_getLen(t *testing.T) {
-	falseCases := []interface{}{
-		nil,
-		0,
-		true,
-		false,
-		'A',
-		struct{}{},
-	}
-	for _, v := range falseCases {
-		ok, l := getLen(v)
-		False(t, ok, "Expected getLen fail to get length of %#v", v)
-		Equal(t, 0, l, "getLen should return 0 for %#v", v)
-	}
+    falseCases := []interface{}{
+        nil,
+        0,
+        true,
+        false,
+        'A',
+        struct{}{},
+    }
+    for _, v := range falseCases {
+        ok, l := getLen(v)
+        False(t, ok, "Expected getLen fail to get length of %#v", v)
+        Equal(t, 0, l, "getLen should return 0 for %#v", v)
+    }
 
-	ch := make(chan int, 5)
-	ch <- 1
-	ch <- 2
-	ch <- 3
-	trueCases := []struct {
-		v interface{}
-		l int
-	}{
-		{[]int{1, 2, 3}, 3},
-		{[...]int{1, 2, 3}, 3},
-		{"ABC", 3},
-		{map[int]int{1: 2, 2: 4, 3: 6}, 3},
-		{ch, 3},
+    ch := make(chan int, 5)
+    ch <- 1
+    ch <- 2
+    ch <- 3
+    trueCases := []struct {
+        v interface{}
+        l int
+    }{
+        {[]int{1, 2, 3}, 3},
+        {[...]int{1, 2, 3}, 3},
+        {"ABC", 3},
+        {map[int]int{1: 2, 2: 4, 3: 6}, 3},
+        {ch, 3},
 
-		{[]int{}, 0},
-		{map[int]int{}, 0},
-		{make(chan int), 0},
+        {[]int{}, 0},
+        {map[int]int{}, 0},
+        {make(chan int), 0},
 
-		{[]int(nil), 0},
-		{map[int]int(nil), 0},
-		{(chan int)(nil), 0},
-	}
+        {[]int(nil), 0},
+        {map[int]int(nil), 0},
+        {(chan int)(nil), 0},
+    }
 
-	for _, c := range trueCases {
-		ok, l := getLen(c.v)
-		True(t, ok, "Expected getLen success to get length of %#v", c.v)
-		Equal(t, c.l, l)
-	}
+    for _, c := range trueCases {
+        ok, l := getLen(c.v)
+        True(t, ok, "Expected getLen success to get length of %#v", c.v)
+        Equal(t, c.l, l)
+    }
 }
 
 func TestLen(t *testing.T) {
-	mockT := new(testing.T)
+    mockT := new(testing.T)
 
-	False(t, Len(mockT, nil, 0), "nil does not have length")
-	False(t, Len(mockT, 0, 0), "int does not have length")
-	False(t, Len(mockT, true, 0), "true does not have length")
-	False(t, Len(mockT, false, 0), "false does not have length")
-	False(t, Len(mockT, 'A', 0), "Rune does not have length")
-	False(t, Len(mockT, struct{}{}, 0), "Struct does not have length")
+    False(t, Len(mockT, nil, 0), "nil does not have length")
+    False(t, Len(mockT, 0, 0), "int does not have length")
+    False(t, Len(mockT, true, 0), "true does not have length")
+    False(t, Len(mockT, false, 0), "false does not have length")
+    False(t, Len(mockT, 'A', 0), "Rune does not have length")
+    False(t, Len(mockT, struct{}{}, 0), "Struct does not have length")
 
-	ch := make(chan int, 5)
-	ch <- 1
-	ch <- 2
-	ch <- 3
+    ch := make(chan int, 5)
+    ch <- 1
+    ch <- 2
+    ch <- 3
 
-	cases := []struct {
-		v interface{}
-		l int
-	}{
-		{[]int{1, 2, 3}, 3},
-		{[...]int{1, 2, 3}, 3},
-		{"ABC", 3},
-		{map[int]int{1: 2, 2: 4, 3: 6}, 3},
-		{ch, 3},
+    cases := []struct {
+        v interface{}
+        l int
+    }{
+        {[]int{1, 2, 3}, 3},
+        {[...]int{1, 2, 3}, 3},
+        {"ABC", 3},
+        {map[int]int{1: 2, 2: 4, 3: 6}, 3},
+        {ch, 3},
 
-		{[]int{}, 0},
-		{map[int]int{}, 0},
-		{make(chan int), 0},
+        {[]int{}, 0},
+        {map[int]int{}, 0},
+        {make(chan int), 0},
 
-		{[]int(nil), 0},
-		{map[int]int(nil), 0},
-		{(chan int)(nil), 0},
-	}
+        {[]int(nil), 0},
+        {map[int]int(nil), 0},
+        {(chan int)(nil), 0},
+    }
 
-	for _, c := range cases {
-		True(t, Len(mockT, c.v, c.l), "%#v have %d items", c.v, c.l)
-	}
+    for _, c := range cases {
+        True(t, Len(mockT, c.v, c.l), "%#v have %d items", c.v, c.l)
+    }
 }
 
 func TestWithinDuration(t *testing.T) {
 
-	mockT := new(testing.T)
-	a := time.Now()
-	b := a.Add(10 * time.Second)
+    mockT := new(testing.T)
+    a := time.Now()
+    b := a.Add(10 * time.Second)
 
-	True(t, WithinDuration(mockT, a, b, 10*time.Second), "A 10s difference is within a 10s time difference")
-	True(t, WithinDuration(mockT, b, a, 10*time.Second), "A 10s difference is within a 10s time difference")
+    True(t, WithinDuration(mockT, a, b, 10*time.Second), "A 10s difference is within a 10s time difference")
+    True(t, WithinDuration(mockT, b, a, 10*time.Second), "A 10s difference is within a 10s time difference")
 
-	False(t, WithinDuration(mockT, a, b, 9*time.Second), "A 10s difference is not within a 9s time difference")
-	False(t, WithinDuration(mockT, b, a, 9*time.Second), "A 10s difference is not within a 9s time difference")
+    False(t, WithinDuration(mockT, a, b, 9*time.Second), "A 10s difference is not within a 9s time difference")
+    False(t, WithinDuration(mockT, b, a, 9*time.Second), "A 10s difference is not within a 9s time difference")
 
-	False(t, WithinDuration(mockT, a, b, -9*time.Second), "A 10s difference is not within a 9s time difference")
-	False(t, WithinDuration(mockT, b, a, -9*time.Second), "A 10s difference is not within a 9s time difference")
+    False(t, WithinDuration(mockT, a, b, -9*time.Second), "A 10s difference is not within a 9s time difference")
+    False(t, WithinDuration(mockT, b, a, -9*time.Second), "A 10s difference is not within a 9s time difference")
 
-	False(t, WithinDuration(mockT, a, b, -11*time.Second), "A 10s difference is not within a 9s time difference")
-	False(t, WithinDuration(mockT, b, a, -11*time.Second), "A 10s difference is not within a 9s time difference")
+    False(t, WithinDuration(mockT, a, b, -11*time.Second), "A 10s difference is not within a 9s time difference")
+    False(t, WithinDuration(mockT, b, a, -11*time.Second), "A 10s difference is not within a 9s time difference")
 }
 
 func TestInDelta(t *testing.T) {
-	mockT := new(testing.T)
+    mockT := new(testing.T)
 
-	True(t, InDelta(mockT, 1.001, 1, 0.01), "|1.001 - 1| <= 0.01")
-	True(t, InDelta(mockT, 1, 1.001, 0.01), "|1 - 1.001| <= 0.01")
-	True(t, InDelta(mockT, 1, 2, 1), "|1 - 2| <= 1")
-	False(t, InDelta(mockT, 1, 2, 0.5), "Expected |1 - 2| <= 0.5 to fail")
-	False(t, InDelta(mockT, 2, 1, 0.5), "Expected |2 - 1| <= 0.5 to fail")
-	False(t, InDelta(mockT, "", nil, 1), "Expected non numerals to fail")
+    True(t, InDelta(mockT, 1.001, 1, 0.01), "|1.001 - 1| <= 0.01")
+    True(t, InDelta(mockT, 1, 1.001, 0.01), "|1 - 1.001| <= 0.01")
+    True(t, InDelta(mockT, 1, 2, 1), "|1 - 2| <= 1")
+    False(t, InDelta(mockT, 1, 2, 0.5), "Expected |1 - 2| <= 0.5 to fail")
+    False(t, InDelta(mockT, 2, 1, 0.5), "Expected |2 - 1| <= 0.5 to fail")
+    False(t, InDelta(mockT, "", nil, 1), "Expected non numerals to fail")
 
-	cases := []struct {
-		a, b  interface{}
-		delta float64
-	}{
-		{uint8(2), uint8(1), 1},
-		{uint16(2), uint16(1), 1},
-		{uint32(2), uint32(1), 1},
-		{uint64(2), uint64(1), 1},
+    cases := []struct {
+        a, b  interface{}
+        delta float64
+    }{
+        {uint8(2), uint8(1), 1},
+        {uint16(2), uint16(1), 1},
+        {uint32(2), uint32(1), 1},
+        {uint64(2), uint64(1), 1},
 
-		{int(2), int(1), 1},
-		{int8(2), int8(1), 1},
-		{int16(2), int16(1), 1},
-		{int32(2), int32(1), 1},
-		{int64(2), int64(1), 1},
+        {int(2), int(1), 1},
+        {int8(2), int8(1), 1},
+        {int16(2), int16(1), 1},
+        {int32(2), int32(1), 1},
+        {int64(2), int64(1), 1},
 
-		{float32(2), float32(1), 1},
-		{float64(2), float64(1), 1},
-	}
+        {float32(2), float32(1), 1},
+        {float64(2), float64(1), 1},
+    }
 
-	for _, tc := range cases {
-		True(t, InDelta(mockT, tc.a, tc.b, tc.delta), "Expected |%V - %V| <= %v", tc.a, tc.b, tc.delta)
-	}
+    for _, tc := range cases {
+        True(t, InDelta(mockT, tc.a, tc.b, tc.delta), "Expected |%V - %V| <= %v", tc.a, tc.b, tc.delta)
+    }
 }

--- a/assert/doc.go
+++ b/assert/doc.go
@@ -79,13 +79,13 @@
 //
 //    assert.Panics(t, func(){
 //
-//	    // call code that should panic
+//      // call code that should panic
 //
 //    } [, message [, format-args]])
 //
 //    assert.NotPanics(t, func(){
 //
-//	    // call code that should not panic
+//      // call code that should not panic
 //
 //    } [, message [, format-args]])
 //
@@ -132,13 +132,13 @@
 //
 //    assert.Panics(func(){
 //
-//	    // call code that should panic
+//      // call code that should panic
 //
 //    } [, message [, format-args]])
 //
 //    assert.NotPanics(func(){
 //
-//	    // call code that should not panic
+//      // call code that should not panic
 //
 //    } [, message [, format-args]])
 //

--- a/assert/errors.go
+++ b/assert/errors.go
@@ -1,7 +1,7 @@
 package assert
 
 import (
-	"errors"
+    "errors"
 )
 
 // AnError is an error instance useful for testing.  If the code does not care

--- a/assert/forward_assertions.go
+++ b/assert/forward_assertions.go
@@ -3,30 +3,30 @@ package assert
 import "time"
 
 type Assertions struct {
-	t TestingT
+    t TestingT
 }
 
 func New(t TestingT) *Assertions {
-	return &Assertions{
-		t: t,
-	}
+    return &Assertions{
+        t: t,
+    }
 }
 
 // Fail reports a failure through
 func (a *Assertions) Fail(failureMessage string, msgAndArgs ...interface{}) bool {
-	return Fail(a.t, failureMessage, msgAndArgs...)
+    return Fail(a.t, failureMessage, msgAndArgs...)
 }
 
 // Implements asserts that an object is implemented by the specified interface.
 //
 //    assert.Implements((*MyInterface)(nil), new(MyObject), "MyObject")
 func (a *Assertions) Implements(interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) bool {
-	return Implements(a.t, interfaceObject, object, msgAndArgs...)
+    return Implements(a.t, interfaceObject, object, msgAndArgs...)
 }
 
 // IsType asserts that the specified objects are of the same type.
 func (a *Assertions) IsType(expectedType interface{}, object interface{}, msgAndArgs ...interface{}) bool {
-	return IsType(a.t, expectedType, object, msgAndArgs...)
+    return IsType(a.t, expectedType, object, msgAndArgs...)
 }
 
 // Equal asserts that two objects are equal.
@@ -35,7 +35,7 @@ func (a *Assertions) IsType(expectedType interface{}, object interface{}, msgAnd
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Equal(expected, actual interface{}, msgAndArgs ...interface{}) bool {
-	return Equal(a.t, expected, actual, msgAndArgs...)
+    return Equal(a.t, expected, actual, msgAndArgs...)
 }
 
 // Exactly asserts that two objects are equal is value and type.
@@ -44,7 +44,7 @@ func (a *Assertions) Equal(expected, actual interface{}, msgAndArgs ...interface
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Exactly(expected, actual interface{}, msgAndArgs ...interface{}) bool {
-	return Exactly(a.t, expected, actual, msgAndArgs...)
+    return Exactly(a.t, expected, actual, msgAndArgs...)
 }
 
 // NotNil asserts that the specified object is not nil.
@@ -53,7 +53,7 @@ func (a *Assertions) Exactly(expected, actual interface{}, msgAndArgs ...interfa
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotNil(object interface{}, msgAndArgs ...interface{}) bool {
-	return NotNil(a.t, object, msgAndArgs...)
+    return NotNil(a.t, object, msgAndArgs...)
 }
 
 // Nil asserts that the specified object is nil.
@@ -62,7 +62,7 @@ func (a *Assertions) NotNil(object interface{}, msgAndArgs ...interface{}) bool 
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Nil(object interface{}, msgAndArgs ...interface{}) bool {
-	return Nil(a.t, object, msgAndArgs...)
+    return Nil(a.t, object, msgAndArgs...)
 }
 
 // Empty asserts that the specified object is empty.  I.e. nil, "", false, 0 or a
@@ -72,7 +72,7 @@ func (a *Assertions) Nil(object interface{}, msgAndArgs ...interface{}) bool {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Empty(object interface{}, msgAndArgs ...interface{}) bool {
-	return Empty(a.t, object, msgAndArgs...)
+    return Empty(a.t, object, msgAndArgs...)
 }
 
 // Empty asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or a
@@ -84,7 +84,7 @@ func (a *Assertions) Empty(object interface{}, msgAndArgs ...interface{}) bool {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) bool {
-	return NotEmpty(a.t, object, msgAndArgs...)
+    return NotEmpty(a.t, object, msgAndArgs...)
 }
 
 // Len asserts that the specified object has specific length.
@@ -94,7 +94,7 @@ func (a *Assertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) boo
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Len(object interface{}, length int, msgAndArgs ...interface{}) bool {
-	return Len(a.t, object, length, msgAndArgs...)
+    return Len(a.t, object, length, msgAndArgs...)
 }
 
 // True asserts that the specified value is true.
@@ -103,7 +103,7 @@ func (a *Assertions) Len(object interface{}, length int, msgAndArgs ...interface
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) True(value bool, msgAndArgs ...interface{}) bool {
-	return True(a.t, value, msgAndArgs...)
+    return True(a.t, value, msgAndArgs...)
 }
 
 // False asserts that the specified value is true.
@@ -112,7 +112,7 @@ func (a *Assertions) True(value bool, msgAndArgs ...interface{}) bool {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) False(value bool, msgAndArgs ...interface{}) bool {
-	return False(a.t, value, msgAndArgs...)
+    return False(a.t, value, msgAndArgs...)
 }
 
 // NotEqual asserts that the specified values are NOT equal.
@@ -121,7 +121,7 @@ func (a *Assertions) False(value bool, msgAndArgs ...interface{}) bool {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotEqual(expected, actual interface{}, msgAndArgs ...interface{}) bool {
-	return NotEqual(a.t, expected, actual, msgAndArgs...)
+    return NotEqual(a.t, expected, actual, msgAndArgs...)
 }
 
 // Contains asserts that the specified string contains the specified substring.
@@ -130,7 +130,7 @@ func (a *Assertions) NotEqual(expected, actual interface{}, msgAndArgs ...interf
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Contains(s, contains string, msgAndArgs ...interface{}) bool {
-	return Contains(a.t, s, contains, msgAndArgs...)
+    return Contains(a.t, s, contains, msgAndArgs...)
 }
 
 // NotContains asserts that the specified string does NOT contain the specified substring.
@@ -139,12 +139,12 @@ func (a *Assertions) Contains(s, contains string, msgAndArgs ...interface{}) boo
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotContains(s, contains string, msgAndArgs ...interface{}) bool {
-	return NotContains(a.t, s, contains, msgAndArgs...)
+    return NotContains(a.t, s, contains, msgAndArgs...)
 }
 
 // Uses a Comparison to assert a complex condition.
 func (a *Assertions) Condition(comp Comparison, msgAndArgs ...interface{}) bool {
-	return Condition(a.t, comp, msgAndArgs...)
+    return Condition(a.t, comp, msgAndArgs...)
 }
 
 // Panics asserts that the code inside the specified PanicTestFunc panics.
@@ -155,7 +155,7 @@ func (a *Assertions) Condition(comp Comparison, msgAndArgs ...interface{}) bool 
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Panics(f PanicTestFunc, msgAndArgs ...interface{}) bool {
-	return Panics(a.t, f, msgAndArgs...)
+    return Panics(a.t, f, msgAndArgs...)
 }
 
 // NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
@@ -166,7 +166,7 @@ func (a *Assertions) Panics(f PanicTestFunc, msgAndArgs ...interface{}) bool {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotPanics(f PanicTestFunc, msgAndArgs ...interface{}) bool {
-	return NotPanics(a.t, f, msgAndArgs...)
+    return NotPanics(a.t, f, msgAndArgs...)
 }
 
 // WithinDuration asserts that the two times are within duration delta of each other.
@@ -175,47 +175,47 @@ func (a *Assertions) NotPanics(f PanicTestFunc, msgAndArgs ...interface{}) bool 
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) WithinDuration(expected, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) bool {
-	return WithinDuration(a.t, expected, actual, delta, msgAndArgs...)
+    return WithinDuration(a.t, expected, actual, delta, msgAndArgs...)
 }
 
 // InDelta asserts that the two numerals are within delta of each other.
 //
-// 	 assert.InDelta(t, math.Pi, (22 / 7.0), 0.01)
+//   assert.InDelta(t, math.Pi, (22 / 7.0), 0.01)
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) InDelta(t TestingT, expected, actual interface{}, delta float64, msgAndArgs ...interface{}) bool {
-	return InDelta(a.t, expected, actual, delta, msgAndArgs...)
+    return InDelta(a.t, expected, actual, delta, msgAndArgs...)
 }
 
 // InEpsilon asserts that expected and actual have a relative error less than epsilon
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) InEpsilon(t TestingT, expected, actual interface{}, epsilon float64, msgAndArgs ...interface{}) bool {
-	return InEpsilon(a.t, expected, actual, epsilon, msgAndArgs...)
+    return InEpsilon(a.t, expected, actual, epsilon, msgAndArgs...)
 }
 
 // NoError asserts that a function returned no error (i.e. `nil`).
 //
 //   actualObj, err := SomeFunction()
 //   if assert.NoError(err) {
-//	   assert.Equal(actualObj, expectedObj)
+//     assert.Equal(actualObj, expectedObj)
 //   }
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NoError(theError error, msgAndArgs ...interface{}) bool {
-	return NoError(a.t, theError, msgAndArgs...)
+    return NoError(a.t, theError, msgAndArgs...)
 }
 
 // Error asserts that a function returned an error (i.e. not `nil`).
 //
 //   actualObj, err := SomeFunction()
 //   if assert.Error(err, "An error was expected") {
-//	   assert.Equal(err, expectedError)
+//     assert.Equal(err, expectedError)
 //   }
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Error(theError error, msgAndArgs ...interface{}) bool {
-	return Error(a.t, theError, msgAndArgs...)
+    return Error(a.t, theError, msgAndArgs...)
 }
 
 // EqualError asserts that a function returned an error (i.e. not `nil`)
@@ -223,10 +223,10 @@ func (a *Assertions) Error(theError error, msgAndArgs ...interface{}) bool {
 //
 //   actualObj, err := SomeFunction()
 //   if assert.Error(err, "An error was expected") {
-//	   assert.Equal(err, expectedError)
+//     assert.Equal(err, expectedError)
 //   }
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...interface{}) bool {
-	return EqualError(a.t, theError, errString, msgAndArgs...)
+    return EqualError(a.t, theError, errString, msgAndArgs...)
 }

--- a/assert/forward_assertions_test.go
+++ b/assert/forward_assertions_test.go
@@ -1,380 +1,380 @@
 package assert
 
 import (
-	"errors"
-	"testing"
-	"time"
+    "errors"
+    "testing"
+    "time"
 )
 
 func TestImplementsWrapper(t *testing.T) {
-	assert := New(new(testing.T))
+    assert := New(new(testing.T))
 
-	if !assert.Implements((*AssertionTesterInterface)(nil), new(AssertionTesterConformingObject)) {
-		t.Error("Implements method should return true: AssertionTesterConformingObject implements AssertionTesterInterface")
-	}
-	if assert.Implements((*AssertionTesterInterface)(nil), new(AssertionTesterNonConformingObject)) {
-		t.Error("Implements method should return false: AssertionTesterNonConformingObject does not implements AssertionTesterInterface")
-	}
+    if !assert.Implements((*AssertionTesterInterface)(nil), new(AssertionTesterConformingObject)) {
+        t.Error("Implements method should return true: AssertionTesterConformingObject implements AssertionTesterInterface")
+    }
+    if assert.Implements((*AssertionTesterInterface)(nil), new(AssertionTesterNonConformingObject)) {
+        t.Error("Implements method should return false: AssertionTesterNonConformingObject does not implements AssertionTesterInterface")
+    }
 }
 
 func TestIsTypeWrapper(t *testing.T) {
-	assert := New(new(testing.T))
+    assert := New(new(testing.T))
 
-	if !assert.IsType(new(AssertionTesterConformingObject), new(AssertionTesterConformingObject)) {
-		t.Error("IsType should return true: AssertionTesterConformingObject is the same type as AssertionTesterConformingObject")
-	}
-	if assert.IsType(new(AssertionTesterConformingObject), new(AssertionTesterNonConformingObject)) {
-		t.Error("IsType should return false: AssertionTesterConformingObject is not the same type as AssertionTesterNonConformingObject")
-	}
+    if !assert.IsType(new(AssertionTesterConformingObject), new(AssertionTesterConformingObject)) {
+        t.Error("IsType should return true: AssertionTesterConformingObject is the same type as AssertionTesterConformingObject")
+    }
+    if assert.IsType(new(AssertionTesterConformingObject), new(AssertionTesterNonConformingObject)) {
+        t.Error("IsType should return false: AssertionTesterConformingObject is not the same type as AssertionTesterNonConformingObject")
+    }
 
 }
 
 func TestEqualWrapper(t *testing.T) {
-	assert := New(new(testing.T))
+    assert := New(new(testing.T))
 
-	if !assert.Equal("Hello World", "Hello World") {
-		t.Error("Equal should return true")
-	}
-	if !assert.Equal(123, 123) {
-		t.Error("Equal should return true")
-	}
-	if !assert.Equal(123.5, 123.5) {
-		t.Error("Equal should return true")
-	}
-	if !assert.Equal([]byte("Hello World"), []byte("Hello World")) {
-		t.Error("Equal should return true")
-	}
-	if !assert.Equal(nil, nil) {
-		t.Error("Equal should return true")
-	}
+    if !assert.Equal("Hello World", "Hello World") {
+        t.Error("Equal should return true")
+    }
+    if !assert.Equal(123, 123) {
+        t.Error("Equal should return true")
+    }
+    if !assert.Equal(123.5, 123.5) {
+        t.Error("Equal should return true")
+    }
+    if !assert.Equal([]byte("Hello World"), []byte("Hello World")) {
+        t.Error("Equal should return true")
+    }
+    if !assert.Equal(nil, nil) {
+        t.Error("Equal should return true")
+    }
 }
 
 func TestNotNilWrapper(t *testing.T) {
-	assert := New(new(testing.T))
+    assert := New(new(testing.T))
 
-	if !assert.NotNil(new(AssertionTesterConformingObject)) {
-		t.Error("NotNil should return true: object is not nil")
-	}
-	if assert.NotNil(nil) {
-		t.Error("NotNil should return false: object is nil")
-	}
+    if !assert.NotNil(new(AssertionTesterConformingObject)) {
+        t.Error("NotNil should return true: object is not nil")
+    }
+    if assert.NotNil(nil) {
+        t.Error("NotNil should return false: object is nil")
+    }
 
 }
 
 func TestNilWrapper(t *testing.T) {
-	assert := New(new(testing.T))
+    assert := New(new(testing.T))
 
-	if !assert.Nil(nil) {
-		t.Error("Nil should return true: object is nil")
-	}
-	if assert.Nil(new(AssertionTesterConformingObject)) {
-		t.Error("Nil should return false: object is not nil")
-	}
+    if !assert.Nil(nil) {
+        t.Error("Nil should return true: object is nil")
+    }
+    if assert.Nil(new(AssertionTesterConformingObject)) {
+        t.Error("Nil should return false: object is not nil")
+    }
 
 }
 
 func TestTrueWrapper(t *testing.T) {
-	assert := New(new(testing.T))
+    assert := New(new(testing.T))
 
-	if !assert.True(true) {
-		t.Error("True should return true")
-	}
-	if assert.True(false) {
-		t.Error("True should return false")
-	}
+    if !assert.True(true) {
+        t.Error("True should return true")
+    }
+    if assert.True(false) {
+        t.Error("True should return false")
+    }
 
 }
 
 func TestFalseWrapper(t *testing.T) {
-	assert := New(new(testing.T))
+    assert := New(new(testing.T))
 
-	if !assert.False(false) {
-		t.Error("False should return true")
-	}
-	if assert.False(true) {
-		t.Error("False should return false")
-	}
+    if !assert.False(false) {
+        t.Error("False should return true")
+    }
+    if assert.False(true) {
+        t.Error("False should return false")
+    }
 
 }
 
 func TestExactlyWrapper(t *testing.T) {
-	assert := New(new(testing.T))
+    assert := New(new(testing.T))
 
-	a := float32(1)
-	b := float64(1)
-	c := float32(1)
-	d := float32(2)
+    a := float32(1)
+    b := float64(1)
+    c := float32(1)
+    d := float32(2)
 
-	if assert.Exactly(a, b) {
-		t.Error("Exactly should return false")
-	}
-	if assert.Exactly(a, d) {
-		t.Error("Exactly should return false")
-	}
-	if !assert.Exactly(a, c) {
-		t.Error("Exactly should return true")
-	}
+    if assert.Exactly(a, b) {
+        t.Error("Exactly should return false")
+    }
+    if assert.Exactly(a, d) {
+        t.Error("Exactly should return false")
+    }
+    if !assert.Exactly(a, c) {
+        t.Error("Exactly should return true")
+    }
 
-	if assert.Exactly(nil, a) {
-		t.Error("Exactly should return false")
-	}
-	if assert.Exactly(a, nil) {
-		t.Error("Exactly should return false")
-	}
+    if assert.Exactly(nil, a) {
+        t.Error("Exactly should return false")
+    }
+    if assert.Exactly(a, nil) {
+        t.Error("Exactly should return false")
+    }
 
 }
 
 func TestNotEqualWrapper(t *testing.T) {
 
-	assert := New(new(testing.T))
+    assert := New(new(testing.T))
 
-	if !assert.NotEqual("Hello World", "Hello World!") {
-		t.Error("NotEqual should return true")
-	}
-	if !assert.NotEqual(123, 1234) {
-		t.Error("NotEqual should return true")
-	}
-	if !assert.NotEqual(123.5, 123.55) {
-		t.Error("NotEqual should return true")
-	}
-	if !assert.NotEqual([]byte("Hello World"), []byte("Hello World!")) {
-		t.Error("NotEqual should return true")
-	}
-	if !assert.NotEqual(nil, new(AssertionTesterConformingObject)) {
-		t.Error("NotEqual should return true")
-	}
+    if !assert.NotEqual("Hello World", "Hello World!") {
+        t.Error("NotEqual should return true")
+    }
+    if !assert.NotEqual(123, 1234) {
+        t.Error("NotEqual should return true")
+    }
+    if !assert.NotEqual(123.5, 123.55) {
+        t.Error("NotEqual should return true")
+    }
+    if !assert.NotEqual([]byte("Hello World"), []byte("Hello World!")) {
+        t.Error("NotEqual should return true")
+    }
+    if !assert.NotEqual(nil, new(AssertionTesterConformingObject)) {
+        t.Error("NotEqual should return true")
+    }
 }
 
 func TestContainsWrapper(t *testing.T) {
 
-	assert := New(new(testing.T))
+    assert := New(new(testing.T))
 
-	if !assert.Contains("Hello World", "Hello") {
-		t.Error("Contains should return true: \"Hello World\" contains \"Hello\"")
-	}
-	if assert.Contains("Hello World", "Salut") {
-		t.Error("Contains should return false: \"Hello World\" does not contain \"Salut\"")
-	}
+    if !assert.Contains("Hello World", "Hello") {
+        t.Error("Contains should return true: \"Hello World\" contains \"Hello\"")
+    }
+    if assert.Contains("Hello World", "Salut") {
+        t.Error("Contains should return false: \"Hello World\" does not contain \"Salut\"")
+    }
 
 }
 
 func TestNotContainsWrapper(t *testing.T) {
 
-	assert := New(new(testing.T))
+    assert := New(new(testing.T))
 
-	if !assert.NotContains("Hello World", "Hello!") {
-		t.Error("NotContains should return true: \"Hello World\" does not contain \"Hello!\"")
-	}
-	if assert.NotContains("Hello World", "Hello") {
-		t.Error("NotContains should return false: \"Hello World\" contains \"Hello\"")
-	}
+    if !assert.NotContains("Hello World", "Hello!") {
+        t.Error("NotContains should return true: \"Hello World\" does not contain \"Hello!\"")
+    }
+    if assert.NotContains("Hello World", "Hello") {
+        t.Error("NotContains should return false: \"Hello World\" contains \"Hello\"")
+    }
 
 }
 
 func TestDidPanicWrapper(t *testing.T) {
 
-	if funcDidPanic, _ := didPanic(func() {
-		panic("Panic!")
-	}); !funcDidPanic {
-		t.Error("didPanic should return true")
-	}
+    if funcDidPanic, _ := didPanic(func() {
+        panic("Panic!")
+    }); !funcDidPanic {
+        t.Error("didPanic should return true")
+    }
 
-	if funcDidPanic, _ := didPanic(func() {
-	}); funcDidPanic {
-		t.Error("didPanic should return false")
-	}
+    if funcDidPanic, _ := didPanic(func() {
+    }); funcDidPanic {
+        t.Error("didPanic should return false")
+    }
 
 }
 
 func TestPanicsWrapper(t *testing.T) {
 
-	assert := New(new(testing.T))
+    assert := New(new(testing.T))
 
-	if !assert.Panics(func() {
-		panic("Panic!")
-	}) {
-		t.Error("Panics should return true")
-	}
+    if !assert.Panics(func() {
+        panic("Panic!")
+    }) {
+        t.Error("Panics should return true")
+    }
 
-	if assert.Panics(func() {
-	}) {
-		t.Error("Panics should return false")
-	}
+    if assert.Panics(func() {
+    }) {
+        t.Error("Panics should return false")
+    }
 
 }
 
 func TestNotPanicsWrapper(t *testing.T) {
 
-	assert := New(new(testing.T))
+    assert := New(new(testing.T))
 
-	if !assert.NotPanics(func() {
-	}) {
-		t.Error("NotPanics should return true")
-	}
+    if !assert.NotPanics(func() {
+    }) {
+        t.Error("NotPanics should return true")
+    }
 
-	if assert.NotPanics(func() {
-		panic("Panic!")
-	}) {
-		t.Error("NotPanics should return false")
-	}
+    if assert.NotPanics(func() {
+        panic("Panic!")
+    }) {
+        t.Error("NotPanics should return false")
+    }
 
 }
 
 func TestEqualWrapper_Funcs(t *testing.T) {
 
-	assert := New(t)
+    assert := New(t)
 
-	type f func() int
-	var f1 f = func() int { return 1 }
-	var f2 f = func() int { return 2 }
+    type f func() int
+    var f1 f = func() int { return 1 }
+    var f2 f = func() int { return 2 }
 
-	var f1_copy f = f1
+    var f1_copy f = f1
 
-	assert.Equal(f1_copy, f1, "Funcs are the same and should be considered equal")
-	assert.NotEqual(f1, f2, "f1 and f2 are different")
+    assert.Equal(f1_copy, f1, "Funcs are the same and should be considered equal")
+    assert.NotEqual(f1, f2, "f1 and f2 are different")
 
 }
 
 func TestNoErrorWrapper(t *testing.T) {
-	assert := New(t)
-	mockAssert := New(new(testing.T))
+    assert := New(t)
+    mockAssert := New(new(testing.T))
 
-	// start with a nil error
-	var err error = nil
+    // start with a nil error
+    var err error = nil
 
-	assert.True(mockAssert.NoError(err), "NoError should return True for nil arg")
+    assert.True(mockAssert.NoError(err), "NoError should return True for nil arg")
 
-	// now set an error
-	err = errors.New("Some error")
+    // now set an error
+    err = errors.New("Some error")
 
-	assert.False(mockAssert.NoError(err), "NoError with error should return False")
+    assert.False(mockAssert.NoError(err), "NoError with error should return False")
 
 }
 
 func TestErrorWrapper(t *testing.T) {
-	assert := New(t)
-	mockAssert := New(new(testing.T))
+    assert := New(t)
+    mockAssert := New(new(testing.T))
 
-	// start with a nil error
-	var err error = nil
+    // start with a nil error
+    var err error = nil
 
-	assert.False(mockAssert.Error(err), "Error should return False for nil arg")
+    assert.False(mockAssert.Error(err), "Error should return False for nil arg")
 
-	// now set an error
-	err = errors.New("Some error")
+    // now set an error
+    err = errors.New("Some error")
 
-	assert.True(mockAssert.Error(err), "Error with error should return True")
+    assert.True(mockAssert.Error(err), "Error with error should return True")
 
 }
 
 func TestEqualErrorWrapper(t *testing.T) {
-	assert := New(t)
-	mockAssert := New(new(testing.T))
+    assert := New(t)
+    mockAssert := New(new(testing.T))
 
-	// start with a nil error
-	var err error
-	assert.False(mockAssert.EqualError(err, ""),
-		"EqualError should return false for nil arg")
+    // start with a nil error
+    var err error
+    assert.False(mockAssert.EqualError(err, ""),
+        "EqualError should return false for nil arg")
 
-	// now set an error
-	err = errors.New("some error")
-	assert.False(mockAssert.EqualError(err, "Not some error"),
-		"EqualError should return false for different error string")
-	assert.True(mockAssert.EqualError(err, "some error"),
-		"EqualError should return true")
+    // now set an error
+    err = errors.New("some error")
+    assert.False(mockAssert.EqualError(err, "Not some error"),
+        "EqualError should return false for different error string")
+    assert.True(mockAssert.EqualError(err, "some error"),
+        "EqualError should return true")
 }
 
 func TestEmptyWrapper(t *testing.T) {
-	assert := New(t)
-	mockAssert := New(new(testing.T))
+    assert := New(t)
+    mockAssert := New(new(testing.T))
 
-	assert.True(mockAssert.Empty(""), "Empty string is empty")
-	assert.True(mockAssert.Empty(nil), "Nil is empty")
-	assert.True(mockAssert.Empty([]string{}), "Empty string array is empty")
-	assert.True(mockAssert.Empty(0), "Zero int value is empty")
-	assert.True(mockAssert.Empty(false), "False value is empty")
+    assert.True(mockAssert.Empty(""), "Empty string is empty")
+    assert.True(mockAssert.Empty(nil), "Nil is empty")
+    assert.True(mockAssert.Empty([]string{}), "Empty string array is empty")
+    assert.True(mockAssert.Empty(0), "Zero int value is empty")
+    assert.True(mockAssert.Empty(false), "False value is empty")
 
-	assert.False(mockAssert.Empty("something"), "Non Empty string is not empty")
-	assert.False(mockAssert.Empty(errors.New("something")), "Non nil object is not empty")
-	assert.False(mockAssert.Empty([]string{"something"}), "Non empty string array is not empty")
-	assert.False(mockAssert.Empty(1), "Non-zero int value is not empty")
-	assert.False(mockAssert.Empty(true), "True value is not empty")
+    assert.False(mockAssert.Empty("something"), "Non Empty string is not empty")
+    assert.False(mockAssert.Empty(errors.New("something")), "Non nil object is not empty")
+    assert.False(mockAssert.Empty([]string{"something"}), "Non empty string array is not empty")
+    assert.False(mockAssert.Empty(1), "Non-zero int value is not empty")
+    assert.False(mockAssert.Empty(true), "True value is not empty")
 
 }
 
 func TestNotEmptyWrapper(t *testing.T) {
-	assert := New(t)
-	mockAssert := New(new(testing.T))
+    assert := New(t)
+    mockAssert := New(new(testing.T))
 
-	assert.False(mockAssert.NotEmpty(""), "Empty string is empty")
-	assert.False(mockAssert.NotEmpty(nil), "Nil is empty")
-	assert.False(mockAssert.NotEmpty([]string{}), "Empty string array is empty")
-	assert.False(mockAssert.NotEmpty(0), "Zero int value is empty")
-	assert.False(mockAssert.NotEmpty(false), "False value is empty")
+    assert.False(mockAssert.NotEmpty(""), "Empty string is empty")
+    assert.False(mockAssert.NotEmpty(nil), "Nil is empty")
+    assert.False(mockAssert.NotEmpty([]string{}), "Empty string array is empty")
+    assert.False(mockAssert.NotEmpty(0), "Zero int value is empty")
+    assert.False(mockAssert.NotEmpty(false), "False value is empty")
 
-	assert.True(mockAssert.NotEmpty("something"), "Non Empty string is not empty")
-	assert.True(mockAssert.NotEmpty(errors.New("something")), "Non nil object is not empty")
-	assert.True(mockAssert.NotEmpty([]string{"something"}), "Non empty string array is not empty")
-	assert.True(mockAssert.NotEmpty(1), "Non-zero int value is not empty")
-	assert.True(mockAssert.NotEmpty(true), "True value is not empty")
+    assert.True(mockAssert.NotEmpty("something"), "Non Empty string is not empty")
+    assert.True(mockAssert.NotEmpty(errors.New("something")), "Non nil object is not empty")
+    assert.True(mockAssert.NotEmpty([]string{"something"}), "Non empty string array is not empty")
+    assert.True(mockAssert.NotEmpty(1), "Non-zero int value is not empty")
+    assert.True(mockAssert.NotEmpty(true), "True value is not empty")
 
 }
 
 func TestLenWrapper(t *testing.T) {
-	assert := New(t)
-	mockAssert := New(new(testing.T))
+    assert := New(t)
+    mockAssert := New(new(testing.T))
 
-	assert.False(mockAssert.Len(nil, 0), "nil does not have length")
-	assert.False(mockAssert.Len(0, 0), "int does not have length")
-	assert.False(mockAssert.Len(true, 0), "true does not have length")
-	assert.False(mockAssert.Len(false, 0), "false does not have length")
-	assert.False(mockAssert.Len('A', 0), "Rune does not have length")
-	assert.False(mockAssert.Len(struct{}{}, 0), "Struct does not have length")
+    assert.False(mockAssert.Len(nil, 0), "nil does not have length")
+    assert.False(mockAssert.Len(0, 0), "int does not have length")
+    assert.False(mockAssert.Len(true, 0), "true does not have length")
+    assert.False(mockAssert.Len(false, 0), "false does not have length")
+    assert.False(mockAssert.Len('A', 0), "Rune does not have length")
+    assert.False(mockAssert.Len(struct{}{}, 0), "Struct does not have length")
 
-	ch := make(chan int, 5)
-	ch <- 1
-	ch <- 2
-	ch <- 3
+    ch := make(chan int, 5)
+    ch <- 1
+    ch <- 2
+    ch <- 3
 
-	cases := []struct {
-		v interface{}
-		l int
-	}{
-		{[]int{1, 2, 3}, 3},
-		{[...]int{1, 2, 3}, 3},
-		{"ABC", 3},
-		{map[int]int{1: 2, 2: 4, 3: 6}, 3},
-		{ch, 3},
+    cases := []struct {
+        v interface{}
+        l int
+    }{
+        {[]int{1, 2, 3}, 3},
+        {[...]int{1, 2, 3}, 3},
+        {"ABC", 3},
+        {map[int]int{1: 2, 2: 4, 3: 6}, 3},
+        {ch, 3},
 
-		{[]int{}, 0},
-		{map[int]int{}, 0},
-		{make(chan int), 0},
+        {[]int{}, 0},
+        {map[int]int{}, 0},
+        {make(chan int), 0},
 
-		{[]int(nil), 0},
-		{map[int]int(nil), 0},
-		{(chan int)(nil), 0},
-	}
+        {[]int(nil), 0},
+        {map[int]int(nil), 0},
+        {(chan int)(nil), 0},
+    }
 
-	for _, c := range cases {
-		assert.True(mockAssert.Len(c.v, c.l), "%#v have %d items", c.v, c.l)
-	}
+    for _, c := range cases {
+        assert.True(mockAssert.Len(c.v, c.l), "%#v have %d items", c.v, c.l)
+    }
 }
 
 func TestWithinDurationWrapper(t *testing.T) {
-	assert := New(t)
-	mockAssert := New(new(testing.T))
-	a := time.Now()
-	b := a.Add(10 * time.Second)
+    assert := New(t)
+    mockAssert := New(new(testing.T))
+    a := time.Now()
+    b := a.Add(10 * time.Second)
 
-	assert.True(mockAssert.WithinDuration(a, b, 10*time.Second), "A 10s difference is within a 10s time difference")
-	assert.True(mockAssert.WithinDuration(b, a, 10*time.Second), "A 10s difference is within a 10s time difference")
+    assert.True(mockAssert.WithinDuration(a, b, 10*time.Second), "A 10s difference is within a 10s time difference")
+    assert.True(mockAssert.WithinDuration(b, a, 10*time.Second), "A 10s difference is within a 10s time difference")
 
-	assert.False(mockAssert.WithinDuration(a, b, 9*time.Second), "A 10s difference is not within a 9s time difference")
-	assert.False(mockAssert.WithinDuration(b, a, 9*time.Second), "A 10s difference is not within a 9s time difference")
+    assert.False(mockAssert.WithinDuration(a, b, 9*time.Second), "A 10s difference is not within a 9s time difference")
+    assert.False(mockAssert.WithinDuration(b, a, 9*time.Second), "A 10s difference is not within a 9s time difference")
 
-	assert.False(mockAssert.WithinDuration(a, b, -9*time.Second), "A 10s difference is not within a 9s time difference")
-	assert.False(mockAssert.WithinDuration(b, a, -9*time.Second), "A 10s difference is not within a 9s time difference")
+    assert.False(mockAssert.WithinDuration(a, b, -9*time.Second), "A 10s difference is not within a 9s time difference")
+    assert.False(mockAssert.WithinDuration(b, a, -9*time.Second), "A 10s difference is not within a 9s time difference")
 
-	assert.False(mockAssert.WithinDuration(a, b, -11*time.Second), "A 10s difference is not within a 9s time difference")
-	assert.False(mockAssert.WithinDuration(b, a, -11*time.Second), "A 10s difference is not within a 9s time difference")
+    assert.False(mockAssert.WithinDuration(a, b, -11*time.Second), "A 10s difference is not within a 9s time difference")
+    assert.False(mockAssert.WithinDuration(b, a, -11*time.Second), "A 10s difference is not within a 9s time difference")
 }

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -1,83 +1,83 @@
 package mock
 
 import (
-	"fmt"
-	"github.com/stretchr/objx"
-	"github.com/stretchr/testify/assert"
-	"reflect"
-	"runtime"
-	"strings"
-	"sync"
+    "fmt"
+    "github.com/stretchr/objx"
+    "github.com/stretchr/testify/assert"
+    "reflect"
+    "runtime"
+    "strings"
+    "sync"
 )
 
 // TestingT is an interface wrapper around *testing.T
 type TestingT interface {
-	Logf(format string, args ...interface{})
-	Errorf(format string, args ...interface{})
+    Logf(format string, args ...interface{})
+    Errorf(format string, args ...interface{})
 }
 
 /*
-	Call
+    Call
 */
 
 // Call represents a method call and is used for setting expectations,
 // as well as recording activity.
 type Call struct {
 
-	// The name of the method that was or will be called.
-	Method string
+    // The name of the method that was or will be called.
+    Method string
 
-	// Holds the arguments of the method.
-	Arguments Arguments
+    // Holds the arguments of the method.
+    Arguments Arguments
 
-	// Holds the arguments that should be returned when
-	// this method is called.
-	ReturnArguments Arguments
+    // Holds the arguments that should be returned when
+    // this method is called.
+    ReturnArguments Arguments
 
-	// The number of times to return the return arguments when setting
-	// expectations. 0 means to always return the value.
-	Repeatability int
+    // The number of times to return the return arguments when setting
+    // expectations. 0 means to always return the value.
+    Repeatability int
 }
 
 // Mock is the workhorse used to track activity on another object.
 // For an example of its usage, refer to the "Example Usage" section at the top of this document.
 type Mock struct {
 
-	// The method name that is currently
-	// being referred to by the On method.
-	onMethodName string
+    // The method name that is currently
+    // being referred to by the On method.
+    onMethodName string
 
-	// An array of the arguments that are
-	// currently being referred to by the On method.
-	onMethodArguments Arguments
+    // An array of the arguments that are
+    // currently being referred to by the On method.
+    onMethodArguments Arguments
 
-	// Represents the calls that are expected of
-	// an object.
-	ExpectedCalls []Call
+    // Represents the calls that are expected of
+    // an object.
+    ExpectedCalls []Call
 
-	// Holds the calls that were made to this mocked object.
-	Calls []Call
+    // Holds the calls that were made to this mocked object.
+    Calls []Call
 
-	// TestData holds any data that might be useful for testing.  Testify ignores
-	// this data completely allowing you to do whatever you like with it.
-	testData objx.Map
+    // TestData holds any data that might be useful for testing.  Testify ignores
+    // this data completely allowing you to do whatever you like with it.
+    testData objx.Map
 
-	mutex sync.Mutex
+    mutex sync.Mutex
 }
 
 // TestData holds any data that might be useful for testing.  Testify ignores
 // this data completely allowing you to do whatever you like with it.
 func (m *Mock) TestData() objx.Map {
 
-	if m.testData == nil {
-		m.testData = make(objx.Map)
-	}
+    if m.testData == nil {
+        m.testData = make(objx.Map)
+    }
 
-	return m.testData
+    return m.testData
 }
 
 /*
-	Setting expectations
+    Setting expectations
 */
 
 // On starts a description of an expectation of the specified method
@@ -85,9 +85,9 @@ func (m *Mock) TestData() objx.Map {
 //
 //     Mock.On("MyMethod", arg1, arg2)
 func (m *Mock) On(methodName string, arguments ...interface{}) *Mock {
-	m.onMethodName = methodName
-	m.onMethodArguments = arguments
-	return m
+    m.onMethodName = methodName
+    m.onMethodArguments = arguments
+    return m
 }
 
 // Return finishes a description of an expectation of the method (and arguments)
@@ -95,22 +95,22 @@ func (m *Mock) On(methodName string, arguments ...interface{}) *Mock {
 //
 //     Mock.On("MyMethod", arg1, arg2).Return(returnArg1, returnArg2)
 func (m *Mock) Return(returnArguments ...interface{}) *Mock {
-	m.ExpectedCalls = append(m.ExpectedCalls, Call{m.onMethodName, m.onMethodArguments, returnArguments, 0})
-	return m
+    m.ExpectedCalls = append(m.ExpectedCalls, Call{m.onMethodName, m.onMethodArguments, returnArguments, 0})
+    return m
 }
 
 // Once indicates that that the mock should only return the value once.
 //
 //    Mock.On("MyMethod", arg1, arg2).Return(returnArg1, returnArg2).Once()
 func (m *Mock) Once() {
-	m.ExpectedCalls[len(m.ExpectedCalls)-1].Repeatability = 1
+    m.ExpectedCalls[len(m.ExpectedCalls)-1].Repeatability = 1
 }
 
 // Twice indicates that that the mock should only return the value twice.
 //
 //    Mock.On("MyMethod", arg1, arg2).Return(returnArg1, returnArg2).Twice()
 func (m *Mock) Twice() {
-	m.ExpectedCalls[len(m.ExpectedCalls)-1].Repeatability = 2
+    m.ExpectedCalls[len(m.ExpectedCalls)-1].Repeatability = 2
 }
 
 // Times indicates that that the mock should only return the indicated number
@@ -118,116 +118,116 @@ func (m *Mock) Twice() {
 //
 //    Mock.On("MyMethod", arg1, arg2).Return(returnArg1, returnArg2).Times(5)
 func (m *Mock) Times(i int) {
-	m.ExpectedCalls[len(m.ExpectedCalls)-1].Repeatability = i
+    m.ExpectedCalls[len(m.ExpectedCalls)-1].Repeatability = i
 }
 
 /*
-	Recording and responding to activity
+    Recording and responding to activity
 */
 
 func (m *Mock) findExpectedCall(method string, arguments ...interface{}) (int, *Call) {
-	for i, call := range m.ExpectedCalls {
-		if call.Method == method && call.Repeatability > -1 {
+    for i, call := range m.ExpectedCalls {
+        if call.Method == method && call.Repeatability > -1 {
 
-			_, diffCount := call.Arguments.Diff(arguments)
-			if diffCount == 0 {
-				return i, &call
-			}
+            _, diffCount := call.Arguments.Diff(arguments)
+            if diffCount == 0 {
+                return i, &call
+            }
 
-		}
-	}
-	return -1, nil
+        }
+    }
+    return -1, nil
 }
 
 func (m *Mock) findClosestCall(method string, arguments ...interface{}) (bool, *Call) {
 
-	diffCount := 0
-	var closestCall *Call = nil
+    diffCount := 0
+    var closestCall *Call = nil
 
-	for _, call := range m.ExpectedCalls {
-		if call.Method == method {
+    for _, call := range m.ExpectedCalls {
+        if call.Method == method {
 
-			_, tempDiffCount := call.Arguments.Diff(arguments)
-			if tempDiffCount < diffCount || diffCount == 0 {
-				diffCount = tempDiffCount
-				closestCall = &call
-			}
+            _, tempDiffCount := call.Arguments.Diff(arguments)
+            if tempDiffCount < diffCount || diffCount == 0 {
+                diffCount = tempDiffCount
+                closestCall = &call
+            }
 
-		}
-	}
+        }
+    }
 
-	if closestCall == nil {
-		return false, nil
-	}
+    if closestCall == nil {
+        return false, nil
+    }
 
-	return true, closestCall
+    return true, closestCall
 }
 
 func callString(method string, arguments Arguments, includeArgumentValues bool) string {
 
-	var argValsString string = ""
-	if includeArgumentValues {
-		var argVals []string
-		for argIndex, arg := range arguments {
-			argVals = append(argVals, fmt.Sprintf("%d: %v", argIndex, arg))
-		}
-		argValsString = fmt.Sprintf("\n\t\t%s", strings.Join(argVals, "\n\t\t"))
-	}
+    var argValsString string = ""
+    if includeArgumentValues {
+        var argVals []string
+        for argIndex, arg := range arguments {
+            argVals = append(argVals, fmt.Sprintf("%d: %v", argIndex, arg))
+        }
+        argValsString = fmt.Sprintf("\n\t\t%s", strings.Join(argVals, "\n\t\t"))
+    }
 
-	return fmt.Sprintf("%s(%s)%s", method, arguments.String(), argValsString)
+    return fmt.Sprintf("%s(%s)%s", method, arguments.String(), argValsString)
 }
 
 // Called tells the mock object that a method has been called, and gets an array
 // of arguments to return.  Panics if the call is unexpected (i.e. not preceeded by
 // appropriate .On .Return() calls)
 func (m *Mock) Called(arguments ...interface{}) Arguments {
-	defer m.mutex.Unlock()
-	m.mutex.Lock()
+    defer m.mutex.Unlock()
+    m.mutex.Lock()
 
-	// get the calling function's name
-	pc, _, _, ok := runtime.Caller(1)
-	if !ok {
-		panic("Couldn't get the caller information")
-	}
-	functionPath := runtime.FuncForPC(pc).Name()
-	parts := strings.Split(functionPath, ".")
-	functionName := parts[len(parts)-1]
+    // get the calling function's name
+    pc, _, _, ok := runtime.Caller(1)
+    if !ok {
+        panic("Couldn't get the caller information")
+    }
+    functionPath := runtime.FuncForPC(pc).Name()
+    parts := strings.Split(functionPath, ".")
+    functionName := parts[len(parts)-1]
 
-	found, call := m.findExpectedCall(functionName, arguments...)
+    found, call := m.findExpectedCall(functionName, arguments...)
 
-	switch {
-	case found < 0:
-		// we have to fail here - because we don't know what to do
-		// as the return arguments.  This is because:
-		//
-		//   a) this is a totally unexpected call to this method,
-		//   b) the arguments are not what was expected, or
-		//   c) the developer has forgotten to add an accompanying On...Return pair.
+    switch {
+    case found < 0:
+        // we have to fail here - because we don't know what to do
+        // as the return arguments.  This is because:
+        //
+        //   a) this is a totally unexpected call to this method,
+        //   b) the arguments are not what was expected, or
+        //   c) the developer has forgotten to add an accompanying On...Return pair.
 
-		closestFound, closestCall := m.findClosestCall(functionName, arguments...)
+        closestFound, closestCall := m.findClosestCall(functionName, arguments...)
 
-		if closestFound {
-			panic(fmt.Sprintf("\n\nmock: Unexpected Method Call\n-----------------------------\n\n%s\n\nThe closest call I have is: \n\n%s\n", callString(functionName, arguments, true), callString(functionName, closestCall.Arguments, true)))
-		} else {
-			panic(fmt.Sprintf("\nassert: mock: I don't know what to return because the method call was unexpected.\n\tEither do Mock.On(\"%s\").Return(...) first, or remove the %s() call.\n\tThis method was unexpected:\n\t\t%s\n\tat: %s", functionName, functionName, callString(functionName, arguments, true), assert.CallerInfo()))
-		}
-	case call.Repeatability == 1:
-		call.Repeatability = -1
-		m.ExpectedCalls[found] = *call
-	case call.Repeatability > 1:
-		call.Repeatability -= 1
-		m.ExpectedCalls[found] = *call
-	}
+        if closestFound {
+            panic(fmt.Sprintf("\n\nmock: Unexpected Method Call\n-----------------------------\n\n%s\n\nThe closest call I have is: \n\n%s\n", callString(functionName, arguments, true), callString(functionName, closestCall.Arguments, true)))
+        } else {
+            panic(fmt.Sprintf("\nassert: mock: I don't know what to return because the method call was unexpected.\n\tEither do Mock.On(\"%s\").Return(...) first, or remove the %s() call.\n\tThis method was unexpected:\n\t\t%s\n\tat: %s", functionName, functionName, callString(functionName, arguments, true), assert.CallerInfo()))
+        }
+    case call.Repeatability == 1:
+        call.Repeatability = -1
+        m.ExpectedCalls[found] = *call
+    case call.Repeatability > 1:
+        call.Repeatability -= 1
+        m.ExpectedCalls[found] = *call
+    }
 
-	// add the call
-	m.Calls = append(m.Calls, Call{functionName, arguments, make([]interface{}, 0), 0})
+    // add the call
+    m.Calls = append(m.Calls, Call{functionName, arguments, make([]interface{}, 0), 0})
 
-	return call.ReturnArguments
+    return call.ReturnArguments
 
 }
 
 /*
-	Assertions
+    Assertions
 */
 
 // AssertExpectationsForObjects asserts that everything specified with On and Return
@@ -235,100 +235,100 @@ func (m *Mock) Called(arguments ...interface{}) Arguments {
 //
 // Calls may have occurred in any order.
 func AssertExpectationsForObjects(t TestingT, testObjects ...interface{}) bool {
-	var success bool = true
-	for _, obj := range testObjects {
-		mockObj := obj.(Mock)
-		success = success && mockObj.AssertExpectations(t)
-	}
-	return success
+    var success bool = true
+    for _, obj := range testObjects {
+        mockObj := obj.(Mock)
+        success = success && mockObj.AssertExpectations(t)
+    }
+    return success
 }
 
 // AssertExpectations asserts that everything specified with On and Return was
 // in fact called as expected.  Calls may have occurred in any order.
 func (m *Mock) AssertExpectations(t TestingT) bool {
 
-	var somethingMissing bool = false
-	var failedExpectations int = 0
+    var somethingMissing bool = false
+    var failedExpectations int = 0
 
-	// iterate through each expectation
-	for _, expectedCall := range m.ExpectedCalls {
-		switch {
-		case !m.methodWasCalled(expectedCall.Method, expectedCall.Arguments):
-			somethingMissing = true
-			failedExpectations++
-			t.Logf("\u274C\t%s(%s)", expectedCall.Method, expectedCall.Arguments.String())
-		case expectedCall.Repeatability > 0:
-			somethingMissing = true
-			failedExpectations++
-		default:
-			t.Logf("\u2705\t%s(%s)", expectedCall.Method, expectedCall.Arguments.String())
-		}
-	}
+    // iterate through each expectation
+    for _, expectedCall := range m.ExpectedCalls {
+        switch {
+        case !m.methodWasCalled(expectedCall.Method, expectedCall.Arguments):
+            somethingMissing = true
+            failedExpectations++
+            t.Logf("\u274C\t%s(%s)", expectedCall.Method, expectedCall.Arguments.String())
+        case expectedCall.Repeatability > 0:
+            somethingMissing = true
+            failedExpectations++
+        default:
+            t.Logf("\u2705\t%s(%s)", expectedCall.Method, expectedCall.Arguments.String())
+        }
+    }
 
-	if somethingMissing {
-		t.Errorf("FAIL: %d out of %d expectation(s) were met.\n\tThe code you are testing needs to make %d more call(s).\n\tat: %s", len(m.ExpectedCalls)-failedExpectations, len(m.ExpectedCalls), failedExpectations, assert.CallerInfo())
-	}
+    if somethingMissing {
+        t.Errorf("FAIL: %d out of %d expectation(s) were met.\n\tThe code you are testing needs to make %d more call(s).\n\tat: %s", len(m.ExpectedCalls)-failedExpectations, len(m.ExpectedCalls), failedExpectations, assert.CallerInfo())
+    }
 
-	return !somethingMissing
+    return !somethingMissing
 }
 
 // AssertNumberOfCalls asserts that the method was called expectedCalls times.
 func (m *Mock) AssertNumberOfCalls(t TestingT, methodName string, expectedCalls int) bool {
-	var actualCalls int = 0
-	for _, call := range m.Calls {
-		if call.Method == methodName {
-			actualCalls++
-		}
-	}
-	return assert.Equal(t, actualCalls, expectedCalls, fmt.Sprintf("Expected number of calls (%d) does not match the actual number of calls (%d).", expectedCalls, actualCalls))
+    var actualCalls int = 0
+    for _, call := range m.Calls {
+        if call.Method == methodName {
+            actualCalls++
+        }
+    }
+    return assert.Equal(t, actualCalls, expectedCalls, fmt.Sprintf("Expected number of calls (%d) does not match the actual number of calls (%d).", expectedCalls, actualCalls))
 }
 
 // AssertCalled asserts that the method was called.
 func (m *Mock) AssertCalled(t TestingT, methodName string, arguments ...interface{}) bool {
-	if !assert.True(t, m.methodWasCalled(methodName, arguments), fmt.Sprintf("The \"%s\" method should have been called with %d argument(s), but was not.", methodName, len(arguments))) {
-		t.Logf("%s", m.ExpectedCalls)
-		return false
-	}
-	return true
+    if !assert.True(t, m.methodWasCalled(methodName, arguments), fmt.Sprintf("The \"%s\" method should have been called with %d argument(s), but was not.", methodName, len(arguments))) {
+        t.Logf("%s", m.ExpectedCalls)
+        return false
+    }
+    return true
 }
 
 // AssertNotCalled asserts that the method was not called.
 func (m *Mock) AssertNotCalled(t TestingT, methodName string, arguments ...interface{}) bool {
-	if !assert.False(t, m.methodWasCalled(methodName, arguments), fmt.Sprintf("The \"%s\" method was called with %d argument(s), but should NOT have been.", methodName, len(arguments))) {
-		t.Logf("%s", m.ExpectedCalls)
-		return false
-	}
-	return true
+    if !assert.False(t, m.methodWasCalled(methodName, arguments), fmt.Sprintf("The \"%s\" method was called with %d argument(s), but should NOT have been.", methodName, len(arguments))) {
+        t.Logf("%s", m.ExpectedCalls)
+        return false
+    }
+    return true
 }
 
 func (m *Mock) methodWasCalled(methodName string, expected []interface{}) bool {
-	for _, call := range m.Calls {
-		if call.Method == methodName {
+    for _, call := range m.Calls {
+        if call.Method == methodName {
 
-			_, differences := Arguments(expected).Diff(call.Arguments)
+            _, differences := Arguments(expected).Diff(call.Arguments)
 
-			if differences == 0 {
-				// found the expected call
-				return true
-			}
+            if differences == 0 {
+                // found the expected call
+                return true
+            }
 
-		}
-	}
-	// we didn't find the expected call
-	return false
+        }
+    }
+    // we didn't find the expected call
+    return false
 }
 
 /*
-	Arguments
+    Arguments
 */
 
 // Arguments holds an array of method arguments or return values.
 type Arguments []interface{}
 
 const (
-	// The "any" argument.  Used in Diff and Assert when
-	// the argument being tested shouldn't be taken into consideration.
-	Anything string = "mock.Anything"
+    // The "any" argument.  Used in Diff and Assert when
+    // the argument being tested shouldn't be taken into consideration.
+    Anything string = "mock.Anything"
 )
 
 // AnythingOfTypeArgument is a string that contains the type of an argument
@@ -339,27 +339,27 @@ type AnythingOfTypeArgument string
 // name of the type to check for.  Used in Diff and Assert.
 //
 // For example:
-//	Assert(t, AnythingOfType("string"), AnythingOfType("int"))
+//  Assert(t, AnythingOfType("string"), AnythingOfType("int"))
 func AnythingOfType(t string) AnythingOfTypeArgument {
-	return AnythingOfTypeArgument(t)
+    return AnythingOfTypeArgument(t)
 }
 
 // Get Returns the argument at the specified index.
 func (args Arguments) Get(index int) interface{} {
-	if index+1 > len(args) {
-		panic(fmt.Sprintf("assert: arguments: Cannot call Get(%d) because there are %d argument(s).", index, len(args)))
-	}
-	return args[index]
+    if index+1 > len(args) {
+        panic(fmt.Sprintf("assert: arguments: Cannot call Get(%d) because there are %d argument(s).", index, len(args)))
+    }
+    return args[index]
 }
 
 // Is gets whether the objects match the arguments specified.
 func (args Arguments) Is(objects ...interface{}) bool {
-	for i, obj := range args {
-		if obj != objects[i] {
-			return false
-		}
-	}
-	return true
+    for i, obj := range args {
+        if obj != objects[i] {
+            return false
+        }
+    }
+    return true
 }
 
 // Diff gets a string describing the differences between the arguments
@@ -368,59 +368,59 @@ func (args Arguments) Is(objects ...interface{}) bool {
 // Returns the diff string and number of differences found.
 func (args Arguments) Diff(objects []interface{}) (string, int) {
 
-	var output string = "\n"
-	var differences int
+    var output string = "\n"
+    var differences int
 
-	var maxArgCount int = len(args)
-	if len(objects) > maxArgCount {
-		maxArgCount = len(objects)
-	}
+    var maxArgCount int = len(args)
+    if len(objects) > maxArgCount {
+        maxArgCount = len(objects)
+    }
 
-	for i := 0; i < maxArgCount; i++ {
-		var actual, expected interface{}
+    for i := 0; i < maxArgCount; i++ {
+        var actual, expected interface{}
 
-		if len(objects) <= i {
-			actual = "(Missing)"
-		} else {
-			actual = objects[i]
-		}
+        if len(objects) <= i {
+            actual = "(Missing)"
+        } else {
+            actual = objects[i]
+        }
 
-		if len(args) <= i {
-			expected = "(Missing)"
-		} else {
-			expected = args[i]
-		}
+        if len(args) <= i {
+            expected = "(Missing)"
+        } else {
+            expected = args[i]
+        }
 
-		if reflect.TypeOf(expected) == reflect.TypeOf((*AnythingOfTypeArgument)(nil)).Elem() {
+        if reflect.TypeOf(expected) == reflect.TypeOf((*AnythingOfTypeArgument)(nil)).Elem() {
 
-			// type checking
-			if reflect.TypeOf(actual).Name() != string(expected.(AnythingOfTypeArgument)) && reflect.TypeOf(actual).String() != string(expected.(AnythingOfTypeArgument)) {
-				// not match
-				differences++
-				output = fmt.Sprintf("%s\t%d: \u274C  type %s != type %s - %s\n", output, i, expected, reflect.TypeOf(actual).Name(), actual)
-			}
+            // type checking
+            if reflect.TypeOf(actual).Name() != string(expected.(AnythingOfTypeArgument)) && reflect.TypeOf(actual).String() != string(expected.(AnythingOfTypeArgument)) {
+                // not match
+                differences++
+                output = fmt.Sprintf("%s\t%d: \u274C  type %s != type %s - %s\n", output, i, expected, reflect.TypeOf(actual).Name(), actual)
+            }
 
-		} else {
+        } else {
 
-			// normal checking
+            // normal checking
 
-			if assert.ObjectsAreEqual(expected, Anything) || assert.ObjectsAreEqual(actual, Anything) || assert.ObjectsAreEqual(actual, expected) {
-				// match
-				output = fmt.Sprintf("%s\t%d: \u2705  %s == %s\n", output, i, actual, expected)
-			} else {
-				// not match
-				differences++
-				output = fmt.Sprintf("%s\t%d: \u274C  %s != %s\n", output, i, actual, expected)
-			}
-		}
+            if assert.ObjectsAreEqual(expected, Anything) || assert.ObjectsAreEqual(actual, Anything) || assert.ObjectsAreEqual(actual, expected) {
+                // match
+                output = fmt.Sprintf("%s\t%d: \u2705  %s == %s\n", output, i, actual, expected)
+            } else {
+                // not match
+                differences++
+                output = fmt.Sprintf("%s\t%d: \u274C  %s != %s\n", output, i, actual, expected)
+            }
+        }
 
-	}
+    }
 
-	if differences == 0 {
-		return "No differences.", differences
-	}
+    if differences == 0 {
+        return "No differences.", differences
+    }
 
-	return output, differences
+    return output, differences
 
 }
 
@@ -428,18 +428,18 @@ func (args Arguments) Diff(objects []interface{}) (string, int) {
 // they do not exactly match.
 func (args Arguments) Assert(t TestingT, objects ...interface{}) bool {
 
-	// get the differences
-	diff, diffCount := args.Diff(objects)
+    // get the differences
+    diff, diffCount := args.Diff(objects)
 
-	if diffCount == 0 {
-		return true
-	}
+    if diffCount == 0 {
+        return true
+    }
 
-	// there are differences... report them...
-	t.Logf(diff)
-	t.Errorf("%sArguments do not match.", assert.CallerInfo())
+    // there are differences... report them...
+    t.Logf(diff)
+    t.Errorf("%sArguments do not match.", assert.CallerInfo())
 
-	return false
+    return false
 
 }
 
@@ -450,61 +450,61 @@ func (args Arguments) Assert(t TestingT, objects ...interface{}) bool {
 // of the arguments.
 func (args Arguments) String(indexOrNil ...int) string {
 
-	if len(indexOrNil) == 0 {
-		// normal String() method - return a string representation of the args
-		var argsStr []string
-		for _, arg := range args {
-			argsStr = append(argsStr, fmt.Sprintf("%s", reflect.TypeOf(arg)))
-		}
-		return strings.Join(argsStr, ",")
-	} else if len(indexOrNil) == 1 {
-		// Index has been specified - get the argument at that index
-		var index int = indexOrNil[0]
-		var s string
-		var ok bool
-		if s, ok = args.Get(index).(string); !ok {
-			panic(fmt.Sprintf("assert: arguments: String(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
-		}
-		return s
-	}
+    if len(indexOrNil) == 0 {
+        // normal String() method - return a string representation of the args
+        var argsStr []string
+        for _, arg := range args {
+            argsStr = append(argsStr, fmt.Sprintf("%s", reflect.TypeOf(arg)))
+        }
+        return strings.Join(argsStr, ",")
+    } else if len(indexOrNil) == 1 {
+        // Index has been specified - get the argument at that index
+        var index int = indexOrNil[0]
+        var s string
+        var ok bool
+        if s, ok = args.Get(index).(string); !ok {
+            panic(fmt.Sprintf("assert: arguments: String(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
+        }
+        return s
+    }
 
-	panic(fmt.Sprintf("assert: arguments: Wrong number of arguments passed to String.  Must be 0 or 1, not %d", len(indexOrNil)))
+    panic(fmt.Sprintf("assert: arguments: Wrong number of arguments passed to String.  Must be 0 or 1, not %d", len(indexOrNil)))
 
 }
 
 // Int gets the argument at the specified index. Panics if there is no argument, or
 // if the argument is of the wrong type.
 func (args Arguments) Int(index int) int {
-	var s int
-	var ok bool
-	if s, ok = args.Get(index).(int); !ok {
-		panic(fmt.Sprintf("assert: arguments: Int(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
-	}
-	return s
+    var s int
+    var ok bool
+    if s, ok = args.Get(index).(int); !ok {
+        panic(fmt.Sprintf("assert: arguments: Int(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
+    }
+    return s
 }
 
 // Error gets the argument at the specified index. Panics if there is no argument, or
 // if the argument is of the wrong type.
 func (args Arguments) Error(index int) error {
-	obj := args.Get(index)
-	var s error
-	var ok bool
-	if obj == nil {
-		return nil
-	}
-	if s, ok = obj.(error); !ok {
-		panic(fmt.Sprintf("assert: arguments: Error(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
-	}
-	return s
+    obj := args.Get(index)
+    var s error
+    var ok bool
+    if obj == nil {
+        return nil
+    }
+    if s, ok = obj.(error); !ok {
+        panic(fmt.Sprintf("assert: arguments: Error(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
+    }
+    return s
 }
 
 // Bool gets the argument at the specified index. Panics if there is no argument, or
 // if the argument is of the wrong type.
 func (args Arguments) Bool(index int) bool {
-	var s bool
-	var ok bool
-	if s, ok = args.Get(index).(bool); !ok {
-		panic(fmt.Sprintf("assert: arguments: Bool(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
-	}
-	return s
+    var s bool
+    var ok bool
+    if s, ok = args.Get(index).(bool); !ok {
+        panic(fmt.Sprintf("assert: arguments: Bool(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
+    }
+    return s
 }

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -17,7 +17,7 @@ type TestingT interface {
 }
 
 /*
-    Call
+   Call
 */
 
 // Call represents a method call and is used for setting expectations,
@@ -77,7 +77,7 @@ func (m *Mock) TestData() objx.Map {
 }
 
 /*
-    Setting expectations
+   Setting expectations
 */
 
 // On starts a description of an expectation of the specified method
@@ -122,7 +122,7 @@ func (m *Mock) Times(i int) {
 }
 
 /*
-    Recording and responding to activity
+   Recording and responding to activity
 */
 
 func (m *Mock) findExpectedCall(method string, arguments ...interface{}) (int, *Call) {
@@ -227,7 +227,7 @@ func (m *Mock) Called(arguments ...interface{}) Arguments {
 }
 
 /*
-    Assertions
+   Assertions
 */
 
 // AssertExpectationsForObjects asserts that everything specified with On and Return
@@ -319,7 +319,7 @@ func (m *Mock) methodWasCalled(methodName string, expected []interface{}) bool {
 }
 
 /*
-    Arguments
+   Arguments
 */
 
 // Arguments holds an array of method arguments or return values.
@@ -443,6 +443,204 @@ func (args Arguments) Assert(t TestingT, objects ...interface{}) bool {
 
 }
 
+// Bool gets the argument at the specified index. Panics if there is no argument, or
+// if the argument is of the wrong type.
+func (args Arguments) Bool(index int) bool {
+    var s bool
+    var ok bool
+    if s, ok = args.Get(index).(bool); !ok {
+        panic(fmt.Sprintf("assert: arguments: Bool(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
+    }
+    return s
+}
+
+// Int8 gets the argument at the specified index. Panics if there is no argument, or
+// if the argument is of the wrong type.
+func (args Arguments) Int8(index int) int8 {
+    var s int8
+    var ok bool
+    if s, ok = args.Get(index).(int8); !ok {
+        panic(fmt.Sprintf("assert: arguments: Int8(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
+    }
+    return s
+}
+
+// Int16 gets the argument at the specified index. Panics if there is no argument, or
+// if the argument is of the wrong type.
+func (args Arguments) Int16(index int) int16 {
+    var s int16
+    var ok bool
+    if s, ok = args.Get(index).(int16); !ok {
+        panic(fmt.Sprintf("assert: arguments: Int16(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
+    }
+    return s
+}
+
+// Int32 gets the argument at the specified index. Panics if there is no argument, or
+// if the argument is of the wrong type.
+func (args Arguments) Int32(index int) int32 {
+    var s int32
+    var ok bool
+    if s, ok = args.Get(index).(int32); !ok {
+        panic(fmt.Sprintf("assert: arguments: Int32(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
+    }
+    return s
+}
+
+// Int64 gets the argument at the specified index. Panics if there is no argument, or
+// if the argument is of the wrong type.
+func (args Arguments) Int64(index int) int64 {
+    var s int64
+    var ok bool
+    if s, ok = args.Get(index).(int64); !ok {
+        panic(fmt.Sprintf("assert: arguments: Int64(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
+    }
+    return s
+}
+
+// Uint8 gets the argument at the specified index. Panics if there is no argument, or
+// if the argument is of the wrong type.
+func (args Arguments) Uint8(index int) uint8 {
+    var s uint8
+    var ok bool
+    if s, ok = args.Get(index).(uint8); !ok {
+        panic(fmt.Sprintf("assert: arguments: Uint8(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
+    }
+    return s
+}
+
+// Uint16 gets the argument at the specified index. Panics if there is no argument, or
+// if the argument is of the wrong type.
+func (args Arguments) Uint16(index int) uint16 {
+    var s uint16
+    var ok bool
+    if s, ok = args.Get(index).(uint16); !ok {
+        panic(fmt.Sprintf("assert: arguments: Uint16(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
+    }
+    return s
+}
+
+// Uint32 gets the argument at the specified index. Panics if there is no argument, or
+// if the argument is of the wrong type.
+func (args Arguments) Uint32(index int) uint32 {
+    var s uint32
+    var ok bool
+    if s, ok = args.Get(index).(uint32); !ok {
+        panic(fmt.Sprintf("assert: arguments: Uint32(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
+    }
+    return s
+}
+
+// Uint64 gets the argument at the specified index. Panics if there is no argument, or
+// if the argument is of the wrong type.
+func (args Arguments) Uint64(index int) uint64 {
+    var s uint64
+    var ok bool
+    if s, ok = args.Get(index).(uint64); !ok {
+        panic(fmt.Sprintf("assert: arguments: Uint64(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
+    }
+    return s
+}
+
+// Float32 gets the argument at the specified index. Panics if there is no argument, or
+// if the argument is of the wrong type.
+func (args Arguments) Float32(index int) float32 {
+    var s float32
+    var ok bool
+    if s, ok = args.Get(index).(float32); !ok {
+        panic(fmt.Sprintf("assert: arguments: Float32(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
+    }
+    return s
+}
+
+// Float64 gets the argument at the specified index. Panics if there is no argument, or
+// if the argument is of the wrong type.
+func (args Arguments) Float64(index int) float64 {
+    var s float64
+    var ok bool
+    if s, ok = args.Get(index).(float64); !ok {
+        panic(fmt.Sprintf("assert: arguments: Float64(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
+    }
+    return s
+}
+
+// Complex64 gets the argument at the specified index. Panics if there is no argument, or
+// if the argument is of the wrong type.
+func (args Arguments) Complex64(index int) complex64 {
+    var s complex64
+    var ok bool
+    if s, ok = args.Get(index).(complex64); !ok {
+        panic(fmt.Sprintf("assert: arguments: Complex64(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
+    }
+    return s
+}
+
+// Complex128 gets the argument at the specified index. Panics if there is no argument, or
+// if the argument is of the wrong type.
+func (args Arguments) Complex128(index int) complex128 {
+    var s complex128
+    var ok bool
+    if s, ok = args.Get(index).(complex128); !ok {
+        panic(fmt.Sprintf("assert: arguments: Complex128(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
+    }
+    return s
+}
+
+// Byte gets the argument at the specified index. Panics if there is no argument, or
+// if the argument is of the wrong type.
+func (args Arguments) Byte(index int) byte {
+    var s byte
+    var ok bool
+    if s, ok = args.Get(index).(byte); !ok {
+        panic(fmt.Sprintf("assert: arguments: Byte(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
+    }
+    return s
+}
+
+// Rune gets the argument at the specified index. Panics if there is no argument, or
+// if the argument is of the wrong type.
+func (args Arguments) Rune(index int) rune {
+    var s rune
+    var ok bool
+    if s, ok = args.Get(index).(rune); !ok {
+        panic(fmt.Sprintf("assert: arguments: Rune(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
+    }
+    return s
+}
+
+// Int gets the argument at the specified index. Panics if there is no argument, or
+// if the argument is of the wrong type.
+func (args Arguments) Int(index int) int {
+    var s int
+    var ok bool
+    if s, ok = args.Get(index).(int); !ok {
+        panic(fmt.Sprintf("assert: arguments: Int(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
+    }
+    return s
+}
+
+// Uint gets the argument at the specified index. Panics if there is no argument, or
+// if the argument is of the wrong type.
+func (args Arguments) Uint(index int) uint {
+    var s uint
+    var ok bool
+    if s, ok = args.Get(index).(uint); !ok {
+        panic(fmt.Sprintf("assert: arguments: Uint(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
+    }
+    return s
+}
+
+// Uintptr gets the argument at the specified index. Panics if there is no argument, or
+// if the argument is of the wrong type.
+func (args Arguments) Uintptr(index int) uintptr {
+    var s uintptr
+    var ok bool
+    if s, ok = args.Get(index).(uintptr); !ok {
+        panic(fmt.Sprintf("assert: arguments: Uintptr(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
+    }
+    return s
+}
+
 // String gets the argument at the specified index. Panics if there is no argument, or
 // if the argument is of the wrong type.
 //
@@ -472,17 +670,6 @@ func (args Arguments) String(indexOrNil ...int) string {
 
 }
 
-// Int gets the argument at the specified index. Panics if there is no argument, or
-// if the argument is of the wrong type.
-func (args Arguments) Int(index int) int {
-    var s int
-    var ok bool
-    if s, ok = args.Get(index).(int); !ok {
-        panic(fmt.Sprintf("assert: arguments: Int(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
-    }
-    return s
-}
-
 // Error gets the argument at the specified index. Panics if there is no argument, or
 // if the argument is of the wrong type.
 func (args Arguments) Error(index int) error {
@@ -494,17 +681,6 @@ func (args Arguments) Error(index int) error {
     }
     if s, ok = obj.(error); !ok {
         panic(fmt.Sprintf("assert: arguments: Error(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
-    }
-    return s
-}
-
-// Bool gets the argument at the specified index. Panics if there is no argument, or
-// if the argument is of the wrong type.
-func (args Arguments) Bool(index int) bool {
-    var s bool
-    var ok bool
-    if s, ok = args.Get(index).(bool); !ok {
-        panic(fmt.Sprintf("assert: arguments: Bool(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
     }
     return s
 }

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -1,669 +1,669 @@
 package mock
 
 import (
-	"errors"
-	"github.com/stretchr/testify/assert"
-	"testing"
+    "errors"
+    "github.com/stretchr/testify/assert"
+    "testing"
 )
 
 /*
-	Test objects
+    Test objects
 */
 
 // ExampleInterface represents an example interface.
 type ExampleInterface interface {
-	TheExampleMethod(a, b, c int) (int, error)
+    TheExampleMethod(a, b, c int) (int, error)
 }
 
 // TestExampleImplementation is a test implementation of ExampleInterface
 type TestExampleImplementation struct {
-	Mock
+    Mock
 }
 
 func (i *TestExampleImplementation) TheExampleMethod(a, b, c int) (int, error) {
-	args := i.Mock.Called(a, b, c)
-	return args.Int(0), errors.New("Whoops")
+    args := i.Mock.Called(a, b, c)
+    return args.Int(0), errors.New("Whoops")
 }
 
 func (i *TestExampleImplementation) TheExampleMethod2(yesorno bool) {
-	i.Mock.Called(yesorno)
+    i.Mock.Called(yesorno)
 }
 
 type ExampleType struct{}
 
 func (i *TestExampleImplementation) TheExampleMethod3(et *ExampleType) error {
-	args := i.Mock.Called(et)
-	return args.Error(0)
+    args := i.Mock.Called(et)
+    return args.Error(0)
 }
 
 /*
-	Mock
+    Mock
 */
 
 func Test_Mock_TestData(t *testing.T) {
 
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+    var mockedService *TestExampleImplementation = new(TestExampleImplementation)
 
-	if assert.NotNil(t, mockedService.TestData()) {
+    if assert.NotNil(t, mockedService.TestData()) {
 
-		mockedService.TestData().Set("something", 123)
-		assert.Equal(t, 123, mockedService.TestData().Get("something").Data())
+        mockedService.TestData().Set("something", 123)
+        assert.Equal(t, 123, mockedService.TestData().Get("something").Data())
 
-	}
+    }
 
 }
 
 func Test_Mock_On(t *testing.T) {
 
-	// make a test impl object
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+    // make a test impl object
+    var mockedService *TestExampleImplementation = new(TestExampleImplementation)
 
-	assert.Equal(t, mockedService.Mock.On("TheExampleMethod"), &mockedService.Mock)
-	assert.Equal(t, "TheExampleMethod", mockedService.Mock.onMethodName)
+    assert.Equal(t, mockedService.Mock.On("TheExampleMethod"), &mockedService.Mock)
+    assert.Equal(t, "TheExampleMethod", mockedService.Mock.onMethodName)
 
 }
 
 func Test_Mock_On_WithArgs(t *testing.T) {
 
-	// make a test impl object
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+    // make a test impl object
+    var mockedService *TestExampleImplementation = new(TestExampleImplementation)
 
-	assert.Equal(t, mockedService.Mock.On("TheExampleMethod", 1, 2, 3), &mockedService.Mock)
-	assert.Equal(t, "TheExampleMethod", mockedService.Mock.onMethodName)
-	assert.Equal(t, 1, mockedService.Mock.onMethodArguments[0])
-	assert.Equal(t, 2, mockedService.Mock.onMethodArguments[1])
-	assert.Equal(t, 3, mockedService.Mock.onMethodArguments[2])
+    assert.Equal(t, mockedService.Mock.On("TheExampleMethod", 1, 2, 3), &mockedService.Mock)
+    assert.Equal(t, "TheExampleMethod", mockedService.Mock.onMethodName)
+    assert.Equal(t, 1, mockedService.Mock.onMethodArguments[0])
+    assert.Equal(t, 2, mockedService.Mock.onMethodArguments[1])
+    assert.Equal(t, 3, mockedService.Mock.onMethodArguments[2])
 
 }
 
 func Test_Mock_Return(t *testing.T) {
 
-	// make a test impl object
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+    // make a test impl object
+    var mockedService *TestExampleImplementation = new(TestExampleImplementation)
 
-	assert.Equal(t, mockedService.Mock.On("TheExampleMethod", "A", "B", true).Return(1, "two", true), &mockedService.Mock)
+    assert.Equal(t, mockedService.Mock.On("TheExampleMethod", "A", "B", true).Return(1, "two", true), &mockedService.Mock)
 
-	// ensure the call was created
-	if assert.Equal(t, 1, len(mockedService.Mock.ExpectedCalls)) {
-		call := mockedService.Mock.ExpectedCalls[0]
+    // ensure the call was created
+    if assert.Equal(t, 1, len(mockedService.Mock.ExpectedCalls)) {
+        call := mockedService.Mock.ExpectedCalls[0]
 
-		assert.Equal(t, "TheExampleMethod", call.Method)
-		assert.Equal(t, "A", call.Arguments[0])
-		assert.Equal(t, "B", call.Arguments[1])
-		assert.Equal(t, true, call.Arguments[2])
-		assert.Equal(t, 1, call.ReturnArguments[0])
-		assert.Equal(t, "two", call.ReturnArguments[1])
-		assert.Equal(t, true, call.ReturnArguments[2])
-		assert.Equal(t, 0, call.Repeatability)
+        assert.Equal(t, "TheExampleMethod", call.Method)
+        assert.Equal(t, "A", call.Arguments[0])
+        assert.Equal(t, "B", call.Arguments[1])
+        assert.Equal(t, true, call.Arguments[2])
+        assert.Equal(t, 1, call.ReturnArguments[0])
+        assert.Equal(t, "two", call.ReturnArguments[1])
+        assert.Equal(t, true, call.ReturnArguments[2])
+        assert.Equal(t, 0, call.Repeatability)
 
-	}
+    }
 
 }
 
 func Test_Mock_Return_Once(t *testing.T) {
 
-	// make a test impl object
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+    // make a test impl object
+    var mockedService *TestExampleImplementation = new(TestExampleImplementation)
 
-	mockedService.Mock.On("TheExampleMethod", "A", "B", true).Return(1, "two", true).Once()
+    mockedService.Mock.On("TheExampleMethod", "A", "B", true).Return(1, "two", true).Once()
 
-	// ensure the call was created
-	if assert.Equal(t, 1, len(mockedService.Mock.ExpectedCalls)) {
-		call := mockedService.Mock.ExpectedCalls[0]
+    // ensure the call was created
+    if assert.Equal(t, 1, len(mockedService.Mock.ExpectedCalls)) {
+        call := mockedService.Mock.ExpectedCalls[0]
 
-		assert.Equal(t, "TheExampleMethod", call.Method)
-		assert.Equal(t, "A", call.Arguments[0])
-		assert.Equal(t, "B", call.Arguments[1])
-		assert.Equal(t, true, call.Arguments[2])
-		assert.Equal(t, 1, call.ReturnArguments[0])
-		assert.Equal(t, "two", call.ReturnArguments[1])
-		assert.Equal(t, true, call.ReturnArguments[2])
-		assert.Equal(t, 1, call.Repeatability)
+        assert.Equal(t, "TheExampleMethod", call.Method)
+        assert.Equal(t, "A", call.Arguments[0])
+        assert.Equal(t, "B", call.Arguments[1])
+        assert.Equal(t, true, call.Arguments[2])
+        assert.Equal(t, 1, call.ReturnArguments[0])
+        assert.Equal(t, "two", call.ReturnArguments[1])
+        assert.Equal(t, true, call.ReturnArguments[2])
+        assert.Equal(t, 1, call.Repeatability)
 
-	}
+    }
 
 }
 
 func Test_Mock_Return_Twice(t *testing.T) {
 
-	// make a test impl object
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+    // make a test impl object
+    var mockedService *TestExampleImplementation = new(TestExampleImplementation)
 
-	mockedService.Mock.On("TheExampleMethod", "A", "B", true).Return(1, "two", true).Twice()
+    mockedService.Mock.On("TheExampleMethod", "A", "B", true).Return(1, "two", true).Twice()
 
-	// ensure the call was created
-	if assert.Equal(t, 1, len(mockedService.Mock.ExpectedCalls)) {
-		call := mockedService.Mock.ExpectedCalls[0]
+    // ensure the call was created
+    if assert.Equal(t, 1, len(mockedService.Mock.ExpectedCalls)) {
+        call := mockedService.Mock.ExpectedCalls[0]
 
-		assert.Equal(t, "TheExampleMethod", call.Method)
-		assert.Equal(t, "A", call.Arguments[0])
-		assert.Equal(t, "B", call.Arguments[1])
-		assert.Equal(t, true, call.Arguments[2])
-		assert.Equal(t, 1, call.ReturnArguments[0])
-		assert.Equal(t, "two", call.ReturnArguments[1])
-		assert.Equal(t, true, call.ReturnArguments[2])
-		assert.Equal(t, 2, call.Repeatability)
+        assert.Equal(t, "TheExampleMethod", call.Method)
+        assert.Equal(t, "A", call.Arguments[0])
+        assert.Equal(t, "B", call.Arguments[1])
+        assert.Equal(t, true, call.Arguments[2])
+        assert.Equal(t, 1, call.ReturnArguments[0])
+        assert.Equal(t, "two", call.ReturnArguments[1])
+        assert.Equal(t, true, call.ReturnArguments[2])
+        assert.Equal(t, 2, call.Repeatability)
 
-	}
+    }
 
 }
 
 func Test_Mock_Return_Times(t *testing.T) {
 
-	// make a test impl object
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+    // make a test impl object
+    var mockedService *TestExampleImplementation = new(TestExampleImplementation)
 
-	mockedService.Mock.On("TheExampleMethod", "A", "B", true).Return(1, "two", true).Times(5)
+    mockedService.Mock.On("TheExampleMethod", "A", "B", true).Return(1, "two", true).Times(5)
 
-	// ensure the call was created
-	if assert.Equal(t, 1, len(mockedService.Mock.ExpectedCalls)) {
-		call := mockedService.Mock.ExpectedCalls[0]
+    // ensure the call was created
+    if assert.Equal(t, 1, len(mockedService.Mock.ExpectedCalls)) {
+        call := mockedService.Mock.ExpectedCalls[0]
 
-		assert.Equal(t, "TheExampleMethod", call.Method)
-		assert.Equal(t, "A", call.Arguments[0])
-		assert.Equal(t, "B", call.Arguments[1])
-		assert.Equal(t, true, call.Arguments[2])
-		assert.Equal(t, 1, call.ReturnArguments[0])
-		assert.Equal(t, "two", call.ReturnArguments[1])
-		assert.Equal(t, true, call.ReturnArguments[2])
-		assert.Equal(t, 5, call.Repeatability)
+        assert.Equal(t, "TheExampleMethod", call.Method)
+        assert.Equal(t, "A", call.Arguments[0])
+        assert.Equal(t, "B", call.Arguments[1])
+        assert.Equal(t, true, call.Arguments[2])
+        assert.Equal(t, 1, call.ReturnArguments[0])
+        assert.Equal(t, "two", call.ReturnArguments[1])
+        assert.Equal(t, true, call.ReturnArguments[2])
+        assert.Equal(t, 5, call.Repeatability)
 
-	}
+    }
 
 }
 
 func Test_Mock_Return_Nothing(t *testing.T) {
 
-	// make a test impl object
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+    // make a test impl object
+    var mockedService *TestExampleImplementation = new(TestExampleImplementation)
 
-	assert.Equal(t, mockedService.Mock.On("TheExampleMethod", "A", "B", true).Return(), &mockedService.Mock)
+    assert.Equal(t, mockedService.Mock.On("TheExampleMethod", "A", "B", true).Return(), &mockedService.Mock)
 
-	// ensure the call was created
-	if assert.Equal(t, 1, len(mockedService.Mock.ExpectedCalls)) {
-		call := mockedService.Mock.ExpectedCalls[0]
+    // ensure the call was created
+    if assert.Equal(t, 1, len(mockedService.Mock.ExpectedCalls)) {
+        call := mockedService.Mock.ExpectedCalls[0]
 
-		assert.Equal(t, "TheExampleMethod", call.Method)
-		assert.Equal(t, "A", call.Arguments[0])
-		assert.Equal(t, "B", call.Arguments[1])
-		assert.Equal(t, true, call.Arguments[2])
-		assert.Equal(t, 0, len(call.ReturnArguments))
+        assert.Equal(t, "TheExampleMethod", call.Method)
+        assert.Equal(t, "A", call.Arguments[0])
+        assert.Equal(t, "B", call.Arguments[1])
+        assert.Equal(t, true, call.Arguments[2])
+        assert.Equal(t, 0, len(call.ReturnArguments))
 
-	}
+    }
 
 }
 
 func Test_Mock_findExpectedCall(t *testing.T) {
 
-	m := new(Mock)
-	m.On("One", 1).Return("one")
-	m.On("Two", 2).Return("two")
-	m.On("Two", 3).Return("three")
+    m := new(Mock)
+    m.On("One", 1).Return("one")
+    m.On("Two", 2).Return("two")
+    m.On("Two", 3).Return("three")
 
-	f, c := m.findExpectedCall("Two", 3)
+    f, c := m.findExpectedCall("Two", 3)
 
-	if assert.Equal(t, 2, f) {
-		if assert.NotNil(t, c) {
-			assert.Equal(t, "Two", c.Method)
-			assert.Equal(t, 3, c.Arguments[0])
-			assert.Equal(t, "three", c.ReturnArguments[0])
-		}
-	}
+    if assert.Equal(t, 2, f) {
+        if assert.NotNil(t, c) {
+            assert.Equal(t, "Two", c.Method)
+            assert.Equal(t, 3, c.Arguments[0])
+            assert.Equal(t, "three", c.ReturnArguments[0])
+        }
+    }
 
 }
 
 func Test_Mock_findExpectedCall_For_Unknown_Method(t *testing.T) {
 
-	m := new(Mock)
-	m.On("One", 1).Return("one")
-	m.On("Two", 2).Return("two")
-	m.On("Two", 3).Return("three")
+    m := new(Mock)
+    m.On("One", 1).Return("one")
+    m.On("Two", 2).Return("two")
+    m.On("Two", 3).Return("three")
 
-	f, _ := m.findExpectedCall("Two")
+    f, _ := m.findExpectedCall("Two")
 
-	assert.Equal(t, -1, f)
+    assert.Equal(t, -1, f)
 
 }
 
 func Test_Mock_findExpectedCall_Respects_Repeatability(t *testing.T) {
 
-	m := new(Mock)
-	m.On("One", 1).Return("one")
-	m.On("Two", 2).Return("two").Once()
-	m.On("Two", 3).Return("three").Twice()
-	m.On("Two", 3).Return("three").Times(8)
+    m := new(Mock)
+    m.On("One", 1).Return("one")
+    m.On("Two", 2).Return("two").Once()
+    m.On("Two", 3).Return("three").Twice()
+    m.On("Two", 3).Return("three").Times(8)
 
-	f, c := m.findExpectedCall("Two", 3)
+    f, c := m.findExpectedCall("Two", 3)
 
-	if assert.Equal(t, 2, f) {
-		if assert.NotNil(t, c) {
-			assert.Equal(t, "Two", c.Method)
-			assert.Equal(t, 3, c.Arguments[0])
-			assert.Equal(t, "three", c.ReturnArguments[0])
-		}
-	}
+    if assert.Equal(t, 2, f) {
+        if assert.NotNil(t, c) {
+            assert.Equal(t, "Two", c.Method)
+            assert.Equal(t, 3, c.Arguments[0])
+            assert.Equal(t, "three", c.ReturnArguments[0])
+        }
+    }
 
 }
 
 func Test_callString(t *testing.T) {
 
-	assert.Equal(t, `Method(int,bool,string)`, callString("Method", []interface{}{1, true, "something"}, false))
+    assert.Equal(t, `Method(int,bool,string)`, callString("Method", []interface{}{1, true, "something"}, false))
 
 }
 
 func Test_Mock_Called(t *testing.T) {
 
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+    var mockedService *TestExampleImplementation = new(TestExampleImplementation)
 
-	mockedService.Mock.On("Test_Mock_Called", 1, 2, 3).Return(5, "6", true)
+    mockedService.Mock.On("Test_Mock_Called", 1, 2, 3).Return(5, "6", true)
 
-	returnArguments := mockedService.Mock.Called(1, 2, 3)
+    returnArguments := mockedService.Mock.Called(1, 2, 3)
 
-	if assert.Equal(t, 1, len(mockedService.Mock.Calls)) {
-		assert.Equal(t, "Test_Mock_Called", mockedService.Mock.Calls[0].Method)
-		assert.Equal(t, 1, mockedService.Mock.Calls[0].Arguments[0])
-		assert.Equal(t, 2, mockedService.Mock.Calls[0].Arguments[1])
-		assert.Equal(t, 3, mockedService.Mock.Calls[0].Arguments[2])
-	}
+    if assert.Equal(t, 1, len(mockedService.Mock.Calls)) {
+        assert.Equal(t, "Test_Mock_Called", mockedService.Mock.Calls[0].Method)
+        assert.Equal(t, 1, mockedService.Mock.Calls[0].Arguments[0])
+        assert.Equal(t, 2, mockedService.Mock.Calls[0].Arguments[1])
+        assert.Equal(t, 3, mockedService.Mock.Calls[0].Arguments[2])
+    }
 
-	if assert.Equal(t, 3, len(returnArguments)) {
-		assert.Equal(t, 5, returnArguments[0])
-		assert.Equal(t, "6", returnArguments[1])
-		assert.Equal(t, true, returnArguments[2])
-	}
+    if assert.Equal(t, 3, len(returnArguments)) {
+        assert.Equal(t, 5, returnArguments[0])
+        assert.Equal(t, "6", returnArguments[1])
+        assert.Equal(t, true, returnArguments[2])
+    }
 
 }
 
 func Test_Mock_Called_For_Bounded_Repeatability(t *testing.T) {
 
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+    var mockedService *TestExampleImplementation = new(TestExampleImplementation)
 
-	mockedService.Mock.On("Test_Mock_Called_For_Bounded_Repeatability", 1, 2, 3).Return(5, "6", true).Once()
-	mockedService.Mock.On("Test_Mock_Called_For_Bounded_Repeatability", 1, 2, 3).Return(-1, "hi", false)
+    mockedService.Mock.On("Test_Mock_Called_For_Bounded_Repeatability", 1, 2, 3).Return(5, "6", true).Once()
+    mockedService.Mock.On("Test_Mock_Called_For_Bounded_Repeatability", 1, 2, 3).Return(-1, "hi", false)
 
-	returnArguments1 := mockedService.Mock.Called(1, 2, 3)
-	returnArguments2 := mockedService.Mock.Called(1, 2, 3)
+    returnArguments1 := mockedService.Mock.Called(1, 2, 3)
+    returnArguments2 := mockedService.Mock.Called(1, 2, 3)
 
-	if assert.Equal(t, 2, len(mockedService.Mock.Calls)) {
-		assert.Equal(t, "Test_Mock_Called_For_Bounded_Repeatability", mockedService.Mock.Calls[0].Method)
-		assert.Equal(t, 1, mockedService.Mock.Calls[0].Arguments[0])
-		assert.Equal(t, 2, mockedService.Mock.Calls[0].Arguments[1])
-		assert.Equal(t, 3, mockedService.Mock.Calls[0].Arguments[2])
+    if assert.Equal(t, 2, len(mockedService.Mock.Calls)) {
+        assert.Equal(t, "Test_Mock_Called_For_Bounded_Repeatability", mockedService.Mock.Calls[0].Method)
+        assert.Equal(t, 1, mockedService.Mock.Calls[0].Arguments[0])
+        assert.Equal(t, 2, mockedService.Mock.Calls[0].Arguments[1])
+        assert.Equal(t, 3, mockedService.Mock.Calls[0].Arguments[2])
 
-		assert.Equal(t, "Test_Mock_Called_For_Bounded_Repeatability", mockedService.Mock.Calls[1].Method)
-		assert.Equal(t, 1, mockedService.Mock.Calls[1].Arguments[0])
-		assert.Equal(t, 2, mockedService.Mock.Calls[1].Arguments[1])
-		assert.Equal(t, 3, mockedService.Mock.Calls[1].Arguments[2])
-	}
+        assert.Equal(t, "Test_Mock_Called_For_Bounded_Repeatability", mockedService.Mock.Calls[1].Method)
+        assert.Equal(t, 1, mockedService.Mock.Calls[1].Arguments[0])
+        assert.Equal(t, 2, mockedService.Mock.Calls[1].Arguments[1])
+        assert.Equal(t, 3, mockedService.Mock.Calls[1].Arguments[2])
+    }
 
-	if assert.Equal(t, 3, len(returnArguments1)) {
-		assert.Equal(t, 5, returnArguments1[0])
-		assert.Equal(t, "6", returnArguments1[1])
-		assert.Equal(t, true, returnArguments1[2])
-	}
+    if assert.Equal(t, 3, len(returnArguments1)) {
+        assert.Equal(t, 5, returnArguments1[0])
+        assert.Equal(t, "6", returnArguments1[1])
+        assert.Equal(t, true, returnArguments1[2])
+    }
 
-	if assert.Equal(t, 3, len(returnArguments2)) {
-		assert.Equal(t, -1, returnArguments2[0])
-		assert.Equal(t, "hi", returnArguments2[1])
-		assert.Equal(t, false, returnArguments2[2])
-	}
+    if assert.Equal(t, 3, len(returnArguments2)) {
+        assert.Equal(t, -1, returnArguments2[0])
+        assert.Equal(t, "hi", returnArguments2[1])
+        assert.Equal(t, false, returnArguments2[2])
+    }
 
 }
 
 func Test_Mock_Called_For_SetTime_Expectation(t *testing.T) {
 
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+    var mockedService *TestExampleImplementation = new(TestExampleImplementation)
 
-	mockedService.Mock.On("TheExampleMethod", 1, 2, 3).Return(5, "6", true).Times(4)
+    mockedService.Mock.On("TheExampleMethod", 1, 2, 3).Return(5, "6", true).Times(4)
 
-	mockedService.TheExampleMethod(1, 2, 3)
-	mockedService.TheExampleMethod(1, 2, 3)
-	mockedService.TheExampleMethod(1, 2, 3)
-	mockedService.TheExampleMethod(1, 2, 3)
-	assert.Panics(t, func() {
-		mockedService.TheExampleMethod(1, 2, 3)
-	})
+    mockedService.TheExampleMethod(1, 2, 3)
+    mockedService.TheExampleMethod(1, 2, 3)
+    mockedService.TheExampleMethod(1, 2, 3)
+    mockedService.TheExampleMethod(1, 2, 3)
+    assert.Panics(t, func() {
+        mockedService.TheExampleMethod(1, 2, 3)
+    })
 
 }
 
 func Test_Mock_Called_Unexpected(t *testing.T) {
 
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+    var mockedService *TestExampleImplementation = new(TestExampleImplementation)
 
-	// make sure it panics if no expectation was made
-	assert.Panics(t, func() {
-		mockedService.Mock.Called(1, 2, 3)
-	}, "Calling unexpected method should panic")
+    // make sure it panics if no expectation was made
+    assert.Panics(t, func() {
+        mockedService.Mock.Called(1, 2, 3)
+    }, "Calling unexpected method should panic")
 
 }
 
 func Test_AssertExpectationsForObjects_Helper(t *testing.T) {
 
-	var mockedService1 *TestExampleImplementation = new(TestExampleImplementation)
-	var mockedService2 *TestExampleImplementation = new(TestExampleImplementation)
-	var mockedService3 *TestExampleImplementation = new(TestExampleImplementation)
+    var mockedService1 *TestExampleImplementation = new(TestExampleImplementation)
+    var mockedService2 *TestExampleImplementation = new(TestExampleImplementation)
+    var mockedService3 *TestExampleImplementation = new(TestExampleImplementation)
 
-	mockedService1.Mock.On("Test_AssertExpectationsForObjects_Helper", 1).Return()
-	mockedService2.Mock.On("Test_AssertExpectationsForObjects_Helper", 2).Return()
-	mockedService3.Mock.On("Test_AssertExpectationsForObjects_Helper", 3).Return()
+    mockedService1.Mock.On("Test_AssertExpectationsForObjects_Helper", 1).Return()
+    mockedService2.Mock.On("Test_AssertExpectationsForObjects_Helper", 2).Return()
+    mockedService3.Mock.On("Test_AssertExpectationsForObjects_Helper", 3).Return()
 
-	mockedService1.Called(1)
-	mockedService2.Called(2)
-	mockedService3.Called(3)
+    mockedService1.Called(1)
+    mockedService2.Called(2)
+    mockedService3.Called(3)
 
-	assert.True(t, AssertExpectationsForObjects(t, mockedService1.Mock, mockedService2.Mock, mockedService3.Mock))
+    assert.True(t, AssertExpectationsForObjects(t, mockedService1.Mock, mockedService2.Mock, mockedService3.Mock))
 
 }
 
 func Test_AssertExpectationsForObjects_Helper_Failed(t *testing.T) {
 
-	var mockedService1 *TestExampleImplementation = new(TestExampleImplementation)
-	var mockedService2 *TestExampleImplementation = new(TestExampleImplementation)
-	var mockedService3 *TestExampleImplementation = new(TestExampleImplementation)
+    var mockedService1 *TestExampleImplementation = new(TestExampleImplementation)
+    var mockedService2 *TestExampleImplementation = new(TestExampleImplementation)
+    var mockedService3 *TestExampleImplementation = new(TestExampleImplementation)
 
-	mockedService1.Mock.On("Test_AssertExpectationsForObjects_Helper_Failed", 1).Return()
-	mockedService2.Mock.On("Test_AssertExpectationsForObjects_Helper_Failed", 2).Return()
-	mockedService3.Mock.On("Test_AssertExpectationsForObjects_Helper_Failed", 3).Return()
+    mockedService1.Mock.On("Test_AssertExpectationsForObjects_Helper_Failed", 1).Return()
+    mockedService2.Mock.On("Test_AssertExpectationsForObjects_Helper_Failed", 2).Return()
+    mockedService3.Mock.On("Test_AssertExpectationsForObjects_Helper_Failed", 3).Return()
 
-	mockedService1.Called(1)
-	mockedService3.Called(3)
+    mockedService1.Called(1)
+    mockedService3.Called(3)
 
-	tt := new(testing.T)
-	assert.False(t, AssertExpectationsForObjects(tt, mockedService1.Mock, mockedService2.Mock, mockedService3.Mock))
+    tt := new(testing.T)
+    assert.False(t, AssertExpectationsForObjects(tt, mockedService1.Mock, mockedService2.Mock, mockedService3.Mock))
 
 }
 
 func Test_Mock_AssertExpectations(t *testing.T) {
 
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+    var mockedService *TestExampleImplementation = new(TestExampleImplementation)
 
-	mockedService.Mock.On("Test_Mock_AssertExpectations", 1, 2, 3).Return(5, 6, 7)
+    mockedService.Mock.On("Test_Mock_AssertExpectations", 1, 2, 3).Return(5, 6, 7)
 
-	tt := new(testing.T)
-	assert.False(t, mockedService.AssertExpectations(tt))
+    tt := new(testing.T)
+    assert.False(t, mockedService.AssertExpectations(tt))
 
-	// make the call now
-	mockedService.Mock.Called(1, 2, 3)
+    // make the call now
+    mockedService.Mock.Called(1, 2, 3)
 
-	// now assert expectations
-	assert.True(t, mockedService.AssertExpectations(tt))
+    // now assert expectations
+    assert.True(t, mockedService.AssertExpectations(tt))
 
 }
 
 func Test_Mock_AssertExpectationsCustomType(t *testing.T) {
 
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+    var mockedService *TestExampleImplementation = new(TestExampleImplementation)
 
-	mockedService.Mock.On("TheExampleMethod3", AnythingOfType("*mock.ExampleType")).Return(nil).Once()
+    mockedService.Mock.On("TheExampleMethod3", AnythingOfType("*mock.ExampleType")).Return(nil).Once()
 
-	tt := new(testing.T)
-	assert.False(t, mockedService.AssertExpectations(tt))
+    tt := new(testing.T)
+    assert.False(t, mockedService.AssertExpectations(tt))
 
-	// make the call now
-	mockedService.TheExampleMethod3(&ExampleType{})
+    // make the call now
+    mockedService.TheExampleMethod3(&ExampleType{})
 
-	// now assert expectations
-	assert.True(t, mockedService.AssertExpectations(tt))
+    // now assert expectations
+    assert.True(t, mockedService.AssertExpectations(tt))
 
 }
 
 func Test_Mock_AssertExpectations_With_Repeatability(t *testing.T) {
 
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+    var mockedService *TestExampleImplementation = new(TestExampleImplementation)
 
-	mockedService.Mock.On("Test_Mock_AssertExpectations_With_Repeatability", 1, 2, 3).Return(5, 6, 7).Twice()
+    mockedService.Mock.On("Test_Mock_AssertExpectations_With_Repeatability", 1, 2, 3).Return(5, 6, 7).Twice()
 
-	tt := new(testing.T)
-	assert.False(t, mockedService.AssertExpectations(tt))
+    tt := new(testing.T)
+    assert.False(t, mockedService.AssertExpectations(tt))
 
-	// make the call now
-	mockedService.Mock.Called(1, 2, 3)
+    // make the call now
+    mockedService.Mock.Called(1, 2, 3)
 
-	assert.False(t, mockedService.AssertExpectations(tt))
+    assert.False(t, mockedService.AssertExpectations(tt))
 
-	mockedService.Mock.Called(1, 2, 3)
+    mockedService.Mock.Called(1, 2, 3)
 
-	// now assert expectations
-	assert.True(t, mockedService.AssertExpectations(tt))
+    // now assert expectations
+    assert.True(t, mockedService.AssertExpectations(tt))
 
 }
 
 func Test_Mock_TwoCallsWithDifferentArguments(t *testing.T) {
 
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+    var mockedService *TestExampleImplementation = new(TestExampleImplementation)
 
-	mockedService.Mock.On("Test_Mock_TwoCallsWithDifferentArguments", 1, 2, 3).Return(5, 6, 7)
-	mockedService.Mock.On("Test_Mock_TwoCallsWithDifferentArguments", 4, 5, 6).Return(5, 6, 7)
+    mockedService.Mock.On("Test_Mock_TwoCallsWithDifferentArguments", 1, 2, 3).Return(5, 6, 7)
+    mockedService.Mock.On("Test_Mock_TwoCallsWithDifferentArguments", 4, 5, 6).Return(5, 6, 7)
 
-	args1 := mockedService.Mock.Called(1, 2, 3)
-	assert.Equal(t, 5, args1.Int(0))
-	assert.Equal(t, 6, args1.Int(1))
-	assert.Equal(t, 7, args1.Int(2))
+    args1 := mockedService.Mock.Called(1, 2, 3)
+    assert.Equal(t, 5, args1.Int(0))
+    assert.Equal(t, 6, args1.Int(1))
+    assert.Equal(t, 7, args1.Int(2))
 
-	args2 := mockedService.Mock.Called(4, 5, 6)
-	assert.Equal(t, 5, args2.Int(0))
-	assert.Equal(t, 6, args2.Int(1))
-	assert.Equal(t, 7, args2.Int(2))
+    args2 := mockedService.Mock.Called(4, 5, 6)
+    assert.Equal(t, 5, args2.Int(0))
+    assert.Equal(t, 6, args2.Int(1))
+    assert.Equal(t, 7, args2.Int(2))
 
 }
 
 func Test_Mock_AssertNumberOfCalls(t *testing.T) {
 
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+    var mockedService *TestExampleImplementation = new(TestExampleImplementation)
 
-	mockedService.Mock.On("Test_Mock_AssertNumberOfCalls", 1, 2, 3).Return(5, 6, 7)
+    mockedService.Mock.On("Test_Mock_AssertNumberOfCalls", 1, 2, 3).Return(5, 6, 7)
 
-	mockedService.Mock.Called(1, 2, 3)
-	assert.True(t, mockedService.AssertNumberOfCalls(t, "Test_Mock_AssertNumberOfCalls", 1))
+    mockedService.Mock.Called(1, 2, 3)
+    assert.True(t, mockedService.AssertNumberOfCalls(t, "Test_Mock_AssertNumberOfCalls", 1))
 
-	mockedService.Mock.Called(1, 2, 3)
-	assert.True(t, mockedService.AssertNumberOfCalls(t, "Test_Mock_AssertNumberOfCalls", 2))
+    mockedService.Mock.Called(1, 2, 3)
+    assert.True(t, mockedService.AssertNumberOfCalls(t, "Test_Mock_AssertNumberOfCalls", 2))
 
 }
 
 func Test_Mock_AssertCalled(t *testing.T) {
 
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+    var mockedService *TestExampleImplementation = new(TestExampleImplementation)
 
-	mockedService.Mock.On("Test_Mock_AssertCalled", 1, 2, 3).Return(5, 6, 7)
+    mockedService.Mock.On("Test_Mock_AssertCalled", 1, 2, 3).Return(5, 6, 7)
 
-	mockedService.Mock.Called(1, 2, 3)
+    mockedService.Mock.Called(1, 2, 3)
 
-	assert.True(t, mockedService.AssertCalled(t, "Test_Mock_AssertCalled", 1, 2, 3))
+    assert.True(t, mockedService.AssertCalled(t, "Test_Mock_AssertCalled", 1, 2, 3))
 
 }
 
 func Test_Mock_AssertCalled_WithAnythingOfTypeArgument(t *testing.T) {
 
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+    var mockedService *TestExampleImplementation = new(TestExampleImplementation)
 
-	mockedService.Mock.On("Test_Mock_AssertCalled_WithAnythingOfTypeArgument", Anything, Anything, Anything).Return()
+    mockedService.Mock.On("Test_Mock_AssertCalled_WithAnythingOfTypeArgument", Anything, Anything, Anything).Return()
 
-	mockedService.Mock.Called(1, "two", []uint8("three"))
+    mockedService.Mock.Called(1, "two", []uint8("three"))
 
-	assert.True(t, mockedService.AssertCalled(t, "Test_Mock_AssertCalled_WithAnythingOfTypeArgument", AnythingOfType("int"), AnythingOfType("string"), AnythingOfType("[]uint8")))
+    assert.True(t, mockedService.AssertCalled(t, "Test_Mock_AssertCalled_WithAnythingOfTypeArgument", AnythingOfType("int"), AnythingOfType("string"), AnythingOfType("[]uint8")))
 
 }
 
 func Test_Mock_AssertCalled_WithArguments(t *testing.T) {
 
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+    var mockedService *TestExampleImplementation = new(TestExampleImplementation)
 
-	mockedService.Mock.On("Test_Mock_AssertCalled_WithArguments", 1, 2, 3).Return(5, 6, 7)
+    mockedService.Mock.On("Test_Mock_AssertCalled_WithArguments", 1, 2, 3).Return(5, 6, 7)
 
-	mockedService.Mock.Called(1, 2, 3)
+    mockedService.Mock.Called(1, 2, 3)
 
-	tt := new(testing.T)
-	assert.True(t, mockedService.AssertCalled(tt, "Test_Mock_AssertCalled_WithArguments", 1, 2, 3))
-	assert.False(t, mockedService.AssertCalled(tt, "Test_Mock_AssertCalled_WithArguments", 2, 3, 4))
+    tt := new(testing.T)
+    assert.True(t, mockedService.AssertCalled(tt, "Test_Mock_AssertCalled_WithArguments", 1, 2, 3))
+    assert.False(t, mockedService.AssertCalled(tt, "Test_Mock_AssertCalled_WithArguments", 2, 3, 4))
 
 }
 
 func Test_Mock_AssertCalled_WithArguments_With_Repeatability(t *testing.T) {
 
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+    var mockedService *TestExampleImplementation = new(TestExampleImplementation)
 
-	mockedService.Mock.On("Test_Mock_AssertCalled_WithArguments_With_Repeatability", 1, 2, 3).Return(5, 6, 7).Once()
-	mockedService.Mock.On("Test_Mock_AssertCalled_WithArguments_With_Repeatability", 2, 3, 4).Return(5, 6, 7).Once()
+    mockedService.Mock.On("Test_Mock_AssertCalled_WithArguments_With_Repeatability", 1, 2, 3).Return(5, 6, 7).Once()
+    mockedService.Mock.On("Test_Mock_AssertCalled_WithArguments_With_Repeatability", 2, 3, 4).Return(5, 6, 7).Once()
 
-	mockedService.Mock.Called(1, 2, 3)
-	mockedService.Mock.Called(2, 3, 4)
+    mockedService.Mock.Called(1, 2, 3)
+    mockedService.Mock.Called(2, 3, 4)
 
-	tt := new(testing.T)
-	assert.True(t, mockedService.AssertCalled(tt, "Test_Mock_AssertCalled_WithArguments_With_Repeatability", 1, 2, 3))
-	assert.True(t, mockedService.AssertCalled(tt, "Test_Mock_AssertCalled_WithArguments_With_Repeatability", 2, 3, 4))
-	assert.False(t, mockedService.AssertCalled(tt, "Test_Mock_AssertCalled_WithArguments_With_Repeatability", 3, 4, 5))
+    tt := new(testing.T)
+    assert.True(t, mockedService.AssertCalled(tt, "Test_Mock_AssertCalled_WithArguments_With_Repeatability", 1, 2, 3))
+    assert.True(t, mockedService.AssertCalled(tt, "Test_Mock_AssertCalled_WithArguments_With_Repeatability", 2, 3, 4))
+    assert.False(t, mockedService.AssertCalled(tt, "Test_Mock_AssertCalled_WithArguments_With_Repeatability", 3, 4, 5))
 
 }
 
 func Test_Mock_AssertNotCalled(t *testing.T) {
 
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+    var mockedService *TestExampleImplementation = new(TestExampleImplementation)
 
-	mockedService.Mock.On("Test_Mock_AssertNotCalled", 1, 2, 3).Return(5, 6, 7)
+    mockedService.Mock.On("Test_Mock_AssertNotCalled", 1, 2, 3).Return(5, 6, 7)
 
-	mockedService.Mock.Called(1, 2, 3)
+    mockedService.Mock.Called(1, 2, 3)
 
-	assert.True(t, mockedService.AssertNotCalled(t, "Test_Mock_NotCalled"))
+    assert.True(t, mockedService.AssertNotCalled(t, "Test_Mock_NotCalled"))
 
 }
 
 /*
-	Arguments helper methods
+    Arguments helper methods
 */
 func Test_Arguments_Get(t *testing.T) {
 
-	var args Arguments = []interface{}{"string", 123, true}
+    var args Arguments = []interface{}{"string", 123, true}
 
-	assert.Equal(t, "string", args.Get(0).(string))
-	assert.Equal(t, 123, args.Get(1).(int))
-	assert.Equal(t, true, args.Get(2).(bool))
+    assert.Equal(t, "string", args.Get(0).(string))
+    assert.Equal(t, 123, args.Get(1).(int))
+    assert.Equal(t, true, args.Get(2).(bool))
 
 }
 
 func Test_Arguments_Is(t *testing.T) {
 
-	var args Arguments = []interface{}{"string", 123, true}
+    var args Arguments = []interface{}{"string", 123, true}
 
-	assert.True(t, args.Is("string", 123, true))
-	assert.False(t, args.Is("wrong", 456, false))
+    assert.True(t, args.Is("string", 123, true))
+    assert.False(t, args.Is("wrong", 456, false))
 
 }
 
 func Test_Arguments_Diff(t *testing.T) {
 
-	var args Arguments = []interface{}{"Hello World", 123, true}
-	var diff string
-	var count int
-	diff, count = args.Diff([]interface{}{"Hello World", 456, "false"})
+    var args Arguments = []interface{}{"Hello World", 123, true}
+    var diff string
+    var count int
+    diff, count = args.Diff([]interface{}{"Hello World", 456, "false"})
 
-	assert.Equal(t, 2, count)
-	assert.Contains(t, diff, `%!s(int=456) != %!s(int=123)`)
-	assert.Contains(t, diff, `false != %!s(bool=true)`)
+    assert.Equal(t, 2, count)
+    assert.Contains(t, diff, `%!s(int=456) != %!s(int=123)`)
+    assert.Contains(t, diff, `false != %!s(bool=true)`)
 
 }
 
 func Test_Arguments_Diff_DifferentNumberOfArgs(t *testing.T) {
 
-	var args Arguments = []interface{}{"string", 123, true}
-	var diff string
-	var count int
-	diff, count = args.Diff([]interface{}{"string", 456, "false", "extra"})
+    var args Arguments = []interface{}{"string", 123, true}
+    var diff string
+    var count int
+    diff, count = args.Diff([]interface{}{"string", 456, "false", "extra"})
 
-	assert.Equal(t, 3, count)
-	assert.Contains(t, diff, `extra != (Missing)`)
+    assert.Equal(t, 3, count)
+    assert.Contains(t, diff, `extra != (Missing)`)
 
 }
 
 func Test_Arguments_Diff_WithAnythingArgument(t *testing.T) {
 
-	var args Arguments = []interface{}{"string", 123, true}
-	var count int
-	_, count = args.Diff([]interface{}{"string", Anything, true})
+    var args Arguments = []interface{}{"string", 123, true}
+    var count int
+    _, count = args.Diff([]interface{}{"string", Anything, true})
 
-	assert.Equal(t, 0, count)
+    assert.Equal(t, 0, count)
 
 }
 
 func Test_Arguments_Diff_WithAnythingArgument_InActualToo(t *testing.T) {
 
-	var args Arguments = []interface{}{"string", Anything, true}
-	var count int
-	_, count = args.Diff([]interface{}{"string", 123, true})
+    var args Arguments = []interface{}{"string", Anything, true}
+    var count int
+    _, count = args.Diff([]interface{}{"string", 123, true})
 
-	assert.Equal(t, 0, count)
+    assert.Equal(t, 0, count)
 
 }
 
 func Test_Arguments_Diff_WithAnythingOfTypeArgument(t *testing.T) {
 
-	var args Arguments = []interface{}{"string", AnythingOfType("int"), true}
-	var count int
-	_, count = args.Diff([]interface{}{"string", 123, true})
+    var args Arguments = []interface{}{"string", AnythingOfType("int"), true}
+    var count int
+    _, count = args.Diff([]interface{}{"string", 123, true})
 
-	assert.Equal(t, 0, count)
+    assert.Equal(t, 0, count)
 
 }
 
 func Test_Arguments_Diff_WithAnythingOfTypeArgument_Failing(t *testing.T) {
 
-	var args Arguments = []interface{}{"string", AnythingOfType("string"), true}
-	var count int
-	var diff string
-	diff, count = args.Diff([]interface{}{"string", 123, true})
+    var args Arguments = []interface{}{"string", AnythingOfType("string"), true}
+    var count int
+    var diff string
+    diff, count = args.Diff([]interface{}{"string", 123, true})
 
-	assert.Equal(t, 1, count)
-	assert.Contains(t, diff, `string != type int - %!s(int=123)`)
+    assert.Equal(t, 1, count)
+    assert.Contains(t, diff, `string != type int - %!s(int=123)`)
 
 }
 
 func Test_Arguments_Assert(t *testing.T) {
 
-	var args Arguments = []interface{}{"string", 123, true}
+    var args Arguments = []interface{}{"string", 123, true}
 
-	assert.True(t, args.Assert(t, "string", 123, true))
+    assert.True(t, args.Assert(t, "string", 123, true))
 
 }
 
 func Test_Arguments_String_Representation(t *testing.T) {
 
-	var args Arguments = []interface{}{"string", 123, true}
-	assert.Equal(t, `string,int,bool`, args.String())
+    var args Arguments = []interface{}{"string", 123, true}
+    assert.Equal(t, `string,int,bool`, args.String())
 
 }
 
 func Test_Arguments_String(t *testing.T) {
 
-	var args Arguments = []interface{}{"string", 123, true}
-	assert.Equal(t, "string", args.String(0))
+    var args Arguments = []interface{}{"string", 123, true}
+    assert.Equal(t, "string", args.String(0))
 
 }
 
 func Test_Arguments_Error(t *testing.T) {
 
-	var err error = errors.New("An Error")
-	var args Arguments = []interface{}{"string", 123, true, err}
-	assert.Equal(t, err, args.Error(3))
+    var err error = errors.New("An Error")
+    var args Arguments = []interface{}{"string", 123, true, err}
+    assert.Equal(t, err, args.Error(3))
 
 }
 
 func Test_Arguments_Error_Nil(t *testing.T) {
 
-	var args Arguments = []interface{}{"string", 123, true, nil}
-	assert.Equal(t, nil, args.Error(3))
+    var args Arguments = []interface{}{"string", 123, true, nil}
+    assert.Equal(t, nil, args.Error(3))
 
 }
 
 func Test_Arguments_Int(t *testing.T) {
 
-	var args Arguments = []interface{}{"string", 123, true}
-	assert.Equal(t, 123, args.Int(1))
+    var args Arguments = []interface{}{"string", 123, true}
+    assert.Equal(t, 123, args.Int(1))
 
 }
 
 func Test_Arguments_Bool(t *testing.T) {
 
-	var args Arguments = []interface{}{"string", 123, true}
-	assert.Equal(t, true, args.Bool(2))
+    var args Arguments = []interface{}{"string", 123, true}
+    assert.Equal(t, true, args.Bool(2))
 
 }

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 /*
-    Test objects
+   Test objects
 */
 
 // ExampleInterface represents an example interface.
@@ -37,7 +37,7 @@ func (i *TestExampleImplementation) TheExampleMethod3(et *ExampleType) error {
 }
 
 /*
-    Mock
+   Mock
 */
 
 func Test_Mock_TestData(t *testing.T) {
@@ -529,7 +529,7 @@ func Test_Mock_AssertNotCalled(t *testing.T) {
 }
 
 /*
-    Arguments helper methods
+   Arguments helper methods
 */
 func Test_Arguments_Get(t *testing.T) {
 
@@ -625,6 +625,132 @@ func Test_Arguments_Assert(t *testing.T) {
 
 }
 
+func Test_Arguments_Bool(t *testing.T) {
+
+    var args Arguments = []interface{}{"string", 123, true}
+    assert.Equal(t, true, args.Bool(2))
+
+}
+
+func Test_Arguments_Int8(t *testing.T) {
+
+    var args Arguments = []interface{}{"string", int8(123), true}
+    assert.Equal(t, int8(123), args.Int8(1))
+
+}
+
+func Test_Arguments_Int16(t *testing.T) {
+
+    var args Arguments = []interface{}{"string", int16(123), true}
+    assert.Equal(t, int16(123), args.Int16(1))
+
+}
+
+func Test_Arguments_Int32(t *testing.T) {
+
+    var args Arguments = []interface{}{"string", int32(123), true}
+    assert.Equal(t, int32(123), args.Int32(1))
+
+}
+
+func Test_Arguments_Int64(t *testing.T) {
+
+    var args Arguments = []interface{}{"string", int64(123), true}
+    assert.Equal(t, int64(123), args.Int64(1))
+
+}
+
+func Test_Arguments_Uint8(t *testing.T) {
+
+    var args Arguments = []interface{}{"string", uint8(123), true}
+    assert.Equal(t, uint8(123), args.Uint8(1))
+
+}
+
+func Test_Arguments_Uint16(t *testing.T) {
+
+    var args Arguments = []interface{}{"string", uint16(123), true}
+    assert.Equal(t, uint16(123), args.Uint16(1))
+
+}
+
+func Test_Arguments_Uint32(t *testing.T) {
+
+    var args Arguments = []interface{}{"string", uint32(123), true}
+    assert.Equal(t, uint32(123), args.Uint32(1))
+
+}
+
+func Test_Arguments_Uint64(t *testing.T) {
+
+    var args Arguments = []interface{}{"string", uint64(123), true}
+    assert.Equal(t, uint64(123), args.Uint64(1))
+
+}
+
+func Test_Arguments_Float32(t *testing.T) {
+
+    var args Arguments = []interface{}{"string", float32(123.0), true}
+    assert.Equal(t, float32(123.0), args.Float32(1))
+
+}
+
+func Test_Arguments_Float64(t *testing.T) {
+
+    var args Arguments = []interface{}{"string", float64(123.0), true}
+    assert.Equal(t, float64(123.0), args.Float64(1))
+
+}
+
+func Test_Arguments_Complex64(t *testing.T) {
+
+    var args Arguments = []interface{}{"string", complex64(123.0), true}
+    assert.Equal(t, complex64(123.0), args.Complex64(1))
+
+}
+
+func Test_Arguments_Complex128(t *testing.T) {
+
+    var args Arguments = []interface{}{"string", complex128(123.0), true}
+    assert.Equal(t, complex128(123.0), args.Complex128(1))
+
+}
+
+func Test_Arguments_Byte(t *testing.T) {
+
+    var args Arguments = []interface{}{"string", byte(123), true}
+    assert.Equal(t, byte(123), args.Byte(1))
+
+}
+
+func Test_Arguments_Rune(t *testing.T) {
+
+    var args Arguments = []interface{}{"string", rune(123), true}
+    assert.Equal(t, rune(123), args.Rune(1))
+
+}
+
+func Test_Arguments_Int(t *testing.T) {
+
+    var args Arguments = []interface{}{"string", 123, true}
+    assert.Equal(t, 123, args.Int(1))
+
+}
+
+func Test_Arguments_Uint(t *testing.T) {
+
+    var args Arguments = []interface{}{"string", uint(123), true}
+    assert.Equal(t, uint(123), args.Uint(1))
+
+}
+
+func Test_Arguments_Uintptr(t *testing.T) {
+
+    var args Arguments = []interface{}{"string", uintptr(123), true}
+    assert.Equal(t, uintptr(123), args.Uintptr(1))
+
+}
+
 func Test_Arguments_String_Representation(t *testing.T) {
 
     var args Arguments = []interface{}{"string", 123, true}
@@ -651,19 +777,5 @@ func Test_Arguments_Error_Nil(t *testing.T) {
 
     var args Arguments = []interface{}{"string", 123, true, nil}
     assert.Equal(t, nil, args.Error(3))
-
-}
-
-func Test_Arguments_Int(t *testing.T) {
-
-    var args Arguments = []interface{}{"string", 123, true}
-    assert.Equal(t, 123, args.Int(1))
-
-}
-
-func Test_Arguments_Bool(t *testing.T) {
-
-    var args Arguments = []interface{}{"string", 123, true}
-    assert.Equal(t, true, args.Bool(2))
 
 }

--- a/require/requirements.go
+++ b/require/requirements.go
@@ -1,7 +1,7 @@
 package require
 
 import (
-	"github.com/stretchr/testify/assert"
+	"github.com/hhkbp2/testify/assert"
 	"time"
 )
 


### PR DESCRIPTION
Hi,

I add some codes for a configurable feature: more entries of the call stack could be printed out on assert failure.
 Refer to [this issue](https://github.com/stretchr/testify/issues/81#issuecomment-54835227) for more info.

The previous two commits in this PR are unrelated since they are just reformats(my code editor would replace all tabs to spaces on saving the file). Please refer to the latest commit for the modification.