### PR TITLE
When diffing with spew, use a format that doesn't include pointer addresses

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1043,8 +1043,8 @@ func diff(expected interface{}, actual interface{}) string {
 		return ""
 	}
 
-	e := spew.Sdump(expected)
-	a := spew.Sdump(actual)
+	e := spew.Sprintf("%#v", expected)
+	a := spew.Sprintf("%#v", actual)
 
 	diff, _ := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
 		A:        difflib.SplitLines(e),


### PR DESCRIPTION
This fixes #317.