### PR TITLE
Added assertion/requirement that checks if two JSON strings represent equivalent objects

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -917,30 +917,15 @@ func NotZero(t TestingT, i interface{}, msgAndArgs ...interface{}) bool {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func JSONEq(t TestingT, expected string, actual string, msgAndArgs ...interface{}) bool {
-	expectSlice := false
-	expectedJSONAsMap := make(map[string]interface{})
-	expectedJSONAsSlice := make([]interface{}, 0, 0)
+	var expectedJSONAsInterface, actualJSONAsInterface interface{}
 
-	actualJSONAsMap := make(map[string]interface{})
-	actualJSONAsSlice := make([]interface{}, 0, 0)
-
-	if err := json.Unmarshal([]byte(expected), &expectedJSONAsMap); err != nil {
-		if err := json.Unmarshal([]byte(expected), &expectedJSONAsSlice); err == nil {
-			expectSlice = true
-		} else {
-			return Fail(t, fmt.Sprintf("Expected value ('%s') is not valid json.\nJSON parsing error: '%s'", expected, err.Error()), msgAndArgs...)
-		}
+	if err := json.Unmarshal([]byte(expected), &expectedJSONAsInterface); err != nil {
+		return Fail(t, fmt.Sprintf("Expected value ('%s') is not valid json.\nJSON parsing error: '%s'", expected, err.Error()), msgAndArgs...)
 	}
 
-	if expectSlice {
-		if err := json.Unmarshal([]byte(actual), &actualJSONAsSlice); err != nil {
-			return Fail(t, fmt.Sprintf("Input ('%s') needs to be valid json.\nJSON parsing error: '%s'", actual, err.Error()), msgAndArgs...)
-		}
-		return Equal(t, expectedJSONAsSlice, actualJSONAsSlice, msgAndArgs...)
-	} else {
-		if err := json.Unmarshal([]byte(actual), &actualJSONAsMap); err != nil {
-			return Fail(t, fmt.Sprintf("Input ('%s') needs to be valid json.\nJSON parsing error: '%s'", actual, err.Error()), msgAndArgs...)
-		}
-		return Equal(t, expectedJSONAsMap, actualJSONAsMap, msgAndArgs...)
+	if err := json.Unmarshal([]byte(actual), &actualJSONAsInterface); err != nil {
+		return Fail(t, fmt.Sprintf("Input ('%s') needs to be valid json.\nJSON parsing error: '%s'", actual, err.Error()), msgAndArgs...)
 	}
+
+	return Equal(t, expectedJSONAsInterface, actualJSONAsInterface, msgAndArgs...)
 }

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	i      interface{}
+	i     interface{}
 	zeros = []interface{}{
 		false,
 		byte(0),
@@ -902,4 +902,19 @@ func TestNotZero(t *testing.T) {
 	for _, test := range nonZeros {
 		True(t, NotZero(mockT, test, "%#v is not the %v zero value", test, reflect.TypeOf(test)))
 	}
+}
+
+func TestJSONEq(t *testing.T) {
+	mockT := new(testing.T)
+
+	True(t, JSONEq(mockT, `{"hello": "world", "foo": "bar"}`, `{"hello": "world", "foo": "bar"}`))
+	True(t, JSONEq(mockT, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`))
+	True(t, JSONEq(mockT, "{\r\n\t\"numeric\": 1.5,\r\n\t\"array\": [{\"foo\": \"bar\"}, 1, \"string\", [\"nested\", \"array\", 5.5]],\r\n\t\"hash\": {\"nested\": \"hash\", \"nested_slice\": [\"this\", \"is\", \"nested\"]},\r\n\t\"string\": \"foo\"\r\n}",
+		"{\r\n\t\"numeric\": 1.5,\r\n\t\"hash\": {\"nested\": \"hash\", \"nested_slice\": [\"this\", \"is\", \"nested\"]},\r\n\t\"string\": \"foo\",\r\n\t\"array\": [{\"foo\": \"bar\"}, 1, \"string\", [\"nested\", \"array\", 5.5]]\r\n}"))
+	True(t, JSONEq(mockT, `["foo", {"hello": "world", "nested": "hash"}]`, `["foo", {"nested": "hash", "hello": "world"}]`))
+	False(t, JSONEq(mockT, `["foo", {"hello": "world", "nested": "hash"}]`, `{"foo": "bar", {"nested": "hash", "hello": "world"}}`))
+	False(t, JSONEq(mockT, `{"foo": "bar"}`, `{"foo": "bar", "hello": "world"}`))
+	False(t, JSONEq(mockT, `{"foo": "bar"}`, "Not JSON"))
+	False(t, JSONEq(mockT, "Not JSON", `{"foo": "bar", "hello": "world"}`))
+	False(t, JSONEq(mockT, "Not JSON", "Not JSON"))
 }

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -904,17 +904,53 @@ func TestNotZero(t *testing.T) {
 	}
 }
 
-func TestJSONEq(t *testing.T) {
+func TestJSONEq_EqualSONString(t *testing.T) {
 	mockT := new(testing.T)
-
 	True(t, JSONEq(mockT, `{"hello": "world", "foo": "bar"}`, `{"hello": "world", "foo": "bar"}`))
+}
+
+func TestJSONEq_EquivalentButNotEqual(t *testing.T) {
+	mockT := new(testing.T)
 	True(t, JSONEq(mockT, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`))
+}
+
+func TestJSONEq_HashOfArraysAndHashes(t *testing.T) {
+	mockT := new(testing.T)
 	True(t, JSONEq(mockT, "{\r\n\t\"numeric\": 1.5,\r\n\t\"array\": [{\"foo\": \"bar\"}, 1, \"string\", [\"nested\", \"array\", 5.5]],\r\n\t\"hash\": {\"nested\": \"hash\", \"nested_slice\": [\"this\", \"is\", \"nested\"]},\r\n\t\"string\": \"foo\"\r\n}",
 		"{\r\n\t\"numeric\": 1.5,\r\n\t\"hash\": {\"nested\": \"hash\", \"nested_slice\": [\"this\", \"is\", \"nested\"]},\r\n\t\"string\": \"foo\",\r\n\t\"array\": [{\"foo\": \"bar\"}, 1, \"string\", [\"nested\", \"array\", 5.5]]\r\n}"))
+}
+
+func TestJSONEq_Array(t *testing.T) {
+	mockT := new(testing.T)
 	True(t, JSONEq(mockT, `["foo", {"hello": "world", "nested": "hash"}]`, `["foo", {"nested": "hash", "hello": "world"}]`))
+}
+
+func TestJSONEq_HashAndArrayNotEquivalent(t *testing.T) {
+	mockT := new(testing.T)
 	False(t, JSONEq(mockT, `["foo", {"hello": "world", "nested": "hash"}]`, `{"foo": "bar", {"nested": "hash", "hello": "world"}}`))
+}
+
+func TestJSONEq_HashesNotEquivalent(t *testing.T) {
+	mockT := new(testing.T)
 	False(t, JSONEq(mockT, `{"foo": "bar"}`, `{"foo": "bar", "hello": "world"}`))
+}
+
+func TestJSONEq_ActualIsNotJSON(t *testing.T) {
+	mockT := new(testing.T)
 	False(t, JSONEq(mockT, `{"foo": "bar"}`, "Not JSON"))
+}
+
+func TestJSONEq_ExpectedIsNotJSON(t *testing.T) {
+	mockT := new(testing.T)
 	False(t, JSONEq(mockT, "Not JSON", `{"foo": "bar", "hello": "world"}`))
+}
+
+func TestJSONEq_ExpectedAndActualNotJSON(t *testing.T) {
+	mockT := new(testing.T)
 	False(t, JSONEq(mockT, "Not JSON", "Not JSON"))
+}
+
+func TestJSONEq_ArraysOfDifferentOrder(t *testing.T) {
+	mockT := new(testing.T)
+	False(t, JSONEq(mockT, `["foo", {"hello": "world", "nested": "hash"}]`, `[{ "hello": "world", "nested": "hash"}, "foo"]`))
 }

--- a/assert/forward_assertions.go
+++ b/assert/forward_assertions.go
@@ -273,3 +273,12 @@ func (a *Assertions) Zero(i interface{}, msgAndArgs ...interface{}) bool {
 func (a *Assertions) NotZero(i interface{}, msgAndArgs ...interface{}) bool {
 	return NotZero(a.t, i, msgAndArgs...)
 }
+
+// JSONEq asserts that two JSON strings are equivalent.
+//
+//  assert.JSONEq(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) JSONEq(expected string, actual string, msgAndArgs ...interface{}) bool {
+	return JSONEq(a.t, expected, actual, msgAndArgs...)
+}

--- a/assert/forward_assertions_test.go
+++ b/assert/forward_assertions_test.go
@@ -536,43 +536,76 @@ func TestNotZeroWrapper(t *testing.T) {
 	}
 }
 
-func TestJSONEqWrapper(t *testing.T) {
+func TestJSONEqWrapper_EqualSONString(t *testing.T) {
 	assert := New(new(testing.T))
-
 	if !assert.JSONEq(`{"hello": "world", "foo": "bar"}`, `{"hello": "world", "foo": "bar"}`) {
 		t.Error("JSONEq should return true")
 	}
 
+}
+
+func TestJSONEqWrapper_EquivalentButNotEqual(t *testing.T) {
+	assert := New(new(testing.T))
 	if !assert.JSONEq(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`) {
 		t.Error("JSONEq should return true")
 	}
 
+}
+
+func TestJSONEqWrapper_HashOfArraysAndHashes(t *testing.T) {
+	assert := New(new(testing.T))
 	if !assert.JSONEq("{\r\n\t\"numeric\": 1.5,\r\n\t\"array\": [{\"foo\": \"bar\"}, 1, \"string\", [\"nested\", \"array\", 5.5]],\r\n\t\"hash\": {\"nested\": \"hash\", \"nested_slice\": [\"this\", \"is\", \"nested\"]},\r\n\t\"string\": \"foo\"\r\n}",
 		"{\r\n\t\"numeric\": 1.5,\r\n\t\"hash\": {\"nested\": \"hash\", \"nested_slice\": [\"this\", \"is\", \"nested\"]},\r\n\t\"string\": \"foo\",\r\n\t\"array\": [{\"foo\": \"bar\"}, 1, \"string\", [\"nested\", \"array\", 5.5]]\r\n}") {
 		t.Error("JSONEq should return true")
 	}
+}
 
+func TestJSONEqWrapper_Array(t *testing.T) {
+	assert := New(new(testing.T))
 	if !assert.JSONEq(`["foo", {"hello": "world", "nested": "hash"}]`, `["foo", {"nested": "hash", "hello": "world"}]`) {
 		t.Error("JSONEq should return true")
 	}
 
+}
+
+func TestJSONEqWrapper_HashAndArrayNotEquivalent(t *testing.T) {
+	assert := New(new(testing.T))
 	if assert.JSONEq(`["foo", {"hello": "world", "nested": "hash"}]`, `{"foo": "bar", {"nested": "hash", "hello": "world"}}`) {
 		t.Error("JSONEq should return false")
 	}
+}
 
+func TestJSONEqWrapper_HashesNotEquivalent(t *testing.T) {
+	assert := New(new(testing.T))
 	if assert.JSONEq(`{"foo": "bar"}`, `{"foo": "bar", "hello": "world"}`) {
 		t.Error("JSONEq should return false")
 	}
+}
 
+func TestJSONEqWrapper_ActualIsNotJSON(t *testing.T) {
+	assert := New(new(testing.T))
 	if assert.JSONEq(`{"foo": "bar"}`, "Not JSON") {
-		t.Error("JSONEq should return false for invalid JSON")
+		t.Error("JSONEq should return false")
 	}
+}
 
+func TestJSONEqWrapper_ExpectedIsNotJSON(t *testing.T) {
+	assert := New(new(testing.T))
 	if assert.JSONEq("Not JSON", `{"foo": "bar", "hello": "world"}`) {
 		t.Error("JSONEq should return false")
 	}
+}
 
+func TestJSONEqWrapper_ExpectedAndActualNotJSON(t *testing.T) {
+	assert := New(new(testing.T))
 	if assert.JSONEq("Not JSON", "Not JSON") {
+		t.Error("JSONEq should return false")
+	}
+}
+
+func TestJSONEqWrapper_ArraysOfDifferentOrder(t *testing.T) {
+	assert := New(new(testing.T))
+	if assert.JSONEq(`["foo", {"hello": "world", "nested": "hash"}]`, `[{ "hello": "world", "nested": "hash"}, "foo"]`) {
 		t.Error("JSONEq should return false")
 	}
 }

--- a/assert/forward_assertions_test.go
+++ b/assert/forward_assertions_test.go
@@ -535,3 +535,44 @@ func TestNotZeroWrapper(t *testing.T) {
 		assert.True(mockAssert.NotZero(test), "Zero should return false for %v", test)
 	}
 }
+
+func TestJSONEqWrapper(t *testing.T) {
+	assert := New(new(testing.T))
+
+	if !assert.JSONEq(`{"hello": "world", "foo": "bar"}`, `{"hello": "world", "foo": "bar"}`) {
+		t.Error("JSONEq should return true")
+	}
+
+	if !assert.JSONEq(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`) {
+		t.Error("JSONEq should return true")
+	}
+
+	if !assert.JSONEq("{\r\n\t\"numeric\": 1.5,\r\n\t\"array\": [{\"foo\": \"bar\"}, 1, \"string\", [\"nested\", \"array\", 5.5]],\r\n\t\"hash\": {\"nested\": \"hash\", \"nested_slice\": [\"this\", \"is\", \"nested\"]},\r\n\t\"string\": \"foo\"\r\n}",
+		"{\r\n\t\"numeric\": 1.5,\r\n\t\"hash\": {\"nested\": \"hash\", \"nested_slice\": [\"this\", \"is\", \"nested\"]},\r\n\t\"string\": \"foo\",\r\n\t\"array\": [{\"foo\": \"bar\"}, 1, \"string\", [\"nested\", \"array\", 5.5]]\r\n}") {
+		t.Error("JSONEq should return true")
+	}
+
+	if !assert.JSONEq(`["foo", {"hello": "world", "nested": "hash"}]`, `["foo", {"nested": "hash", "hello": "world"}]`) {
+		t.Error("JSONEq should return true")
+	}
+
+	if assert.JSONEq(`["foo", {"hello": "world", "nested": "hash"}]`, `{"foo": "bar", {"nested": "hash", "hello": "world"}}`) {
+		t.Error("JSONEq should return false")
+	}
+
+	if assert.JSONEq(`{"foo": "bar"}`, `{"foo": "bar", "hello": "world"}`) {
+		t.Error("JSONEq should return false")
+	}
+
+	if assert.JSONEq(`{"foo": "bar"}`, "Not JSON") {
+		t.Error("JSONEq should return false for invalid JSON")
+	}
+
+	if assert.JSONEq("Not JSON", `{"foo": "bar", "hello": "world"}`) {
+		t.Error("JSONEq should return false")
+	}
+
+	if assert.JSONEq("Not JSON", "Not JSON") {
+		t.Error("JSONEq should return false")
+	}
+}

--- a/require/forward_requirements.go
+++ b/require/forward_requirements.go
@@ -219,3 +219,12 @@ func (a *Assertions) Zero(i interface{}, msgAndArgs ...interface{}) {
 func (a *Assertions) NotZero(i interface{}, msgAndArgs ...interface{}) {
 	NotZero(a.t, i, msgAndArgs...)
 }
+
+// JSONEq asserts that two JSON strings are equivalent.
+//
+//  assert.JSONEq(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) JSONEq(expected string, actual string, msgAndArgs ...interface{}) {
+	JSONEq(a.t, expected, actual, msgAndArgs...)
+}

--- a/require/forward_requirements_test.go
+++ b/require/forward_requirements_test.go
@@ -282,3 +282,56 @@ func TestNotZeroWrapper(t *testing.T) {
 		t.Error("Check should fail")
 	}
 }
+
+func TestJSONEqWrapper(t *testing.T) {
+	//	mockRequire := New(new(testing.T))
+
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+
+	mockRequire.JSONEq(`{"hello": "world", "foo": "bar"}`, `{"hello": "world", "foo": "bar"}`)
+	if mockT.Failed {
+		t.Error("JSONEq should pass")
+	}
+
+	mockRequire.JSONEq(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
+	if mockT.Failed {
+		t.Error("JSONEq should pass")
+	}
+
+	mockRequire.JSONEq("{\r\n\t\"numeric\": 1.5,\r\n\t\"array\": [{\"foo\": \"bar\"}, 1, \"string\", [\"nested\", \"array\", 5.5]],\r\n\t\"hash\": {\"nested\": \"hash\", \"nested_slice\": [\"this\", \"is\", \"nested\"]},\r\n\t\"string\": \"foo\"\r\n}",
+		"{\r\n\t\"numeric\": 1.5,\r\n\t\"hash\": {\"nested\": \"hash\", \"nested_slice\": [\"this\", \"is\", \"nested\"]},\r\n\t\"string\": \"foo\",\r\n\t\"array\": [{\"foo\": \"bar\"}, 1, \"string\", [\"nested\", \"array\", 5.5]]\r\n}")
+	if mockT.Failed {
+		t.Error("JSONEq should pass")
+	}
+
+	mockRequire.JSONEq(`["foo", {"hello": "world", "nested": "hash"}]`, `["foo", {"nested": "hash", "hello": "world"}]`)
+	if mockT.Failed {
+		t.Error("JSONEq should pass")
+	}
+
+	mockRequire.JSONEq(`["foo", {"hello": "world", "nested": "hash"}]`, `{"foo": "bar", {"nested": "hash", "hello": "world"}}`)
+	if !mockT.Failed {
+		t.Error("JSONEq should fail")
+	}
+
+	mockRequire.JSONEq(`{"foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
+	if !mockT.Failed {
+		t.Error("JSONEq should fail")
+	}
+
+	mockRequire.JSONEq(`{"foo": "bar"}`, "Not JSON")
+	if !mockT.Failed {
+		t.Error("JSONEq should fail")
+	}
+
+	mockRequire.JSONEq("Not JSON", `{"foo": "bar", "hello": "world"}`)
+	if !mockT.Failed {
+		t.Error("JSONEq should fail")
+	}
+
+	mockRequire.JSONEq("Not JSON", "Not JSON")
+	if !mockT.Failed {
+		t.Error("JSONEq should fail")
+	}
+}

--- a/require/forward_requirements_test.go
+++ b/require/forward_requirements_test.go
@@ -283,57 +283,6 @@ func TestNotZeroWrapper(t *testing.T) {
 	}
 }
 
-func TestJSONEqWrapper(t *testing.T) {
-	mockT := new(MockT)
-	mockRequire := New(mockT)
-
-	mockRequire.JSONEq(`{"hello": "world", "foo": "bar"}`, `{"hello": "world", "foo": "bar"}`)
-	if mockT.Failed {
-		t.Error("JSONEq should pass")
-	}
-
-	mockRequire.JSONEq(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
-	if mockT.Failed {
-		t.Error("JSONEq should pass")
-	}
-
-	mockRequire.JSONEq("{\r\n\t\"numeric\": 1.5,\r\n\t\"array\": [{\"foo\": \"bar\"}, 1, \"string\", [\"nested\", \"array\", 5.5]],\r\n\t\"hash\": {\"nested\": \"hash\", \"nested_slice\": [\"this\", \"is\", \"nested\"]},\r\n\t\"string\": \"foo\"\r\n}",
-		"{\r\n\t\"numeric\": 1.5,\r\n\t\"hash\": {\"nested\": \"hash\", \"nested_slice\": [\"this\", \"is\", \"nested\"]},\r\n\t\"string\": \"foo\",\r\n\t\"array\": [{\"foo\": \"bar\"}, 1, \"string\", [\"nested\", \"array\", 5.5]]\r\n}")
-	if mockT.Failed {
-		t.Error("JSONEq should pass")
-	}
-
-	mockRequire.JSONEq(`["foo", {"hello": "world", "nested": "hash"}]`, `["foo", {"nested": "hash", "hello": "world"}]`)
-	if mockT.Failed {
-		t.Error("JSONEq should pass")
-	}
-
-	mockRequire.JSONEq(`["foo", {"hello": "world", "nested": "hash"}]`, `{"foo": "bar", {"nested": "hash", "hello": "world"}}`)
-	if !mockT.Failed {
-		t.Error("JSONEq should fail")
-	}
-
-	mockRequire.JSONEq(`{"foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
-	if !mockT.Failed {
-		t.Error("JSONEq should fail")
-	}
-
-	mockRequire.JSONEq(`{"foo": "bar"}`, "Not JSON")
-	if !mockT.Failed {
-		t.Error("JSONEq should fail")
-	}
-
-	mockRequire.JSONEq("Not JSON", `{"foo": "bar", "hello": "world"}`)
-	if !mockT.Failed {
-		t.Error("JSONEq should fail")
-	}
-
-	mockRequire.JSONEq("Not JSON", "Not JSON")
-	if !mockT.Failed {
-		t.Error("JSONEq should fail")
-	}
-}
-
 func TestJSONEqWrapper_EqualSONString(t *testing.T) {
 	mockT := new(MockT)
 	mockRequire := New(mockT)

--- a/require/forward_requirements_test.go
+++ b/require/forward_requirements_test.go
@@ -284,8 +284,6 @@ func TestNotZeroWrapper(t *testing.T) {
 }
 
 func TestJSONEqWrapper(t *testing.T) {
-	//	mockRequire := New(new(testing.T))
-
 	mockT := new(MockT)
 	mockRequire := New(mockT)
 
@@ -333,5 +331,106 @@ func TestJSONEqWrapper(t *testing.T) {
 	mockRequire.JSONEq("Not JSON", "Not JSON")
 	if !mockT.Failed {
 		t.Error("JSONEq should fail")
+	}
+}
+
+func TestJSONEqWrapper_EqualSONString(t *testing.T) {
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+
+	mockRequire.JSONEq(`{"hello": "world", "foo": "bar"}`, `{"hello": "world", "foo": "bar"}`)
+	if mockT.Failed {
+		t.Error("Check should pass")
+	}
+}
+
+func TestJSONEqWrapper_EquivalentButNotEqual(t *testing.T) {
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+
+	mockRequire.JSONEq(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
+	if mockT.Failed {
+		t.Error("Check should pass")
+	}
+}
+
+func TestJSONEqWrapper_HashOfArraysAndHashes(t *testing.T) {
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+
+	mockRequire.JSONEq("{\r\n\t\"numeric\": 1.5,\r\n\t\"array\": [{\"foo\": \"bar\"}, 1, \"string\", [\"nested\", \"array\", 5.5]],\r\n\t\"hash\": {\"nested\": \"hash\", \"nested_slice\": [\"this\", \"is\", \"nested\"]},\r\n\t\"string\": \"foo\"\r\n}",
+		"{\r\n\t\"numeric\": 1.5,\r\n\t\"hash\": {\"nested\": \"hash\", \"nested_slice\": [\"this\", \"is\", \"nested\"]},\r\n\t\"string\": \"foo\",\r\n\t\"array\": [{\"foo\": \"bar\"}, 1, \"string\", [\"nested\", \"array\", 5.5]]\r\n}")
+	if mockT.Failed {
+		t.Error("Check should pass")
+	}
+}
+
+func TestJSONEqWrapper_Array(t *testing.T) {
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+
+	mockRequire.JSONEq(`["foo", {"hello": "world", "nested": "hash"}]`, `["foo", {"nested": "hash", "hello": "world"}]`)
+	if mockT.Failed {
+		t.Error("Check should pass")
+	}
+}
+
+func TestJSONEqWrapper_HashAndArrayNotEquivalent(t *testing.T) {
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+
+	mockRequire.JSONEq(`["foo", {"hello": "world", "nested": "hash"}]`, `{"foo": "bar", {"nested": "hash", "hello": "world"}}`)
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestJSONEqWrapper_HashesNotEquivalent(t *testing.T) {
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+
+	mockRequire.JSONEq(`{"foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestJSONEqWrapper_ActualIsNotJSON(t *testing.T) {
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+
+	mockRequire.JSONEq(`{"foo": "bar"}`, "Not JSON")
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestJSONEqWrapper_ExpectedIsNotJSON(t *testing.T) {
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+
+	mockRequire.JSONEq("Not JSON", `{"foo": "bar", "hello": "world"}`)
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestJSONEqWrapper_ExpectedAndActualNotJSON(t *testing.T) {
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+
+	mockRequire.JSONEq("Not JSON", "Not JSON")
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestJSONEqWrapper_ArraysOfDifferentOrder(t *testing.T) {
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+
+	mockRequire.JSONEq(`["foo", {"hello": "world", "nested": "hash"}]`, `[{ "hello": "world", "nested": "hash"}, "foo"]`)
+	if !mockT.Failed {
+		t.Error("Check should fail")
 	}
 }

--- a/require/requirements.go
+++ b/require/requirements.go
@@ -235,32 +235,17 @@ func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interf
 //
 // Returns whether the assertion was successful (true) or not (false).
 func JSONEq(t TestingT, expected string, actual string, msgAndArgs ...interface{}) {
-	expectSlice := false
-	expectedJSONAsMap := make(map[string]interface{})
-	expectedJSONAsSlice := make([]interface{}, 0, 0)
+	var expectedJSONAsInterface, actualJSONAsInterface interface{}
 
-	actualJSONAsMap := make(map[string]interface{})
-	actualJSONAsSlice := make([]interface{}, 0, 0)
-
-	if err := json.Unmarshal([]byte(expected), &expectedJSONAsMap); err != nil {
-		if err := json.Unmarshal([]byte(expected), &expectedJSONAsSlice); err == nil {
-			expectSlice = true
-		} else {
-			t.FailNow()
-		}
+	if err := json.Unmarshal([]byte(expected), &expectedJSONAsInterface); err != nil {
+		t.FailNow()
 	}
 
-	if expectSlice {
-		if err := json.Unmarshal([]byte(actual), &actualJSONAsSlice); err != nil {
-			t.FailNow()
-		}
-		Equal(t, expectedJSONAsSlice, actualJSONAsSlice, msgAndArgs...)
-	} else {
-		if err := json.Unmarshal([]byte(actual), &actualJSONAsMap); err != nil {
-			t.FailNow()
-		}
-		Equal(t, expectedJSONAsMap, actualJSONAsMap, msgAndArgs...)
+	if err := json.Unmarshal([]byte(actual), &actualJSONAsInterface); err != nil {
+		t.FailNow()
 	}
+
+	Equal(t, expectedJSONAsInterface, actualJSONAsInterface, msgAndArgs...)
 }
 
 /*

--- a/require/requirements_test.go
+++ b/require/requirements_test.go
@@ -286,3 +286,53 @@ func TestNotZero(t *testing.T) {
 		t.Error("Check should fail")
 	}
 }
+
+func TestJSONEq(t *testing.T) {
+	mockT := new(MockT)
+
+	JSONEq(mockT, `{"hello": "world", "foo": "bar"}`, `{"hello": "world", "foo": "bar"}`)
+	if mockT.Failed {
+		t.Error("Check should pass")
+	}
+
+	JSONEq(mockT, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
+	if mockT.Failed {
+		t.Error("Check should pass")
+	}
+
+	JSONEq(mockT, "{\r\n\t\"numeric\": 1.5,\r\n\t\"array\": [{\"foo\": \"bar\"}, 1, \"string\", [\"nested\", \"array\", 5.5]],\r\n\t\"hash\": {\"nested\": \"hash\", \"nested_slice\": [\"this\", \"is\", \"nested\"]},\r\n\t\"string\": \"foo\"\r\n}",
+		"{\r\n\t\"numeric\": 1.5,\r\n\t\"hash\": {\"nested\": \"hash\", \"nested_slice\": [\"this\", \"is\", \"nested\"]},\r\n\t\"string\": \"foo\",\r\n\t\"array\": [{\"foo\": \"bar\"}, 1, \"string\", [\"nested\", \"array\", 5.5]]\r\n}")
+	if mockT.Failed {
+		t.Error("Check should pass")
+	}
+
+	JSONEq(mockT, `["foo", {"hello": "world", "nested": "hash"}]`, `["foo", {"nested": "hash", "hello": "world"}]`)
+	if mockT.Failed {
+		t.Error("Check should pass")
+	}
+
+	JSONEq(mockT, `["foo", {"hello": "world", "nested": "hash"}]`, `{"foo": "bar", {"nested": "hash", "hello": "world"}}`)
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+
+	JSONEq(mockT, `{"foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+
+	JSONEq(mockT, `{"foo": "bar"}`, "Not JSON")
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+
+	JSONEq(mockT, "Not JSON", `{"foo": "bar", "hello": "world"}`)
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+
+	JSONEq(mockT, "Not JSON", "Not JSON")
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}

--- a/require/requirements_test.go
+++ b/require/requirements_test.go
@@ -287,51 +287,82 @@ func TestNotZero(t *testing.T) {
 	}
 }
 
-func TestJSONEq(t *testing.T) {
+func TestJSONEq_EqualSONString(t *testing.T) {
 	mockT := new(MockT)
-
 	JSONEq(mockT, `{"hello": "world", "foo": "bar"}`, `{"hello": "world", "foo": "bar"}`)
 	if mockT.Failed {
 		t.Error("Check should pass")
 	}
+}
 
+func TestJSONEq_EquivalentButNotEqual(t *testing.T) {
+	mockT := new(MockT)
 	JSONEq(mockT, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
 	if mockT.Failed {
 		t.Error("Check should pass")
 	}
+}
 
+func TestJSONEq_HashOfArraysAndHashes(t *testing.T) {
+	mockT := new(MockT)
 	JSONEq(mockT, "{\r\n\t\"numeric\": 1.5,\r\n\t\"array\": [{\"foo\": \"bar\"}, 1, \"string\", [\"nested\", \"array\", 5.5]],\r\n\t\"hash\": {\"nested\": \"hash\", \"nested_slice\": [\"this\", \"is\", \"nested\"]},\r\n\t\"string\": \"foo\"\r\n}",
 		"{\r\n\t\"numeric\": 1.5,\r\n\t\"hash\": {\"nested\": \"hash\", \"nested_slice\": [\"this\", \"is\", \"nested\"]},\r\n\t\"string\": \"foo\",\r\n\t\"array\": [{\"foo\": \"bar\"}, 1, \"string\", [\"nested\", \"array\", 5.5]]\r\n}")
 	if mockT.Failed {
 		t.Error("Check should pass")
 	}
+}
 
+func TestJSONEq_Array(t *testing.T) {
+	mockT := new(MockT)
 	JSONEq(mockT, `["foo", {"hello": "world", "nested": "hash"}]`, `["foo", {"nested": "hash", "hello": "world"}]`)
 	if mockT.Failed {
 		t.Error("Check should pass")
 	}
+}
 
+func TestJSONEq_HashAndArrayNotEquivalent(t *testing.T) {
+	mockT := new(MockT)
 	JSONEq(mockT, `["foo", {"hello": "world", "nested": "hash"}]`, `{"foo": "bar", {"nested": "hash", "hello": "world"}}`)
 	if !mockT.Failed {
 		t.Error("Check should fail")
 	}
+}
 
+func TestJSONEq_HashesNotEquivalent(t *testing.T) {
+	mockT := new(MockT)
 	JSONEq(mockT, `{"foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
 	if !mockT.Failed {
 		t.Error("Check should fail")
 	}
+}
 
+func TestJSONEq_ActualIsNotJSON(t *testing.T) {
+	mockT := new(MockT)
 	JSONEq(mockT, `{"foo": "bar"}`, "Not JSON")
 	if !mockT.Failed {
 		t.Error("Check should fail")
 	}
+}
 
+func TestJSONEq_ExpectedIsNotJSON(t *testing.T) {
+	mockT := new(MockT)
 	JSONEq(mockT, "Not JSON", `{"foo": "bar", "hello": "world"}`)
 	if !mockT.Failed {
 		t.Error("Check should fail")
 	}
+}
 
+func TestJSONEq_ExpectedAndActualNotJSON(t *testing.T) {
+	mockT := new(MockT)
 	JSONEq(mockT, "Not JSON", "Not JSON")
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
+func TestJSONEq_ArraysOfDifferentOrder(t *testing.T) {
+	mockT := new(MockT)
+	JSONEq(mockT, `["foo", {"hello": "world", "nested": "hash"}]`, `[{ "hello": "world", "nested": "hash"}, "foo"]`)
 	if !mockT.Failed {
 		t.Error("Check should fail")
 	}


### PR DESCRIPTION
While writing an API I found myself writing a lot of copy-pasta in my tests to check whether or two JSON strings represent equivalent objects. I can't be the only person using JSON strings so hopefully others will find this useful.

All this assertion does is unmarshal a string into a slice or map of `interface{}` and leverage the Equal assertion to verify equality.