### PR TITLE
Clearer messages

### DIFF
--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -1,385 +1,346 @@
 /*
 * CODE GENERATED AUTOMATICALLY WITH github.com/stretchr/testify/_codegen
 * THIS FILE MUST NOT BE EDITED BY HAND
-*/
+ */
 
 package assert
 
 import (
-
 	http "net/http"
 	url "net/url"
 	time "time"
 )
-
 
 // Condition uses a Comparison to assert a complex condition.
 func (a *Assertions) Condition(comp Comparison, msgAndArgs ...interface{}) bool {
 	return Condition(a.t, comp, msgAndArgs...)
 }
 
-
 // Contains asserts that the specified string, list(array, slice...) or map contains the
 // specified substring or element.
-// 
+//
 //    a.Contains("Hello World", "World", "But 'Hello World' does contain 'World'")
 //    a.Contains(["Hello", "World"], "World", "But ["Hello", "World"] does contain 'World'")
 //    a.Contains({"Hello": "World"}, "Hello", "But {'Hello': 'World'} does contain 'Hello'")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Contains(s interface{}, contains interface{}, msgAndArgs ...interface{}) bool {
 	return Contains(a.t, s, contains, msgAndArgs...)
 }
 
-
 // Empty asserts that the specified object is empty.  I.e. nil, "", false, 0 or either
 // a slice or a channel with len == 0.
-// 
+//
 //  a.Empty(obj)
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Empty(object interface{}, msgAndArgs ...interface{}) bool {
 	return Empty(a.t, object, msgAndArgs...)
 }
 
-
 // Equal asserts that two objects are equal.
-// 
+//
 //    a.Equal(123, 123, "123 and 123 should be equal")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Equal(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
 	return Equal(a.t, expected, actual, msgAndArgs...)
 }
 
-
 // EqualError asserts that a function returned an error (i.e. not `nil`)
 // and that it is equal to the provided error.
-// 
+//
 //   actualObj, err := SomeFunction()
 //   if assert.Error(t, err, "An error was expected") {
 // 	   assert.Equal(t, err, expectedError)
 //   }
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...interface{}) bool {
 	return EqualError(a.t, theError, errString, msgAndArgs...)
 }
 
-
 // EqualValues asserts that two objects are equal or convertable to the same types
 // and equal.
-// 
+//
 //    a.EqualValues(uint32(123), int32(123), "123 and 123 should be equal")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) EqualValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
 	return EqualValues(a.t, expected, actual, msgAndArgs...)
 }
 
-
 // Error asserts that a function returned an error (i.e. not `nil`).
-// 
+//
 //   actualObj, err := SomeFunction()
 //   if a.Error(err, "An error was expected") {
 // 	   assert.Equal(t, err, expectedError)
 //   }
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Error(err error, msgAndArgs ...interface{}) bool {
 	return Error(a.t, err, msgAndArgs...)
 }
 
-
 // Exactly asserts that two objects are equal is value and type.
-// 
+//
 //    a.Exactly(int32(123), int64(123), "123 and 123 should NOT be equal")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Exactly(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
 	return Exactly(a.t, expected, actual, msgAndArgs...)
 }
-
 
 // Fail reports a failure through
 func (a *Assertions) Fail(failureMessage string, msgAndArgs ...interface{}) bool {
 	return Fail(a.t, failureMessage, msgAndArgs...)
 }
 
-
 // FailNow fails test
 func (a *Assertions) FailNow(failureMessage string, msgAndArgs ...interface{}) bool {
 	return FailNow(a.t, failureMessage, msgAndArgs...)
 }
 
-
 // False asserts that the specified value is false.
-// 
+//
 //    a.False(myBool, "myBool should be false")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) False(value bool, msgAndArgs ...interface{}) bool {
 	return False(a.t, value, msgAndArgs...)
 }
 
-
 // HTTPBodyContains asserts that a specified handler returns a
 // body that contains a string.
-// 
+//
 //  a.HTTPBodyContains(myHandler, "www.google.com", nil, "I'm Feeling Lucky")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPBodyContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}) bool {
 	return HTTPBodyContains(a.t, handler, method, url, values, str)
 }
 
-
 // HTTPBodyNotContains asserts that a specified handler returns a
 // body that does not contain a string.
-// 
+//
 //  a.HTTPBodyNotContains(myHandler, "www.google.com", nil, "I'm Feeling Lucky")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPBodyNotContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}) bool {
 	return HTTPBodyNotContains(a.t, handler, method, url, values, str)
 }
 
