### PR TITLE
Add GreaterThan and SmallerThan assertions

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1058,3 +1058,51 @@ func diff(expected interface{}, actual interface{}) string {
 
 	return "\n\nDiff:\n" + diff
 }
+
+// GreaterThan asserts that first numerical value is greater than second numerical value.
+//
+//    assert.GreaterThan(t, firstNumericalValue, secondNumericalValue, "First value must be greater than second value")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func GreaterThan(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool {
+	expectedToFloat, expectedOk := toFloat(expected)
+	actualToFloat, actualOk := toFloat(actual)
+
+	if !expectedOk || !actualOk {
+		return Fail(t, fmt.Sprintf("Parameters must be numerical"), msgAndArgs...)
+	}
+
+	if expectedToFloat == actualToFloat {
+		return Fail(t, fmt.Sprintf("Values can not be equals"), msgAndArgs...)
+	}
+
+	if expectedToFloat < actualToFloat {
+		return Fail(t, fmt.Sprintf("Should be false"), msgAndArgs...)
+	}
+
+	return true
+}
+
+// SmallerThan asserts that first numerical value is less than second numerical value.
+//
+//    assert.SmallerThan(t, firstNumericalValue, secondNumericalValue, "First value must be less than second value")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func SmallerThan(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool {
+	expectedToFloat, expectedOk := toFloat(expected)
+	actualToFloat, actualOk := toFloat(actual)
+
+	if !expectedOk || !actualOk {
+		return Fail(t, fmt.Sprintf("Parameters must be numerical"), msgAndArgs...)
+	}
+
+	if expectedToFloat == actualToFloat {
+		return Fail(t, fmt.Sprintf("Values can not be equals"), msgAndArgs...)
+	}
+
+	if expectedToFloat > actualToFloat {
+		return Fail(t, fmt.Sprintf("Should be false"), msgAndArgs...)
+	}
+
+	return true
+}

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -1208,3 +1208,59 @@ func TestFailNowWithFullTestingT(t *testing.T) {
 		FailNow(mockT, "failed")
 	}, "should call mockT.FailNow() rather than panicking")
 }
+
+func TestGreaterThan(t *testing.T) {
+	mockT := new(testing.T)
+
+	if GreaterThan(mockT, "1", "2") {
+		t.Error("Parameters must be numerical")
+	}
+
+	if GreaterThan(mockT, true, false) {
+		t.Error("Parameters must be numerical")
+	}
+
+	if GreaterThan(mockT, 1, 1) {
+		t.Error("Values can not be equals")
+	}
+
+	if GreaterThan(mockT, 5, 50) {
+		t.Error("Should return false")
+	}
+
+	if !GreaterThan(mockT, 10, 1) {
+		t.Error("GreaterThan should return true")
+	}
+
+	if !GreaterThan(mockT, 100.0, 1.0) {
+		t.Error("GreaterThan should return true")
+	}
+}
+
+func TestSmallerThan(t *testing.T) {
+	mockT := new(testing.T)
+
+	if SmallerThan(mockT, "1", "2") {
+		t.Error("Parameters must be numerical")
+	}
+
+	if SmallerThan(mockT, true, false) {
+		t.Error("Parameters must be numerical")
+	}
+
+	if SmallerThan(mockT, 1, 1) {
+		t.Error("Values can not be equals")
+	}
+
+	if SmallerThan(mockT, 50, 5) {
+		t.Error("Should return false")
+	}
+
+	if !SmallerThan(mockT, 1, 10) {
+		t.Error("SmallerThan should return true")
+	}
+
+	if !SmallerThan(mockT, 1.0, 10.0) {
+		t.Error("SmallerThan should return true")
+	}
+}


### PR DESCRIPTION
Add this to make easier to assert over numerical values and when is needed to verify which value is greater/smaller than other one.

For some time I had to use assertions like this:

``` go
package main

import "testing"
import "github.com/stretchr/testify/assert"

func TestGreaterThan(t *testing.T) {
  firstVallue, secondVallue := 1, 10

  assert.True(t, firstValue > secondValue)
  assert.False(t, firstValue > secondValue)

  // OR 

  assert.True(t, firstValue < secondValue)
  assert.False(t, firstValue < secondValue)
} 
```

So my idea is to make this easier with something like that:

``` go
package main

import "testing"
import "github.com/stretchr/testify/assert"

func TestGreaterThan(t *testing.T) {
  firstVallue, secondVallue := 1, 10

  assert.GreaterThan(t, firstValue, secondValue)
  assert.GreaterThan(t, firstValue, secondValue)

  // OR 

  assert.SmallerThan(t, firstValue, secondValue)
  assert.SmallerThan(t, firstValue, secondValue)
}
```
