### PR TITLE
Fix reversed vars in EqualError plus some golint stuff

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -405,11 +405,11 @@ func getLen(x interface{}) (ok bool, length int) {
 func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) bool {
 	ok, l := getLen(object)
 	if !ok {
-		return Fail(t, fmt.Sprintf("\"%s\" could not be applied builtin len()", object), msgAndArgs...)
+		return Fail(t, fmt.Sprintf("%q could not be applied builtin len()", object), msgAndArgs...)
 	}
 
 	if l != length {
-		return Fail(t, fmt.Sprintf("\"%s\" should have %d item(s), but has %d", object, length, l), msgAndArgs...)
+		return Fail(t, fmt.Sprintf("%q should have %d item(s), but has %d", object, length, l), msgAndArgs...)
 	}
 	return true
 }
@@ -498,10 +498,10 @@ func Contains(t TestingT, s, contains interface{}, msgAndArgs ...interface{}) bo
 
 	ok, found := includeElement(s, contains)
 	if !ok {
-		return Fail(t, fmt.Sprintf("\"%s\" could not be applied builtin len()", s), msgAndArgs...)
+		return Fail(t, fmt.Sprintf("%q could not be applied builtin len()", s), msgAndArgs...)
 	}
 	if !found {
-		return Fail(t, fmt.Sprintf("\"%s\" does not contain \"%s\"", s, contains), msgAndArgs...)
+		return Fail(t, fmt.Sprintf("%q does not contain %q", s, contains), msgAndArgs...)
 	}
 
 	return true
@@ -519,10 +519,10 @@ func NotContains(t TestingT, s, contains interface{}, msgAndArgs ...interface{})
 
 	ok, found := includeElement(s, contains)
 	if !ok {
-		return Fail(t, fmt.Sprintf("\"%s\" could not be applied builtin len()", s), msgAndArgs...)
+		return Fail(t, fmt.Sprintf("%q could not be applied builtin len()", s), msgAndArgs...)
 	}
 	if found {
-		return Fail(t, fmt.Sprintf("\"%s\" should not contain \"%s\"", s, contains), msgAndArgs...)
+		return Fail(t, fmt.Sprintf("%q should not contain %q", s, contains), msgAndArgs...)
 	}
 
 	return true
