### PR TITLE
Fixed regexp messages.  Resolves #120.

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -751,12 +751,12 @@ func matchRegexp(rx interface{}, str interface{}) bool {
 //  assert.Regexp(t, "start...$", "it's not starting")
 //
 // Returns whether the assertion was successful (true) or not (false).
-func Regexp(t TestingT, rx interface{}, str interface{}) bool {
+func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) bool {
 
 	match := matchRegexp(rx, str)
 
 	if !match {
-		Fail(t, "Expect \"%v\" to match \"%v\"", str, rx)
+		Fail(t, fmt.Sprintf("Expect \"%v\" to match \"%v\"", str, rx), msgAndArgs...)
 	}
 
 	return match
@@ -768,11 +768,11 @@ func Regexp(t TestingT, rx interface{}, str interface{}) bool {
 //  assert.NotRegexp(t, "^start", "it's not starting")
 //
 // Returns whether the assertion was successful (true) or not (false).
-func NotRegexp(t TestingT, rx interface{}, str interface{}) bool {
+func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) bool {
 	match := matchRegexp(rx, str)
 
 	if match {
-		Fail(t, "Expect \"%v\" to NOT match \"%v\"", str, rx)
+		Fail(t, fmt.Sprintf("Expect \"%v\" to NOT match \"%v\"", str, rx), msgAndArgs...)
 	}
 
 	return !match

--- a/assert/forward_assertions.go
+++ b/assert/forward_assertions.go
@@ -237,8 +237,8 @@ func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...
 //  assert.Regexp(t, "start...$", "it's not starting")
 //
 // Returns whether the assertion was successful (true) or not (false).
-func (a *Assertions) Regexp(rx interface{}, str interface{}) bool {
-	return Regexp(a.t, rx, str)
+func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) bool {
+	return Regexp(a.t, rx, str, msgAndArgs...)
 }
 
 // NotRegexp asserts that a specified regexp does not match a string.
@@ -247,6 +247,6 @@ func (a *Assertions) Regexp(rx interface{}, str interface{}) bool {
 //  assert.NotRegexp(t, "^start", "it's not starting")
 //
 // Returns whether the assertion was successful (true) or not (false).
-func (a *Assertions) NotRegexp(rx interface{}, str interface{}) bool {
-	return NotRegexp(a.t, rx, str)
+func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) bool {
+	return NotRegexp(a.t, rx, str, msgAndArgs...)
 }

--- a/require/forward_requirements.go
+++ b/require/forward_requirements.go
@@ -198,14 +198,14 @@ func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...
 //
 //  require.Regexp(t, regexp.MustCompile("start"), "it's starting")
 //  require.Regexp(t, "start...$", "it's not starting")
-func (a *Assertions) Regexp(rx interface{}, str interface{}) {
-	Regexp(a.t, rx, str)
+func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+	Regexp(a.t, rx, str, msgAndArgs...)
 }
 
 // NotRegexp asserts that a specified regexp does not match a string.
 //
 //  require.NotRegexp(t, regexp.MustCompile("starts"), "it's starting")
 //  require.NotRegexp(t, "^start", "it's not starting")
-func (a *Assertions) NotRegexp(rx interface{}, str interface{}) {
-	NotRegexp(a.t, rx, str)
+func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+	NotRegexp(a.t, rx, str, msgAndArgs...)
 }

--- a/require/requirements.go
+++ b/require/requirements.go
@@ -1,8 +1,9 @@
 package require
 
 import (
-	"github.com/stretchr/testify/assert"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type TestingT interface {
@@ -202,8 +203,8 @@ func InEpsilon(t TestingT, expected, actual interface{}, epsilon float64, msgAnd
 //
 //  require.Regexp(t, regexp.MustCompile("start"), "it's starting")
 //  require.Regexp(t, "start...$", "it's not starting")
-func Regexp(t TestingT, rx interface{}, str interface{}) {
-	if !assert.Regexp(t, rx, str) {
+func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+	if !assert.Regexp(t, rx, str, msgAndArgs...) {
 		t.FailNow()
 	}
 }
@@ -212,8 +213,8 @@ func Regexp(t TestingT, rx interface{}, str interface{}) {
 //
 //  require.NotRegexp(t, regexp.MustCompile("starts"), "it's starting")
 //  require.NotRegexp(t, "^start", "it's not starting")
-func NotRegexp(t TestingT, rx interface{}, str interface{}) {
-	if !assert.NotRegexp(t, rx, str) {
+func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+	if !assert.NotRegexp(t, rx, str, msgAndArgs...) {
 		t.FailNow()
 	}
 }


### PR DESCRIPTION
I've also added the typical `msgAndArgs ...interface{}` argument to the Regexp calls, for consistency's sake.