### PR TITLE
Run gofmt on assertion_forward.go

### DIFF
--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -1,385 +1,346 @@
 /*
 * CODE GENERATED AUTOMATICALLY WITH github.com/stretchr/testify/_codegen
 * THIS FILE MUST NOT BE EDITED BY HAND
-*/
+ */
 
 package assert
 
 import (
-
 	http "net/http"
 	url "net/url"
 	time "time"
 )
-
 
 // Condition uses a Comparison to assert a complex condition.
 func (a *Assertions) Condition(comp Comparison, msgAndArgs ...interface{}) bool {
 	return Condition(a.t, comp, msgAndArgs...)
 }
 
-
 // Contains asserts that the specified string, list(array, slice...) or map contains the
 // specified substring or element.
-// 
+//
 //    a.Contains("Hello World", "World", "But 'Hello World' does contain 'World'")
 //    a.Contains(["Hello", "World"], "World", "But ["Hello", "World"] does contain 'World'")
 //    a.Contains({"Hello": "World"}, "Hello", "But {'Hello': 'World'} does contain 'Hello'")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Contains(s interface{}, contains interface{}, msgAndArgs ...interface{}) bool {
 	return Contains(a.t, s, contains, msgAndArgs...)
 }
 
-
 // Empty asserts that the specified object is empty.  I.e. nil, "", false, 0 or either
 // a slice or a channel with len == 0.
-// 
+//
 //  a.Empty(obj)
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Empty(object interface{}, msgAndArgs ...interface{}) bool {
 	return Empty(a.t, object, msgAndArgs...)
 }
 
-
 // Equal asserts that two objects are equal.
-// 
+//
 //    a.Equal(123, 123, "123 and 123 should be equal")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Equal(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
 	return Equal(a.t, expected, actual, msgAndArgs...)
 }
 
-
 // EqualError asserts that a function returned an error (i.e. not `nil`)
 // and that it is equal to the provided error.
-// 
+//
 //   actualObj, err := SomeFunction()
 //   if assert.Error(t, err, "An error was expected") {
 // 	   assert.Equal(t, err, expectedError)
 //   }
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...interface{}) bool {
 	return EqualError(a.t, theError, errString, msgAndArgs...)
 }
 
-
 // EqualValues asserts that two objects are equal or convertable to the same types
 // and equal.
-// 
+//
 //    a.EqualValues(uint32(123), int32(123), "123 and 123 should be equal")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) EqualValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
 	return EqualValues(a.t, expected, actual, msgAndArgs...)
 }
 
-
 // Error asserts that a function returned an error (i.e. not `nil`).
-// 
+//
 //   actualObj, err := SomeFunction()
 //   if a.Error(err, "An error was expected") {
 // 	   assert.Equal(t, err, expectedError)
 //   }
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Error(err error, msgAndArgs ...interface{}) bool {
 	return Error(a.t, err, msgAndArgs...)
 }
 
-
 // Exactly asserts that two objects are equal is value and type.
-// 
+//
 //    a.Exactly(int32(123), int64(123), "123 and 123 should NOT be equal")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Exactly(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
 	return Exactly(a.t, expected, actual, msgAndArgs...)
 }
-
 
 // Fail reports a failure through
 func (a *Assertions) Fail(failureMessage string, msgAndArgs ...interface{}) bool {
 	return Fail(a.t, failureMessage, msgAndArgs...)
 }
 
-
 // FailNow fails test
 func (a *Assertions) FailNow(failureMessage string, msgAndArgs ...interface{}) bool {
 	return FailNow(a.t, failureMessage, msgAndArgs...)
 }
 
-
 // False asserts that the specified value is false.
-// 
+//
 //    a.False(myBool, "myBool should be false")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) False(value bool, msgAndArgs ...interface{}) bool {
 	return False(a.t, value, msgAndArgs...)
 }
 
-
 // HTTPBodyContains asserts that a specified handler returns a
 // body that contains a string.
-// 
+//
 //  a.HTTPBodyContains(myHandler, "www.google.com", nil, "I'm Feeling Lucky")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPBodyContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}) bool {
 	return HTTPBodyContains(a.t, handler, method, url, values, str)
 }
 
-
 // HTTPBodyNotContains asserts that a specified handler returns a
 // body that does not contain a string.
-// 
+//
 //  a.HTTPBodyNotContains(myHandler, "www.google.com", nil, "I'm Feeling Lucky")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPBodyNotContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}) bool {
 	return HTTPBodyNotContains(a.t, handler, method, url, values, str)
 }
 
-
 // HTTPError asserts that a specified handler returns an error status code.
