### PR TITLE
Fix golint warnings

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -23,10 +23,6 @@ type TestingT interface {
 	Errorf(format string, args ...interface{})
 }
 
-type FailNower interface {
-	FailNow()
-}
-
 // Comparison a custom function that returns true on success and false on failure
 type Comparison func() (success bool)
 
@@ -185,6 +181,10 @@ func indentMessageLines(message string, tabs int) string {
 	return outBuf.String()
 }
 
+type failNower interface {
+	FailNow()
+}
+
 // FailNow fails test
 func FailNow(t TestingT, failureMessage string, msgAndArgs ...interface{}) bool {
 	Fail(t, failureMessage, msgAndArgs...)
@@ -195,7 +195,7 @@ func FailNow(t TestingT, failureMessage string, msgAndArgs ...interface{}) bool 
 	// TestingT.
 	// See issue #263
 
-	if t, ok := t.(FailNower); ok {
+	if t, ok := t.(failNower); ok {
 		t.FailNow()
 	} else {
 		panic("test failed and t is missing `FailNow()`")

--- a/http/doc.go
+++ b/http/doc.go
@@ -1,2 +1,2 @@
-//  A set of tools to make testing http activity using the Go testing system easier.
+// Package http DEPRECATED USE net/http/httptest
 package http

--- a/http/test_response_writer.go
+++ b/http/test_response_writer.go
@@ -4,10 +4,7 @@ import (
 	"net/http"
 )
 
-// TestResponseWriter is a http.ResponseWriter object that keeps track of all activity
-// allowing you to make assertions about how it was used.
-//
-// DEPRECATED: We recommend you use http://golang.org/pkg/net/http/httptest instead.
+// TestResponseWriter DEPRECATED: We recommend you use http://golang.org/pkg/net/http/httptest instead.
 type TestResponseWriter struct {
 
 	// StatusCode is the last int written by the call to WriteHeader(int)
@@ -20,7 +17,7 @@ type TestResponseWriter struct {
 	header http.Header
 }
 
-// Header gets the http.Header describing the headers that were set in this response.
+// Header DEPRECATED: We recommend you use http://golang.org/pkg/net/http/httptest instead.
 func (rw *TestResponseWriter) Header() http.Header {
 
 	if rw.header == nil {
@@ -30,7 +27,7 @@ func (rw *TestResponseWriter) Header() http.Header {
 	return rw.header
 }
 
-// Write writes the specified bytes to Output.
+// Write DEPRECATED: We recommend you use http://golang.org/pkg/net/http/httptest instead.
 func (rw *TestResponseWriter) Write(bytes []byte) (int, error) {
 
 	// assume 200 success if no header has been set
@@ -46,7 +43,7 @@ func (rw *TestResponseWriter) Write(bytes []byte) (int, error) {
 
 }
 
-// WriteHeader stores the HTTP status code in the StatusCode.
+// WriteHeader DEPRECATED: We recommend you use http://golang.org/pkg/net/http/httptest instead.
 func (rw *TestResponseWriter) WriteHeader(i int) {
 	rw.StatusCode = i
 }

--- a/http/test_round_tripper.go
+++ b/http/test_round_tripper.go
@@ -5,10 +5,12 @@ import (
 	"net/http"
 )
 
+// TestRoundTripper DEPRECATED USE net/http/httptest
 type TestRoundTripper struct {
 	mock.Mock
 }
 
+// RoundTrip DEPRECATED USE net/http/httptest
 func (t *TestRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	args := t.Called(req)
 	return args.Get(0).(*http.Response), args.Error(1)

--- a/mock/doc.go
+++ b/mock/doc.go
@@ -1,4 +1,5 @@
-// Provides a system by which it is possible to mock your objects and verify calls are happening as expected.
+// Package mock provides a system by which it is possible to mock your objects
+// and verify calls are happening as expected.
 //
 // Example Usage
 //

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -68,7 +68,7 @@ func (i *TestExampleImplementation) TheExampleMethodFuncType(fn ExampleFuncType)
 
 func Test_Mock_TestData(t *testing.T) {
 
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	var mockedService = new(TestExampleImplementation)
 
 	if assert.NotNil(t, mockedService.TestData()) {
 
@@ -80,7 +80,7 @@ func Test_Mock_TestData(t *testing.T) {
 func Test_Mock_On(t *testing.T) {
 
 	// make a test impl object
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	var mockedService = new(TestExampleImplementation)
 
 	c := mockedService.On("TheExampleMethod")
 	assert.Equal(t, []*Call{c}, mockedService.ExpectedCalls)
@@ -89,7 +89,7 @@ func Test_Mock_On(t *testing.T) {
 
 func Test_Mock_Chained_On(t *testing.T) {
 	// make a test impl object
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	var mockedService = new(TestExampleImplementation)
 
 	mockedService.
 		On("TheExampleMethod", 1, 2, 3).
@@ -117,7 +117,7 @@ func Test_Mock_Chained_On(t *testing.T) {
 func Test_Mock_On_WithArgs(t *testing.T) {
 
 	// make a test impl object
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	var mockedService = new(TestExampleImplementation)
 
 	c := mockedService.On("TheExampleMethod", 1, 2, 3, 4)
 
@@ -129,7 +129,7 @@ func Test_Mock_On_WithArgs(t *testing.T) {
 func Test_Mock_On_WithFuncArg(t *testing.T) {
 
 	// make a test impl object
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	var mockedService = new(TestExampleImplementation)
 
 	c := mockedService.
 		On("TheExampleMethodFunc", AnythingOfType("func(string) error")).
@@ -179,10 +179,10 @@ func Test_Mock_On_WithPtrArgMatcher(t *testing.T) {
 
 	mockedService.On("TheExampleMethod3",
 		MatchedBy(func(a *ExampleType) bool { return a.ran == false }),
-	).Return(errors.New("error!"))
+	).Return(errors.New("error"))
 
 	assert.Equal(t, mockedService.TheExampleMethod3(&ExampleType{true}), nil)
-	assert.EqualError(t, mockedService.TheExampleMethod3(&ExampleType{false}), "error!")
+	assert.EqualError(t, mockedService.TheExampleMethod3(&ExampleType{false}), "error")
 }
 
 func Test_Mock_On_WithFuncArgMatcher(t *testing.T) {
@@ -207,7 +207,7 @@ func Test_Mock_On_WithFuncArgMatcher(t *testing.T) {
 func Test_Mock_On_WithVariadicFunc(t *testing.T) {
 
 	// make a test impl object
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	var mockedService = new(TestExampleImplementation)
 
 	c := mockedService.
 		On("TheExampleMethodVariadic", []int{1, 2, 3}).
@@ -229,7 +229,7 @@ func Test_Mock_On_WithVariadicFunc(t *testing.T) {
 func Test_Mock_On_WithVariadicFuncWithInterface(t *testing.T) {
 
 	// make a test impl object
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	var mockedService = new(TestExampleImplementation)
 
 	c := mockedService.On("TheExampleMethodVariadicInterface", []interface{}{1, 2, 3}).
 		Return(nil)
@@ -250,7 +250,7 @@ func Test_Mock_On_WithVariadicFuncWithInterface(t *testing.T) {
 func Test_Mock_On_WithVariadicFuncWithEmptyInterfaceArray(t *testing.T) {
 
 	// make a test impl object
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	var mockedService = new(TestExampleImplementation)
 
 	var expected []interface{}
 	c := mockedService.
@@ -272,7 +272,7 @@ func Test_Mock_On_WithVariadicFuncWithEmptyInterfaceArray(t *testing.T) {
 
 func Test_Mock_On_WithFuncPanics(t *testing.T) {
 	// make a test impl object
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	var mockedService = new(TestExampleImplementation)
 
 	assert.Panics(t, func() {
 		mockedService.On("TheExampleMethodFunc", func(string) error { return nil })
@@ -282,7 +282,7 @@ func Test_Mock_On_WithFuncPanics(t *testing.T) {
 func Test_Mock_On_WithFuncTypeArg(t *testing.T) {
 
 	// make a test impl object
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	var mockedService = new(TestExampleImplementation)
 
 	c := mockedService.
 		On("TheExampleMethodFuncType", AnythingOfType("mock.ExampleFuncType")).
@@ -301,7 +301,7 @@ func Test_Mock_On_WithFuncTypeArg(t *testing.T) {
 func Test_Mock_Return(t *testing.T) {
 
 	// make a test impl object
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	var mockedService = new(TestExampleImplementation)
 
 	c := mockedService.
 		On("TheExampleMethod", "A", "B", true).
@@ -325,7 +325,7 @@ func Test_Mock_Return(t *testing.T) {
 func Test_Mock_Return_WaitUntil(t *testing.T) {
 
 	// make a test impl object
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	var mockedService = new(TestExampleImplementation)
 	ch := time.After(time.Second)
 
 	c := mockedService.Mock.
@@ -352,7 +352,7 @@ func Test_Mock_Return_WaitUntil(t *testing.T) {
 func Test_Mock_Return_After(t *testing.T) {
 
 	// make a test impl object
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	var mockedService = new(TestExampleImplementation)
 
 	c := mockedService.Mock.
 		On("TheExampleMethod", "A", "B", true).
@@ -378,7 +378,7 @@ func Test_Mock_Return_After(t *testing.T) {
 func Test_Mock_Return_Run(t *testing.T) {
 
 	// make a test impl object
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	var mockedService = new(TestExampleImplementation)
 
 	fn := func(args Arguments) {
 		arg := args.Get(0).(*ExampleType)
@@ -409,7 +409,7 @@ func Test_Mock_Return_Run(t *testing.T) {
 
 func Test_Mock_Return_Run_Out_Of_Order(t *testing.T) {
 	// make a test impl object
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	var mockedService = new(TestExampleImplementation)
 	f := func(args Arguments) {
 		arg := args.Get(0).(*ExampleType)
 		arg.ran = true
@@ -435,7 +435,7 @@ func Test_Mock_Return_Run_Out_Of_Order(t *testing.T) {
 func Test_Mock_Return_Once(t *testing.T) {
 
 	// make a test impl object
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	var mockedService = new(TestExampleImplementation)
 
 	c := mockedService.On("TheExampleMethod", "A", "B", true).
 		Return(1, "two", true).
@@ -459,7 +459,7 @@ func Test_Mock_Return_Once(t *testing.T) {
 func Test_Mock_Return_Twice(t *testing.T) {
 
 	// make a test impl object
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	var mockedService = new(TestExampleImplementation)
 
 	c := mockedService.
 		On("TheExampleMethod", "A", "B", true).
@@ -484,7 +484,7 @@ func Test_Mock_Return_Twice(t *testing.T) {
 func Test_Mock_Return_Times(t *testing.T) {
 
 	// make a test impl object
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	var mockedService = new(TestExampleImplementation)
 
 	c := mockedService.
 		On("TheExampleMethod", "A", "B", true).
@@ -509,7 +509,7 @@ func Test_Mock_Return_Times(t *testing.T) {
 func Test_Mock_Return_Nothing(t *testing.T) {
 
 	// make a test impl object
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	var mockedService = new(TestExampleImplementation)
 
 	c := mockedService.
 		On("TheExampleMethod", "A", "B", true).
@@ -586,7 +586,7 @@ func Test_callString(t *testing.T) {
 
 func Test_Mock_Called(t *testing.T) {
 
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	var mockedService = new(TestExampleImplementation)
 
 	mockedService.On("Test_Mock_Called", 1, 2, 3).Return(5, "6", true)
 
@@ -613,7 +613,7 @@ func asyncCall(m *Mock, ch chan Arguments) {
 
 func Test_Mock_Called_blocks(t *testing.T) {
 
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	var mockedService = new(TestExampleImplementation)
 
 	mockedService.Mock.On("asyncCall", 1, 2, 3).Return(5, "6", true).After(2 * time.Millisecond)
 
@@ -646,7 +646,7 @@ func Test_Mock_Called_blocks(t *testing.T) {
 
 func Test_Mock_Called_For_Bounded_Repeatability(t *testing.T) {
 
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	var mockedService = new(TestExampleImplementation)
 
 	mockedService.
 		On("Test_Mock_Called_For_Bounded_Repeatability", 1, 2, 3).
@@ -687,7 +687,7 @@ func Test_Mock_Called_For_Bounded_Repeatability(t *testing.T) {
 
 func Test_Mock_Called_For_SetTime_Expectation(t *testing.T) {
 
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	var mockedService = new(TestExampleImplementation)
 
 	mockedService.On("TheExampleMethod", 1, 2, 3).Return(5, "6", true).Times(4)
 
@@ -703,7 +703,7 @@ func Test_Mock_Called_For_SetTime_Expectation(t *testing.T) {
 
 func Test_Mock_Called_Unexpected(t *testing.T) {
 
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	var mockedService = new(TestExampleImplementation)
 
 	// make sure it panics if no expectation was made
 	assert.Panics(t, func() {
@@ -714,9 +714,9 @@ func Test_Mock_Called_Unexpected(t *testing.T) {
 
 func Test_AssertExpectationsForObjects_Helper(t *testing.T) {
 
-	var mockedService1 *TestExampleImplementation = new(TestExampleImplementation)
-	var mockedService2 *TestExampleImplementation = new(TestExampleImplementation)
-	var mockedService3 *TestExampleImplementation = new(TestExampleImplementation)
+	var mockedService1 = new(TestExampleImplementation)
+	var mockedService2 = new(TestExampleImplementation)
+	var mockedService3 = new(TestExampleImplementation)
 
 	mockedService1.On("Test_AssertExpectationsForObjects_Helper", 1).Return()
 	mockedService2.On("Test_AssertExpectationsForObjects_Helper", 2).Return()
@@ -732,9 +732,9 @@ func Test_AssertExpectationsForObjects_Helper(t *testing.T) {
 
 func Test_AssertExpectationsForObjects_Helper_Failed(t *testing.T) {
 
-	var mockedService1 *TestExampleImplementation = new(TestExampleImplementation)
-	var mockedService2 *TestExampleImplementation = new(TestExampleImplementation)
-	var mockedService3 *TestExampleImplementation = new(TestExampleImplementation)
+	var mockedService1 = new(TestExampleImplementation)
+	var mockedService2 = new(TestExampleImplementation)
+	var mockedService3 = new(TestExampleImplementation)
 
 	mockedService1.On("Test_AssertExpectationsForObjects_Helper_Failed", 1).Return()
 	mockedService2.On("Test_AssertExpectationsForObjects_Helper_Failed", 2).Return()
@@ -750,7 +750,7 @@ func Test_AssertExpectationsForObjects_Helper_Failed(t *testing.T) {
 
 func Test_Mock_AssertExpectations(t *testing.T) {
 
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	var mockedService = new(TestExampleImplementation)
 
 	mockedService.On("Test_Mock_AssertExpectations", 1, 2, 3).Return(5, 6, 7)
 
@@ -767,7 +767,7 @@ func Test_Mock_AssertExpectations(t *testing.T) {
 
 func Test_Mock_AssertExpectationsCustomType(t *testing.T) {
 
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	var mockedService = new(TestExampleImplementation)
 
 	mockedService.On("TheExampleMethod3", AnythingOfType("*mock.ExampleType")).Return(nil).Once()
 
@@ -784,7 +784,7 @@ func Test_Mock_AssertExpectationsCustomType(t *testing.T) {
 
 func Test_Mock_AssertExpectations_With_Repeatability(t *testing.T) {
 
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	var mockedService = new(TestExampleImplementation)
 
 	mockedService.On("Test_Mock_AssertExpectations_With_Repeatability", 1, 2, 3).Return(5, 6, 7).Twice()
 
@@ -805,7 +805,7 @@ func Test_Mock_AssertExpectations_With_Repeatability(t *testing.T) {
 
 func Test_Mock_TwoCallsWithDifferentArguments(t *testing.T) {
 
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	var mockedService = new(TestExampleImplementation)
 
 	mockedService.On("Test_Mock_TwoCallsWithDifferentArguments", 1, 2, 3).Return(5, 6, 7)
 	mockedService.On("Test_Mock_TwoCallsWithDifferentArguments", 4, 5, 6).Return(5, 6, 7)
@@ -824,7 +824,7 @@ func Test_Mock_TwoCallsWithDifferentArguments(t *testing.T) {
 
 func Test_Mock_AssertNumberOfCalls(t *testing.T) {
 
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	var mockedService = new(TestExampleImplementation)
 
 	mockedService.On("Test_Mock_AssertNumberOfCalls", 1, 2, 3).Return(5, 6, 7)
 
@@ -838,7 +838,7 @@ func Test_Mock_AssertNumberOfCalls(t *testing.T) {
 
 func Test_Mock_AssertCalled(t *testing.T) {
 
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	var mockedService = new(TestExampleImplementation)
 
 	mockedService.On("Test_Mock_AssertCalled", 1, 2, 3).Return(5, 6, 7)
 
@@ -850,7 +850,7 @@ func Test_Mock_AssertCalled(t *testing.T) {
 
 func Test_Mock_AssertCalled_WithAnythingOfTypeArgument(t *testing.T) {
 
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	var mockedService = new(TestExampleImplementation)
 
 	mockedService.
 		On("Test_Mock_AssertCalled_WithAnythingOfTypeArgument", Anything, Anything, Anything).
@@ -864,7 +864,7 @@ func Test_Mock_AssertCalled_WithAnythingOfTypeArgument(t *testing.T) {
 
 func Test_Mock_AssertCalled_WithArguments(t *testing.T) {
 
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	var mockedService = new(TestExampleImplementation)
 
 	mockedService.On("Test_Mock_AssertCalled_WithArguments", 1, 2, 3).Return(5, 6, 7)
 
@@ -878,7 +878,7 @@ func Test_Mock_AssertCalled_WithArguments(t *testing.T) {
 
 func Test_Mock_AssertCalled_WithArguments_With_Repeatability(t *testing.T) {
 
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	var mockedService = new(TestExampleImplementation)
 
 	mockedService.On("Test_Mock_AssertCalled_WithArguments_With_Repeatability", 1, 2, 3).Return(5, 6, 7).Once()
 	mockedService.On("Test_Mock_AssertCalled_WithArguments_With_Repeatability", 2, 3, 4).Return(5, 6, 7).Once()
@@ -895,7 +895,7 @@ func Test_Mock_AssertCalled_WithArguments_With_Repeatability(t *testing.T) {
 
 func Test_Mock_AssertNotCalled(t *testing.T) {
 
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	var mockedService = new(TestExampleImplementation)
 
 	mockedService.On("Test_Mock_AssertNotCalled", 1, 2, 3).Return(5, 6, 7)
 
@@ -910,7 +910,7 @@ func Test_Mock_AssertNotCalled(t *testing.T) {
 */
 func Test_Arguments_Get(t *testing.T) {
 
-	var args Arguments = []interface{}{"string", 123, true}
+	var args = Arguments([]interface{}{"string", 123, true})
 
 	assert.Equal(t, "string", args.Get(0).(string))
 	assert.Equal(t, 123, args.Get(1).(int))
@@ -920,7 +920,7 @@ func Test_Arguments_Get(t *testing.T) {
 
 func Test_Arguments_Is(t *testing.T) {
 
-	var args Arguments = []interface{}{"string", 123, true}
+	var args = Arguments([]interface{}{"string", 123, true})
 
 	assert.True(t, args.Is("string", 123, true))
 	assert.False(t, args.Is("wrong", 456, false))
@@ -929,7 +929,7 @@ func Test_Arguments_Is(t *testing.T) {
 
 func Test_Arguments_Diff(t *testing.T) {
 
-	var args Arguments = []interface{}{"Hello World", 123, true}
+	var args = Arguments([]interface{}{"Hello World", 123, true})
 	var diff string
 	var count int
 	diff, count = args.Diff([]interface{}{"Hello World", 456, "false"})
@@ -942,7 +942,7 @@ func Test_Arguments_Diff(t *testing.T) {
 
 func Test_Arguments_Diff_DifferentNumberOfArgs(t *testing.T) {
 
-	var args Arguments = []interface{}{"string", 123, true}
+	var args = Arguments([]interface{}{"string", 123, true})
 	var diff string
 	var count int
 	diff, count = args.Diff([]interface{}{"string", 456, "false", "extra"})
@@ -954,7 +954,7 @@ func Test_Arguments_Diff_DifferentNumberOfArgs(t *testing.T) {
 
 func Test_Arguments_Diff_WithAnythingArgument(t *testing.T) {
 
-	var args Arguments = []interface{}{"string", 123, true}
+	var args = Arguments([]interface{}{"string", 123, true})
 	var count int
 	_, count = args.Diff([]interface{}{"string", Anything, true})
 
@@ -964,7 +964,7 @@ func Test_Arguments_Diff_WithAnythingArgument(t *testing.T) {
 
 func Test_Arguments_Diff_WithAnythingArgument_InActualToo(t *testing.T) {
 
-	var args Arguments = []interface{}{"string", Anything, true}
+	var args = Arguments([]interface{}{"string", Anything, true})
 	var count int
 	_, count = args.Diff([]interface{}{"string", 123, true})
 
@@ -974,7 +974,7 @@ func Test_Arguments_Diff_WithAnythingArgument_InActualToo(t *testing.T) {
 
 func Test_Arguments_Diff_WithAnythingOfTypeArgument(t *testing.T) {
 
-	var args Arguments = []interface{}{"string", AnythingOfType("int"), true}
+	var args = Arguments([]interface{}{"string", AnythingOfType("int"), true})
 	var count int
 	_, count = args.Diff([]interface{}{"string", 123, true})
 
@@ -984,7 +984,7 @@ func Test_Arguments_Diff_WithAnythingOfTypeArgument(t *testing.T) {
 
 func Test_Arguments_Diff_WithAnythingOfTypeArgument_Failing(t *testing.T) {
 
-	var args Arguments = []interface{}{"string", AnythingOfType("string"), true}
+	var args = Arguments([]interface{}{"string", AnythingOfType("string"), true})
 	var count int
 	var diff string
 	diff, count = args.Diff([]interface{}{"string", 123, true})
@@ -998,7 +998,7 @@ func Test_Arguments_Diff_WithArgMatcher(t *testing.T) {
 	matchFn := func(a int) bool {
 		return a == 123
 	}
-	var args Arguments = []interface{}{"string", MatchedBy(matchFn), true}
+	var args = Arguments([]interface{}{"string", MatchedBy(matchFn), true})
 
 	diff, count := args.Diff([]interface{}{"string", 124, true})
 	assert.Equal(t, 1, count)
@@ -1018,7 +1018,7 @@ func Test_Arguments_Diff_WithArgMatcher(t *testing.T) {
 
 func Test_Arguments_Assert(t *testing.T) {
 
-	var args Arguments = []interface{}{"string", 123, true}
+	var args = Arguments([]interface{}{"string", 123, true})
 
 	assert.True(t, args.Assert(t, "string", 123, true))
 
@@ -1026,43 +1026,43 @@ func Test_Arguments_Assert(t *testing.T) {
 
 func Test_Arguments_String_Representation(t *testing.T) {
 
-	var args Arguments = []interface{}{"string", 123, true}
+	var args = Arguments([]interface{}{"string", 123, true})
 	assert.Equal(t, `string,int,bool`, args.String())
 
 }
 
 func Test_Arguments_String(t *testing.T) {
 
-	var args Arguments = []interface{}{"string", 123, true}
+	var args = Arguments([]interface{}{"string", 123, true})
 	assert.Equal(t, "string", args.String(0))
 
 }
 
 func Test_Arguments_Error(t *testing.T) {
 
-	var err error = errors.New("An Error")
-	var args Arguments = []interface{}{"string", 123, true, err}
+	var err = errors.New("An Error")
+	var args = Arguments([]interface{}{"string", 123, true, err})
 	assert.Equal(t, err, args.Error(3))
 
 }
 
 func Test_Arguments_Error_Nil(t *testing.T) {
 
-	var args Arguments = []interface{}{"string", 123, true, nil}
+	var args = Arguments([]interface{}{"string", 123, true, nil})
 	assert.Equal(t, nil, args.Error(3))
 
 }
 
 func Test_Arguments_Int(t *testing.T) {
 
-	var args Arguments = []interface{}{"string", 123, true}
+	var args = Arguments([]interface{}{"string", 123, true})
 	assert.Equal(t, 123, args.Int(1))
 
 }
 
 func Test_Arguments_Bool(t *testing.T) {
 
-	var args Arguments = []interface{}{"string", 123, true}
+	var args = Arguments([]interface{}{"string", 123, true})
 	assert.Equal(t, true, args.Bool(2))
 
 }

--- a/require/doc.go
+++ b/require/doc.go
@@ -1,4 +1,5 @@
-// Alternative testing tools which stop test execution if test failed.
+// Package require implements the same assertions as the `assert` package but
+// stops test execution when a test fails.
 //
 // Example Usage
 //

--- a/require/forward_requirements.go
+++ b/require/forward_requirements.go
@@ -1,9 +1,12 @@
 package require
 
+// Assertions provides assertion methods around the
+// TestingT interface.
 type Assertions struct {
 	t TestingT
 }
 
+// New makes a new Assertions object for the specified TestingT.
 func New(t TestingT) *Assertions {
 	return &Assertions{
 		t: t,

--- a/require/requirements.go
+++ b/require/requirements.go
@@ -1,5 +1,6 @@
 package require
 
+// TestingT is an interface wrapper around *testing.T
 type TestingT interface {
 	Errorf(format string, args ...interface{})
 	FailNow()

--- a/suite/doc.go
+++ b/suite/doc.go
@@ -1,4 +1,4 @@
-// The suite package contains logic for creating testing suite structs
+// Package suite contains logic for creating testing suite structs
 // and running the methods on those structs as tests.  The most useful
 // piece of this package is that you can create setup/teardown methods
 // on your testing suites, which will run before/after the whole suite


### PR DESCRIPTION
Most lints are fixed except two:

 - `assert.AnError` is kept unrenamed to keep changes backwards compatible.
 - mock.argumentMatcher is unexported for the time being.

We've also changed the comments in the `http` package to be more aggressive with the deprecation warnings.

Finally we have unexported FailNower. This is a breaking change but since we released FailNower a couple of days ago it should be OK.