### PR TITLE
Support map keys for Contains/NotContains assertion.

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -476,6 +476,16 @@ func includeElement(list interface{}, element interface{}) (ok, found bool) {
 		return true, strings.Contains(listValue.String(), elementValue.String())
 	}
 
+	if reflect.TypeOf(list).Kind() == reflect.Map {
+		mapKeys := listValue.MapKeys()
+		for i := 0; i < len(mapKeys); i++ {
+			if ObjectsAreEqual(mapKeys[i].Interface(), element) {
+				return true, true
+			}
+		}
+		return true, false
+	}
+
 	for i := 0; i < listValue.Len(); i++ {
 		if ObjectsAreEqual(listValue.Index(i).Interface(), element) {
 			return true, true
@@ -485,11 +495,12 @@ func includeElement(list interface{}, element interface{}) (ok, found bool) {
 
 }
 
-// Contains asserts that the specified string or list(array, slice...) contains the
+// Contains asserts that the specified string, list(array, slice...) or map contains the
 // specified substring or element.
 //
 //    assert.Contains(t, "Hello World", "World", "But 'Hello World' does contain 'World'")
 //    assert.Contains(t, ["Hello", "World"], "World", "But ["Hello", "World"] does contain 'World'")
+//    assert.Contains(t, {"Hello": "World"}, "Hello", "But {'Hello': 'World'} does contain 'Hello'")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func Contains(t TestingT, s, contains interface{}, msgAndArgs ...interface{}) bool {
@@ -506,11 +517,12 @@ func Contains(t TestingT, s, contains interface{}, msgAndArgs ...interface{}) bo
 
 }
 
-// NotContains asserts that the specified string or list(array, slice...) does NOT contain the
+// NotContains asserts that the specified string, list(array, slice...) or map does NOT contain the
 // specified substring or element.
 //
 //    assert.NotContains(t, "Hello World", "Earth", "But 'Hello World' does NOT contain 'Earth'")
 //    assert.NotContains(t, ["Hello", "World"], "Earth", "But ['Hello', 'World'] does NOT contain 'Earth'")
+//    assert.NotContains(t, {"Hello": "World"}, "Earth", "But {'Hello': 'World'} does NOT contain 'Earth'")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func NotContains(t TestingT, s, contains interface{}, msgAndArgs ...interface{}) bool {

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -255,6 +255,7 @@ func TestContains(t *testing.T) {
 		{"g", "h"},
 		{"j", "k"},
 	}
+	simpleMap := map[interface{}]interface{}{"Foo": "Bar"}
 
 	if !Contains(mockT, "Hello World", "Hello") {
 		t.Error("Contains should return true: \"Hello World\" contains \"Hello\"")
@@ -275,12 +276,22 @@ func TestContains(t *testing.T) {
 	if Contains(mockT, complexList, &A{"g", "e"}) {
 		t.Error("Contains should return false: complexList contains {\"g\", \"e\"}")
 	}
+	if Contains(mockT, complexList, &A{"g", "e"}) {
+		t.Error("Contains should return false: complexList contains {\"g\", \"e\"}")
+	}
+	if !Contains(mockT, simpleMap, "Foo") {
+		t.Error("Contains should return true: \"{\"Foo\": \"Bar\"}\" contains \"Foo\"")
+	}
+	if Contains(mockT, simpleMap, "Bar") {
+		t.Error("Contains should return false: \"{\"Foo\": \"Bar\"}\" does not contains \"Bar\"")
+	}
 }
 
 func TestNotContains(t *testing.T) {
 
 	mockT := new(testing.T)
 	list := []string{"Foo", "Bar"}
+	simpleMap := map[interface{}]interface{}{"Foo": "Bar"}
 
 	if !NotContains(mockT, "Hello World", "Hello!") {
 		t.Error("NotContains should return true: \"Hello World\" does not contain \"Hello!\"")
@@ -295,13 +306,19 @@ func TestNotContains(t *testing.T) {
 	if NotContains(mockT, list, "Foo") {
 		t.Error("NotContains should return false: \"[\"Foo\", \"Bar\"]\" contains \"Foo\"")
 	}
-
+	if NotContains(mockT, simpleMap, "Foo") {
+		t.Error("Contains should return true: \"{\"Foo\": \"Bar\"}\" contains \"Foo\"")
+	}
+	if !NotContains(mockT, simpleMap, "Bar") {
+		t.Error("Contains should return false: \"{\"Foo\": \"Bar\"}\" does not contains \"Bar\"")
+	}
 }
 
 func Test_includeElement(t *testing.T) {
 
 	list1 := []string{"Foo", "Bar"}
 	list2 := []int{1, 2}
+	simpleMap := map[interface{}]interface{}{"Foo": "Bar"}
 
 	ok, found := includeElement("Hello World", "World")
 	True(t, ok)
@@ -335,10 +352,17 @@ func Test_includeElement(t *testing.T) {
 	True(t, ok)
 	False(t, found)
 
+	ok, found = includeElement(simpleMap, "Foo")
+	True(t, ok)
+	True(t, found)
+
+	ok, found = includeElement(simpleMap, "Bar")
+	True(t, ok)
+	False(t, found)
+
 	ok, found = includeElement(1433, "1")
 	False(t, ok)
 	False(t, found)
-
 }
 
 func TestCondition(t *testing.T) {


### PR DESCRIPTION
Makes `assert.Contains` and `assert.NotContains` work with `map` keys.

```
assert.Contains(t, &map[interface{}]interface{}{"Foo": "Bar"}, "Foo") // passes
assert.Contains(t, &map[interface{}]interface{}{"Bar": "Foo"}, "Foo") // fails
```

This fixes #118 .