### PR TITLE
AssertExpectationsForObjects takes *Mock

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -341,17 +341,26 @@ func (m *Mock) Called(arguments ...interface{}) Arguments {
 	Assertions
 */
 
+type assertExpectationser interface {
+	AssertExpectations(TestingT) bool
+}
+
 // AssertExpectationsForObjects asserts that everything specified with On and Return
 // of the specified objects was in fact called as expected.
 //
 // Calls may have occurred in any order.
 func AssertExpectationsForObjects(t TestingT, testObjects ...interface{}) bool {
-	var success = true
 	for _, obj := range testObjects {
-		mockObj := obj.(Mock)
-		success = success && mockObj.AssertExpectations(t)
+		if m, ok := obj.(Mock); ok {
+			t.Logf("Deprecated mock.AssertExpectationsForObjects(myMock.Mock) use mock.AssertExpectationsForObjects(myMock)")
+			obj = &m
+		}
+		m := obj.(assertExpectationser)
+		if !m.AssertExpectations(t) {
+			return false
+		}
 	}
-	return success
+	return true
 }
 
 // AssertExpectations asserts that everything specified with On and Return was

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -727,6 +727,7 @@ func Test_AssertExpectationsForObjects_Helper(t *testing.T) {
 	mockedService3.Called(3)
 
 	assert.True(t, AssertExpectationsForObjects(t, mockedService1.Mock, mockedService2.Mock, mockedService3.Mock))
+	assert.True(t, AssertExpectationsForObjects(t, mockedService1, mockedService2, mockedService3))
 
 }
 
@@ -745,6 +746,7 @@ func Test_AssertExpectationsForObjects_Helper_Failed(t *testing.T) {
 
 	tt := new(testing.T)
 	assert.False(t, AssertExpectationsForObjects(tt, mockedService1.Mock, mockedService2.Mock, mockedService3.Mock))
+	assert.False(t, AssertExpectationsForObjects(tt, mockedService1, mockedService2, mockedService3))
 
 }
 


### PR DESCRIPTION
Fixes #342

It also logs a depreation warning.