### PR TITLE
Use Go 1.7 subtests so suites can properly nest

### DIFF
--- a/suite/suite_test.go
+++ b/suite/suite_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // SuiteRequireTwice is intended to test the usage of suite.Require in two
@@ -19,7 +20,7 @@ type SuiteRequireTwice struct{ Suite }
 // A regression would result on these tests panicking rather than failing.
 func TestSuiteRequireTwice(t *testing.T) {
 	ok := testing.RunTests(
-		func(_, _ string) (bool, error) { return true, nil },
+		allTestsFilter,
 		[]testing.InternalTest{{
 			Name: "TestSuiteRequireTwice",
 			F: func(t *testing.T) {
@@ -267,16 +268,19 @@ func (sc *StdoutCapture) StopCapture() (string, error) {
 }
 
 func TestSuiteLogging(t *testing.T) {
-	testT := testing.T{}
-
 	suiteLoggingTester := new(SuiteLoggingTester)
-
 	capture := StdoutCapture{}
+	internalTest := testing.InternalTest{
+		Name: "SomeTest",
+		F: func(subT *testing.T) {
+			Run(subT, suiteLoggingTester)
+		},
+	}
 	capture.StartCapture()
-	Run(&testT, suiteLoggingTester)
+	testing.RunTests(allTestsFilter, []testing.InternalTest{internalTest})
 	output, err := capture.StopCapture()
-
-	assert.Nil(t, err, "Got an error trying to capture stdout!")
+	require.NoError(t, err, "Got an error trying to capture stdout and stderr!")
+	require.NotEmpty(t, output, "output content must not be empty")
 
 	// Failed tests' output is always printed
 	assert.Contains(t, output, "TESTLOGFAIL")


### PR DESCRIPTION
This removes dependencies on Go Testing Internals and
also enables test methods within a suite to have subtests.

As things are now (screenshots from Gogland):
<img width="502" alt="screen shot 2017-01-19 at 1 38 42 pm" src="https://cloud.githubusercontent.com/assets/2622905/22126696/9d0bd70c-de4d-11e6-9bb7-1686ff9fd061.png">

After my diff, subtests properly nest under the suite (meaning you could easily run the suite multiple times with different params and results are nicely attributed to the suite rather than just tacked on to the list):
<img width="564" alt="screen shot 2017-01-19 at 1 44 32 pm" src="https://cloud.githubusercontent.com/assets/2622905/22126705/a6ea54ba-de4d-11e6-95f3-1367b82a9922.png">


Fixes #346 

Note: This currently breaks the logging capture part of the suite tests since Go1.7 now rolls up test output to parent T. I wanted to discuss best way to fix that. I tried to figure out how to access the rolled up test output in the parent T but I don't think it's possible even with reflection due to it being unexported. The solution I'm considering now would be to invoke go test directly via "os/exec" and capture the output that way, but I am not thrilled with that solution. Any ideas?