### PR TITLE
Add comments for Equal and NotEqual to clarify pointer comparison

### DIFF
--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -43,6 +43,9 @@ func (a *Assertions) Empty(object interface{}, msgAndArgs ...interface{}) bool {
 //    a.Equal(123, 123, "123 and 123 should be equal")
 //
 // Returns whether the assertion was successful (true) or not (false).
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
 func (a *Assertions) Equal(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
 	return Equal(a.t, expected, actual, msgAndArgs...)
 }
@@ -262,6 +265,9 @@ func (a *Assertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) boo
 //    a.NotEqual(obj1, obj2, "two objects shouldn't be equal")
 //
 // Returns whether the assertion was successful (true) or not (false).
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
 func (a *Assertions) NotEqual(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
 	return NotEqual(a.t, expected, actual, msgAndArgs...)
 }

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -270,6 +270,9 @@ func IsType(t TestingT, expectedType interface{}, object interface{}, msgAndArgs
 //    assert.Equal(t, 123, 123, "123 and 123 should be equal")
 //
 // Returns whether the assertion was successful (true) or not (false).
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
 func Equal(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool {
 
 	if !ObjectsAreEqual(expected, actual) {
@@ -556,6 +559,9 @@ func False(t TestingT, value bool, msgAndArgs ...interface{}) bool {
 //    assert.NotEqual(t, obj1, obj2, "two objects shouldn't be equal")
 //
 // Returns whether the assertion was successful (true) or not (false).
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
 func NotEqual(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool {
 
 	if ObjectsAreEqual(expected, actual) {

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -192,7 +192,9 @@ func TestEqual(t *testing.T) {
 	if !Equal(mockT, uint64(123), uint64(123)) {
 		t.Error("Equal should return true")
 	}
-
+	if !Equal(mockT, &struct{}{}, &struct{}{}) {
+		t.Error("Equal should return true (pointer equality is based on equality of underlying value)")
+	}
 }
 
 func TestFormatUnequalValues(t *testing.T) {
@@ -341,6 +343,9 @@ func TestNotEqual(t *testing.T) {
 		t.Error("NotEqual should return false")
 	}
 	if NotEqual(mockT, new(AssertionTesterConformingObject), new(AssertionTesterConformingObject)) {
+		t.Error("NotEqual should return false")
+	}
+	if NotEqual(mockT, &struct{}{}, &struct{}{}) {
 		t.Error("NotEqual should return false")
 	}
 }

--- a/require/require.go
+++ b/require/require.go
@@ -50,6 +50,9 @@ func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 //    assert.Equal(t, 123, 123, "123 and 123 should be equal")
 //
 // Returns whether the assertion was successful (true) or not (false).
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
 func Equal(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if !assert.Equal(t, expected, actual, msgAndArgs...) {
 		t.FailNow()
@@ -319,6 +322,9 @@ func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 //    assert.NotEqual(t, obj1, obj2, "two objects shouldn't be equal")
 //
 // Returns whether the assertion was successful (true) or not (false).
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
 func NotEqual(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if !assert.NotEqual(t, expected, actual, msgAndArgs...) {
 		t.FailNow()

--- a/require/require_forward.go
+++ b/require/require_forward.go
@@ -44,6 +44,9 @@ func (a *Assertions) Empty(object interface{}, msgAndArgs ...interface{}) {
 //    a.Equal(123, 123, "123 and 123 should be equal")
 //
 // Returns whether the assertion was successful (true) or not (false).
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
 func (a *Assertions) Equal(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	Equal(a.t, expected, actual, msgAndArgs...)
 }
@@ -263,6 +266,9 @@ func (a *Assertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) {
 //    a.NotEqual(obj1, obj2, "two objects shouldn't be equal")
 //
 // Returns whether the assertion was successful (true) or not (false).
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
 func (a *Assertions) NotEqual(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	NotEqual(a.t, expected, actual, msgAndArgs...)
 }


### PR DESCRIPTION
Clarify that pointer equality is determined by equality of values
rather than memory address.

Fixes #358