-
 // HTTPError asserts that a specified handler returns an error status code.
-// 
+//
 //  a.HTTPError(myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPError(handler http.HandlerFunc, method string, url string, values url.Values) bool {
 	return HTTPError(a.t, handler, method, url, values)
 }
 
-
 // HTTPRedirect asserts that a specified handler returns a redirect status code.
-// 
+//
 //  a.HTTPRedirect(myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPRedirect(handler http.HandlerFunc, method string, url string, values url.Values) bool {
 	return HTTPRedirect(a.t, handler, method, url, values)
 }
 
-
 // HTTPSuccess asserts that a specified handler returns a success status code.
-// 
+//
 //  a.HTTPSuccess(myHandler, "POST", "http://www.google.com", nil)
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPSuccess(handler http.HandlerFunc, method string, url string, values url.Values) bool {
 	return HTTPSuccess(a.t, handler, method, url, values)
 }
 
-
 // Implements asserts that an object is implemented by the specified interface.
-// 
+//
 //    a.Implements((*MyInterface)(nil), new(MyObject), "MyObject")
 func (a *Assertions) Implements(interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) bool {
 	return Implements(a.t, interfaceObject, object, msgAndArgs...)
 }
 
-
 // InDelta asserts that the two numerals are within delta of each other.
-// 
+//
 // 	 a.InDelta(math.Pi, (22 / 7.0), 0.01)
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) InDelta(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) bool {
 	return InDelta(a.t, expected, actual, delta, msgAndArgs...)
 }
-
 
 // InDeltaSlice is the same as InDelta, except it compares two slices.
 func (a *Assertions) InDeltaSlice(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) bool {
 	return InDeltaSlice(a.t, expected, actual, delta, msgAndArgs...)
 }
 
-
 // InEpsilon asserts that expected and actual have a relative error less than epsilon
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) InEpsilon(expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) bool {
 	return InEpsilon(a.t, expected, actual, epsilon, msgAndArgs...)
 }
-
 
 // InEpsilonSlice is the same as InEpsilon, except it compares two slices.
 func (a *Assertions) InEpsilonSlice(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) bool {
 	return InEpsilonSlice(a.t, expected, actual, delta, msgAndArgs...)
 }
 
-
 // IsType asserts that the specified objects are of the same type.
 func (a *Assertions) IsType(expectedType interface{}, object interface{}, msgAndArgs ...interface{}) bool {
 	return IsType(a.t, expectedType, object, msgAndArgs...)
 }
 
-
 // JSONEq asserts that two JSON strings are equivalent.
-// 
+//
 //  a.JSONEq(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) JSONEq(expected string, actual string, msgAndArgs ...interface{}) bool {
 	return JSONEq(a.t, expected, actual, msgAndArgs...)
 }
 
-
 // Len asserts that the specified object has specific length.
 // Len also fails if the object has a type that len() not accept.
-// 
+//
 //    a.Len(mySlice, 3, "The size of slice is not 3")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Len(object interface{}, length int, msgAndArgs ...interface{}) bool {
 	return Len(a.t, object, length, msgAndArgs...)
 }
 
-
 // Nil asserts that the specified object is nil.
-// 
+//
 //    a.Nil(err, "err should be nothing")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Nil(object interface{}, msgAndArgs ...interface{}) bool {
 	return Nil(a.t, object, msgAndArgs...)
 }
 
-
 // NoError asserts that a function returned no error (i.e. `nil`).
-// 
+//
 //   actualObj, err := SomeFunction()
 //   if a.NoError(err) {
 // 	   assert.Equal(t, actualObj, expectedObj)
 //   }
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NoError(err error, msgAndArgs ...interface{}) bool {
 	return NoError(a.t, err, msgAndArgs...)
 }
 
-
 // NotContains asserts that the specified string, list(array, slice...) or map does NOT contain the
 // specified substring or element.
-// 
+//
 //    a.NotContains("Hello World", "Earth", "But 'Hello World' does NOT contain 'Earth'")
 //    a.NotContains(["Hello", "World"], "Earth", "But ['Hello', 'World'] does NOT contain 'Earth'")
 //    a.NotContains({"Hello": "World"}, "Earth", "But {'Hello': 'World'} does NOT contain 'Earth'")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotContains(s interface{}, contains interface{}, msgAndArgs ...interface{}) bool {
 	return NotContains(a.t, s, contains, msgAndArgs...)
 }
 