@@ -751,9 +751,9 @@ func EqualError(t TestingT, theError error, errString string, msgAndArgs ...inte
 	if !NotNil(t, theError, "An error is expected but got nil. %s", message) {
 		return false
 	}
-	s := "An error with value \"%s\" is expected but got \"%s\". %s"
+	s := "An error with value %q is expected but got %q. %s"
 	return Equal(t, theError.Error(), errString,
-		s, errString, theError.Error(), message)
+		s, theError.Error(), errString, message)
 }
 
 // matchRegexp return true if a specified regexp matches a string.

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -760,7 +760,7 @@ func TestRegexp(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		False(t, Regexp(mockT, tc.rx, tc.str), "Expected \"%s\" to not match \"%s\"", tc.rx, tc.str)
+		False(t, Regexp(mockT, tc.rx, tc.str), "Expected %q to not match %q", tc.rx, tc.str)
 		False(t, Regexp(mockT, regexp.MustCompile(tc.rx), tc.str))
 		True(t, NotRegexp(mockT, tc.rx, tc.str))
 		True(t, NotRegexp(mockT, regexp.MustCompile(tc.rx), tc.str))

--- a/assert/doc.go
+++ b/assert/doc.go
@@ -1,4 +1,4 @@
-// A set of comprehensive testing tools for use with the normal Go testing system.
+// Package assert contains a set of comprehensive testing tools for use with the normal Go testing system.
 //
 // Example Usage
 //

--- a/assert/forward_assertions_test.go
+++ b/assert/forward_assertions_test.go
@@ -259,9 +259,9 @@ func TestEqualWrapper_Funcs(t *testing.T) {
 	var f1 f = func() int { return 1 }
 	var f2 f = func() int { return 2 }
 
-	var f1_copy f = f1
+	var f1Copy = f1
 
-	assert.Equal(f1_copy, f1, "Funcs are the same and should be considered equal")
+	assert.Equal(f1Copy, f1, "Funcs are the same and should be considered equal")
 	assert.NotEqual(f1, f2, "f1 and f2 are different")
 
 }
@@ -271,7 +271,7 @@ func TestNoErrorWrapper(t *testing.T) {
 	mockAssert := New(new(testing.T))
 
 	// start with a nil error
-	var err error = nil
+	var err error
 
 	assert.True(mockAssert.NoError(err), "NoError should return True for nil arg")
 
@@ -287,7 +287,7 @@ func TestErrorWrapper(t *testing.T) {
 	mockAssert := New(new(testing.T))
 
 	// start with a nil error
-	var err error = nil
+	var err error
 
 	assert.False(mockAssert.Error(err), "Error should return False for nil arg")
 
@@ -510,7 +510,7 @@ func TestRegexpWrapper(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		False(t, assert.Regexp(tc.rx, tc.str), "Expected \"%s\" to not match \"%s\"", tc.rx, tc.str)
+		False(t, assert.Regexp(tc.rx, tc.str), "Expected %q to not match %q", tc.rx, tc.str)
 		False(t, assert.Regexp(regexp.MustCompile(tc.rx), tc.str))
 		True(t, assert.NotRegexp(tc.rx, tc.str))
 		True(t, assert.NotRegexp(regexp.MustCompile(tc.rx), tc.str))

--- a/assert/http_assertions.go
+++ b/assert/http_assertions.go
@@ -59,9 +59,9 @@ func HTTPError(t TestingT, handler http.HandlerFunc, mode, url string, values ur
 	return code >= http.StatusBadRequest
 }
 
-// HttpBody is a helper that returns HTTP body of the response. It returns
+// HTTPBody is a helper that returns HTTP body of the response. It returns
 // empty string if building a new request fails.
-func HttpBody(handler http.HandlerFunc, mode, url string, values url.Values) string {
+func HTTPBody(handler http.HandlerFunc, mode, url string, values url.Values) string {
 	w := httptest.NewRecorder()
 	req, err := http.NewRequest(mode, url+"?"+values.Encode(), nil)
 	if err != nil {
@@ -78,11 +78,11 @@ func HttpBody(handler http.HandlerFunc, mode, url string, values url.Values) str
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPBodyContains(t TestingT, handler http.HandlerFunc, mode, url string, values url.Values, str interface{}) bool {
-	body := HttpBody(handler, mode, url, values)
+	body := HTTPBody(handler, mode, url, values)
 
 	contains := strings.Contains(body, fmt.Sprint(str))
 	if !contains {
-		Fail(t, fmt.Sprintf("Expected response body for \"%s\" to contain \"%s\" but found \"%s\"", url+"?"+values.Encode(), str, body))
+		Fail(t, fmt.Sprintf("Expected response body for %q to contain %q but found %q", url+"?"+values.Encode(), str, body))
 	}
 
 	return contains
@@ -95,11 +95,11 @@ func HTTPBodyContains(t TestingT, handler http.HandlerFunc, mode, url string, va
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPBodyNotContains(t TestingT, handler http.HandlerFunc, mode, url string, values url.Values, str interface{}) bool {
-	body := HttpBody(handler, mode, url, values)
+	body := HTTPBody(handler, mode, url, values)
 
 	contains := strings.Contains(body, fmt.Sprint(str))
 	if contains {
-		Fail(t, "Expected response body for %s to NOT contain \"%s\" but found \"%s\"", url+"?"+values.Encode(), str, body)
+		Fail(t, "Expected response body for %s to NOT contain %q but found %q", url+"?"+values.Encode(), str, body)
 	}
 
 	return !contains

--- a/assert/http_assertions_test.go
+++ b/assert/http_assertions_test.go
@@ -58,7 +58,7 @@ func httpHelloName(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(fmt.Sprintf("Hello, %s!", name)))
 }
 
-func TestHttpBody(t *testing.T) {
+func TestHTTPBody(t *testing.T) {
 	assert := New(t)
 	mockT := new(testing.T)
 
@@ -71,7 +71,7 @@ func TestHttpBody(t *testing.T) {
 	assert.True(HTTPBodyNotContains(mockT, httpHelloName, "GET", "/", url.Values{"name": []string{"World"}}, "world"))
 }
 
-func TestHttpBodyWrappers(t *testing.T) {
+func TestHTTPBodyWrappers(t *testing.T) {
 	assert := New(t)
 	mockAssert := New(new(testing.T))
 

--- a/doc.go
+++ b/doc.go
@@ -1,6 +1,4 @@
-// A set of packages that provide many tools for testifying that your code will behave as you intend.
-//
-// testify contains the following packages:
+// Package testify contains a set of packages that provide many tools for testifying that your code will behave as you intend.
 //
 // The assert package provides a comprehensive set of assertion functions that tie in to the Go testing system.
 //

--- a/http/doc.go
+++ b/http/doc.go
@@ -1,2 +1,2 @@
-//  A set of tools to make testing http activity using the Go testing system easier.
+// Package http constains a set of tools to make testing http activity using the Go testing system easier.
 package http

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -2,8 +2,9 @@ package mock
 
 import (
 	"errors"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 /*
@@ -42,7 +43,7 @@ func (i *TestExampleImplementation) TheExampleMethod3(et *ExampleType) error {
 
 func Test_Mock_TestData(t *testing.T) {
 
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	mockedService := &TestExampleImplementation{}
 
 	if assert.NotNil(t, mockedService.TestData()) {
 
@@ -56,7 +57,7 @@ func Test_Mock_TestData(t *testing.T) {
 func Test_Mock_On(t *testing.T) {
 
 	// make a test impl object
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	mockedService := &TestExampleImplementation{}
 
 	assert.Equal(t, mockedService.On("TheExampleMethod"), &mockedService.Mock)
 	assert.Equal(t, "TheExampleMethod", mockedService.onMethodName)
@@ -66,7 +67,7 @@ func Test_Mock_On(t *testing.T) {
 func Test_Mock_On_WithArgs(t *testing.T) {
 
 	// make a test impl object
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	mockedService := &TestExampleImplementation{}
 
 	assert.Equal(t, mockedService.On("TheExampleMethod", 1, 2, 3), &mockedService.Mock)
 	assert.Equal(t, "TheExampleMethod", mockedService.onMethodName)
@@ -79,7 +80,7 @@ func Test_Mock_On_WithArgs(t *testing.T) {
 func Test_Mock_Return(t *testing.T) {
 
 	// make a test impl object
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	mockedService := &TestExampleImplementation{}
 
 	assert.Equal(t, mockedService.On("TheExampleMethod", "A", "B", true).Return(1, "two", true), &mockedService.Mock)
 
@@ -103,7 +104,7 @@ func Test_Mock_Return(t *testing.T) {
 func Test_Mock_Return_Once(t *testing.T) {
 
 	// make a test impl object
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	mockedService := &TestExampleImplementation{}
 
 	mockedService.On("TheExampleMethod", "A", "B", true).Return(1, "two", true).Once()
 
@@ -127,7 +128,7 @@ func Test_Mock_Return_Once(t *testing.T) {
 func Test_Mock_Return_Twice(t *testing.T) {
 
 	// make a test impl object
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	mockedService := &TestExampleImplementation{}
 
 	mockedService.On("TheExampleMethod", "A", "B", true).Return(1, "two", true).Twice()
 
@@ -151,7 +152,7 @@ func Test_Mock_Return_Twice(t *testing.T) {
 func Test_Mock_Return_Times(t *testing.T) {
 
 	// make a test impl object
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	mockedService := &TestExampleImplementation{}
 
 	mockedService.On("TheExampleMethod", "A", "B", true).Return(1, "two", true).Times(5)
 
@@ -175,7 +176,7 @@ func Test_Mock_Return_Times(t *testing.T) {
 func Test_Mock_Return_Nothing(t *testing.T) {
 
 	// make a test impl object
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	mockedService := &TestExampleImplementation{}
 
 	assert.Equal(t, mockedService.On("TheExampleMethod", "A", "B", true).Return(), &mockedService.Mock)
 
@@ -253,7 +254,7 @@ func Test_callString(t *testing.T) {
 
 func Test_Mock_Called(t *testing.T) {
 
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	mockedService := &TestExampleImplementation{}
 
 	mockedService.On("Test_Mock_Called", 1, 2, 3).Return(5, "6", true)
 
@@ -276,7 +277,7 @@ func Test_Mock_Called(t *testing.T) {
 
 func Test_Mock_Called_For_Bounded_Repeatability(t *testing.T) {
 
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	mockedService := &TestExampleImplementation{}
 
 	mockedService.On("Test_Mock_Called_For_Bounded_Repeatability", 1, 2, 3).Return(5, "6", true).Once()
 	mockedService.On("Test_Mock_Called_For_Bounded_Repeatability", 1, 2, 3).Return(-1, "hi", false)
@@ -312,7 +313,7 @@ func Test_Mock_Called_For_Bounded_Repeatability(t *testing.T) {
 
 func Test_Mock_Called_For_SetTime_Expectation(t *testing.T) {
 
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	mockedService := &TestExampleImplementation{}
 
 	mockedService.On("TheExampleMethod", 1, 2, 3).Return(5, "6", true).Times(4)
 
@@ -328,7 +329,7 @@ func Test_Mock_Called_For_SetTime_Expectation(t *testing.T) {
 
 func Test_Mock_Called_Unexpected(t *testing.T) {
 
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	mockedService := &TestExampleImplementation{}
 
 	// make sure it panics if no expectation was made
 	assert.Panics(t, func() {
@@ -339,9 +340,9 @@ func Test_Mock_Called_Unexpected(t *testing.T) {
 
 func Test_AssertExpectationsForObjects_Helper(t *testing.T) {
 
-	var mockedService1 *TestExampleImplementation = new(TestExampleImplementation)
-	var mockedService2 *TestExampleImplementation = new(TestExampleImplementation)
-	var mockedService3 *TestExampleImplementation = new(TestExampleImplementation)
+	mockedService1 := &TestExampleImplementation{}
+	mockedService2 := &TestExampleImplementation{}
+	mockedService3 := &TestExampleImplementation{}
 
 	mockedService1.On("Test_AssertExpectationsForObjects_Helper", 1).Return()
 	mockedService2.On("Test_AssertExpectationsForObjects_Helper", 2).Return()
@@ -357,9 +358,9 @@ func Test_AssertExpectationsForObjects_Helper(t *testing.T) {
 
 func Test_AssertExpectationsForObjects_Helper_Failed(t *testing.T) {
 
-	var mockedService1 *TestExampleImplementation = new(TestExampleImplementation)
-	var mockedService2 *TestExampleImplementation = new(TestExampleImplementation)
-	var mockedService3 *TestExampleImplementation = new(TestExampleImplementation)
+	mockedService1 := &TestExampleImplementation{}
+	mockedService2 := &TestExampleImplementation{}
+	mockedService3 := &TestExampleImplementation{}
 
 	mockedService1.On("Test_AssertExpectationsForObjects_Helper_Failed", 1).Return()
 	mockedService2.On("Test_AssertExpectationsForObjects_Helper_Failed", 2).Return()
@@ -375,7 +376,7 @@ func Test_AssertExpectationsForObjects_Helper_Failed(t *testing.T) {
 
 func Test_Mock_AssertExpectations(t *testing.T) {
 
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	mockedService := &TestExampleImplementation{}
 
 	mockedService.On("Test_Mock_AssertExpectations", 1, 2, 3).Return(5, 6, 7)
 
@@ -392,7 +393,7 @@ func Test_Mock_AssertExpectations(t *testing.T) {
 
 func Test_Mock_AssertExpectationsCustomType(t *testing.T) {
 
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	mockedService := &TestExampleImplementation{}
 
 	mockedService.On("TheExampleMethod3", AnythingOfType("*mock.ExampleType")).Return(nil).Once()
 
@@ -409,7 +410,7 @@ func Test_Mock_AssertExpectationsCustomType(t *testing.T) {
 
 func Test_Mock_AssertExpectations_With_Repeatability(t *testing.T) {
 
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	mockedService := &TestExampleImplementation{}
 
 	mockedService.On("Test_Mock_AssertExpectations_With_Repeatability", 1, 2, 3).Return(5, 6, 7).Twice()
 
@@ -430,7 +431,7 @@ func Test_Mock_AssertExpectations_With_Repeatability(t *testing.T) {
 
 func Test_Mock_TwoCallsWithDifferentArguments(t *testing.T) {
 
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	mockedService := &TestExampleImplementation{}
 
 	mockedService.On("Test_Mock_TwoCallsWithDifferentArguments", 1, 2, 3).Return(5, 6, 7)
 	mockedService.On("Test_Mock_TwoCallsWithDifferentArguments", 4, 5, 6).Return(5, 6, 7)
@@ -449,7 +450,7 @@ func Test_Mock_TwoCallsWithDifferentArguments(t *testing.T) {
 
 func Test_Mock_AssertNumberOfCalls(t *testing.T) {
 
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	mockedService := &TestExampleImplementation{}
 
 	mockedService.On("Test_Mock_AssertNumberOfCalls", 1, 2, 3).Return(5, 6, 7)
 
@@ -463,7 +464,7 @@ func Test_Mock_AssertNumberOfCalls(t *testing.T) {
 
 func Test_Mock_AssertCalled(t *testing.T) {
 
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	mockedService := &TestExampleImplementation{}
 
 	mockedService.On("Test_Mock_AssertCalled", 1, 2, 3).Return(5, 6, 7)
 
@@ -475,7 +476,7 @@ func Test_Mock_AssertCalled(t *testing.T) {
 
 func Test_Mock_AssertCalled_WithAnythingOfTypeArgument(t *testing.T) {
 
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	mockedService := &TestExampleImplementation{}
 
 	mockedService.On("Test_Mock_AssertCalled_WithAnythingOfTypeArgument", Anything, Anything, Anything).Return()
 
@@ -487,7 +488,7 @@ func Test_Mock_AssertCalled_WithAnythingOfTypeArgument(t *testing.T) {
 
 func Test_Mock_AssertCalled_WithArguments(t *testing.T) {
 
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	mockedService := &TestExampleImplementation{}
 
 	mockedService.On("Test_Mock_AssertCalled_WithArguments", 1, 2, 3).Return(5, 6, 7)
 
@@ -501,7 +502,7 @@ func Test_Mock_AssertCalled_WithArguments(t *testing.T) {
 
 func Test_Mock_AssertCalled_WithArguments_With_Repeatability(t *testing.T) {
 
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	mockedService := &TestExampleImplementation{}
 
 	mockedService.On("Test_Mock_AssertCalled_WithArguments_With_Repeatability", 1, 2, 3).Return(5, 6, 7).Once()
 	mockedService.On("Test_Mock_AssertCalled_WithArguments_With_Repeatability", 2, 3, 4).Return(5, 6, 7).Once()
@@ -518,7 +519,7 @@ func Test_Mock_AssertCalled_WithArguments_With_Repeatability(t *testing.T) {
 
 func Test_Mock_AssertNotCalled(t *testing.T) {
 
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	mockedService := &TestExampleImplementation{}
 
 	mockedService.On("Test_Mock_AssertNotCalled", 1, 2, 3).Return(5, 6, 7)
 
@@ -641,7 +642,7 @@ func Test_Arguments_String(t *testing.T) {
 
 func Test_Arguments_Error(t *testing.T) {
 
-	var err error = errors.New("An Error")
+	err := errors.New("An Error")
 	var args Arguments = []interface{}{"string", 123, true, err}
 	assert.Equal(t, err, args.Error(3))
 


### PR DESCRIPTION
This rolls in the change made in #126 plus some golint fixes.