### PR TITLE
Glide Support Added

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,10 @@
+package: github.com/stretchr/testify
+import:
+  - package: github.com/davecgh/go-spew
+    ref:     master
+    repo:    https://github.com/davecgh/go-spew.git
+    vcs:     git
+  - package: github.com/pmezard/go-difflib
+    ref:     master
+    repo:    https://github.com/pmezard/go-difflib.git
+    vcs:     git


### PR DESCRIPTION
This patch adds support for the Glide dependency management system by creating a "glide.yaml" file with dependencies on "github.com/davecgh/go-spew" and "github.com/pmezard/go-difflib".

This change will allow other projects to depend upon testify via Glide without having to explicitly depend upon testify's transitive dependencies.