### PR TITLE
When testing the equality after conversion, test the underlying values

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -43,8 +43,15 @@ func ObjectsAreEqual(expected, actual interface{}) bool {
 	}
 
 	// Attempt comparison after type conversion
-	if actualValue.Type().ConvertibleTo(expectedValue.Type()) && expectedValue == actualValue.Convert(expectedValue.Type()) {
-		return true
+	if actualValue.Type().ConvertibleTo(expectedValue.Type()) {
+		convertedValue := actualValue.Convert(expectedValue.Type())
+		if expectedValue == convertedValue {
+			return true
+		}
+
+		if expectedValue.Type().Comparable() && expectedValue.Interface() == convertedValue.Interface() {
+			return true
+		}
 	}
 
 	// Last ditch effort


### PR DESCRIPTION
In 1.4, comparisons between `int`s and `uint`s seem not to work. This may be
because in 1.4, interface values are always stored as pointers:

> The implementation of interface values has been modified. In earlier
> releases, the interface contained a word that was either a pointer or a
> one-word scalar value, depending on the type of the concrete object stored.
> This implementation was problematical for the garbage collector, so as of
> 1.4 interface values always hold a pointer.

(from https://golang.org/doc/go1.4)

So, when the assertion code obtains a reflect.Value struct, and compares it
with the expected reflect.Value, it may be comparing the pointers held by
that object, and not the scalar value.

Either way, comparing the underlying value of the reflect.Value structs
appears to fix the tests, and by extension #112.

Thanks for the awesome library!