-
 // NotEmpty asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or either
 // a slice or a channel with len == 0.
-// 
+//
 //  if a.NotEmpty(obj) {
 //    assert.Equal(t, "two", obj[1])
 //  }
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) bool {
 	return NotEmpty(a.t, object, msgAndArgs...)
 }
 
-
 // NotEqual asserts that the specified values are NOT equal.
-// 
+//
 //    a.NotEqual(obj1, obj2, "two objects shouldn't be equal")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotEqual(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
 	return NotEqual(a.t, expected, actual, msgAndArgs...)
 }
 
-
 // NotNil asserts that the specified object is not nil.
-// 
+//
 //    a.NotNil(err, "err should be something")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotNil(object interface{}, msgAndArgs ...interface{}) bool {
 	return NotNil(a.t, object, msgAndArgs...)
 }
 
-
 // NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
-// 
+//
 //   a.NotPanics(func(){
 //     RemainCalm()
 //   }, "Calling RemainCalm() should NOT panic")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotPanics(f PanicTestFunc, msgAndArgs ...interface{}) bool {
 	return NotPanics(a.t, f, msgAndArgs...)
 }
 
-
 // NotRegexp asserts that a specified regexp does not match a string.
-// 
+//
 //  a.NotRegexp(regexp.MustCompile("starts"), "it's starting")
 //  a.NotRegexp("^start", "it's not starting")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) bool {
 	return NotRegexp(a.t, rx, str, msgAndArgs...)
 }
-
 
 // NotZero asserts that i is not the zero value for its type and returns the truth.
 func (a *Assertions) NotZero(i interface{}, msgAndArgs ...interface{}) bool {
 	return NotZero(a.t, i, msgAndArgs...)
 }
 
-
 // Panics asserts that the code inside the specified PanicTestFunc panics.
-// 
+//
 //   a.Panics(func(){
 //     GoCrazy()
 //   }, "Calling GoCrazy() should panic")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Panics(f PanicTestFunc, msgAndArgs ...interface{}) bool {
 	return Panics(a.t, f, msgAndArgs...)
 }
 
-
 // Regexp asserts that a specified regexp matches a string.
-// 
+//
 //  a.Regexp(regexp.MustCompile("start"), "it's starting")
 //  a.Regexp("start...$", "it's not starting")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) bool {
 	return Regexp(a.t, rx, str, msgAndArgs...)
 }
 
-
 // True asserts that the specified value is true.
-// 
+//
 //    a.True(myBool, "myBool should be true")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) True(value bool, msgAndArgs ...interface{}) bool {
 	return True(a.t, value, msgAndArgs...)
 }
 
-
 // WithinDuration asserts that the two times are within duration delta of each other.
-// 
+//
 //   a.WithinDuration(time.Now(), time.Now(), 10*time.Second, "The difference should not be more than 10s")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) WithinDuration(expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) bool {
 	return WithinDuration(a.t, expected, actual, delta, msgAndArgs...)
 }
-
 
 // Zero asserts that i is the zero value for its type and returns the truth.
 func (a *Assertions) Zero(i interface{}, msgAndArgs ...interface{}) bool {


### PR DESCRIPTION
- NoError prints the error message on the next line, unquoted, which makes multiline error messages much clearer.  Sample of an error message which includes a multiline stacktrace:

		Error:  Received unexpected error:
				Hi!

					/Volumes/Pouch/Users/russegan/dev/go/src/gitlab.protectv.local/ncryptify/client.git/client_test.go:27 (0x75c8c)
						TestNew: assert.NoError(merry.New("Hi!"), "with message")
					/usr/local/Cellar/go/1.7rc1/libexec/src/testing/testing.go:610 (0x70a01)
				tRunner: fn(t)
					/usr/local/Cellar/go/1.7rc1/libexec/src/runtime/asm_amd64.s:2086 (0x5d131)
				goexit: BYTE	$0x90	// NOP
		Messages:	with message

- Error,NoError,and EqualError now don’t inline the user’s extra messages.  user’s messages are printed in the “Messages:” section, as with all other assertions.
- EqualError now avoids isNil(), mirroring the changes already made to Error and NoError.
- Equal and EqualError now print the expected and actual values each on a newline, aligned vertically, which makes it easier for a human to visually detect the differences.  Examples:

		Error:		Error message not equal:
				"no failure" (expected)
				"failure" (actual)
		Messages:	with message

		Error:	Not equal:
				"high" (expected)
				"low" (actual)
		Messages:	with message