### PR TITLE
Handle case where one object is nil and the other is not

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -51,8 +51,11 @@ func ObjectsAreEqualValues(expected, actual interface{}) bool {
 	}
 
 	actualType := reflect.TypeOf(actual)
+	if actualType == nil {
+		return false
+	}
 	expectedValue := reflect.ValueOf(expected)
-	if expectedValue.Type().ConvertibleTo(actualType) {
+	if expectedValue.IsValid() && expectedValue.Type().ConvertibleTo(actualType) {
 		// Attempt comparison after type conversion
 		return reflect.DeepEqual(expectedValue.Convert(actualType).Interface(), actual)
 	}

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -132,6 +132,12 @@ func TestObjectsAreEqual(t *testing.T) {
 	if !ObjectsAreEqualValues(uint32(10), int32(10)) {
 		t.Error("ObjectsAreEqualValues should return true")
 	}
+	if ObjectsAreEqualValues(0, nil) {
+		t.Fail()
+	}
+	if ObjectsAreEqualValues(nil, 0) {
+		t.Fail()
+	}
 
 }
 


### PR DESCRIPTION
I get this an awful lot when doing assert.EqualValues on expected error values.