### PR TITLE
Fix race condition with ExpectedCalls

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -112,6 +112,9 @@ func (m *Mock) On(methodName string, arguments ...interface{}) *Mock {
 //
 //     Mock.On("MyMethod", arg1, arg2).Return(returnArg1, returnArg2)
 func (m *Mock) Return(returnArguments ...interface{}) *Mock {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
 	m.ExpectedCalls = append(m.ExpectedCalls, Call{m.onMethodName, m.onMethodArguments, returnArguments, 0, nil, nil})
 	return m
 }


### PR DESCRIPTION
There is race condition caused when a method being tested calls a mocked
method within a go routine. For example, caching might be done a go
routine and that caching might be mocked.

There is already a mutex protecting the lists on the Mock object -
however Return() appends to ExpectedCalls and findExpectedCall could
run at the same time.