### PR TITLE
Fix order of params in Equal

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -239,7 +239,7 @@ func Equal(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) 
 
 	if !ObjectsAreEqual(expected, actual) {
 		return Fail(t, fmt.Sprintf("Not equal: %#v (expected)\n"+
-			"        != %#v (actual)", actual, expected), msgAndArgs...)
+			"        != %#v (actual)", expected, actual), msgAndArgs...)
 	}
 
 	return true


### PR DESCRIPTION
This reverts the change introduced in https://github.com/stretchr/testify/pull/205 which changed it from being correct to being wrong.