### PR TITLE
Include type information in output

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -262,8 +262,8 @@ func Equal(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) 
 
 	if !ObjectsAreEqual(expected, actual) {
 		diff := diff(expected, actual)
-		return Fail(t, fmt.Sprintf("Not equal: %#v (%[1]T (expected)\n"+
-			"        != %#v %[2]T (actual)%s", expected, actual, diff), msgAndArgs...)
+		return Fail(t, fmt.Sprintf("Not equal: %#v (%[1]T) (expected)\n"+
+			"        != %#v (%[2]T) (actual)%s", expected, actual, diff), msgAndArgs...)
 	}
 
 	return true

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -262,8 +262,8 @@ func Equal(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) 
 
 	if !ObjectsAreEqual(expected, actual) {
 		diff := diff(expected, actual)
-		return Fail(t, fmt.Sprintf("Not equal: %#v (expected)\n"+
-			"        != %#v (actual)%s", expected, actual, diff), msgAndArgs...)
+		return Fail(t, fmt.Sprintf("Not equal: %#v (%[1]T (expected)\n"+
+			"        != %#v %[2]T (actual)%s", expected, actual, diff), msgAndArgs...)
 	}
 
 	return true


### PR DESCRIPTION
Modifies the output of (assert|require).Equal to include the type of the variables being compared

Fixes #322 
