### PR TITLE
Address #162: InDelta should fail when actual value is not a number.

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"math"
 	"reflect"
 	"regexp"
 	"runtime"
@@ -654,6 +655,14 @@ func InDelta(t TestingT, expected, actual interface{}, delta float64, msgAndArgs
 
 	if !aok || !bok {
 		return Fail(t, fmt.Sprintf("Parameters must be numerical"), msgAndArgs...)
+	}
+
+	if math.IsNaN(af) {
+		return Fail(t, fmt.Sprintf("Actual must not be NaN"), msgAndArgs...)
+	}
+
+	if math.IsNaN(bf) {
+		return Fail(t, fmt.Sprintf("Expected %v with delta %v, but was NaN", expected, delta), msgAndArgs...)
 	}
 
 	dt := af - bf

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -2,6 +2,7 @@ package assert
 
 import (
 	"errors"
+	"math"
 	"regexp"
 	"testing"
 	"time"
@@ -652,6 +653,8 @@ func TestInDelta(t *testing.T) {
 	False(t, InDelta(mockT, 1, 2, 0.5), "Expected |1 - 2| <= 0.5 to fail")
 	False(t, InDelta(mockT, 2, 1, 0.5), "Expected |2 - 1| <= 0.5 to fail")
 	False(t, InDelta(mockT, "", nil, 1), "Expected non numerals to fail")
+	False(t, InDelta(mockT, 42, math.NaN(), 0.01), "Expected NaN for actual to fail")
+	False(t, InDelta(mockT, math.NaN(), 42, 0.01), "Expected NaN for expected to fail")
 
 	cases := []struct {
 		a, b  interface{}


### PR DESCRIPTION
Address #162: InDelta should fail when actual value is not a number.

Comparting a float with NaN is always false so the assertion would always pass.
Added a check that either the actual or expected values are NaN.

InDelta will now fail if either the actual or expected value are NaN.