### PR TITLE
Disable memoized require.Assertions in Suite

### DIFF
--- a/suite/suite.go
+++ b/suite/suite.go
@@ -18,8 +18,7 @@ var matchMethod = flag.String("m", "", "regular expression to select tests of th
 // retrieving the current *testing.T context.
 type Suite struct {
 	*assert.Assertions
-	require *require.Assertions
-	t       *testing.T
+	t *testing.T
 }
 
 // T retrieves the current *testing.T context.
@@ -35,10 +34,7 @@ func (suite *Suite) SetT(t *testing.T) {
 
 // Require returns a require context for suite.
 func (suite *Suite) Require() *require.Assertions {
-	if suite.require == nil {
-		suite.require = require.New(suite.T())
-	}
-	return suite.require
+	return require.New(suite.T())
 }
 
 // Assert returns an assert context for suite.  Normally, you can call

--- a/suite/suite_test.go
+++ b/suite/suite_test.go
@@ -145,7 +145,6 @@ func TestSuiteGetters(t *testing.T) {
 	assert.NotNil(t, suite.Assert())
 	assert.Equal(t, suite.Assertions, suite.Assert())
 	assert.NotNil(t, suite.Require())
-	assert.Equal(t, suite.require, suite.Require())
 }
 
 type SuiteLoggingTester struct {


### PR DESCRIPTION
A quick fix for https://github.com/stretchr/testify/issues/149.

I wasn't able to figure exactly _why_ this was happening, but now `suite.Require()` is actually usable.