### PR TITLE
Fix panic when comparing unequal maps.

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -37,10 +37,10 @@ func ObjectsAreEqual(expected, actual interface{}) bool {
 	}
 
 	actualType := reflect.TypeOf(actual)
-	if reflect.TypeOf(actual).ConvertibleTo(reflect.TypeOf(expected)) {
+	if actualType.ConvertibleTo(reflect.TypeOf(expected)) {
 		expectedValue := reflect.ValueOf(expected)
 		// Attempt comparison after type conversion
-		if actual == expectedValue.Convert(actualType).Interface() {
+		if reflect.DeepEqual(actual, expectedValue.Convert(actualType).Interface()) {
 			return true
 		}
 	}

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -40,6 +40,9 @@ func TestObjectsAreEqual(t *testing.T) {
 	if !ObjectsAreEqual(nil, nil) {
 		t.Error("objectsAreEqual should return true")
 	}
+	if ObjectsAreEqual(map[int]int{5: 10}, map[int]int{10: 20}) {
+		t.Error("objectsAreEqual should return false")
+	}
 
 }
 


### PR DESCRIPTION
The change in #94 resulted in using == to compare two values that might not be
comparable. Hence, this resulted in a panic for situations like:

```
ObjectsAreEqual(map[int]int{5: 10}, map[int]int{10: 20})
```

The fix is to use reflect.DeepEqual() instead.
