### PR TITLE
log test success messages, viewable with go test -v

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -14,6 +14,7 @@ import (
 // TestingT is an interface wrapper around *testing.T
 type TestingT interface {
 	Errorf(format string, args ...interface{})
+	Logf(format string, args ...interface{})
 }
 
 // Comparison a custom function that returns true on success and false on failure
@@ -159,6 +160,19 @@ func Fail(t TestingT, failureMessage string, msgAndArgs ...interface{}) bool {
 	return false
 }
 
+func LogPass(t TestingT, msgAndArgs ...interface{}) {
+	message := messageFromMsgAndArgs(msgAndArgs...)
+	if len(message) > 0 {
+		t.Logf("\r%s\r\tPASS:\t%s\n",
+			getWhitespaceString(),
+			message)
+	} else {
+		t.Logf("\r%s\r\tPASS\n",
+			getWhitespaceString())
+	}
+}
+
+
 // Implements asserts that an object is implemented by the specified interface.
 //
 //    assert.Implements(t, (*MyInterface)(nil), new(MyObject), "MyObject")
@@ -169,6 +183,7 @@ func Implements(t TestingT, interfaceObject interface{}, object interface{}, msg
 	if !reflect.TypeOf(object).Implements(interfaceType) {
 		return Fail(t, fmt.Sprintf("Object must implement %v", interfaceType), msgAndArgs...)
 	}
+	LogPass(t, msgAndArgs...)
 
 	return true
 
@@ -180,6 +195,7 @@ func IsType(t TestingT, expectedType interface{}, object interface{}, msgAndArgs
 	if !ObjectsAreEqual(reflect.TypeOf(object), reflect.TypeOf(expectedType)) {
 		return Fail(t, fmt.Sprintf("Object expected to be of type %v, but was %v", reflect.TypeOf(expectedType), reflect.TypeOf(object)), msgAndArgs...)
 	}
+	LogPass(t, msgAndArgs...)
 
 	return true
 }
@@ -195,6 +211,7 @@ func Equal(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) 
 		return Fail(t, fmt.Sprintf("Not equal: %#v (expected)\n"+
 			"        != %#v (actual)", expected, actual), msgAndArgs...)
 	}
+	LogPass(t, msgAndArgs...)
 
 	return true
 
@@ -237,7 +254,9 @@ func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
 		}
 	}
 
