### PR TITLE
Fixed isEmpty for pointer types, and simplified it.

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -294,58 +294,10 @@ func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
 	return Fail(t, fmt.Sprintf("Expected nil, but got: %#v", object), msgAndArgs...)
 }
 
-var zeros = []interface{}{
-	int(0),
-	int8(0),
-	int16(0),
-	int32(0),
-	int64(0),
-	uint(0),
-	uint8(0),
-	uint16(0),
-	uint32(0),
-	uint64(0),
-	float32(0),
-	float64(0),
-}
-
 // isEmpty gets whether the specified object is considered empty or not.
 func isEmpty(object interface{}) bool {
-
-	if object == nil {
-		return true
-	} else if object == "" {
-		return true
-	} else if object == false {
-		return true
-	}
-
-	for _, v := range zeros {
-		if object == v {
-			return true
-		}
-	}
-
-	objValue := reflect.ValueOf(object)
-
-	switch objValue.Kind() {
-	case reflect.Map:
-		fallthrough
-	case reflect.Slice, reflect.Chan:
-		{
-			return (objValue.Len() == 0)
-		}
-	case reflect.Ptr:
-		{
-			switch object.(type) {
-			case *time.Time:
-				return object.(*time.Time).IsZero()
-			default:
-				return false
-			}
-		}
-	}
-	return false
+	value := reflect.ValueOf(object)
+	return value == reflect.Zero(value.Type())
 }
 
 // Empty asserts that the specified object is empty.  I.e. nil, "", false, 0 or either


### PR DESCRIPTION
Fixed the isEmpty bug with nil pointers.

Changed to adopt behavior consistent with reflection. Note that this is a breaking change, e.g. non-nil slices with length 0 were empty before, and now aren't.