### PR TITLE
Add require.Assertions like assert.Assertions

### DIFF
--- a/require/forward_requirements.go
+++ b/require/forward_requirements.go
@@ -1,0 +1,211 @@
+package require
+
+import (
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type Assertions struct {
+	t TestingT
+}
+
+func New(t TestingT) *Assertions {
+	return &Assertions{
+		t: t,
+	}
+}
+
+// Fail reports a failure through
+func (a *Assertions) Fail(failureMessage string, msgAndArgs ...interface{}) {
+	FailNow(a.t, failureMessage, msgAndArgs...)
+}
+
+// Implements asserts that an object is implemented by the specified interface.
+
+func (a *Assertions) Implements(interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
+	Implements(a.t, interfaceObject, object, msgAndArgs...)
+}
+
+// IsType asserts that the specified objects are of the same type.
+func (a *Assertions) IsType(expectedType interface{}, object interface{}, msgAndArgs ...interface{}) {
+	IsType(a.t, expectedType, object, msgAndArgs...)
+}
+
+// Equal asserts that two objects are equal.
+//
+//    require.Equal(123, 123, "123 and 123 should be equal")
+func (a *Assertions) Equal(expected, actual interface{}, msgAndArgs ...interface{}) {
+	Equal(a.t, expected, actual, msgAndArgs...)
+}
+
+// Exactly asserts that two objects are equal is value and type.
+//
+//    require.Exactly(int32(123), int64(123), "123 and 123 should NOT be equal")
+func (a *Assertions) Exactly(expected, actual interface{}, msgAndArgs ...interface{}) {
+	Exactly(a.t, expected, actual, msgAndArgs...)
+}
+
+// NotNil asserts that the specified object is not nil.
+//
+//    require.NotNil(err, "err should be something")
+func (a *Assertions) NotNil(object interface{}, msgAndArgs ...interface{}) {
+	NotNil(a.t, object, msgAndArgs...)
+}
+
+// Nil asserts that the specified object is nil.
+//
+//    require.Nil(err, "err should be nothing")
+func (a *Assertions) Nil(object interface{}, msgAndArgs ...interface{}) {
+	Nil(a.t, object, msgAndArgs...)
+}
+
+// Empty asserts that the specified object is empty.  I.e. nil, "", false, 0 or a
+// slice with len == 0.
+//
+// require.Empty(obj)
+func (a *Assertions) Empty(object interface{}, msgAndArgs ...interface{}) {
+	Empty(a.t, object, msgAndArgs...)
+}
+
+// Empty asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or a
+// slice with len == 0.
+//
+// if require.NotEmpty(obj) {
+//   require.Equal("two", obj[1])
+// }
+func (a *Assertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) {
+	NotEmpty(a.t, object, msgAndArgs...)
+}
+
+// Len asserts that the specified object has specific length.
+// Len also fails if the object has a type that len() not accept.
+//
+//    require.Len(mySlice, 3, "The size of slice is not 3")
+func (a *Assertions) Len(object interface{}, length int, msgAndArgs ...interface{}) {
+	Len(a.t, object, length, msgAndArgs...)
+}
+
+// True asserts that the specified value is true.
+//
+//    require.True(myBool, "myBool should be true")
+func (a *Assertions) True(value bool, msgAndArgs ...interface{}) {
+	True(a.t, value, msgAndArgs...)
+}
+
+// False asserts that the specified value is true.
+//
+//    require.False(myBool, "myBool should be false")
+func (a *Assertions) False(value bool, msgAndArgs ...interface{}) {
+	False(a.t, value, msgAndArgs...)
+}
+
+// NotEqual asserts that the specified values are NOT equal.
+//
+//    require.NotEqual(obj1, obj2, "two objects shouldn't be equal")
+func (a *Assertions) NotEqual(expected, actual interface{}, msgAndArgs ...interface{}) {
+	NotEqual(a.t, expected, actual, msgAndArgs...)
+}
+
+// Contains asserts that the specified string contains the specified substring.
+//
+//    require.Contains("Hello World", "World", "But 'Hello World' does contain 'World'")
+func (a *Assertions) Contains(s, contains interface{}, msgAndArgs ...interface{}) {
+	Contains(a.t, s, contains, msgAndArgs...)
+}
+
+// NotContains asserts that the specified string does NOT contain the specified substring.
+//
+//    require.NotContains("Hello World", "Earth", "But 'Hello World' does NOT contain 'Earth'")
+func (a *Assertions) NotContains(s, contains interface{}, msgAndArgs ...interface{}) {
+	NotContains(a.t, s, contains, msgAndArgs...)
+}
+
+// Uses a Comparison to assert a complex condition.
+func (a *Assertions) Condition(comp assert.Comparison, msgAndArgs ...interface{}) {
+	Condition(a.t, comp, msgAndArgs...)
+}
+
+// Panics asserts that the code inside the specified PanicTestFunc panics.
+//
+//   require.Panics(func(){
+//     GoCrazy()
+//   }, "Calling GoCrazy() should panic")
+func (a *Assertions) Panics(f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	Panics(a.t, f, msgAndArgs...)
+}
+
+// NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
+//
+//   require.NotPanics(func(){
+//     RemainCalm()
+//   }, "Calling RemainCalm() should NOT panic")
+func (a *Assertions) NotPanics(f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	NotPanics(a.t, f, msgAndArgs...)
+}
+
+// WithinDuration asserts that the two times are within duration delta of each other.
+//
+//   require.WithinDuration(time.Now(), time.Now(), 10*time.Second, "The difference should not be more than 10s")
+func (a *Assertions) WithinDuration(expected, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) {
+	WithinDuration(a.t, expected, actual, delta, msgAndArgs...)
+}
+
+// InDelta asserts that the two numerals are within delta of each other.
+//
+// 	 require.InDelta(t, math.Pi, (22 / 7.0), 0.01)
+func (a *Assertions) InDelta(expected, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	InDelta(a.t, expected, actual, delta, msgAndArgs...)
+}
+
+// InEpsilon asserts that expected and actual have a relative error less than epsilon
+func (a *Assertions) InEpsilon(expected, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
+	InEpsilon(a.t, expected, actual, epsilon, msgAndArgs...)
+}
+
+// NoError asserts that a function returned no error (i.e. `nil`).
+//
+//   actualObj, err := SomeFunction()
+//   if require.NoError(err) {
+//	   require.Equal(actualObj, expectedObj)
+//   }
+func (a *Assertions) NoError(theError error, msgAndArgs ...interface{}) {
+	NoError(a.t, theError, msgAndArgs...)
+}
+
+// Error asserts that a function returned an error (i.e. not `nil`).
+//
+//   actualObj, err := SomeFunction()
+//   if require.Error(err, "An error was expected") {
+//	   require.Equal(err, expectedError)
+//   }
+func (a *Assertions) Error(theError error, msgAndArgs ...interface{}) {
+	Error(a.t, theError, msgAndArgs...)
+}
+
+// EqualError asserts that a function returned an error (i.e. not `nil`)
+// and that it is equal to the provided error.
+//
+//   actualObj, err := SomeFunction()
+//   if require.Error(err, "An error was expected") {
+//	   require.Equal(err, expectedError)
+//   }
+func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...interface{}) {
+	EqualError(a.t, theError, errString, msgAndArgs...)
+}
+
+// Regexp asserts that a specified regexp matches a string.
+//
+//  require.Regexp(t, regexp.MustCompile("start"), "it's starting")
+//  require.Regexp(t, "start...$", "it's not starting")
+func (a *Assertions) Regexp(rx interface{}, str interface{}) {
+	Regexp(a.t, rx, str)
+}
+
+// NotRegexp asserts that a specified regexp does not match a string.
+//
+//  require.NotRegexp(t, regexp.MustCompile("starts"), "it's starting")
+//  require.NotRegexp(t, "^start", "it's not starting")
+func (a *Assertions) NotRegexp(rx interface{}, str interface{}) {
+	NotRegexp(a.t, rx, str)
+}

--- a/require/forward_requirements_test.go
+++ b/require/forward_requirements_test.go
@@ -1,0 +1,260 @@
+package require
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestImplementsWrapper(t *testing.T) {
+	require := New(t)
+
+	require.Implements((*AssertionTesterInterface)(nil), new(AssertionTesterConformingObject))
+
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+	mockRequire.Implements((*AssertionTesterInterface)(nil), new(AssertionTesterNonConformingObject))
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestIsTypeWrapper(t *testing.T) {
+	require := New(t)
+	require.IsType(new(AssertionTesterConformingObject), new(AssertionTesterConformingObject))
+
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+	mockRequire.IsType(new(AssertionTesterConformingObject), new(AssertionTesterNonConformingObject))
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestEqualWrapper(t *testing.T) {
+	require := New(t)
+	require.Equal(1, 1)
+
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+	mockRequire.Equal(1, 2)
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestNotEqualWrapper(t *testing.T) {
+	require := New(t)
+	require.NotEqual(1, 2)
+
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+	mockRequire.NotEqual(2, 2)
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestExactlyWrapper(t *testing.T) {
+	require := New(t)
+
+	a := float32(1)
+	b := float32(1)
+	c := float64(1)
+
+	require.Exactly(a, b)
+
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+	mockRequire.Exactly(a, c)
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestNotNilWrapper(t *testing.T) {
+	require := New(t)
+	require.NotNil(t, new(AssertionTesterConformingObject))
+
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+	mockRequire.NotNil(nil)
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestNilWrapper(t *testing.T) {
+	require := New(t)
+	require.Nil(nil)
+
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+	mockRequire.Nil(new(AssertionTesterConformingObject))
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestTrueWrapper(t *testing.T) {
+	require := New(t)
+	require.True(true)
+
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+	mockRequire.True(false)
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestFalseWrapper(t *testing.T) {
+	require := New(t)
+	require.False(false)
+
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+	mockRequire.False(true)
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestContainsWrapper(t *testing.T) {
+	require := New(t)
+	require.Contains("Hello World", "Hello")
+
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+	mockRequire.Contains("Hello World", "Salut")
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestNotContainsWrapper(t *testing.T) {
+	require := New(t)
+	require.NotContains("Hello World", "Hello!")
+
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+	mockRequire.NotContains("Hello World", "Hello")
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestPanicsWrapper(t *testing.T) {
+	require := New(t)
+	require.Panics(func() {
+		panic("Panic!")
+	})
+
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+	mockRequire.Panics(func() {})
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestNotPanicsWrapper(t *testing.T) {
+	require := New(t)
+	require.NotPanics(func() {})
+
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+	mockRequire.NotPanics(func() {
+		panic("Panic!")
+	})
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestNoErrorWrapper(t *testing.T) {
+	require := New(t)
+	require.NoError(nil)
+
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+	mockRequire.NoError(errors.New("some error"))
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestErrorWrapper(t *testing.T) {
+	require := New(t)
+	require.Error(errors.New("some error"))
+
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+	mockRequire.Error(nil)
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestEqualErrorWrapper(t *testing.T) {
+	require := New(t)
+	require.EqualError(errors.New("some error"), "some error")
+
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+	mockRequire.EqualError(errors.New("some error"), "Not some error")
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestEmptyWrapper(t *testing.T) {
+	require := New(t)
+	require.Empty("")
+
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+	mockRequire.Empty("x")
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestNotEmptyWrapper(t *testing.T) {
+	require := New(t)
+	require.NotEmpty("x")
+
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+	mockRequire.NotEmpty("")
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestWithinDurationWrapper(t *testing.T) {
+	require := New(t)
+	a := time.Now()
+	b := a.Add(10 * time.Second)
+
+	require.WithinDuration(a, b, 15*time.Second)
+
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+	mockRequire.WithinDuration(a, b, 5*time.Second)
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestInDeltaWrapper(t *testing.T) {
+	require := New(t)
+	require.InDelta(1.001, 1, 0.01)
+
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+	mockRequire.InDelta(1, 2, 0.5)
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}

--- a/require/requirements.go
+++ b/require/requirements.go
@@ -89,6 +89,16 @@ func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	}
 }
 
+// Len asserts that the specified object has specific length.
+// Len also fails if the object has a type that len() not accept.
+//
+//    require.Len(t, mySlice, 3, "The size of slice is not 3")
+func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) {
+	if !assert.Len(t, object, length, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
 // True asserts that the specified value is true.
 //
 //    require.True(t, myBool, "myBool should be true")
@@ -119,7 +129,7 @@ func NotEqual(t TestingT, expected, actual interface{}, msgAndArgs ...interface{
 // Contains asserts that the specified string contains the specified substring.
 //
 //    require.Contains(t, "Hello World", "World", "But 'Hello World' does contain 'World'")
-func Contains(t TestingT, s, contains string, msgAndArgs ...interface{}) {
+func Contains(t TestingT, s, contains interface{}, msgAndArgs ...interface{}) {
 	if !assert.Contains(t, s, contains, msgAndArgs...) {
 		t.FailNow()
 	}
@@ -128,7 +138,7 @@ func Contains(t TestingT, s, contains string, msgAndArgs ...interface{}) {
 // NotContains asserts that the specified string does NOT contain the specified substring.
 //
 //    require.NotContains(t, "Hello World", "Earth", "But 'Hello World' does NOT contain 'Earth'")
-func NotContains(t TestingT, s, contains string, msgAndArgs ...interface{}) {
+func NotContains(t TestingT, s, contains interface{}, msgAndArgs ...interface{}) {
 	if !assert.NotContains(t, s, contains, msgAndArgs...) {
 		t.FailNow()
 	}
@@ -184,6 +194,26 @@ func InDelta(t TestingT, expected, actual interface{}, delta float64, msgAndArgs
 // InEpsilon asserts that expected and actual have a relative error less than epsilon
 func InEpsilon(t TestingT, expected, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
 	if !assert.InEpsilon(t, expected, actual, epsilon, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// Regexp asserts that a specified regexp matches a string.
+//
+//  require.Regexp(t, regexp.MustCompile("start"), "it's starting")
+//  require.Regexp(t, "start...$", "it's not starting")
+func Regexp(t TestingT, rx interface{}, str interface{}) {
+	if !assert.Regexp(t, rx, str) {
+		t.FailNow()
+	}
+}
+
+// NotRegexp asserts that a specified regexp does not match a string.
+//
+//  require.NotRegexp(t, regexp.MustCompile("starts"), "it's starting")
+//  require.NotRegexp(t, "^start", "it's not starting")
+func NotRegexp(t TestingT, rx interface{}, str interface{}) {
+	if !assert.NotRegexp(t, rx, str) {
 		t.FailNow()
 	}
 }

--- a/require/requirements.go
+++ b/require/requirements.go
@@ -35,8 +35,6 @@ func IsType(t TestingT, expectedType interface{}, object interface{}, msgAndArgs
 // Equal asserts that two objects are equal.
 //
 //    require.Equal(t, 123, 123, "123 and 123 should be equal")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func Equal(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) {
 	if !assert.Equal(t, expected, actual, msgAndArgs...) {
 		t.FailNow()
@@ -46,8 +44,6 @@ func Equal(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) 
 // Exactly asserts that two objects are equal is value and type.
 //
 //    require.Exactly(t, int32(123), int64(123), "123 and 123 should NOT be equal")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func Exactly(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) {
 	if !assert.Exactly(t, expected, actual, msgAndArgs...) {
 		t.FailNow()
@@ -57,8 +53,6 @@ func Exactly(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}
 // NotNil asserts that the specified object is not nil.
 //
 //    require.NotNil(t, err, "err should be something")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if !assert.NotNil(t, object, msgAndArgs...) {
 		t.FailNow()
@@ -68,8 +62,6 @@ func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 // Nil asserts that the specified object is nil.
 //
 //    require.Nil(t, err, "err should be nothing")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if !assert.Nil(t, object, msgAndArgs...) {
 		t.FailNow()
@@ -80,8 +72,6 @@ func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 // a slice or a channel with len == 0.
 //
 // require.Empty(t, obj)
-//
-// Returns whether the assertion was successful (true) or not (false).
 func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if !assert.Empty(t, object, msgAndArgs...) {
 		t.FailNow()
@@ -93,8 +83,6 @@ func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 //
 // require.NotEmpty(t, obj)
 // require.Equal(t, "one", obj[0])
-//
-// Returns whether the assertion was successful (true) or not (false).
 func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if !assert.NotEmpty(t, object, msgAndArgs...) {
 		t.FailNow()
@@ -104,8 +92,6 @@ func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 // True asserts that the specified value is true.
 //
 //    require.True(t, myBool, "myBool should be true")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func True(t TestingT, value bool, msgAndArgs ...interface{}) {
 	if !assert.True(t, value, msgAndArgs...) {
 		t.FailNow()
@@ -115,8 +101,6 @@ func True(t TestingT, value bool, msgAndArgs ...interface{}) {
 // False asserts that the specified value is true.
 //
 //    require.False(t, myBool, "myBool should be false")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func False(t TestingT, value bool, msgAndArgs ...interface{}) {
 	if !assert.False(t, value, msgAndArgs...) {
 		t.FailNow()
@@ -126,8 +110,6 @@ func False(t TestingT, value bool, msgAndArgs ...interface{}) {
 // NotEqual asserts that the specified values are NOT equal.
 //
 //    require.NotEqual(t, obj1, obj2, "two objects shouldn't be equal")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func NotEqual(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) {
 	if !assert.NotEqual(t, expected, actual, msgAndArgs...) {
 		t.FailNow()
@@ -137,8 +119,6 @@ func NotEqual(t TestingT, expected, actual interface{}, msgAndArgs ...interface{
 // Contains asserts that the specified string contains the specified substring.
 //
 //    require.Contains(t, "Hello World", "World", "But 'Hello World' does contain 'World'")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func Contains(t TestingT, s, contains string, msgAndArgs ...interface{}) {
 	if !assert.Contains(t, s, contains, msgAndArgs...) {
 		t.FailNow()
@@ -148,8 +128,6 @@ func Contains(t TestingT, s, contains string, msgAndArgs ...interface{}) {
 // NotContains asserts that the specified string does NOT contain the specified substring.
 //
 //    require.NotContains(t, "Hello World", "Earth", "But 'Hello World' does NOT contain 'Earth'")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func NotContains(t TestingT, s, contains string, msgAndArgs ...interface{}) {
 	if !assert.NotContains(t, s, contains, msgAndArgs...) {
 		t.FailNow()
@@ -168,8 +146,6 @@ func Condition(t TestingT, comp assert.Comparison, msgAndArgs ...interface{}) {
 //   require.Panics(t, func(){
 //     GoCrazy()
 //   }, "Calling GoCrazy() should panic")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func Panics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	if !assert.Panics(t, f, msgAndArgs...) {
 		t.FailNow()
@@ -181,8 +157,6 @@ func Panics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 //   require.NotPanics(t, func(){
 //     RemainCalm()
 //   }, "Calling RemainCalm() should NOT panic")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func NotPanics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	if !assert.NotPanics(t, f, msgAndArgs...) {
 		t.FailNow()
@@ -192,8 +166,6 @@ func NotPanics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 // WithinDuration asserts that the two times are within duration delta of each other.
 //
 //   require.WithinDuration(t, time.Now(), time.Now(), 10*time.Second, "The difference should not be more than 10s")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func WithinDuration(t TestingT, expected, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) {
 	if !assert.WithinDuration(t, expected, actual, delta, msgAndArgs...) {
 		t.FailNow()
@@ -203,8 +175,6 @@ func WithinDuration(t TestingT, expected, actual time.Time, delta time.Duration,
 // InDelta asserts that the two numerals are within delta of each other.
 //
 //   require.InDelta(t, math.Pi, (22 / 7.0), 0.01)
-//
-// Returns whether the assertion was successful (true) or not (false).
 func InDelta(t TestingT, expected, actual interface{}, delta float64, msgAndArgs ...interface{}) {
 	if !assert.InDelta(t, expected, actual, delta, msgAndArgs...) {
 		t.FailNow()
@@ -212,8 +182,6 @@ func InDelta(t TestingT, expected, actual interface{}, delta float64, msgAndArgs
 }
 
 // InEpsilon asserts that expected and actual have a relative error less than epsilon
-//
-// Returns whether the assertion was successful (true) or not (false).
 func InEpsilon(t TestingT, expected, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
 	if !assert.InEpsilon(t, expected, actual, epsilon, msgAndArgs...) {
 		t.FailNow()
@@ -243,8 +211,6 @@ func NoError(t TestingT, err error, msgAndArgs ...interface{}) {
 //   require.Error(t, err, "An error was expected")
 //   require.Equal(t, err, expectedError)
 //   }
-//
-// Returns whether the assertion was successful (true) or not (false).
 func Error(t TestingT, err error, msgAndArgs ...interface{}) {
 	if !assert.Error(t, err, msgAndArgs...) {
 		t.FailNow()
@@ -258,8 +224,6 @@ func Error(t TestingT, err error, msgAndArgs ...interface{}) {
 //   require.Error(t, err, "An error was expected")
 //   require.Equal(t, err, expectedError)
 //   }
-//
-// Returns whether the assertion was successful (true) or not (false).
 func EqualError(t TestingT, theError error, errString string, msgAndArgs ...interface{}) {
 	if !assert.EqualError(t, theError, errString, msgAndArgs...) {
 		t.FailNow()


### PR DESCRIPTION
The motivation for this PR is to get stop-on-assertion-failure semantics for assert methods in a test suite. Example:

```go
type MySuite struct {
    suite.Suite
    *require.Assertions // override the default assertions
}

func (s *MySuite) TestAddition() {
    s.Equal(3, 1+1) // should fail and exit
    s.Equal(5, 2+2) // this failure should not be part of the output
}
```

This PR contains the following changes:

- A new struct `require.Assertions` which is identical to `assert.Assertions` + tests.
- Update the `require` package to match the `assert` package (`Len`, `Regexp`, `NotRegexp` was missing, `Contains` and `NotContains` had different signatures).
- Correct documentation for `require`, which currently states that `bool`s are returned when in fact they aren't.