### PR TITLE
descriptive assertion error when comparing string aliases

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -294,7 +294,9 @@ func formatUnequalValues(expected, actual interface{}) (e string, a string) {
 	aType := reflect.TypeOf(expected)
 	bType := reflect.TypeOf(actual)
 
-	if aType != bType && isAmbiguousType(aType) && isAmbiguousType(bType) {
+	// if the types are both numeric or both strings,
+	// print them with type information
+	if aType != bType && ((isNumericType(aType) && isNumericType(bType)) || (aType.Kind() == reflect.String && bType.Kind() == reflect.String)) {
 		return fmt.Sprintf("%v(%#v)", aType, expected),
 			fmt.Sprintf("%v(%#v)", bType, actual)
 	}
@@ -303,17 +305,13 @@ func formatUnequalValues(expected, actual interface{}) (e string, a string) {
 		fmt.Sprintf("%#v", actual)
 }
 
-func isAmbiguousType(t reflect.Type) bool {
+func isNumericType(t reflect.Type) bool {
 	switch t.Kind() {
-	// numbers are ambiguous when printed
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		return true
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 		return true
 	case reflect.Float32, reflect.Float64:
-		return true
-		// strings are also ambiguous as printed
-	case reflect.String:
 		return true
 	}
 

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -294,7 +294,7 @@ func formatUnequalValues(expected, actual interface{}) (e string, a string) {
 	aType := reflect.TypeOf(expected)
 	bType := reflect.TypeOf(actual)
 
-	if aType != bType && isNumericType(aType) && isNumericType(bType) {
+	if aType != bType && isAmbiguousType(aType) && isAmbiguousType(bType) {
 		return fmt.Sprintf("%v(%#v)", aType, expected),
 			fmt.Sprintf("%v(%#v)", bType, actual)
 	}
@@ -303,13 +303,17 @@ func formatUnequalValues(expected, actual interface{}) (e string, a string) {
 		fmt.Sprintf("%#v", actual)
 }
 
-func isNumericType(t reflect.Type) bool {
+func isAmbiguousType(t reflect.Type) bool {
 	switch t.Kind() {
+	// numbers are ambiguous when printed
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		return true
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 		return true
 	case reflect.Float32, reflect.Float64:
+		return true
+		// strings are also ambiguous as printed
+	case reflect.String:
 		return true
 	}
 

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -78,6 +78,8 @@ var (
 	}
 )
 
+type StringAlias string
+
 // AssertionTesterInterface defines an interface to be used for testing assertion methods
 type AssertionTesterInterface interface {
 	TestMethod()
@@ -207,6 +209,10 @@ func TestFormatUnequalValues(t *testing.T) {
 	expected, actual = formatUnequalValues(int64(123), int32(123))
 	Equal(t, `int64(123)`, expected, "value should include type")
 	Equal(t, `int32(123)`, actual, "value should include type")
+
+        expected, actual = formatUnequalValues("different string types", StringAlias("different string types"))
+        Equal(t, `string("different string types")`, expected, "value should include type")
+        Equal(t, `assert.StringAlias("different string types")`, actual, "value should include type")
 
 	type testStructType struct {
 		Val string

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -210,9 +210,14 @@ func TestFormatUnequalValues(t *testing.T) {
 	Equal(t, `int64(123)`, expected, "value should include type")
 	Equal(t, `int32(123)`, actual, "value should include type")
 
-        expected, actual = formatUnequalValues("different string types", StringAlias("different string types"))
-        Equal(t, `string("different string types")`, expected, "value should include type")
-        Equal(t, `assert.StringAlias("different string types")`, actual, "value should include type")
+	expected, actual = formatUnequalValues("different string types", StringAlias("different string types"))
+	Equal(t, `string("different string types")`, expected, "value should include type")
+	Equal(t, `assert.StringAlias("different string types")`, actual, "value should include type")
+
+	// when strings are compared to numeric types, extra type information should not be present.
+	expected, actual = formatUnequalValues("string type", 12345)
+	Equal(t, `"string type"`, expected, "value should not include type")
+	Equal(t, "12345", actual, "value should not include type")
 
 	type testStructType struct {
 		Val string


### PR DESCRIPTION
Hi

I think the current error message when comparing string aliases is a bit confusing:

```go
Error:          Not equal: 
expected: "hi there"
received: "hi there"
``` 
With this diff, it becomes:

```go
Error:          Not equal: 
expected: string("hi there")
received: main.MyType("hi there")
``` 

:pear: thanks for taking a look!