### PR TITLE
Add FailNow back

### DIFF
--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -107,6 +107,12 @@ func (a *Assertions) Fail(failureMessage string, msgAndArgs ...interface{}) bool
 }
 
 
+// FailNow fails test
+func (a *Assertions) FailNow(failureMessage string, msgAndArgs ...interface{}) bool {
+	return FailNow(a.t, failureMessage, msgAndArgs...)
+}
+
+
 // False asserts that the specified value is false.
 // 
 //    a.False(myBool, "myBool should be false")

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -21,6 +21,7 @@ import (
 // TestingT is an interface wrapper around *testing.T
 type TestingT interface {
 	Errorf(format string, args ...interface{})
+	FailNow()
 }
 
 // Comparison a custom function that returns true on success and false on failure
@@ -179,6 +180,13 @@ func indentMessageLines(message string, tabs int) string {
 	}
 
 	return outBuf.String()
+}
+
+// FailNow fails test
+func FailNow(t TestingT, failureMessage string, msgAndArgs ...interface{}) bool {
+	Fail(t, failureMessage, msgAndArgs...)
+	t.FailNow()
+	return false
 }
 
 // Fail reports a failure through

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -17,6 +17,7 @@ import (
 type TestingT interface {
 	Logf(format string, args ...interface{})
 	Errorf(format string, args ...interface{})
+	FailNow()
 }
 
 /*

--- a/require/require.go
+++ b/require/require.go
@@ -126,6 +126,14 @@ func Fail(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
 }
 
 
+// FailNow fails test
+func FailNow(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
+  if !assert.FailNow(t, failureMessage, msgAndArgs...) {
+    t.FailNow()
+  }
+}
+
+
 // False asserts that the specified value is false.
 // 
 //    assert.False(t, myBool, "myBool should be false")

--- a/require/require_forward.go
+++ b/require/require_forward.go
@@ -108,6 +108,12 @@ func (a *Assertions) Fail(failureMessage string, msgAndArgs ...interface{}) {
 }
 
 
+// FailNow fails test
+func (a *Assertions) FailNow(failureMessage string, msgAndArgs ...interface{}) {
+	FailNow(a.t, failureMessage, msgAndArgs...)
+}
+
+
 // False asserts that the specified value is false.
 // 
 //    a.False(myBool, "myBool should be false")


### PR DESCRIPTION
Fix breaking change where we removed FailNow. Note FailNow is also exported in `assert` to keep symmetry between `assert` and `require`.

It's still a small breaking change since FailNow now returns a bool like the rest of the functions. However that should be compatible with all existing code bases since.