### PR TITLE
Fix NotNil assertion for typed nil values

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -287,24 +287,10 @@ func Exactly(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
-
-	success := true
-
-	if object == nil {
-		success = false
-	} else {
-		value := reflect.ValueOf(object)
-		kind := value.Kind()
-		if kind >= reflect.Chan && kind <= reflect.Slice && value.IsNil() {
-			success = false
-		}
+	if !isNil(object) {
+		return true
 	}
-
-	if !success {
-		Fail(t, "Expected value not to be nil.", msgAndArgs...)
-	}
-
-	return success
+	return Fail(t, "Expected value not to be nil.", msgAndArgs...)
 }
 
 // isNil checks if a specified object is nil or not, without Failing.

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	i      interface{}
+	i     interface{}
 	zeros = []interface{}{
 		false,
 		byte(0),
@@ -197,6 +197,9 @@ func TestNotNil(t *testing.T) {
 	}
 	if NotNil(mockT, nil) {
 		t.Error("NotNil should return false: object is nil")
+	}
+	if NotNil(mockT, (*struct{})(nil)) {
+		t.Error("NotNil should return false: object is (*struct{})(nil)")
 	}
 
 }

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -211,6 +211,9 @@ func TestNil(t *testing.T) {
 	if !Nil(mockT, nil) {
 		t.Error("Nil should return true: object is nil")
 	}
+	if !Nil(mockT, (*struct{})(nil)) {
+		t.Error("Nil should return true: object is (*struct{})(nil)")
+	}
 	if Nil(mockT, new(AssertionTesterConformingObject)) {
 		t.Error("Nil should return false: object is not nil")
 	}


### PR DESCRIPTION
The NotNil assertion had an error in its handling of typed nil values.
This change makes use of the helper function isNil (used by the Nil
assertion).  The helper function has correct handling of typed nil
values and when negated provides the expected semantics for
`assert.NotNil(t, x)`.

    if x == nil {
        assert.Fail(t, "nil", x)
    }

edit: I messed up the code block the first time. negated assertions are tricky :wink: