### PR TITLE
Outputting a more descriptive message when struct arguments are used.

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -620,6 +620,25 @@ func Panics(t TestingT, f PanicTestFunc, msgAndArgs ...interface{}) bool {
 	return true
 }
 
+// Panics asserts that the code inside the specified PanicTestFunc panics.
+//
+//   assert.Panics(t, func(){
+//     GoCrazy()
+//   }, "Calling GoCrazy() should panic")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func PanicsWithMessage(t TestingT, f PanicTestFunc, expectedMessage interface{}, msgAndArgs ...interface{}) bool {
+
+	funcDidPanic, panicValue := didPanic(f)
+	if !funcDidPanic {
+		return Fail(t, fmt.Sprintf("func %#v should panic\n\r\tPanic value:\t%v", f, panicValue), msgAndArgs...)
+	} else {
+		Equal(t, expectedMessage, panicValue)
+	}
+
+	return true
+}
+
 // NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
 //
 //   assert.NotPanics(t, func(){

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -216,6 +216,7 @@ func (m *Mock) findClosestCall(method string, arguments ...interface{}) (bool, *
 			if tempDiffCount < diffCount || diffCount == 0 {
 				diffCount = tempDiffCount
 				closestCall = &call
+				break
 			}
 
 		}

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -216,7 +216,6 @@ func (m *Mock) findClosestCall(method string, arguments ...interface{}) (bool, *
 			if tempDiffCount < diffCount || diffCount == 0 {
 				diffCount = tempDiffCount
 				closestCall = &call
-				break
 			}
 
 		}


### PR DESCRIPTION
Outputting a more descriptive message when struct arguments don't match on an unexpected call.
