### PR TITLE
Fix fmt verbs in Len()

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -436,11 +436,11 @@ func getLen(x interface{}) (ok bool, length int) {
 func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) bool {
 	ok, l := getLen(object)
 	if !ok {
-		return Fail(t, fmt.Sprintf("\"%s\" could not be applied builtin len()", object), msgAndArgs...)
+		return Fail(t, fmt.Sprintf("\"%v\" could not be applied builtin len()", object), msgAndArgs...)
 	}
 
 	if l != length {
-		return Fail(t, fmt.Sprintf("\"%s\" should have %d item(s), but has %d", object, length, l), msgAndArgs...)
+		return Fail(t, fmt.Sprintf("\"%v\" should have %d item(s), but has %d", object, length, l), msgAndArgs...)
 	}
 	return true
 }


### PR DESCRIPTION
Fix `%s` to `%v` in `Len()`.

Signed-off-by: Soshi Katsuta <soshi.katsuta@gmail.com>