### PR TITLE
Export mock.argumentMatcher

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -472,14 +472,14 @@ func AnythingOfType(t string) AnythingOfTypeArgument {
 	return AnythingOfTypeArgument(t)
 }
 
-// argumentMatcher performs custom argument matching, returning whether or
+// ArgumentMatcher performs custom argument matching, returning whether or
 // not the argument is matched by the expectation fixture function.
-type argumentMatcher struct {
+type ArgumentMatcher struct {
 	// fn is a function which accepts one argument, and returns a bool.
 	fn reflect.Value
 }
 
-func (f argumentMatcher) Matches(argument interface{}) bool {
+func (f ArgumentMatcher) Matches(argument interface{}) bool {
 	expectType := f.fn.Type().In(0)
 
 	if reflect.TypeOf(argument).AssignableTo(expectType) {
@@ -489,7 +489,7 @@ func (f argumentMatcher) Matches(argument interface{}) bool {
 	return false
 }
 
-func (f argumentMatcher) String() string {
+func (f ArgumentMatcher) String() string {
 	return fmt.Sprintf("func(%s) bool", f.fn.Type().In(0).Name())
 }
 
@@ -504,7 +504,7 @@ func (f argumentMatcher) String() string {
 // |fn|, must be a function accepting a single argument (of the expected type)
 // which returns a bool. If |fn| doesn't match the required signature,
 // MathedBy() panics.
-func MatchedBy(fn interface{}) argumentMatcher {
+func MatchedBy(fn interface{}) ArgumentMatcher {
 	fnType := reflect.TypeOf(fn)
 
 	if fnType.Kind() != reflect.Func {
@@ -517,7 +517,7 @@ func MatchedBy(fn interface{}) argumentMatcher {
 		panic(fmt.Sprintf("assert: arguments: %s does not return a bool", fn))
 	}
 
-	return argumentMatcher{fn: reflect.ValueOf(fn)}
+	return ArgumentMatcher{fn: reflect.ValueOf(fn)}
 }
 
 // Get Returns the argument at the specified index.
@@ -567,7 +567,7 @@ func (args Arguments) Diff(objects []interface{}) (string, int) {
 			expected = args[i]
 		}
 
-		if matcher, ok := expected.(argumentMatcher); ok {
+		if matcher, ok := expected.(ArgumentMatcher); ok {
 			if matcher.Matches(actual) {
 				output = fmt.Sprintf("%s\t%d: \u2705  %s matched by %s\n", output, i, actual, matcher)
 			} else {


### PR DESCRIPTION
This allows the creation of predicate-generating functions, which can make code a lot cleaner. To give a very simple example, this is not possible with the current non-exported argumentMatcher:

``` go
type Counter struct{ x int }

func counterArg(expectedX int) mock.ArgumentMatcher {
    return mock.MatchedBy(func(c *Counter) bool {
        return c.x == expectedX
    })
}

mock.On("Method", counterArg(1))
mock.On("Method", counterArg(2))
mock.On("Method", counterArg(3))
```

Also fixes the outstanding lint issues from #230
