### PR TITLE
Forwards EqualValues assertion

### DIFF
--- a/assert/forward_assertions.go
+++ b/assert/forward_assertions.go
@@ -38,6 +38,16 @@ func (a *Assertions) Equal(expected, actual interface{}, msgAndArgs ...interface
 	return Equal(a.t, expected, actual, msgAndArgs...)
 }
 
+// EqualValues asserts that two objects are equal or convertable to the same types
+// and equal.
+//
+//    assert.EqualValues(uint32(123), int32(123), "123 and 123 should be equal")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) EqualValues(expected, actual interface{}, msgAndArgs ...interface{}) bool {
+	return EqualValues(a.t, expected, actual, msgAndArgs...)
+}
+
 // Exactly asserts that two objects are equal is value and type.
 //
 //    assert.Exactly(int32(123), int64(123), "123 and 123 should NOT be equal")

--- a/assert/forward_assertions_test.go
+++ b/assert/forward_assertions_test.go
@@ -50,6 +50,14 @@ func TestEqualWrapper(t *testing.T) {
 	}
 }
 
+func TestEqualValuesWrapper(t *testing.T) {
+	assert := New(new(testing.T))
+
+	if !assert.EqualValues(uint32(10), int32(10)) {
+		t.Error("EqualValues should return true")
+	}
+}
+
 func TestNotNilWrapper(t *testing.T) {
 	assert := New(new(testing.T))
 


### PR DESCRIPTION
I noticed the new EqualValues assertion, but it was conspicuously missing from forwarding_assertions. This PR adds it.