### PR TITLE
Add `Mock#Reset()`

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -457,6 +457,13 @@ func (m *Mock) calls() []Call {
 	return append([]Call{}, m.Calls...)
 }
 
+// Reset removes all programmed expectations from a mock
+func (m *Mock) Reset() {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.ExpectedCalls = nil
+}
+
 /*
 	Arguments
 */

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -1156,3 +1156,17 @@ func Test_WaitUntil_Parallel(t *testing.T) {
 	// Allow the first call to execute, so the second one executes afterwards
 	ch2 <- time.Now()
 }
+
+func Test_Reset(t *testing.T) {
+	// make a test impl object
+	var mockedService = new(TestExampleImplementation)
+
+	mockedService.
+		On("TheExampleMethod2", 1, 2, 3).
+		Return(0)
+
+	assert.Equal(t, 1, len(mockedService.ExpectedCalls))
+
+	mockedService.Reset()
+	assert.Equal(t, 0, len(mockedService.ExpectedCalls))	
+}


### PR DESCRIPTION
Provide a methods for clearing all programed expectations from a mock; useful during a TestSuite tear-down method to ensure you have a clean slate between test-runs.