### PR TITLE
Remove unnecessary branches.

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -35,11 +35,7 @@ func ObjectsAreEqual(expected, actual interface{}) bool {
 		return expected == actual
 	}
 
-	if reflect.DeepEqual(expected, actual) {
-		return true
-	}
-
-	return false
+	return reflect.DeepEqual(expected, actual)
 
 }
 
@@ -54,9 +50,7 @@ func ObjectsAreEqualValues(expected, actual interface{}) bool {
 	expectedValue := reflect.ValueOf(expected)
 	if expectedValue.Type().ConvertibleTo(actualType) {
 		// Attempt comparison after type conversion
-		if reflect.DeepEqual(expectedValue.Convert(actualType).Interface(), actual) {
-			return true
-		}
+		return reflect.DeepEqual(expectedValue.Convert(actualType).Interface(), actual)
 	}
 
 	return false


### PR DESCRIPTION
reflect.DeepEqual already returns exactly what we want in both of these cases.

Tests all seem to pass except testify/require, which fails with:

```
~/gocode/src/github.com/jaguilar/testify$ go test -v ./...
# github.com/jaguilar/testify/require
require/requirements.go:275: undefined: assert.Zero
require/requirements.go:282: undefined: assert.NotZero
```