### PR TITLE
Add RunParallel for running suites with t.Parallel

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -12,6 +12,14 @@
 			"Rev": "04cdfd42973bb9c8589fd6a731800cf222fde1a9"
 		},
 		{
+			"ImportPath": "github.com/mitchellh/copystructure",
+			"Rev": "5af94aef99f597e6a9e1f6ac6be6ce0f3c96b49d"
+		},
+		{
+			"ImportPath": "github.com/mitchellh/reflectwalk",
+			"Rev": "9ad27c461a633e32a235a061d523aefe8f18571d"
+		},
+		{
 			"ImportPath": "github.com/pmezard/go-difflib/difflib",
 			"Rev": "d8ed2627bdf02c080bf22230dbb337003b7aba2d"
 		},

--- a/suite/parallel_suite.go
+++ b/suite/parallel_suite.go
@@ -1,0 +1,100 @@
+package suite
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"sync"
+	"testing"
+)
+
+// RunParallel takes a testing suite and runs all of the tests attached
+// to it. This function is required for test suites that want to execute concurrently
+// via t.Parallel().
+//
+// Example:
+// type ParallelTestSuite struct {
+//    internalState int
+// }
+//
+// Setup and Teardown functions which need to modify test state can accept pointer receivers safely.
+// The calling of these functions is synchronized between the tests.
+// func (s *ParallelTestSuite) SetupTest() {
+//     s.internalState++
+// }
+//
+// func (s *ParallelTestSuite) TearDownTest() {
+// 	s.internalState++
+// }
+//
+// All test methods in the suite will be run in parallel.
+// All tests should accept value receivers to prevent data races in the test suite.
+// All tests must accept t *testing.T as their only argument.
+// func (s ParallelTestSuite) Test(t *testing.T) {
+//     // do something
+// }
+//
+// Tests should be run this way.
+// func TestParallelSuite(t *testing.T) {
+// 	RunParallel(t, new(ParallelTestSuite))
+// }
+// RunParallel synchronizes calls to SetupTestSuite and TearDownTestSuite. Any data accessed outside
+// of those functions must be manually synchronized to be goroutine safe.
+func RunParallel(t *testing.T, suite interface{}) {
+	if setupAllSuite, ok := suite.(SetupAllSuite); ok {
+		setupAllSuite.SetupSuite()
+	}
+	defer func() {
+		if tearDownAllSuite, ok := suite.(TearDownAllSuite); ok {
+			tearDownAllSuite.TearDownSuite()
+		}
+	}()
+
+	// Locks for synchronizing access to SetupTest() and TearDownTest().
+	setupMtx, teardownMtx := sync.Mutex{}, sync.Mutex{}
+
+	methodFinder := reflect.TypeOf(suite)
+	tests := []testing.InternalTest{}
+	for index := 0; index < methodFinder.NumMethod(); index++ {
+		method := methodFinder.Method(index)
+		ok, err := methodFilter(method.Name)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "testify: invalid regexp for -m: %s\n", err)
+			os.Exit(1)
+		}
+
+		if ok {
+			test := testing.InternalTest{
+				Name: method.Name,
+				F: func(t *testing.T) {
+					t.Parallel()
+					setupTestSuite, ok := suite.(SetupTestSuite)
+					if ok {
+						setupMtx.Lock()
+						setupTestSuite.SetupTest()
+						// This will deadlock if SetupTest() panics.
+						// We cannot defer unlocking here because that would seralize running the tests.
+						setupMtx.Unlock()
+					}
+
+					defer func() {
+						if tearDownTestSuite, ok := suite.(TearDownTestSuite); ok {
+							teardownMtx.Lock()
+							tearDownTestSuite.TearDownTest()
+							// This will deadlock if TearDownTest() panics.
+							teardownMtx.Unlock()
+						}
+					}()
+
+					method.Func.Call([]reflect.Value{reflect.ValueOf(suite), reflect.ValueOf(t)})
+				},
+			}
+			tests = append(tests, test)
+		}
+	}
+
+	if !testing.RunTests(func(_, _ string) (bool, error) { return true, nil },
+		tests) {
+		t.Fail()
+	}
+}

