### PR TITLE
Added assert.Equals check that was removed

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -37,6 +37,12 @@ func ObjectsAreEqual(expected, actual interface{}) bool {
 		return true
 	}
 
+	// This was removed in https://github.com/stretchr/testify/commit/e22aedd37671fb115be6c0c25129c405cb575cfd which
+	// breaks nearly all of our tests that test interface values
+	if fmt.Sprintf("%#v", expected) == fmt.Sprintf("%#v", actual) {
+		return true
+	}
+
 	return false
 
 }


### PR DESCRIPTION
The recent change to assert.Equals broke all of our tests that tested interface vales. We would really like to see this added back so we don't have to maintain a fork of testify.