### PR TITLE
Changing format of NoError output to make use of errors

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -833,7 +833,7 @@ func InEpsilonSlice(t TestingT, expected, actual interface{}, epsilon float64, m
 // Returns whether the assertion was successful (true) or not (false).
 func NoError(t TestingT, err error, msgAndArgs ...interface{}) bool {
 	if err != nil {
-		return Fail(t, fmt.Sprintf("Received unexpected error %q", err), msgAndArgs...)
+		return Fail(t, fmt.Sprintf("Received unexpected error %+v", err), msgAndArgs...)
 	}
 
 	return true


### PR DESCRIPTION
While %+v shouldn't significantly change the formatting of most errors, it prints a stacktrace for errors that have been created or wrapped with pkgs/errors, which is extremely helpful for debugging.