### PR TITLE
Address #159: Meaningful panic when expecting Func

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -97,6 +97,13 @@ func (m *Mock) TestData() objx.Map {
 func (m *Mock) On(methodName string, arguments ...interface{}) *Mock {
 	m.onMethodName = methodName
 	m.onMethodArguments = arguments
+
+	for _, arg := range arguments {
+		if v := reflect.ValueOf(arg); v.Kind() == reflect.Func {
+			panic(fmt.Sprintf("cannot use Func in expectations. Use mock.AnythingOfType(\"%T\")", arg))
+		}
+	}
+
 	return m
 }
 

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -39,6 +39,18 @@ func (i *TestExampleImplementation) TheExampleMethod3(et *ExampleType) error {
 	return args.Error(0)
 }
 
+func (i *TestExampleImplementation) TheExampleMethodFunc(fn func(string) error) error {
+	args := i.Called(fn)
+	return args.Error(0)
+}
+
+type ExampleFuncType func(string) error
+
+func (i *TestExampleImplementation) TheExampleMethodFuncType(fn ExampleFuncType) error {
+	args := i.Called(fn)
+	return args.Error(0)
+}
+
 /*
 	Mock
 */
@@ -76,6 +88,34 @@ func Test_Mock_On_WithArgs(t *testing.T) {
 	assert.Equal(t, 1, mockedService.onMethodArguments[0])
 	assert.Equal(t, 2, mockedService.onMethodArguments[1])
 	assert.Equal(t, 3, mockedService.onMethodArguments[2])
+
+}
+
+func Test_Mock_On_WithFuncArg(t *testing.T) {
+
+	// make a test impl object
+	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+
+	assert.Equal(t, mockedService.On("TheExampleMethodFunc", AnythingOfType("func(string) error")).Return(nil), &mockedService.Mock)
+	assert.Equal(t, "TheExampleMethodFunc", mockedService.onMethodName)
+	assert.Equal(t, AnythingOfType("func(string) error"), mockedService.onMethodArguments[0])
+
+	fn := func(string) error { return nil }
+	mockedService.TheExampleMethodFunc(fn)
+
+}
+
+func Test_Mock_On_WithFuncTypeArg(t *testing.T) {
+
+	// make a test impl object
+	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+
+	assert.Equal(t, mockedService.On("TheExampleMethodFuncType", AnythingOfType("mock.ExampleFuncType")).Return(nil), &mockedService.Mock)
+	assert.Equal(t, "TheExampleMethodFuncType", mockedService.onMethodName)
+	assert.Equal(t, AnythingOfType("mock.ExampleFuncType"), mockedService.onMethodArguments[0])
+
+	fn := func(string) error { return nil }
+	mockedService.TheExampleMethodFuncType(fn)
 
 }
 

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -105,6 +105,15 @@ func Test_Mock_On_WithFuncArg(t *testing.T) {
 
 }
 
+func Test_Mock_On_WithFuncPanics(t *testing.T) {
+	// make a test impl object
+	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+
+	assert.Panics(t, func() {
+		mockedService.On("TheExampleMethodFunc", func(string) error { return nil })
+	})
+}
+
 func Test_Mock_On_WithFuncTypeArg(t *testing.T) {
 
 	// make a test impl object


### PR DESCRIPTION
We cannot compare two Func arguments to check if they are equal using the
reflect package. This leads to the following misleading panic:

```go
handler := func(http.ResponseWriter, *http.Request) {}
muxMock.On("HandleFunc", "/", handler) muxMock.HandleFunc("/", handler)
// panics arguing handler != handler
```

Since we cannot fix this behaviour using reflection, this patch provides a
better panic with a meaningful workaround.

```go
handler := func(http.ResponseWriter, *http.Request) {}
muxMock.On("HandleFunc", "/", handler)
// panics recommending defining the expectatin with:
//   AnythingOfType("func(http.ResponseWriter, *http.Request)")
```

Solution following the panic's instructions:

```go
handler := func(http.ResponseWriter, *http.Request) {}
muxMock.On("HandleFunc", "/",
 mock.AnythingOfType("func(http.ResponseWriter, *http.Request)"))
muxMock.HandleFunc("/", handler)
```

This PR also adds tests for the `AnythingOfType` solution, to make sure the
behaviour is not broken in future developments.