-// 
+//
 //  a.HTTPError(myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPError(handler http.HandlerFunc, method string, url string, values url.Values) bool {
 	return HTTPError(a.t, handler, method, url, values)
 }
 
-
 // HTTPRedirect asserts that a specified handler returns a redirect status code.
-// 
+//
 //  a.HTTPRedirect(myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPRedirect(handler http.HandlerFunc, method string, url string, values url.Values) bool {
 	return HTTPRedirect(a.t, handler, method, url, values)
 }
 
-
 // HTTPSuccess asserts that a specified handler returns a success status code.
-// 
+//
 //  a.HTTPSuccess(myHandler, "POST", "http://www.google.com", nil)
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPSuccess(handler http.HandlerFunc, method string, url string, values url.Values) bool {
 	return HTTPSuccess(a.t, handler, method, url, values)
 }
 
-
 // Implements asserts that an object is implemented by the specified interface.
-// 
+//
 //    a.Implements((*MyInterface)(nil), new(MyObject), "MyObject")
 func (a *Assertions) Implements(interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) bool {
 	return Implements(a.t, interfaceObject, object, msgAndArgs...)
 }
 
-
 // InDelta asserts that the two numerals are within delta of each other.
-// 
+//
 // 	 a.InDelta(math.Pi, (22 / 7.0), 0.01)
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) InDelta(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) bool {
 	return InDelta(a.t, expected, actual, delta, msgAndArgs...)
 }
-
 
 // InDeltaSlice is the same as InDelta, except it compares two slices.
 func (a *Assertions) InDeltaSlice(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) bool {
 	return InDeltaSlice(a.t, expected, actual, delta, msgAndArgs...)
 }
 
-
 // InEpsilon asserts that expected and actual have a relative error less than epsilon
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) InEpsilon(expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) bool {
 	return InEpsilon(a.t, expected, actual, epsilon, msgAndArgs...)
 }
-
 
 // InEpsilonSlice is the same as InEpsilon, except it compares two slices.
 func (a *Assertions) InEpsilonSlice(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) bool {
 	return InEpsilonSlice(a.t, expected, actual, delta, msgAndArgs...)
 }
 
-
 // IsType asserts that the specified objects are of the same type.
 func (a *Assertions) IsType(expectedType interface{}, object interface{}, msgAndArgs ...interface{}) bool {
 	return IsType(a.t, expectedType, object, msgAndArgs...)
 }
 
-
 // JSONEq asserts that two JSON strings are equivalent.
-// 
+//
 //  a.JSONEq(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) JSONEq(expected string, actual string, msgAndArgs ...interface{}) bool {
 	return JSONEq(a.t, expected, actual, msgAndArgs...)
 }
 
-
 // Len asserts that the specified object has specific length.
 // Len also fails if the object has a type that len() not accept.
-// 
+//
 //    a.Len(mySlice, 3, "The size of slice is not 3")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Len(object interface{}, length int, msgAndArgs ...interface{}) bool {
 	return Len(a.t, object, length, msgAndArgs...)
 }
 
-
 // Nil asserts that the specified object is nil.
-// 
+//
 //    a.Nil(err, "err should be nothing")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Nil(object interface{}, msgAndArgs ...interface{}) bool {
 	return Nil(a.t, object, msgAndArgs...)
 }
 
-
 // NoError asserts that a function returned no error (i.e. `nil`).
-// 
+//
 //   actualObj, err := SomeFunction()
 //   if a.NoError(err) {
 // 	   assert.Equal(t, actualObj, expectedObj)
 //   }
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NoError(err error, msgAndArgs ...interface{}) bool {
 	return NoError(a.t, err, msgAndArgs...)
 }
 
-
 // NotContains asserts that the specified string, list(array, slice...) or map does NOT contain the
 // specified substring or element.
-// 
+//
 //    a.NotContains("Hello World", "Earth", "But 'Hello World' does NOT contain 'Earth'")
 //    a.NotContains(["Hello", "World"], "Earth", "But ['Hello', 'World'] does NOT contain 'Earth'")
 //    a.NotContains({"Hello": "World"}, "Earth", "But {'Hello': 'World'} does NOT contain 'Earth'")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotContains(s interface{}, contains interface{}, msgAndArgs ...interface{}) bool {
 	return NotContains(a.t, s, contains, msgAndArgs...)
 }
 
-
 // NotEmpty asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or either
 // a slice or a channel with len == 0.
-// 
+//
 //  if a.NotEmpty(obj) {
 //    assert.Equal(t, "two", obj[1])
 //  }
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) bool {
 	return NotEmpty(a.t, object, msgAndArgs...)
 }
 
