### PR TITLE
Wrap NoError message with quote marks

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -695,7 +695,7 @@ func NoError(t TestingT, err error, msgAndArgs ...interface{}) bool {
 		return true
 	}
 
-	return Fail(t, fmt.Sprintf("No error is expected but got %v", err), msgAndArgs...)
+	return Fail(t, fmt.Sprintf("Received unexpected error %q", err), msgAndArgs...)
 }
 
 // Error asserts that a function returned an error (i.e. not `nil`).


### PR DESCRIPTION
Previous behavior was to print the error with no delimiters:

	No error is expected but got unexpected character in stream

New behavior is to print the error surrounded by quotes:

	Recieved unexpected error "unexpected character in stream"