### PR TITLE
Fix mock.go's Int Bool and Error shortcut methods

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -478,7 +478,7 @@ func (args Arguments) Int(index int) int {
 	var s int
 	var ok bool
 	if s, ok = args.Get(index).(int); !ok {
-		panic(fmt.Sprintf("assert: arguments: Int(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
+		panic(fmt.Sprintf("assert: arguments: Int(%d) failed because object wasn't correct type: %v", index, args.Get(index)))
 	}
 	return s
 }
@@ -493,7 +493,7 @@ func (args Arguments) Error(index int) error {
 		return nil
 	}
 	if s, ok = obj.(error); !ok {
-		panic(fmt.Sprintf("assert: arguments: Error(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
+		panic(fmt.Sprintf("assert: arguments: Error(%d) failed because object wasn't correct type: %v", index, args.Get(index)))
 	}
 	return s
 }
@@ -504,7 +504,7 @@ func (args Arguments) Bool(index int) bool {
 	var s bool
 	var ok bool
 	if s, ok = args.Get(index).(bool); !ok {
-		panic(fmt.Sprintf("assert: arguments: Bool(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
+		panic(fmt.Sprintf("assert: arguments: Bool(%d) failed because object wasn't correct type: %v", index, args.Get(index)))
 	}
 	return s
 }


### PR DESCRIPTION
When using testify, I saw panic: assert: arguments: Error(0) failed because object wasn't correct type: {{ad6e7d77-1745-4761-6c4b-a79ab92a4a0f e6e975ef-3637-4047-436a-018ee9d2de52 %!s(int=17) <nil> <nil> %!s(bool=false) %!s(*string=<nil>) ...
when using the Error(index) function.

This commit simply changes to using %v for printing the unexpected structure in the Bool, Int, and Error shortcut methods.
