### PR TITLE
AssertNumberOfCalls: wrong order of arguments

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -352,7 +352,7 @@ func (m *Mock) AssertNumberOfCalls(t TestingT, methodName string, expectedCalls 
 			actualCalls++
 		}
 	}
-	return assert.Equal(t, actualCalls, expectedCalls, fmt.Sprintf("Expected number of calls (%d) does not match the actual number of calls (%d).", expectedCalls, actualCalls))
+	return assert.Equal(t, expectedCalls, actualCalls, fmt.Sprintf("Expected number of calls (%d) does not match the actual number of calls (%d).", expectedCalls, actualCalls))
 }
 
 // AssertCalled asserts that the method was called.


### PR DESCRIPTION
The assert.Equal called had the actual and expected values mixed up. 

This resulted in the following code
```
mockProvider.AssertNumberOfCalls(t, "GetUserToken", 1)
```
producing 
```	
Error:		Not equal: 2 (expected)
		        != 1 (actual)
	
Messages:	Expected number of calls (1) does not match the actual number of calls (2).
```