### PR TITLE
fixing comments for better GoDoc formatting

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -382,7 +382,7 @@ func isEmpty(object interface{}) bool {
 // Empty asserts that the specified object is empty.  I.e. nil, "", false, 0 or either
 // a slice or a channel with len == 0.
 //
-// assert.Empty(t, obj)
+//  assert.Empty(t, obj)
 //
 // Returns whether the assertion was successful (true) or not (false).
 func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -399,9 +399,9 @@ func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
 // NotEmpty asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or either
 // a slice or a channel with len == 0.
 //
-// if assert.NotEmpty(t, obj) {
-//   assert.Equal(t, "two", obj[1])
-// }
+//  if assert.NotEmpty(t, obj) {
+//    assert.Equal(t, "two", obj[1])
+//  }
 //
 // Returns whether the assertion was successful (true) or not (false).
 func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {

--- a/assert/forward_assertions.go
+++ b/assert/forward_assertions.go
@@ -81,7 +81,7 @@ func (a *Assertions) Nil(object interface{}, msgAndArgs ...interface{}) bool {
 // Empty asserts that the specified object is empty.  I.e. nil, "", false, 0 or a
 // slice with len == 0.
 //
-// assert.Empty(obj)
+//  assert.Empty(obj)
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Empty(object interface{}, msgAndArgs ...interface{}) bool {

--- a/assert/forward_assertions.go
+++ b/assert/forward_assertions.go
@@ -91,9 +91,9 @@ func (a *Assertions) Empty(object interface{}, msgAndArgs ...interface{}) bool {
 // NotEmpty asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or a
 // slice with len == 0.
 //
-// if assert.NotEmpty(obj) {
-//   assert.Equal("two", obj[1])
-// }
+//  if assert.NotEmpty(obj) {
+//    assert.Equal("two", obj[1])
+//  }
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) bool {


### PR DESCRIPTION
Small edits to the comments on the `Empty` and `NotEmpty` funcs. Before the change the docs look like this:

![image](https://cloud.githubusercontent.com/assets/1844771/11319570/5b24aa38-9030-11e5-98ca-cfb70b89a6c6.png)

After the fix, we have proper formatting:

![image](https://cloud.githubusercontent.com/assets/1844771/11319562/25c3426e-9030-11e5-8fa0-78038caa8a3b.png)