--- a/suite/parallel_suite_test.go
+++ b/suite/parallel_suite_test.go
@@ -1,48 +1,65 @@
 package suite
 
 import (
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
+// Use globals to test setup and teardown logic because RunParallel makes a
+// copy of the suite struct. These globals allow us to count setup/teardown
+// calls between suite copies.
+var (
+	suiteInt         int64
+	teardownSuiteInt int64
+	testInt          int64
+	teardownTestInt  int64
+)
+
+type nested struct {
+	n int
+}
+
+type complexData struct {
+	nested nested
+}
+
 type ParallelTestSuite struct {
 	Suite
-	testInt          int
-	teardownTestInt  int
-	suiteInt         int
-	teardownSuiteInt int
+	suiteInt         int64
+	setupSimpleData  int
+	setupComplexData complexData
 }
 
 func (s *ParallelTestSuite) SetupSuite() {
-	s.suiteInt++
+	atomic.AddInt64(&suiteInt, 1)
+	s.setupSimpleData = 1
+	s.setupComplexData = complexData{nested: nested{7}}
 }
 
 func (s *ParallelTestSuite) TearDownSuite() {
-	s.teardownSuiteInt++
+	atomic.AddInt64(&teardownSuiteInt, 1)
 }
 
 func (s *ParallelTestSuite) SetupTest() {
-	s.testInt++
+	atomic.AddInt64(&testInt, 1)
 }
 
 func (s *ParallelTestSuite) TearDownTest() {
-	s.teardownTestInt++
+	atomic.AddInt64(&teardownTestInt, 1)
 }
 
-func (s ParallelTestSuite) TestOne(t *testing.T) {
-	t.Logf("Accessing shared suite data from TestOne:%d", s.suiteInt)
-	t.Logf("Accessing shared test data from TestOne:%d", s.testInt)
+func (s *ParallelTestSuite) TestOne(t *testing.T) {
+	//Access shared data from TestOne and TestTwo which should trigger race conditions.
 	s.suiteInt++
 }
 
-func (s ParallelTestSuite) TestTwo(t *testing.T) {
-	t.Logf("Accessing shared suite data from TestTwo:%d", s.suiteInt)
-	t.Logf("Accessing shared test data from TestTwo:%d", s.testInt)
+func (s *ParallelTestSuite) TestTwo(t *testing.T) {
 	s.suiteInt++
 }
 
-func (s ParallelTestSuite) TestSkip(t *testing.T) {
+func (s *ParallelTestSuite) TestSkip(t *testing.T) {
 	t.Skip()
 	t.FailNow()
 }
@@ -52,8 +69,11 @@ func TestParallelSuiteRunner(t *testing.T) {
 	// go test -v -race -run TestParallelSuiteRunner
 	suite := new(ParallelTestSuite)
 	RunParallel(t, suite)
-	assert.Equal(t, 3, suite.testInt)
-	assert.Equal(t, 3, suite.teardownTestInt)
-	assert.Equal(t, 1, suite.suiteInt)
-	assert.Equal(t, 1, suite.teardownSuiteInt)
+	assert.Equal(t, int64(3), testInt)
+	assert.Equal(t, int64(3), teardownTestInt)
+	assert.Equal(t, int64(1), suiteInt)
+	assert.Equal(t, int64(1), teardownSuiteInt)
+	assert.Equal(t, int64(0), suite.suiteInt)
+	assert.Equal(t, 1, suite.setupSimpleData)
+	assert.Equal(t, 7, suite.setupComplexData.nested.n)
 }

--- a/suite/parallel_suite_test.go
+++ b/suite/parallel_suite_test.go
@@ -26,7 +26,6 @@ type complexData struct {
 }
 
 type ParallelTestSuite struct {
-	Suite
 	suiteInt         int64
 	setupSimpleData  int
 	setupComplexData complexData
@@ -76,4 +75,16 @@ func TestParallelSuiteRunner(t *testing.T) {
 	assert.Equal(t, int64(0), suite.suiteInt)
 	assert.Equal(t, 1, suite.setupSimpleData)
 	assert.Equal(t, 7, suite.setupComplexData.nested.n)
+}
+
+type EmbeddedParallelTestSuite struct {
+	Suite
+}
+
+func (s *EmbeddedParallelTestSuite) TestOne() {
+}
+
+func TestEmbeddedParallelSuiteRunner(t *testing.T) {
+	suite := new(EmbeddedParallelTestSuite)
+	RunParallel(t, suite)
 }

--- a/suite/parallel_suite_test.go
+++ b/suite/parallel_suite_test.go
@@ -1,0 +1,59 @@
+package suite
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type ParallelTestSuite struct {
+	Suite
+	testInt          int
+	teardownTestInt  int
+	suiteInt         int
+	teardownSuiteInt int
+}
+
+func (s *ParallelTestSuite) SetupSuite() {
+	s.suiteInt++
+}
+
+func (s *ParallelTestSuite) TearDownSuite() {
+	s.teardownSuiteInt++
+}
+
+func (s *ParallelTestSuite) SetupTest() {
+	s.testInt++
+}
+
+func (s *ParallelTestSuite) TearDownTest() {
+	s.teardownTestInt++
+}
+
+func (s ParallelTestSuite) TestOne(t *testing.T) {
+	t.Logf("Accessing shared suite data from TestOne:%d", s.suiteInt)
+	t.Logf("Accessing shared test data from TestOne:%d", s.testInt)
+	s.suiteInt++
+}
+
+func (s ParallelTestSuite) TestTwo(t *testing.T) {
+	t.Logf("Accessing shared suite data from TestTwo:%d", s.suiteInt)
+	t.Logf("Accessing shared test data from TestTwo:%d", s.testInt)
+	s.suiteInt++
+}
+
+func (s ParallelTestSuite) TestSkip(t *testing.T) {
+	t.Skip()
+	t.FailNow()
+}
+
+func TestParallelSuiteRunner(t *testing.T) {
+	// Run with the following to detect data races:
+	// go test -v -race -run TestParallelSuiteRunner
+	suite := new(ParallelTestSuite)
+	RunParallel(t, suite)
+	assert.Equal(t, 3, suite.testInt)
+	assert.Equal(t, 3, suite.teardownTestInt)
+	assert.Equal(t, 1, suite.suiteInt)
+	assert.Equal(t, 1, suite.teardownSuiteInt)
+}


### PR DESCRIPTION
Hello. My name is Andrew and I love using testify.

The purpose of this pr is to add a test suite runner that enables running suites in parallel (addressing #187). 

I am making this pr for feedback on my general methodologies here before writing more tests.

The general idea is to limit the amount of state exposed by the TestingSuite interface and to synchronize access to shared data via the Setup* and TearDown* interfaces.

RunParallel differs from Run in a few ways. It does not operate on the TestingSuite interface because it is very difficult to provide goroutine saftey when TestingSuite#T() returns a pointer to a testing object. Instead we take a functional approach here by passing in the *testing.T object created in the InternalTest closure into each test method.

Internal data can be safely set here via the Setup* and TearDown* interface methods. We serialize access to the SetupTest and TearDownTest methods because they can be called in parallel. Mutating test state can be done via pointer receivers on these methods.

All test methods should accept value receivers so that they don't cause data races. Any shared state those tests need can be safely setup via the above interface methods.

All feedback is welcomed and if anyone can point me to docs on how to best contribute to this project, I would appreciate it.