### PR TITLE
Output entries of the call stack if assertion fails

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -3,6 +3,7 @@ package assert
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"reflect"
 	"regexp"
@@ -10,6 +11,22 @@ import (
 	"strings"
 	"time"
 )
+
+var (
+	CallStackCount = 1
+)
+
+func GetCallStackCount() int {
+	return CallStackCount
+}
+
+func SetCallStackCount(count int) error {
+	if count > 0 {
+		CallStackCount = count
+		return nil
+	}
+	return errors.New("Invalid value, count should be greater than 0")
+}
 
 // TestingT is an interface wrapper around *testing.T
 type TestingT interface {
@@ -77,7 +94,8 @@ the problem actually occured in calling code.*/
 func CallerInfo() []string {
 
 	infos := make([]string, 0)
-	for i := 0; ; i++ {
+	count := 0
+	for i := 0; count < CallStackCount; i++ {
 		_, file, line, ok := runtime.Caller(i)
 		if !ok {
 			break
@@ -87,6 +105,7 @@ func CallerInfo() []string {
 		file = parts[len(parts)-1]
 		if (dir != "assert" && dir != "mock" && dir != "require") || file == "mock_test.go" {
 			infos = append(infos, fmt.Sprintf("%s:%d", file, line))
+			count++
 		}
 	}
 

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -59,32 +59,38 @@ func ObjectsAreEqualValues(expected, actual interface{}) bool {
 	return false
 }
 
+func reverseStringSlice(input []string) []string {
+	output := make([]string, 0, len(input))
+	length := len(input)
+	for i := length - 1; i >= 0; i-- {
+		output = append(output, input[i])
+	}
+	return output
+}
+
 /* CallerInfo is necessary because the assert functions use the testing object
 internally, causing it to print the file:line of the assert method, rather than where
 the problem actually occured in calling code.*/
 
-// CallerInfo returns a string containing the file and line number of the assert call
-// that failed.
-func CallerInfo() string {
+// CallerInfo returns a slice of strings containing the file and line number of
+// the whole call stack, from top to the bottom one where the assert call failed.
+func CallerInfo() []string {
 
-	file := ""
-	line := 0
-	ok := false
-
+	infos := make([]string, 0)
 	for i := 0; ; i++ {
-		_, file, line, ok = runtime.Caller(i)
+		_, file, line, ok := runtime.Caller(i)
 		if !ok {
-			return ""
+			break
 		}
 		parts := strings.Split(file, "/")
 		dir := parts[len(parts)-2]
 		file = parts[len(parts)-1]
 		if (dir != "assert" && dir != "mock" && dir != "require") || file == "mock_test.go" {
-			break
+			infos = append(infos, fmt.Sprintf("%s:%d", file, line))
 		}
 	}
 
-	return fmt.Sprintf("%s:%d", file, line)
+	return reverseStringSlice(infos)
 }
 
 // getWhitespaceString returns a string that is long enough to overwrite the default
@@ -142,20 +148,20 @@ func indentMessageLines(message string, tabs int) string {
 func Fail(t TestingT, failureMessage string, msgAndArgs ...interface{}) bool {
 
 	message := messageFromMsgAndArgs(msgAndArgs...)
-
+	callerInfo := strings.Join(CallerInfo(), "\n\t")
 	if len(message) > 0 {
 		t.Errorf("\r%s\r\tLocation:\t%s\n"+
 			"\r\tError:%s\n"+
 			"\r\tMessages:\t%s\n\r",
 			getWhitespaceString(),
-			CallerInfo(),
+			callerInfo,
 			indentMessageLines(failureMessage, 2),
 			message)
 	} else {
 		t.Errorf("\r%s\r\tLocation:\t%s\n"+
 			"\r\tError:%s\n\r",
 			getWhitespaceString(),
-			CallerInfo(),
+			callerInfo,
 			indentMessageLines(failureMessage, 2))
 	}
 

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -499,6 +499,204 @@ func (args Arguments) Assert(t TestingT, objects ...interface{}) bool {
 
 }
 
+// Bool gets the argument at the specified index. Panics if there is no argument, or
+// if the argument is of the wrong type.
+func (args Arguments) Bool(index int) bool {
+	var s bool
+	var ok bool
+	if s, ok = args.Get(index).(bool); !ok {
+		panic(fmt.Sprintf("assert: arguments: Bool(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
+	}
+	return s
+}
+
+// Int8 gets the argument at the specified index. Panics if there is no argument, or
+// if the argument is of the wrong type.
+func (args Arguments) Int8(index int) int8 {
+	var s int8
+	var ok bool
+	if s, ok = args.Get(index).(int8); !ok {
+		panic(fmt.Sprintf("assert: arguments: Int8(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
+	}
+	return s
+}
+
+// Int16 gets the argument at the specified index. Panics if there is no argument, or
+// if the argument is of the wrong type.
+func (args Arguments) Int16(index int) int16 {
+	var s int16
+	var ok bool
+	if s, ok = args.Get(index).(int16); !ok {
+		panic(fmt.Sprintf("assert: arguments: Int16(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
+	}
+	return s
+}
+
+// Int32 gets the argument at the specified index. Panics if there is no argument, or
+// if the argument is of the wrong type.
+func (args Arguments) Int32(index int) int32 {
+	var s int32
+	var ok bool
+	if s, ok = args.Get(index).(int32); !ok {
+		panic(fmt.Sprintf("assert: arguments: Int32(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
+	}
+	return s
+}
+
+// Int64 gets the argument at the specified index. Panics if there is no argument, or
+// if the argument is of the wrong type.
+func (args Arguments) Int64(index int) int64 {
+	var s int64
+	var ok bool
+	if s, ok = args.Get(index).(int64); !ok {
+		panic(fmt.Sprintf("assert: arguments: Int64(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
+	}
+	return s
+}
+
+// Uint8 gets the argument at the specified index. Panics if there is no argument, or
+// if the argument is of the wrong type.
+func (args Arguments) Uint8(index int) uint8 {
+	var s uint8
+	var ok bool
+	if s, ok = args.Get(index).(uint8); !ok {
+		panic(fmt.Sprintf("assert: arguments: Uint8(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
+	}
+	return s
+}
+
+// Uint16 gets the argument at the specified index. Panics if there is no argument, or
+// if the argument is of the wrong type.
+func (args Arguments) Uint16(index int) uint16 {
+	var s uint16
+	var ok bool
+	if s, ok = args.Get(index).(uint16); !ok {
+		panic(fmt.Sprintf("assert: arguments: Uint16(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
+	}
+	return s
+}
+
+// Uint32 gets the argument at the specified index. Panics if there is no argument, or
+// if the argument is of the wrong type.
+func (args Arguments) Uint32(index int) uint32 {
+	var s uint32
+	var ok bool
+	if s, ok = args.Get(index).(uint32); !ok {
+		panic(fmt.Sprintf("assert: arguments: Uint32(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
+	}
+	return s
+}
+
+// Uint64 gets the argument at the specified index. Panics if there is no argument, or
+// if the argument is of the wrong type.
+func (args Arguments) Uint64(index int) uint64 {
+	var s uint64
+	var ok bool
+	if s, ok = args.Get(index).(uint64); !ok {
+		panic(fmt.Sprintf("assert: arguments: Uint64(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
+	}
+	return s
+}
+
+// Float32 gets the argument at the specified index. Panics if there is no argument, or
+// if the argument is of the wrong type.
+func (args Arguments) Float32(index int) float32 {
+	var s float32
+	var ok bool
+	if s, ok = args.Get(index).(float32); !ok {
+		panic(fmt.Sprintf("assert: arguments: Float32(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
+	}
+	return s
+}
+
+// Float64 gets the argument at the specified index. Panics if there is no argument, or
+// if the argument is of the wrong type.
+func (args Arguments) Float64(index int) float64 {
+	var s float64
+	var ok bool
+	if s, ok = args.Get(index).(float64); !ok {
+		panic(fmt.Sprintf("assert: arguments: Float64(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
+	}
+	return s
+}
+
+// Complex64 gets the argument at the specified index. Panics if there is no argument, or
+// if the argument is of the wrong type.
+func (args Arguments) Complex64(index int) complex64 {
+	var s complex64
+	var ok bool
+	if s, ok = args.Get(index).(complex64); !ok {
+		panic(fmt.Sprintf("assert: arguments: Complex64(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
+	}
+	return s
+}
+
+// Complex128 gets the argument at the specified index. Panics if there is no argument, or
+// if the argument is of the wrong type.
+func (args Arguments) Complex128(index int) complex128 {
+	var s complex128
+	var ok bool
+	if s, ok = args.Get(index).(complex128); !ok {
+		panic(fmt.Sprintf("assert: arguments: Complex128(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
+	}
+	return s
+}
+
+// Byte gets the argument at the specified index. Panics if there is no argument, or
+// if the argument is of the wrong type.
+func (args Arguments) Byte(index int) byte {
+	var s byte
+	var ok bool
+	if s, ok = args.Get(index).(byte); !ok {
+		panic(fmt.Sprintf("assert: arguments: Byte(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
+	}
+	return s
+}
+
+// Rune gets the argument at the specified index. Panics if there is no argument, or
+// if the argument is of the wrong type.
+func (args Arguments) Rune(index int) rune {
+	var s rune
+	var ok bool
+	if s, ok = args.Get(index).(rune); !ok {
+		panic(fmt.Sprintf("assert: arguments: Rune(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
+	}
+	return s
+}
+
+// Int gets the argument at the specified index. Panics if there is no argument, or
+// if the argument is of the wrong type.
+func (args Arguments) Int(index int) int {
+	var s int
+	var ok bool
+	if s, ok = args.Get(index).(int); !ok {
+		panic(fmt.Sprintf("assert: arguments: Int(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
+	}
+	return s
+}
+
+// Uint gets the argument at the specified index. Panics if there is no argument, or
+// if the argument is of the wrong type.
+func (args Arguments) Uint(index int) uint {
+	var s uint
+	var ok bool
+	if s, ok = args.Get(index).(uint); !ok {
+		panic(fmt.Sprintf("assert: arguments: Uint(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
+	}
+	return s
+}
+
+// Uintptr gets the argument at the specified index. Panics if there is no argument, or
+// if the argument is of the wrong type.
+func (args Arguments) Uintptr(index int) uintptr {
+	var s uintptr
+	var ok bool
+	if s, ok = args.Get(index).(uintptr); !ok {
+		panic(fmt.Sprintf("assert: arguments: Uintptr(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
+	}
+	return s
+}
+
 // String gets the argument at the specified index. Panics if there is no argument, or
 // if the argument is of the wrong type.
 //
@@ -528,17 +726,6 @@ func (args Arguments) String(indexOrNil ...int) string {
 
 }
 
-// Int gets the argument at the specified index. Panics if there is no argument, or
-// if the argument is of the wrong type.
-func (args Arguments) Int(index int) int {
-	var s int
-	var ok bool
-	if s, ok = args.Get(index).(int); !ok {
-		panic(fmt.Sprintf("assert: arguments: Int(%d) failed because object wasn't correct type: %v", index, args.Get(index)))
-	}
-	return s
-}
-
 // Error gets the argument at the specified index. Panics if there is no argument, or
 // if the argument is of the wrong type.
 func (args Arguments) Error(index int) error {
@@ -550,17 +737,6 @@ func (args Arguments) Error(index int) error {
 	}
 	if s, ok = obj.(error); !ok {
 		panic(fmt.Sprintf("assert: arguments: Error(%d) failed because object wasn't correct type: %v", index, args.Get(index)))
-	}
-	return s
-}
-
-// Bool gets the argument at the specified index. Panics if there is no argument, or
-// if the argument is of the wrong type.
-func (args Arguments) Bool(index int) bool {
-	var s bool
-	var ok bool
-	if s, ok = args.Get(index).(bool); !ok {
-		panic(fmt.Sprintf("assert: arguments: Bool(%d) failed because object wasn't correct type: %v", index, args.Get(index)))
 	}
 	return s
 }

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -799,6 +799,132 @@ func Test_Arguments_Assert(t *testing.T) {
 
 }
 
+func Test_Arguments_Bool(t *testing.T) {
+
+	var args Arguments = []interface{}{"string", 123, true}
+	assert.Equal(t, true, args.Bool(2))
+
+}
+
+func Test_Arguments_Int8(t *testing.T) {
+
+	var args Arguments = []interface{}{"string", int8(123), true}
+	assert.Equal(t, int8(123), args.Int8(1))
+
+}
+
+func Test_Arguments_Int16(t *testing.T) {
+
+	var args Arguments = []interface{}{"string", int16(123), true}
+	assert.Equal(t, int16(123), args.Int16(1))
+
+}
+
+func Test_Arguments_Int32(t *testing.T) {
+
+	var args Arguments = []interface{}{"string", int32(123), true}
+	assert.Equal(t, int32(123), args.Int32(1))
+
+}
+
+func Test_Arguments_Int64(t *testing.T) {
+
+	var args Arguments = []interface{}{"string", int64(123), true}
+	assert.Equal(t, int64(123), args.Int64(1))
+
+}
+
+func Test_Arguments_Uint8(t *testing.T) {
+
+	var args Arguments = []interface{}{"string", uint8(123), true}
+	assert.Equal(t, uint8(123), args.Uint8(1))
+
+}
+
+func Test_Arguments_Uint16(t *testing.T) {
+
+	var args Arguments = []interface{}{"string", uint16(123), true}
+	assert.Equal(t, uint16(123), args.Uint16(1))
+
+}
+
+func Test_Arguments_Uint32(t *testing.T) {
+
+	var args Arguments = []interface{}{"string", uint32(123), true}
+	assert.Equal(t, uint32(123), args.Uint32(1))
+
+}
+
+func Test_Arguments_Uint64(t *testing.T) {
+
+	var args Arguments = []interface{}{"string", uint64(123), true}
+	assert.Equal(t, uint64(123), args.Uint64(1))
+
+}
+
+func Test_Arguments_Float32(t *testing.T) {
+
+	var args Arguments = []interface{}{"string", float32(123.0), true}
+	assert.Equal(t, float32(123.0), args.Float32(1))
+
+}
+
+func Test_Arguments_Float64(t *testing.T) {
+
+	var args Arguments = []interface{}{"string", float64(123.0), true}
+	assert.Equal(t, float64(123.0), args.Float64(1))
+
+}
+
+func Test_Arguments_Complex64(t *testing.T) {
+
+	var args Arguments = []interface{}{"string", complex64(123.0), true}
+	assert.Equal(t, complex64(123.0), args.Complex64(1))
+
+}
+
+func Test_Arguments_Complex128(t *testing.T) {
+
+	var args Arguments = []interface{}{"string", complex128(123.0), true}
+	assert.Equal(t, complex128(123.0), args.Complex128(1))
+
+}
+
+func Test_Arguments_Byte(t *testing.T) {
+
+	var args Arguments = []interface{}{"string", byte(123), true}
+	assert.Equal(t, byte(123), args.Byte(1))
+
+}
+
+func Test_Arguments_Rune(t *testing.T) {
+
+	var args Arguments = []interface{}{"string", rune(123), true}
+	assert.Equal(t, rune(123), args.Rune(1))
+
+}
+
+func Test_Arguments_Int(t *testing.T) {
+
+	var args Arguments = []interface{}{"string", 123, true}
+	assert.Equal(t, 123, args.Int(1))
+
+}
+
+func Test_Arguments_Uint(t *testing.T) {
+
+	var args Arguments = []interface{}{"string", uint(123), true}
+	assert.Equal(t, uint(123), args.Uint(1))
+
+}
+
+func Test_Arguments_Uintptr(t *testing.T) {
+
+	var args Arguments = []interface{}{"string", uintptr(123), true}
+	assert.Equal(t, uintptr(123), args.Uintptr(1))
+
+}
+
 func Test_Arguments_String_Representation(t *testing.T) {
 
 	var args Arguments = []interface{}{"string", 123, true}
@@ -825,19 +951,5 @@ func Test_Arguments_Error_Nil(t *testing.T) {
 
 	var args Arguments = []interface{}{"string", 123, true, nil}
 	assert.Equal(t, nil, args.Error(3))
-
-}
-
-func Test_Arguments_Int(t *testing.T) {
-
-	var args Arguments = []interface{}{"string", 123, true}
-	assert.Equal(t, 123, args.Int(1))
-
-}
-
-func Test_Arguments_Bool(t *testing.T) {
-
-	var args Arguments = []interface{}{"string", 123, true}
-	assert.Equal(t, true, args.Bool(2))
 
 }


### PR DESCRIPTION
Hi,

This is a reopen of previous PR #82, which contained lots of noises changing tabs to spaces due to the misconfiguration of my editor. I have cleaned up these noises in #82 and added some type-casting helper function for all primitive types in class mock.Arguments.