### PR TITLE
Due to function name format differences, code fails with GCCGO

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -3,6 +3,7 @@ package mock
 import (
 	"fmt"
 	"reflect"
+	"regexp"
 	"runtime"
 	"strings"
 	"sync"
@@ -265,6 +266,14 @@ func (m *Mock) Called(arguments ...interface{}) Arguments {
 		panic("Couldn't get the caller information")
 	}
 	functionPath := runtime.FuncForPC(pc).Name()
+	//Next four lines are required to use GCCGO function naming conventions.
+	//For Ex:  github_com_docker_libkv_store_mock.WatchTree.pN39_github_com_docker_libkv_store_mock.Mock
+	//uses inteface information unlike golang github.com/docker/libkv/store/mock.(*Mock).WatchTree
+	//With GCCGO we need to remove interface information starting from pN<dd>.
+	re := regexp.MustCompile("\\.pN\\d+_")
+	if re.MatchString(functionPath) {
+		functionPath = re.Split(functionPath, -1)[0]
+	}
 	parts := strings.Split(functionPath, ".")
 	functionName := parts[len(parts)-1]
 


### PR DESCRIPTION
Error happens when running Docker unit tests using gccgo. Function names are different in gccgo and hence output from runtime.FuncForPC cannot be parsed correctly with the current code.
GCCGO 
functionPath  github_com_docker_libkv_store_mock.WatchTree.pN39_github_com_docker_libkv_store_mock.Mock

Golang
functionPath  github.com/docker/libkv/store/mock.(*Mock).WatchTree


Signed-off-by: Srini Brahmaroutu <srbrahma@us.ibm.com>