### PR TITLE
Add getters for *assert.Assertions and *require.Assertions

### DIFF
--- a/suite/suite.go
+++ b/suite/suite.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var matchMethod = flag.String("m", "", "regular expression to select tests of the suite to run")
@@ -17,7 +18,8 @@ var matchMethod = flag.String("m", "", "regular expression to select tests of th
 // retrieving the current *testing.T context.
 type Suite struct {
 	*assert.Assertions
-	t *testing.T
+	require *require.Assertions
+	t       *testing.T
 }
 
 // T retrieves the current *testing.T context.
@@ -29,6 +31,26 @@ func (suite *Suite) T() *testing.T {
 func (suite *Suite) SetT(t *testing.T) {
 	suite.t = t
 	suite.Assertions = assert.New(t)
+}
+
+// Require returns a require context for suite.
+func (suite *Suite) Require() *require.Assertions {
+	if suite.require == nil {
+		suite.require = require.New(suite.T())
+	}
+	return suite.require
+}
+
+// Assert returns an assert context for suite.  Normally, you can call
+// `suite.NoError(expected, actual)`, but for situations where the embedded
+// methods are overridden (for example, you might want to override
+// assert.Assertions with require.Assertions), this method is provided so you
+// can call `suite.Assert().NoError()`.
+func (suite *Suite) Assert() *assert.Assertions {
+	if suite.Assertions == nil {
+		suite.Assertions = assert.New(suite.T())
+	}
+	return suite.Assertions
 }
 
 // Run takes a testing suite and runs all of the tests attached

--- a/suite/suite_test.go
+++ b/suite/suite_test.go
@@ -139,6 +139,15 @@ func TestRunSuite(t *testing.T) {
 
 }
 
+func TestSuiteGetters(t *testing.T) {
+	suite := new(SuiteTester)
+	suite.SetT(t)
+	assert.NotNil(t, suite.Assert())
+	assert.Equal(t, suite.Assertions, suite.Assert())
+	assert.NotNil(t, suite.Require())
+	assert.Equal(t, suite.require, suite.Require())
+}
+
 type SuiteLoggingTester struct {
 	Suite
 }


### PR DESCRIPTION
Added getter methods to the `Suite` type for both `*assert.Assertions` and `*require.Assertions`.  This allows the following:

```go
func (ste *SomeSuite) TestSomething() {
    someVar, err := someFuncWithErrors()
    ste.Require().NoError(err)
    ste.Equal(expectedVar, someVar)
}

type RequireSuite struct {
    Suite
    *require.Assertions
}

func (ste *RequireSuite) SetT(t *testing.T) {
    ste.Assertions = require.New(t)
    ste.Suite.SetT(t)
}

func (ste *RequireSuite) TestSomething() {
    someVar, err := someFuncWithErrors()
    ste.NoError(err)
    ste.Assert().Equal(expectedVar, someVar)
}
```