### PR TITLE
Fix a typo

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -132,7 +132,7 @@ func (c *Call) After(d time.Duration) *Call {
 // mocking a method such as unmarshalers that takes a pointer to a struct and
 // sets properties in such struct
 //
-//    Mock.On("Unmarshal", AnythingOfType("*map[string]interface{}").Return().Run(function(args Arguments) {
+//    Mock.On("Unmarshal", AnythingOfType("*map[string]interface{}").Return().Run(func(args Arguments) {
 //    	arg := args.Get(0).(*map[string]interface{})
 //    	arg["foo"] = "bar"
 //    })


### PR DESCRIPTION
Fix a tiny typo found while browsing go documentation.