### PR TITLE
Exclude `ConvertibleTo` from equality test

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -36,15 +36,6 @@ func ObjectsAreEqual(expected, actual interface{}) bool {
 		return true
 	}
 
-	actualType := reflect.TypeOf(actual)
-	expectedValue := reflect.ValueOf(expected)
-	if expectedValue.Type().ConvertibleTo(actualType) {
-		// Attempt comparison after type conversion
-		if reflect.DeepEqual(actual, expectedValue.Convert(actualType).Interface()) {
-			return true
-		}
-	}
-
 	// Last ditch effort
 	if fmt.Sprintf("%#v", expected) == fmt.Sprintf("%#v", actual) {
 		return true

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -43,6 +43,18 @@ func TestObjectsAreEqual(t *testing.T) {
 	if ObjectsAreEqual(map[int]int{5: 10}, map[int]int{10: 20}) {
 		t.Error("objectsAreEqual should return false")
 	}
+	if ObjectsAreEqual('x', "x") {
+		t.Error("objectsAreEqual should return false")
+	}
+	if ObjectsAreEqual("x", 'x') {
+		t.Error("objectsAreEqual should return false")
+	}
+	if ObjectsAreEqual(0, 0.1) {
+		t.Error("objectsAreEqual should return false")
+	}
+	if ObjectsAreEqual(0.1, 0) {
+		t.Error("objectsAreEqual should return false")
+	}
 
 }
 
@@ -91,10 +103,10 @@ func TestEqual(t *testing.T) {
 	if !Equal(mockT, nil, nil) {
 		t.Error("Equal should return true")
 	}
-	if !Equal(mockT, int32(123), int64(123)) {
+	if !Equal(mockT, int32(123), int32(123)) {
 		t.Error("Equal should return true")
 	}
-	if !Equal(mockT, int64(123), uint64(123)) {
+	if !Equal(mockT, uint64(123), uint64(123)) {
 		t.Error("Equal should return true")
 	}
 	funcA := func() int { return 42 }


### PR DESCRIPTION
`ObjectsAreEqual` using `ConvertibleTo` causes the `ObjectsAreEqual` function to be asymmetrical and producing incorrect assertions.

To give a few invalid examples that this patch fixes:

* `ObjectsAreEqual(2.2, 2) == true` but `ObjectsAreEqual(2, 2.2) == false`
* `ObjectsAreEqual('x', "x") == true` but `ObjectsAreEqual("x", 'x') == false`