### PR TITLE
Using gospew to print out complex data structures when Equals fails

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -9,6 +9,8 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/davecgh/go-spew/spew"
 )
 
 // TestingT is an interface wrapper around *testing.T
@@ -192,8 +194,24 @@ func IsType(t TestingT, expectedType interface{}, object interface{}, msgAndArgs
 func Equal(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool {
 
 	if !ObjectsAreEqual(expected, actual) {
-		return Fail(t, fmt.Sprintf("Not equal: %#v (expected)\n"+
-			"        != %#v (actual)", expected, actual), msgAndArgs...)
+		var msg string
+		tp := reflect.TypeOf(expected)
+		k := tp.Kind()
+		if k == reflect.Ptr {
+			tp = tp.Elem()
+			k = tp.Kind()
+		}
+		if k == reflect.Struct || k == reflect.Map || k == reflect.Slice || k == reflect.Array {
+			msg = fmt.Sprintf("Not equal:\n"+
+				"---- Expected ----\n%s\n--------------\n"+
+				"---- Actual ------\n%s\n--------------",
+				spew.Sdump(expected),
+				spew.Sdump(actual))
+		} else {
+			msg = fmt.Sprintf("Not equal: %#v (expected)\n"+
+				"        != %#v (actual)", expected, actual)
+		}
+		return Fail(t, msg, msgAndArgs...)
 	}
 
 	return true


### PR DESCRIPTION
When comparing structs, maps, arrays and slices, this makes the failure message easier to read and actually shows details of the nested data structures.  Here's an example output:

```
Location:       yamlconf_test.go:119
	Error:		Not equal:
			---- Expected ----
			(*yamlconf.TestCfg)(0xc2080387c0)({
			 Version: (int) 1,
			 N: (*yamlconf.Nested)(0xc20800e0c0)({
			  S: (string) (len=1) "3",
			  I: (int) 3
			 })
			})
			
			--------------
			---- Actual ------
			(*yamlconf.TestCfg)(0xc208038e90)({
			 Version: (int) 1,
			 N: (*yamlconf.Nested)(0xc20800e780)({
			  S: (string) "",
			  I: (int) 55
			 })
			})
			
			--------------
	Messages:	Config from updated file should contain correct data
```