### PR TITLE
Add Before and After assertions to Testify Assert

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -666,6 +666,34 @@ func NotPanics(t TestingT, f PanicTestFunc, msgAndArgs ...interface{}) bool {
 	return true
 }
 
+// Before asserts that the actual time is before the expected time.
+//
+//   assert.Before(t, time.Now(), time.Now().Add(time.Hour), "The current time should be befote one hour from now")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func Before(t TestingT, actual, target time.Time, msgAndArgs ...interface{}) bool {
+
+	if !actual.Before(target) {
+		return Fail(t, fmt.Sprintf("%v is not before %v", actual, target), msgAndArgs...)
+	}
+
+	return true
+}
+
+// After asserts that the actual time is before the expected time.
+//
+//   assert.After(t, time.Now().Add(time.Hour), time.Now(), "One hour later should be after the current time")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func After(t TestingT, actual, target time.Time, msgAndArgs ...interface{}) bool {
+
+	if !actual.After(target) {
+		return Fail(t, fmt.Sprintf("%v is not after %v", actual, target), msgAndArgs...)
+	}
+
+	return true
+}
+
 // WithinDuration asserts that the two times are within duration delta of each other.
 //
 //   assert.WithinDuration(t, time.Now(), time.Now(), 10*time.Second, "The difference should not be more than 10s")

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -740,6 +740,32 @@ func TestLen(t *testing.T) {
 	}
 }
 
+func TestBefore(t *testing.T) {
+
+	mockT := new(testing.T)
+	noonUTC, _ := time.Parse(time.RFC3339, "2016-04-23T12:00:00+00:00")
+	oneUTC := noonUTC.Add(time.Hour)
+	noonEST, _ := time.Parse(time.RFC3339, "2016-04-23T12:00:00-05:00")
+
+	True(t, Before(mockT, noonUTC, oneUTC), "Noon should be before 1pm")
+	True(t, Before(mockT, noonUTC, noonEST), "Noon UTC should be before noon EST")
+	False(t, Before(mockT, oneUTC, noonUTC), "1pm should not be before noon")
+	False(t, Before(mockT, noonUTC, noonUTC), "Noon should not be before itself")
+}
+
+func TestAfter(t *testing.T) {
+
+	mockT := new(testing.T)
+	noonUTC, _ := time.Parse(time.RFC3339, "2016-04-23T12:00:00+00:00")
+	oneUTC := noonUTC.Add(time.Hour)
+	noonEST, _ := time.Parse(time.RFC3339, "2016-04-23T12:00:00-05:00")
+
+	True(t, After(mockT, oneUTC, noonUTC), "1pm should be after noon")
+	True(t, After(mockT, noonEST, noonUTC), "Noon EST should be after noon UTC")
+	False(t, After(mockT, noonUTC, oneUTC), "Noon should not be after 1pm")
+	False(t, After(mockT, noonUTC, noonUTC), "Noon should not be after itself")
+}
+
 func TestWithinDuration(t *testing.T) {
 
 	mockT := new(testing.T)


### PR DESCRIPTION
One possible concern with these assertions is the order of the target and actual times. In assertions like `Equal`, the target value comes first. I chose to put the actual value first in the `Before` and `After` assertions because it feels like a more natural syntax for comparisons
