### PR TITLE
Clarify assert.Equal failure message given mismatched numeric types

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -262,12 +262,51 @@ func Equal(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) 
 
 	if !ObjectsAreEqual(expected, actual) {
 		diff := diff(expected, actual)
-		return Fail(t, fmt.Sprintf("Not equal: %#v (expected)\n"+
-			"        != %#v (actual)%s", expected, actual, diff), msgAndArgs...)
+		expected, actual = formatUnequalValues(expected, actual)
+		return Fail(t, fmt.Sprintf("Not equal: %v (expected)\n"+
+			"        != %v (actual)%s", expected, actual, diff), msgAndArgs...)
 	}
 
 	return true
 
+}
+
+// formatUnequalValues takes two values of arbitrary types and returns string
+// representations appropriate to be presented to the user.
+//
+// If the values are not of like type, the returned strings will be prefixed
+// with the type name, and the value will be enclosed in parenthesis similar
+// to a type conversion in the Go grammar.
+func formatUnequalValues(expected, actual interface{}) (e string, a string) {
+	aType := reflect.TypeOf(expected)
+	bType := reflect.TypeOf(actual)
+
+	if aType != bType && isNumericType(aType) && isNumericType(bType) {
+		return fmt.Sprintf("%v(%#v)", aType, expected),
+			fmt.Sprintf("%v(%#v)", bType, actual)
+	}
+
+	return fmt.Sprintf("%#v", expected),
+		fmt.Sprintf("%#v", actual)
+}
+
+var numericTypes = map[string]bool{
+	"float32": true,
+	"float64": true,
+	"int":     true,
+	"int8":    true,
+	"int16":   true,
+	"int32":   true,
+	"int64":   true,
+	"uint":    true,
+	"uint8":   true,
+	"uint16":  true,
+	"uint32":  true,
+	"uint64":  true,
+}
+
+func isNumericType(t reflect.Type) bool {
+	return numericTypes[t.String()]
 }
 
 // EqualValues asserts that two objects are equal or convertable to the same types

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -290,23 +290,17 @@ func formatUnequalValues(expected, actual interface{}) (e string, a string) {
 		fmt.Sprintf("%#v", actual)
 }
 
-var numericTypes = map[string]bool{
-	"float32": true,
-	"float64": true,
-	"int":     true,
-	"int8":    true,
-	"int16":   true,
-	"int32":   true,
-	"int64":   true,
-	"uint":    true,
-	"uint8":   true,
-	"uint16":  true,
-	"uint32":  true,
-	"uint64":  true,
-}
-
 func isNumericType(t reflect.Type) bool {
-	return numericTypes[t.String()]
+	switch t.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return true
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return true
+	case reflect.Float32, reflect.Float64:
+		return true
+	}
+
+	return false
 }
 
 // EqualValues asserts that two objects are equal or convertable to the same types

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -263,8 +263,8 @@ func Equal(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) 
 	if !ObjectsAreEqual(expected, actual) {
 		diff := diff(expected, actual)
 		expected, actual = formatUnequalValues(expected, actual)
-		return Fail(t, fmt.Sprintf("Not equal: %v (expected)\n"+
-			"        != %v (actual)%s", expected, actual, diff), msgAndArgs...)
+		return Fail(t, fmt.Sprintf("Not equal: %s (expected)\n"+
+			"        != %s (actual)%s", expected, actual, diff), msgAndArgs...)
 	}
 
 	return true

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -195,6 +195,20 @@ func TestEqual(t *testing.T) {
 
 }
 
+func TestFormatUnequalValues(t *testing.T) {
+	expected, actual := formatUnequalValues("foo", "bar")
+	Equal(t, `"foo"`, expected, "value should not include type")
+	Equal(t, `"bar"`, actual, "value should not include type")
+
+	expected, actual = formatUnequalValues(123, 123)
+	Equal(t, `123`, expected, "value should not include type")
+	Equal(t, `123`, actual, "value should not include type")
+
+	expected, actual = formatUnequalValues(int64(123), int32(123))
+	Equal(t, `int64(123)`, expected, "value should include type")
+	Equal(t, `int32(123)`, actual, "value should include type")
+}
+
 func TestNotNil(t *testing.T) {
 
 	mockT := new(testing.T)

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -207,6 +207,14 @@ func TestFormatUnequalValues(t *testing.T) {
 	expected, actual = formatUnequalValues(int64(123), int32(123))
 	Equal(t, `int64(123)`, expected, "value should include type")
 	Equal(t, `int32(123)`, actual, "value should include type")
+
+	type testStructType struct {
+		Val string
+	}
+
+	expected, actual = formatUnequalValues(&testStructType{Val: "test"}, &testStructType{Val: "test"})
+	Equal(t, `&assert.testStructType{Val:"test"}`, expected, "value should not include type annotation")
+	Equal(t, `&assert.testStructType{Val:"test"}`, actual, "value should not include type annotation")
 }
 
 func TestNotNil(t *testing.T) {


### PR DESCRIPTION
Resolves #155.

This change causes type names to be printed when the failure message would otherwise be ambiguous. Specifically, it addresses equality assertions on numeric values of unlike types.

### Example
_Before:_
```go
assert.Equal(t, int64(123), int32(123))
//
// Not equal: 123 (expected)
//       != 123 (actual)
```

_After:_
```go
assert.Equal(t, int64(123), int32(123))
//
// Not equal: int64(123) (expected)
//      != int32(123) (actual)
```