-
 // NotEqual asserts that the specified values are NOT equal.
-// 
+//
 //    a.NotEqual(obj1, obj2, "two objects shouldn't be equal")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotEqual(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
 	return NotEqual(a.t, expected, actual, msgAndArgs...)
 }
 
-
 // NotNil asserts that the specified object is not nil.
-// 
+//
 //    a.NotNil(err, "err should be something")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotNil(object interface{}, msgAndArgs ...interface{}) bool {
 	return NotNil(a.t, object, msgAndArgs...)
 }
 
-
 // NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
-// 
+//
 //   a.NotPanics(func(){
 //     RemainCalm()
 //   }, "Calling RemainCalm() should NOT panic")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotPanics(f PanicTestFunc, msgAndArgs ...interface{}) bool {
 	return NotPanics(a.t, f, msgAndArgs...)
 }
 
-
 // NotRegexp asserts that a specified regexp does not match a string.
-// 
+//
 //  a.NotRegexp(regexp.MustCompile("starts"), "it's starting")
 //  a.NotRegexp("^start", "it's not starting")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) bool {
 	return NotRegexp(a.t, rx, str, msgAndArgs...)
 }
-
 
 // NotZero asserts that i is not the zero value for its type and returns the truth.
 func (a *Assertions) NotZero(i interface{}, msgAndArgs ...interface{}) bool {
 	return NotZero(a.t, i, msgAndArgs...)
 }
 
-
 // Panics asserts that the code inside the specified PanicTestFunc panics.
-// 
+//
 //   a.Panics(func(){
 //     GoCrazy()
 //   }, "Calling GoCrazy() should panic")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Panics(f PanicTestFunc, msgAndArgs ...interface{}) bool {
 	return Panics(a.t, f, msgAndArgs...)
 }
 
-
 // Regexp asserts that a specified regexp matches a string.
-// 
+//
 //  a.Regexp(regexp.MustCompile("start"), "it's starting")
 //  a.Regexp("start...$", "it's not starting")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) bool {
 	return Regexp(a.t, rx, str, msgAndArgs...)
 }
 
-
 // True asserts that the specified value is true.
-// 
+//
 //    a.True(myBool, "myBool should be true")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) True(value bool, msgAndArgs ...interface{}) bool {
 	return True(a.t, value, msgAndArgs...)
 }
 
-
 // WithinDuration asserts that the two times are within duration delta of each other.
-// 
+//
 //   a.WithinDuration(time.Now(), time.Now(), 10*time.Second, "The difference should not be more than 10s")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) WithinDuration(expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) bool {
 	return WithinDuration(a.t, expected, actual, delta, msgAndArgs...)
 }
