### PR TITLE
Fixes mock: Confusing error when Repeatability does not match

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -225,15 +225,15 @@ func (m *Mock) findExpectedCall(method string, arguments ...interface{}) (int, *
 }
 
 func (m *Mock) findClosestCall(method string, arguments ...interface{}) (bool, *Call) {
-	diffCount := 0
+	closestDiffCount := 0
 	var closestCall *Call
 
 	for _, call := range m.expectedCalls() {
 		if call.Method == method {
 
 			_, tempDiffCount := call.Arguments.Diff(arguments)
-			if tempDiffCount < diffCount || diffCount == 0 {
-				diffCount = tempDiffCount
+			if tempDiffCount < closestDiffCount || closestDiffCount == 0 {
+				closestDiffCount = tempDiffCount
 				closestCall = call
 			}
 
@@ -296,7 +296,15 @@ func (m *Mock) Called(arguments ...interface{}) Arguments {
 		closestFound, closestCall := m.findClosestCall(functionName, arguments...)
 
 		if closestFound {
-			panic(fmt.Sprintf("\n\nmock: Unexpected Method Call\n-----------------------------\n\n%s\n\nThe closest call I have is: \n\n%s\n", callString(functionName, arguments, true), callString(functionName, closestCall.Arguments, true)))
+			if functionName == closestCall.Method && closestCall.Repeatability == -1 {
+				panic(fmt.Sprintf(
+					"\n\nmock: Unexpected Method Call\n-----------------------------\n\n%s\n\n" +
+					"Found call, but Repeatability is exhausted. Use Times(n), Once(), Twice() or nothing to finetune.\n\n",
+					callString(functionName, arguments, true),
+				))
+			} else {
+				panic(fmt.Sprintf("\n\nmock: Unexpected Method Call\n-----------------------------\n\n%s\n\nThe closest call I have is: \n\n%s\n", callString(functionName, arguments, true), callString(functionName, closestCall.Arguments, true)))
+			}
 		} else {
 			panic(fmt.Sprintf("\nassert: mock: I don't know what to return because the method call was unexpected.\n\tEither do Mock.On(\"%s\").Return(...) first, or remove the %s() call.\n\tThis method was unexpected:\n\t\t%s\n\tat: %s", functionName, functionName, callString(functionName, arguments, true), assert.CallerInfo()))
 		}

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -296,7 +296,9 @@ func (m *Mock) Called(arguments ...interface{}) Arguments {
 		closestFound, closestCall := m.findClosestCall(functionName, arguments...)
 
 		if closestFound {
-			if functionName == closestCall.Method && closestCall.Repeatability == -1 {
+			m.mutex.lock()
+			defer m.mutex.unlock()
+			if closestCall.Repeatability == -1 {
 				panic(fmt.Sprintf(
 					"\n\nmock: Unexpected Method Call\n-----------------------------\n\n%s\n\n" +
 					"Found call, but Repeatability is exhausted. Use Times(n), Once(), Twice() or nothing to finetune.\n\n",


### PR DESCRIPTION
Fixes #280.

When running our test with my fork I now get this error message:

```
[..]
mock: Unexpected Method Call
-----------------------------

GetStatusWithMatcher(func(string) bool)
        0: (func(string) bool)(0x494c80)

Found call, but Repeatability is exhausted. Use Times(n), Once(), Twice() or nothing to finetune.

goroutine 18 [running]:
github.com/stretchr/testify/mock.(*Mock).Called(0xc82000b100, 0xc8200d4270, 0x1, 0x1, 0x0, 0x0, 0x0)
    /usr/code/.gobuild/src/github.com/stretchr/testify/mock/mock.go:304 +0x4de
_/usr/code/controller.(*fleetMock).GetStatusWithMatcher(0xc82000b100, 0xc8200d2140, 0x0, 0x0, 0x0, 0x0, 0x0)
    /usr/code/controller/fleet_mock_test.go:40 +0xed
[...]
```

Arguably not perfect but better. Feel free to merge and then change the message to something more reasonable. The change was lovely easy to implement :heart: 

I also took the liberty to rename `diffCount` as I was actually confused for a minute there what this is. `closestDiffCount` striked me as more obvious.
- NOTE:\* The tests seem to be failing. I have no idea why. A hint would be nice.
