### PR TITLE
Fix #347 - Diff data race

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -18,6 +18,10 @@ import (
 	"github.com/pmezard/go-difflib/difflib"
 )
 
+func init() {
+	spew.Config.SortKeys = true
+}
+
 // TestingT is an interface wrapper around *testing.T
 type TestingT interface {
 	Errorf(format string, args ...interface{})
@@ -989,7 +993,6 @@ func diff(expected interface{}, actual interface{}) string {
 		return ""
 	}
 
-	spew.Config.SortKeys = true
 	e := spew.Sdump(expected)
 	a := spew.Sdump(actual)
 


### PR DESCRIPTION
Fix for [this issue](https://github.com/stretchr/testify/issues/347). `diff()` would not pass the go race detector, because it writes to the spew global config with no synchronization. This is easy to see when using assertions that result in non-empty diffs in tests using `t.Parallel()`. The config member assignment has been moved to the assert package's `init()` function. There are no other code paths that write to the spew config, so this should be isolated to the `diff()` function.

Unfortunately, one cannot write a test to ensure the absence of data races, since the go `race` package has no public API, so the simplest way to check is by running `go test -race path/to/assert`