-
 
 // Zero asserts that i is the zero value for its type and returns the truth.
 func (a *Assertions) Zero(i interface{}, msgAndArgs ...interface{}) bool {

--- a/require/require.go
+++ b/require/require.go
@@ -1,464 +1,425 @@
 /*
 * CODE GENERATED AUTOMATICALLY WITH github.com/stretchr/testify/_codegen
 * THIS FILE MUST NOT BE EDITED BY HAND
-*/
+ */
 
 package require
 
 import (
-
 	assert "github.com/stretchr/testify/assert"
 	http "net/http"
 	url "net/url"
 	time "time"
 )
 
-
 // Condition uses a Comparison to assert a complex condition.
 func Condition(t TestingT, comp assert.Comparison, msgAndArgs ...interface{}) {
-  if !assert.Condition(t, comp, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.Condition(t, comp, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // Contains asserts that the specified string, list(array, slice...) or map contains the
 // specified substring or element.
-// 
+//
 //    assert.Contains(t, "Hello World", "World", "But 'Hello World' does contain 'World'")
 //    assert.Contains(t, ["Hello", "World"], "World", "But ["Hello", "World"] does contain 'World'")
 //    assert.Contains(t, {"Hello": "World"}, "Hello", "But {'Hello': 'World'} does contain 'Hello'")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func Contains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
-  if !assert.Contains(t, s, contains, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.Contains(t, s, contains, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // Empty asserts that the specified object is empty.  I.e. nil, "", false, 0 or either
 // a slice or a channel with len == 0.
-// 
+//
 //  assert.Empty(t, obj)
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
-  if !assert.Empty(t, object, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.Empty(t, object, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // Equal asserts that two objects are equal.
-// 
+//
 //    assert.Equal(t, 123, 123, "123 and 123 should be equal")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func Equal(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
-  if !assert.Equal(t, expected, actual, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.Equal(t, expected, actual, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // EqualError asserts that a function returned an error (i.e. not `nil`)
 // and that it is equal to the provided error.
-// 
+//
 //   actualObj, err := SomeFunction()
 //   if assert.Error(t, err, "An error was expected") {
 // 	   assert.Equal(t, err, expectedError)
 //   }
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func EqualError(t TestingT, theError error, errString string, msgAndArgs ...interface{}) {
-  if !assert.EqualError(t, theError, errString, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.EqualError(t, theError, errString, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // EqualValues asserts that two objects are equal or convertable to the same types
 // and equal.
-// 
+//
 //    assert.EqualValues(t, uint32(123), int32(123), "123 and 123 should be equal")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func EqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
-  if !assert.EqualValues(t, expected, actual, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.EqualValues(t, expected, actual, msgAndArgs...) {
+		t.FailNow()
+	}
 }
 
-
 // Error asserts that a function returned an error (i.e. not `nil`).
-// 
+//
 //   actualObj, err := SomeFunction()
 //   if assert.Error(t, err, "An error was expected") {
 // 	   assert.Equal(t, err, expectedError)
 //   }
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func Error(t TestingT, err error, msgAndArgs ...interface{}) {
-  if !assert.Error(t, err, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.Error(t, err, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // Exactly asserts that two objects are equal is value and type.
-// 
+//
 //    assert.Exactly(t, int32(123), int64(123), "123 and 123 should NOT be equal")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func Exactly(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
-  if !assert.Exactly(t, expected, actual, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.Exactly(t, expected, actual, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // Fail reports a failure through
 func Fail(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
-  if !assert.Fail(t, failureMessage, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.Fail(t, failureMessage, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // FailNow fails test
 func FailNow(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
-  if !assert.FailNow(t, failureMessage, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.FailNow(t, failureMessage, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // False asserts that the specified value is false.
-// 
+//
 //    assert.False(t, myBool, "myBool should be false")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func False(t TestingT, value bool, msgAndArgs ...interface{}) {
-  if !assert.False(t, value, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.False(t, value, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // HTTPBodyContains asserts that a specified handler returns a
 // body that contains a string.
-// 
+//
 //  assert.HTTPBodyContains(t, myHandler, "www.google.com", nil, "I'm Feeling Lucky")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPBodyContains(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}) {
-  if !assert.HTTPBodyContains(t, handler, method, url, values, str) {
-    t.FailNow()
-  }
+	if !assert.HTTPBodyContains(t, handler, method, url, values, str) {
+		t.FailNow()
+	}
 }
-
 
 // HTTPBodyNotContains asserts that a specified handler returns a
 // body that does not contain a string.
-// 
+//
 //  assert.HTTPBodyNotContains(t, myHandler, "www.google.com", nil, "I'm Feeling Lucky")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPBodyNotContains(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}) {
-  if !assert.HTTPBodyNotContains(t, handler, method, url, values, str) {
-    t.FailNow()
-  }
+	if !assert.HTTPBodyNotContains(t, handler, method, url, values, str) {
+		t.FailNow()
+	}
 }
-
 
 // HTTPError asserts that a specified handler returns an error status code.
-// 
+//
 //  assert.HTTPError(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPError(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values) {
-  if !assert.HTTPError(t, handler, method, url, values) {
-    t.FailNow()
-  }
+	if !assert.HTTPError(t, handler, method, url, values) {
+		t.FailNow()
+	}
 }
-
 
 // HTTPRedirect asserts that a specified handler returns a redirect status code.
-// 
+//
 //  assert.HTTPRedirect(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPRedirect(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values) {
-  if !assert.HTTPRedirect(t, handler, method, url, values) {
-    t.FailNow()
-  }
+	if !assert.HTTPRedirect(t, handler, method, url, values) {
+		t.FailNow()
+	}
 }
-
 
 // HTTPSuccess asserts that a specified handler returns a success status code.
-// 
+//
 //  assert.HTTPSuccess(t, myHandler, "POST", "http://www.google.com", nil)
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPSuccess(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values) {
-  if !assert.HTTPSuccess(t, handler, method, url, values) {
-    t.FailNow()
-  }
+	if !assert.HTTPSuccess(t, handler, method, url, values) {
+		t.FailNow()
+	}
 }
-
 
 // Implements asserts that an object is implemented by the specified interface.
-// 
+//
 //    assert.Implements(t, (*MyInterface)(nil), new(MyObject), "MyObject")
 func Implements(t TestingT, interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
-  if !assert.Implements(t, interfaceObject, object, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.Implements(t, interfaceObject, object, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // InDelta asserts that the two numerals are within delta of each other.
-// 
+//
 // 	 assert.InDelta(t, math.Pi, (22 / 7.0), 0.01)
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func InDelta(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
-  if !assert.InDelta(t, expected, actual, delta, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.InDelta(t, expected, actual, delta, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // InDeltaSlice is the same as InDelta, except it compares two slices.
 func InDeltaSlice(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
-  if !assert.InDeltaSlice(t, expected, actual, delta, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.InDeltaSlice(t, expected, actual, delta, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // InEpsilon asserts that expected and actual have a relative error less than epsilon
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func InEpsilon(t TestingT, expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
-  if !assert.InEpsilon(t, expected, actual, epsilon, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.InEpsilon(t, expected, actual, epsilon, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // InEpsilonSlice is the same as InEpsilon, except it compares two slices.
 func InEpsilonSlice(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
-  if !assert.InEpsilonSlice(t, expected, actual, delta, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.InEpsilonSlice(t, expected, actual, delta, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // IsType asserts that the specified objects are of the same type.
 func IsType(t TestingT, expectedType interface{}, object interface{}, msgAndArgs ...interface{}) {
-  if !assert.IsType(t, expectedType, object, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.IsType(t, expectedType, object, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // JSONEq asserts that two JSON strings are equivalent.
-// 
+//
 //  assert.JSONEq(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func JSONEq(t TestingT, expected string, actual string, msgAndArgs ...interface{}) {
-  if !assert.JSONEq(t, expected, actual, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.JSONEq(t, expected, actual, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // Len asserts that the specified object has specific length.
 // Len also fails if the object has a type that len() not accept.
-// 
+//
 //    assert.Len(t, mySlice, 3, "The size of slice is not 3")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) {
-  if !assert.Len(t, object, length, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.Len(t, object, length, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // Nil asserts that the specified object is nil.
-// 
+//
 //    assert.Nil(t, err, "err should be nothing")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
-  if !assert.Nil(t, object, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.Nil(t, object, msgAndArgs...) {
+		t.FailNow()
+	}
 }
 
-
 // NoError asserts that a function returned no error (i.e. `nil`).
-// 
+//
 //   actualObj, err := SomeFunction()
 //   if assert.NoError(t, err) {
 // 	   assert.Equal(t, actualObj, expectedObj)
 //   }
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func NoError(t TestingT, err error, msgAndArgs ...interface{}) {
-  if !assert.NoError(t, err, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.NoError(t, err, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // NotContains asserts that the specified string, list(array, slice...) or map does NOT contain the
 // specified substring or element.
-// 
+//
 //    assert.NotContains(t, "Hello World", "Earth", "But 'Hello World' does NOT contain 'Earth'")
 //    assert.NotContains(t, ["Hello", "World"], "Earth", "But ['Hello', 'World'] does NOT contain 'Earth'")
 //    assert.NotContains(t, {"Hello": "World"}, "Earth", "But {'Hello': 'World'} does NOT contain 'Earth'")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func NotContains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
-  if !assert.NotContains(t, s, contains, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.NotContains(t, s, contains, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // NotEmpty asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or either
 // a slice or a channel with len == 0.
-// 
+//
 //  if assert.NotEmpty(t, obj) {
 //    assert.Equal(t, "two", obj[1])
 //  }
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
-  if !assert.NotEmpty(t, object, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.NotEmpty(t, object, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // NotEqual asserts that the specified values are NOT equal.
-// 
+//
 //    assert.NotEqual(t, obj1, obj2, "two objects shouldn't be equal")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func NotEqual(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
-  if !assert.NotEqual(t, expected, actual, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.NotEqual(t, expected, actual, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // NotNil asserts that the specified object is not nil.
-// 
+//
 //    assert.NotNil(t, err, "err should be something")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
-  if !assert.NotNil(t, object, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.NotNil(t, object, msgAndArgs...) {
+		t.FailNow()
+	}
 }
 
-
 // NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
-// 
+//
 //   assert.NotPanics(t, func(){
 //     RemainCalm()
 //   }, "Calling RemainCalm() should NOT panic")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func NotPanics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
-  if !assert.NotPanics(t, f, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.NotPanics(t, f, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // NotRegexp asserts that a specified regexp does not match a string.
-// 
+//
 //  assert.NotRegexp(t, regexp.MustCompile("starts"), "it's starting")
 //  assert.NotRegexp(t, "^start", "it's not starting")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
-  if !assert.NotRegexp(t, rx, str, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.NotRegexp(t, rx, str, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // NotZero asserts that i is not the zero value for its type and returns the truth.
 func NotZero(t TestingT, i interface{}, msgAndArgs ...interface{}) {
-  if !assert.NotZero(t, i, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.NotZero(t, i, msgAndArgs...) {
+		t.FailNow()
+	}
 }
 
-
 // Panics asserts that the code inside the specified PanicTestFunc panics.
-// 
+//
 //   assert.Panics(t, func(){
 //     GoCrazy()
 //   }, "Calling GoCrazy() should panic")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func Panics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
-  if !assert.Panics(t, f, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.Panics(t, f, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // Regexp asserts that a specified regexp matches a string.
-// 
+//
 //  assert.Regexp(t, regexp.MustCompile("start"), "it's starting")
 //  assert.Regexp(t, "start...$", "it's not starting")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
-  if !assert.Regexp(t, rx, str, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.Regexp(t, rx, str, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // True asserts that the specified value is true.
-// 
+//
 //    assert.True(t, myBool, "myBool should be true")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func True(t TestingT, value bool, msgAndArgs ...interface{}) {
-  if !assert.True(t, value, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.True(t, value, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // WithinDuration asserts that the two times are within duration delta of each other.
-// 
+//
 //   assert.WithinDuration(t, time.Now(), time.Now(), 10*time.Second, "The difference should not be more than 10s")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func WithinDuration(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) {
-  if !assert.WithinDuration(t, expected, actual, delta, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.WithinDuration(t, expected, actual, delta, msgAndArgs...) {
+		t.FailNow()
+	}
 }
-
 
 // Zero asserts that i is the zero value for its type and returns the truth.
 func Zero(t TestingT, i interface{}, msgAndArgs ...interface{}) {
-  if !assert.Zero(t, i, msgAndArgs...) {
-    t.FailNow()
-  }
+	if !assert.Zero(t, i, msgAndArgs...) {
+		t.FailNow()
+	}
 }

--- a/require/require_forward.go
+++ b/require/require_forward.go
@@ -1,386 +1,347 @@
 /*
 * CODE GENERATED AUTOMATICALLY WITH github.com/stretchr/testify/_codegen
 * THIS FILE MUST NOT BE EDITED BY HAND
-*/
+ */
 
 package require
 
 import (
-
 	assert "github.com/stretchr/testify/assert"
 	http "net/http"
 	url "net/url"
 	time "time"
 )
 
-
 // Condition uses a Comparison to assert a complex condition.
 func (a *Assertions) Condition(comp assert.Comparison, msgAndArgs ...interface{}) {
 	Condition(a.t, comp, msgAndArgs...)
 }
 
-
 // Contains asserts that the specified string, list(array, slice...) or map contains the
 // specified substring or element.
-// 
+//
 //    a.Contains("Hello World", "World", "But 'Hello World' does contain 'World'")
 //    a.Contains(["Hello", "World"], "World", "But ["Hello", "World"] does contain 'World'")
 //    a.Contains({"Hello": "World"}, "Hello", "But {'Hello': 'World'} does contain 'Hello'")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Contains(s interface{}, contains interface{}, msgAndArgs ...interface{}) {
 	Contains(a.t, s, contains, msgAndArgs...)
 }
 
-
 // Empty asserts that the specified object is empty.  I.e. nil, "", false, 0 or either
 // a slice or a channel with len == 0.
-// 
+//
 //  a.Empty(obj)
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Empty(object interface{}, msgAndArgs ...interface{}) {
 	Empty(a.t, object, msgAndArgs...)
 }
 
-
 // Equal asserts that two objects are equal.
-// 
+//
 //    a.Equal(123, 123, "123 and 123 should be equal")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Equal(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	Equal(a.t, expected, actual, msgAndArgs...)
 }
 
-
 // EqualError asserts that a function returned an error (i.e. not `nil`)
 // and that it is equal to the provided error.
-// 
+//
 //   actualObj, err := SomeFunction()
 //   if assert.Error(t, err, "An error was expected") {
 // 	   assert.Equal(t, err, expectedError)
 //   }
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...interface{}) {
 	EqualError(a.t, theError, errString, msgAndArgs...)
 }
 
-
 // EqualValues asserts that two objects are equal or convertable to the same types
 // and equal.
-// 
+//
 //    a.EqualValues(uint32(123), int32(123), "123 and 123 should be equal")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) EqualValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	EqualValues(a.t, expected, actual, msgAndArgs...)
 }
 
-
 // Error asserts that a function returned an error (i.e. not `nil`).
-// 
+//
 //   actualObj, err := SomeFunction()
 //   if a.Error(err, "An error was expected") {
 // 	   assert.Equal(t, err, expectedError)
 //   }
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Error(err error, msgAndArgs ...interface{}) {
 	Error(a.t, err, msgAndArgs...)
 }
 
-
 // Exactly asserts that two objects are equal is value and type.
-// 
+//
 //    a.Exactly(int32(123), int64(123), "123 and 123 should NOT be equal")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Exactly(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	Exactly(a.t, expected, actual, msgAndArgs...)
 }
-
 
 // Fail reports a failure through
 func (a *Assertions) Fail(failureMessage string, msgAndArgs ...interface{}) {
 	Fail(a.t, failureMessage, msgAndArgs...)
 }
 
-
 // FailNow fails test
 func (a *Assertions) FailNow(failureMessage string, msgAndArgs ...interface{}) {
 	FailNow(a.t, failureMessage, msgAndArgs...)
 }
 
-
 // False asserts that the specified value is false.
-// 
+//
 //    a.False(myBool, "myBool should be false")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) False(value bool, msgAndArgs ...interface{}) {
 	False(a.t, value, msgAndArgs...)
 }
 
-
 // HTTPBodyContains asserts that a specified handler returns a
 // body that contains a string.
-// 
+//
 //  a.HTTPBodyContains(myHandler, "www.google.com", nil, "I'm Feeling Lucky")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPBodyContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}) {
 	HTTPBodyContains(a.t, handler, method, url, values, str)
 }
 
-
 // HTTPBodyNotContains asserts that a specified handler returns a
 // body that does not contain a string.
-// 
+//
 //  a.HTTPBodyNotContains(myHandler, "www.google.com", nil, "I'm Feeling Lucky")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPBodyNotContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}) {
 	HTTPBodyNotContains(a.t, handler, method, url, values, str)
 }
 
-
 // HTTPError asserts that a specified handler returns an error status code.
-// 
+//
 //  a.HTTPError(myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPError(handler http.HandlerFunc, method string, url string, values url.Values) {
 	HTTPError(a.t, handler, method, url, values)
 }
 
-
 // HTTPRedirect asserts that a specified handler returns a redirect status code.
-// 
+//
 //  a.HTTPRedirect(myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPRedirect(handler http.HandlerFunc, method string, url string, values url.Values) {
 	HTTPRedirect(a.t, handler, method, url, values)
 }
 
-
 // HTTPSuccess asserts that a specified handler returns a success status code.
-// 
+//
 //  a.HTTPSuccess(myHandler, "POST", "http://www.google.com", nil)
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPSuccess(handler http.HandlerFunc, method string, url string, values url.Values) {
 	HTTPSuccess(a.t, handler, method, url, values)
 }
 
-
 // Implements asserts that an object is implemented by the specified interface.
-// 
+//
 //    a.Implements((*MyInterface)(nil), new(MyObject), "MyObject")
 func (a *Assertions) Implements(interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
 	Implements(a.t, interfaceObject, object, msgAndArgs...)
 }
 
-
 // InDelta asserts that the two numerals are within delta of each other.
-// 
+//
 // 	 a.InDelta(math.Pi, (22 / 7.0), 0.01)
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) InDelta(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
 	InDelta(a.t, expected, actual, delta, msgAndArgs...)
 }
-
 
 // InDeltaSlice is the same as InDelta, except it compares two slices.
 func (a *Assertions) InDeltaSlice(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
 	InDeltaSlice(a.t, expected, actual, delta, msgAndArgs...)
 }
 
-
 // InEpsilon asserts that expected and actual have a relative error less than epsilon
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) InEpsilon(expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
 	InEpsilon(a.t, expected, actual, epsilon, msgAndArgs...)
 }
-
 
 // InEpsilonSlice is the same as InEpsilon, except it compares two slices.
 func (a *Assertions) InEpsilonSlice(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
 	InEpsilonSlice(a.t, expected, actual, delta, msgAndArgs...)
 }
 
-
 // IsType asserts that the specified objects are of the same type.
 func (a *Assertions) IsType(expectedType interface{}, object interface{}, msgAndArgs ...interface{}) {
 	IsType(a.t, expectedType, object, msgAndArgs...)
 }
 
-
 // JSONEq asserts that two JSON strings are equivalent.
-// 
+//
 //  a.JSONEq(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) JSONEq(expected string, actual string, msgAndArgs ...interface{}) {
 	JSONEq(a.t, expected, actual, msgAndArgs...)
 }
 
-
 // Len asserts that the specified object has specific length.
 // Len also fails if the object has a type that len() not accept.
-// 
+//
 //    a.Len(mySlice, 3, "The size of slice is not 3")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Len(object interface{}, length int, msgAndArgs ...interface{}) {
 	Len(a.t, object, length, msgAndArgs...)
 }
 
-
 // Nil asserts that the specified object is nil.
-// 
+//
 //    a.Nil(err, "err should be nothing")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Nil(object interface{}, msgAndArgs ...interface{}) {
 	Nil(a.t, object, msgAndArgs...)
 }
 
-
 // NoError asserts that a function returned no error (i.e. `nil`).
-// 
+//
 //   actualObj, err := SomeFunction()
 //   if a.NoError(err) {
 // 	   assert.Equal(t, actualObj, expectedObj)
 //   }
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NoError(err error, msgAndArgs ...interface{}) {
 	NoError(a.t, err, msgAndArgs...)
 }
 
-
 // NotContains asserts that the specified string, list(array, slice...) or map does NOT contain the
 // specified substring or element.
-// 
+//
 //    a.NotContains("Hello World", "Earth", "But 'Hello World' does NOT contain 'Earth'")
 //    a.NotContains(["Hello", "World"], "Earth", "But ['Hello', 'World'] does NOT contain 'Earth'")
 //    a.NotContains({"Hello": "World"}, "Earth", "But {'Hello': 'World'} does NOT contain 'Earth'")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotContains(s interface{}, contains interface{}, msgAndArgs ...interface{}) {
 	NotContains(a.t, s, contains, msgAndArgs...)
 }
 
-
 // NotEmpty asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or either
 // a slice or a channel with len == 0.
-// 
+//
 //  if a.NotEmpty(obj) {
 //    assert.Equal(t, "two", obj[1])
 //  }
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) {
 	NotEmpty(a.t, object, msgAndArgs...)
 }
 
-
 // NotEqual asserts that the specified values are NOT equal.
-// 
+//
 //    a.NotEqual(obj1, obj2, "two objects shouldn't be equal")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotEqual(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	NotEqual(a.t, expected, actual, msgAndArgs...)
 }
 
-
 // NotNil asserts that the specified object is not nil.
-// 
+//
 //    a.NotNil(err, "err should be something")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotNil(object interface{}, msgAndArgs ...interface{}) {
 	NotNil(a.t, object, msgAndArgs...)
 }
 
-
 // NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
-// 
+//
 //   a.NotPanics(func(){
 //     RemainCalm()
 //   }, "Calling RemainCalm() should NOT panic")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotPanics(f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	NotPanics(a.t, f, msgAndArgs...)
 }
 
-
 // NotRegexp asserts that a specified regexp does not match a string.
-// 
+//
 //  a.NotRegexp(regexp.MustCompile("starts"), "it's starting")
 //  a.NotRegexp("^start", "it's not starting")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) {
 	NotRegexp(a.t, rx, str, msgAndArgs...)
 }
-
 
 // NotZero asserts that i is not the zero value for its type and returns the truth.
 func (a *Assertions) NotZero(i interface{}, msgAndArgs ...interface{}) {
 	NotZero(a.t, i, msgAndArgs...)
 }
 
-
 // Panics asserts that the code inside the specified PanicTestFunc panics.
-// 
+//
 //   a.Panics(func(){
 //     GoCrazy()
 //   }, "Calling GoCrazy() should panic")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Panics(f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	Panics(a.t, f, msgAndArgs...)
 }
 
-
 // Regexp asserts that a specified regexp matches a string.
-// 
+//
 //  a.Regexp(regexp.MustCompile("start"), "it's starting")
 //  a.Regexp("start...$", "it's not starting")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) {
 	Regexp(a.t, rx, str, msgAndArgs...)
 }
 
-
 // True asserts that the specified value is true.
-// 
+//
 //    a.True(myBool, "myBool should be true")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) True(value bool, msgAndArgs ...interface{}) {
 	True(a.t, value, msgAndArgs...)
 }
 
-
 // WithinDuration asserts that the two times are within duration delta of each other.
-// 
+//
 //   a.WithinDuration(time.Now(), time.Now(), 10*time.Second, "The difference should not be more than 10s")
-// 
+//
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) WithinDuration(expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) {
 	WithinDuration(a.t, expected, actual, delta, msgAndArgs...)
 }
-
 
 // Zero asserts that i is the zero value for its type and returns the truth.
 func (a *Assertions) Zero(i interface{}, msgAndArgs ...interface{}) {


### PR DESCRIPTION
Fixes whitespace issues in `assertion_forward.go`. (All other files were already formatted).