### PR TITLE
Adjust NotNil error message

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -301,7 +301,7 @@ func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
 	}
 
 	if !success {
-		Fail(t, "Expected not to be nil.", msgAndArgs...)
+		Fail(t, "Expected value not to be nil.", msgAndArgs...)
 	}
 
 	return success


### PR DESCRIPTION
Minor fix. The error message on the NotNil assertion was a little odd to read previously.