### PR TITLE
FIX# EqualError error output swaps the actual and expected values 

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -239,7 +239,7 @@ func Equal(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) 
 
 	if !ObjectsAreEqual(expected, actual) {
 		return Fail(t, fmt.Sprintf("Not equal: %#v (expected)\n"+
-			"        != %#v (actual)", expected, actual), msgAndArgs...)
+			"        != %#v (actual)", actual, expected), msgAndArgs...)
 	}
 
 	return true


### PR DESCRIPTION
Issue #185 