### PR TITLE
Suite: add support for test name prefixes

### DIFF
--- a/suite/doc.go
+++ b/suite/doc.go
@@ -18,6 +18,10 @@
 // with "Test" will not be run by testify, and can safely be used as
 // helper methods.
 //
+// For parameterized suites (which may run multiple times for different
+// scenarios), the TestNamePrefixer interface can be implemented to
+// provide meaningful prefixes to test names for each variation.
+//
 // Once you've built your testing suite, you need to run the suite
 // (using suite.Run from testify) inside any function that matches the
 // identity that "go test" is already looking for (i.e.

--- a/suite/interfaces.go
+++ b/suite/interfaces.go
@@ -32,3 +32,10 @@ type TearDownAllSuite interface {
 type TearDownTestSuite interface {
 	TearDownTest()
 }
+
+// TestNamePrefixer has a SuiteTestNamePrefix method, which will run
+// before the tests in the suite are run, causing the returned prefix
+// to be prepended to the method name of each test in the suite.
+type TestNamePrefixer interface {
+	SuiteTestNamePrefix() string
+}

--- a/suite/suite.go
+++ b/suite/suite.go
@@ -56,6 +56,12 @@ func (suite *Suite) Assert() *assert.Assertions {
 // Run takes a testing suite and runs all of the tests attached
 // to it.
 func Run(t *testing.T, suite TestingSuite) {
+	RunWithPrefix(t, suite, "")
+}
+
+// RunWithPrefix takes a testing suite and runs all of the tests attached
+// to it, prepending the specified prefix to each test name
+func RunWithPrefix(t *testing.T, suite TestingSuite, prefix string) {
 	suite.SetT(t)
 
 	if setupAllSuite, ok := suite.(SetupAllSuite); ok {
@@ -66,6 +72,10 @@ func Run(t *testing.T, suite TestingSuite) {
 			tearDownAllSuite.TearDownSuite()
 		}
 	}()
+
+	if prefixer, ok := suite.(TestNamePrefixer); ok {
+		prefix = prefixer.SuiteTestNamePrefix()
+	}
 
 	methodFinder := reflect.TypeOf(suite)
 	tests := []testing.InternalTest{}
@@ -78,7 +88,7 @@ func Run(t *testing.T, suite TestingSuite) {
 		}
 		if ok {
 			test := testing.InternalTest{
-				Name: method.Name,
+				Name: prefix + method.Name,
 				F: func(t *testing.T) {
 					parentT := suite.T()
 					suite.SetT(t)


### PR DESCRIPTION
When running parameterized test suites, output from go test (and other tooling) isn't as intuitive as it could be, with the name for each test in the suite duplicated for each variation of the suite being run.  I propose adding support for optional test name prefixes that can be used to help distinguish results in those scenarios.

This commit actually has two approaches implemented; a simple RunWithPrefix method, and a TestNamePrefixer interface that suites can implement to provide a prefix.  I'd like feedback on which route is preferred before finalizing the tests.

The RunWithPrefix should be sufficient - the caller of Run() likely created the suite and should have full context on all the options given to a parameterized suite in order to provide meaningful prefixes.

The TestNamePrefixer interface is 'safer' with regard to backward compatibility; if someone in a group (that does not vendor dependencies) uses a new version of testify and adds prefix support, other collaborators will not be forced to upgrade.  It also fits in with other suite functionality, though is a bit less concise in usage.  (FYI the interface name doesn't match method name since the implementation shouldn't be detected as a test, but I wanted to avoid stutter with the package name).


Any other feedback is welcome!