-	if !success {
+	if success {
+		LogPass(t, msgAndArgs...)
+	} else {
 		Fail(t, "Expected not to be nil.", msgAndArgs...)
 	}
 
@@ -266,6 +285,7 @@ func isNil(object interface{}) bool {
 // Returns whether the assertion was successful (true) or not (false).
 func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
 	if isNil(object) {
+		LogPass(t, msgAndArgs...)
 		return true
 	}
 	return Fail(t, fmt.Sprintf("Expected nil, but got: %#v", object), msgAndArgs...)
@@ -334,7 +354,9 @@ func isEmpty(object interface{}) bool {
 func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
 
 	pass := isEmpty(object)
-	if !pass {
+	if pass {
+		LogPass(t, msgAndArgs...)
+	} else {
 		Fail(t, fmt.Sprintf("Should be empty, but was %v", object), msgAndArgs...)
 	}
 
@@ -353,7 +375,9 @@ func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
 func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
 
 	pass := !isEmpty(object)
-	if !pass {
+	if pass {
+		LogPass(t, msgAndArgs...)
+	} else {
 		Fail(t, fmt.Sprintf("Should NOT be empty, but was %v", object), msgAndArgs...)
 	}
 
@@ -388,6 +412,7 @@ func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) 
 	if l != length {
 		return Fail(t, fmt.Sprintf("\"%s\" should have %d item(s), but has %d", object, length, l), msgAndArgs...)
 	}
+	LogPass(t, msgAndArgs...)
 	return true
 }
 
@@ -401,6 +426,7 @@ func True(t TestingT, value bool, msgAndArgs ...interface{}) bool {
 	if value != true {
 		return Fail(t, "Should be true", msgAndArgs...)
 	}
+	LogPass(t, msgAndArgs...)
 
 	return true
 
@@ -416,6 +442,7 @@ func False(t TestingT, value bool, msgAndArgs ...interface{}) bool {
 	if value != false {
 		return Fail(t, "Should be false", msgAndArgs...)
 	}
+	LogPass(t, msgAndArgs...)
 
 	return true
 
@@ -431,6 +458,7 @@ func NotEqual(t TestingT, expected, actual interface{}, msgAndArgs ...interface{
 	if ObjectsAreEqual(expected, actual) {
 		return Fail(t, "Should not be equal", msgAndArgs...)
 	}
+	LogPass(t, msgAndArgs...)
 
 	return true
 
@@ -480,6 +508,7 @@ func Contains(t TestingT, s, contains interface{}, msgAndArgs ...interface{}) bo
 	if !found {
 		return Fail(t, fmt.Sprintf("\"%s\" does not contain \"%s\"", s, contains), msgAndArgs...)
 	}
+	LogPass(t, msgAndArgs...)
 
 	return true
 
@@ -501,6 +530,7 @@ func NotContains(t TestingT, s, contains interface{}, msgAndArgs ...interface{})
 	if found {
 		return Fail(t, fmt.Sprintf("\"%s\" should not contain \"%s\"", s, contains), msgAndArgs...)
 	}
+	LogPass(t, msgAndArgs...)
 
 	return true
 
@@ -509,7 +539,9 @@ func NotContains(t TestingT, s, contains interface{}, msgAndArgs ...interface{})
 // Condition uses a Comparison to assert a complex condition.
 func Condition(t TestingT, comp Comparison, msgAndArgs ...interface{}) bool {
 	result := comp()
-	if !result {
+	if result {
+		LogPass(t, msgAndArgs...)
+	} else {
 		Fail(t, "Condition failed!", msgAndArgs...)
 	}
 	return result
@@ -553,6 +585,7 @@ func Panics(t TestingT, f PanicTestFunc, msgAndArgs ...interface{}) bool {
 	if funcDidPanic, panicValue := didPanic(f); !funcDidPanic {
 		return Fail(t, fmt.Sprintf("func %#v should panic\n\r\tPanic value:\t%v", f, panicValue), msgAndArgs...)
 	}
+	LogPass(t, msgAndArgs...)
 
 	return true
 }
@@ -569,6 +602,7 @@ func NotPanics(t TestingT, f PanicTestFunc, msgAndArgs ...interface{}) bool {
 	if funcDidPanic, panicValue := didPanic(f); funcDidPanic {
 		return Fail(t, fmt.Sprintf("func %#v should not panic\n\r\tPanic value:\t%v", f, panicValue), msgAndArgs...)
 	}
+	LogPass(t, msgAndArgs...)
 
 	return true
 }
@@ -584,6 +618,7 @@ func WithinDuration(t TestingT, expected, actual time.Time, delta time.Duration,
 	if dt < -delta || dt > delta {
 		return Fail(t, fmt.Sprintf("Max difference between %v and %v allowed is %v, but difference was %v", expected, actual, delta, dt), msgAndArgs...)
 	}
+	LogPass(t, msgAndArgs...)
 
 	return true
 }
@@ -640,6 +675,7 @@ func InDelta(t TestingT, expected, actual interface{}, delta float64, msgAndArgs
 	if dt < -delta || dt > delta {
 		return Fail(t, fmt.Sprintf("Max difference between %v and %v allowed is %v, but difference was %v", expected, actual, delta, dt), msgAndArgs...)
 	}
+	LogPass(t, msgAndArgs...)
 
 	return true
 }
@@ -692,6 +728,7 @@ func InEpsilon(t TestingT, expected, actual interface{}, epsilon float64, msgAnd
 // Returns whether the assertion was successful (true) or not (false).
 func NoError(t TestingT, err error, msgAndArgs ...interface{}) bool {
 	if isNil(err) {
+		LogPass(t, msgAndArgs...)
 		return true
 	}
 


### PR DESCRIPTION
Hi,

Thanks for the awesome module :-)

This commit calls t.Logf (with hopefully compatible whitespace indentation) for each successful assertion. Without '-v' to 'go test' this should have no effect. With '-v' it shows a log of passing tests - something I have become accustomed to with other test frameworks and something I'd like to use with testify.

If you like the approach, but don't want it "always on", I could make it conditional on some state in the assertion object, but I thought the '-v' switch to 'go test' would already suffice for that.

regards,

jb