### PR TITLE
Add using 'Equal' method of structure to test equality

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -50,8 +50,7 @@ func ObjectsAreEqual(expected, actual interface{}) bool {
 		}
 		return bytes.Equal(exp, act)
 	}
-	return reflect.DeepEqual(expected, actual)
-
+	return deepEqual(expected, actual)
 }
 
 // ObjectsAreEqualValues gets whether two objects are equal, or if their
@@ -68,7 +67,7 @@ func ObjectsAreEqualValues(expected, actual interface{}) bool {
 	expectedValue := reflect.ValueOf(expected)
 	if expectedValue.IsValid() && expectedValue.Type().ConvertibleTo(actualType) {
 		// Attempt comparison after type conversion
-		return reflect.DeepEqual(expectedValue.Convert(actualType).Interface(), actual)
+		return deepEqual(expectedValue.Convert(actualType).Interface(), actual)
 	}
 
 	return false

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -203,6 +203,9 @@ func TestEqual(t *testing.T) {
 	if Equal(mockT, m["bar"], "something") {
 		t.Error("Equal should return false")
 	}
+	if !Equal(mockT, equalT{1, 2}, equalT{1, 1}) {
+		t.Error("Equal should return true: equalT{1, 2} equals equalT{1, 1}")
+	}
 }
 
 // bufferT implements TestingT. Its implementation of Errorf writes the output that would be produced by

--- a/assert/equals.go
+++ b/assert/equals.go
@@ -1,0 +1,174 @@
+package assert
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+const (
+	// if struct implements this method, it will be used to check equality
+	equalMethodName = "Equal"
+)
+
+type visit struct {
+	a1  unsafe.Pointer
+	a2  unsafe.Pointer
+	typ reflect.Type
+}
+
+// check equality of two interfaces, in case if interface has method 'Equal', uses it
+func deepEqual(x, y interface{}) bool {
+	if x == nil || y == nil {
+		return x == y
+	}
+	v1 := reflect.ValueOf(x)
+	v2 := reflect.ValueOf(y)
+	if v1.Type() != v2.Type() {
+		return false
+	}
+	return deepValueEqual(v1, v2, make(map[visit]bool), 0)
+}
+
+func deepValueEqual(v1, v2 reflect.Value, visited map[visit]bool, depth int) bool {
+	if !v1.IsValid() || !v2.IsValid() {
+		return v1.IsValid() == v2.IsValid()
+	}
+	if v1.Type() != v2.Type() {
+		return false
+	}
+
+	// if depth > 10 { panic("deepValueEqual") }	// for debugging
+	hard := func(k reflect.Kind) bool {
+		switch k {
+		case reflect.Array, reflect.Map, reflect.Slice, reflect.Struct:
+			return true
+		}
+		return false
+	}
+
+	if v1.CanAddr() && v2.CanAddr() && hard(v1.Kind()) {
+		addr1 := unsafe.Pointer(v1.UnsafeAddr())
+		addr2 := unsafe.Pointer(v2.UnsafeAddr())
+		if uintptr(addr1) > uintptr(addr2) {
+			// Canonicalize order to reduce number of entries in visited.
+			// Assumes non-moving garbage collector.
+			addr1, addr2 = addr2, addr1
+		}
+
+		// Short circuit if references are already seen.
+		typ := v1.Type()
+		v := visit{addr1, addr2, typ}
+		if visited[v] {
+			return true
+		}
+
+		// Remember for later.
+		visited[v] = true
+	}
+
+	switch v1.Kind() {
+	case reflect.Bool:
+		return v1.Bool() == v2.Bool()
+	case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Int:
+		return v1.Int() == v2.Int()
+	case reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uint, reflect.Uintptr:
+		return v1.Uint() == v2.Uint()
+	case reflect.Float32, reflect.Float64:
+		// TODO add precision
+		return v1.Float() == v2.Float()
+	case reflect.Complex64, reflect.Complex128:
+		return v1.Complex() == v2.Complex()
+	case reflect.String:
+		return v1.String() == v2.String()
+	case reflect.Chan, reflect.UnsafePointer:
+		return v1.Pointer() == v2.Pointer()
+	case reflect.Array:
+		for i := 0; i < v1.Len(); i++ {
+			if !deepValueEqual(v1.Index(i), v2.Index(i), visited, depth+1) {
+				return false
+			}
+		}
+		return true
+	case reflect.Slice:
+		if v1.IsNil() != v2.IsNil() {
+			return false
+		}
+		if v1.Len() != v2.Len() {
+			return false
+		}
+		if v1.Pointer() == v2.Pointer() {
+			return true
+		}
+		for i := 0; i < v1.Len(); i++ {
+			if !deepValueEqual(v1.Index(i), v2.Index(i), visited, depth+1) {
+				return false
+			}
+		}
+		return true
+	case reflect.Interface:
+		if v1.IsNil() || v2.IsNil() {
+			return v1.IsNil() == v2.IsNil()
+		}
+		return deepValueEqual(v1.Elem(), v2.Elem(), visited, depth+1)
+	case reflect.Ptr:
+		if v1.Pointer() == v2.Pointer() {
+			return true
+		}
+		return deepValueEqual(v1.Elem(), v2.Elem(), visited, depth+1)
+	case reflect.Struct:
+		// if struct has equal method, use it
+		if m := getEqualMethod(v1); m.IsValid() {
+			result := m.Call([]reflect.Value{v2})
+			return result[0].Bool()
+		}
+		for i, n := 0, v1.NumField(); i < n; i++ {
+			if !deepValueEqual(v1.Field(i), v2.Field(i), visited, depth+1) {
+				return false
+			}
+		}
+		return true
+	case reflect.Map:
+		if v1.IsNil() != v2.IsNil() {
+			return false
+		}
+		if v1.Len() != v2.Len() {
+			return false
+		}
+		if v1.Pointer() == v2.Pointer() {
+			return true
+		}
+		for _, k := range v1.MapKeys() {
+			val1 := v1.MapIndex(k)
+			val2 := v2.MapIndex(k)
+			if !val1.IsValid() || !val2.IsValid() || !deepValueEqual(v1.MapIndex(k), v2.MapIndex(k), visited, depth+1) {
+				return false
+			}
+		}
+		return true
+	case reflect.Func:
+		if v1.IsNil() && v2.IsNil() {
+			return true
+		}
+		// Can't do better than this:
+		return false
+	default:
+		return false
+	}
+}
+
+// getEqualMethod returns function 'T.Equal(T)', if v implements it,
+// otherwise returns invalid Value
+func getEqualMethod(v reflect.Value) reflect.Value {
+	m := v.MethodByName(equalMethodName)
+	if !m.IsValid() {
+		return m
+	}
+	mt := m.Type()
+	if mt.NumIn() != 1 || !v.Type().AssignableTo(mt.In(0)) {
+		return reflect.Value{}
+	}
+	if mt.NumOut() != 1 || mt.Out(0).Kind() != reflect.Bool {
+		return reflect.Value{}
+	}
+	return m
+}

--- a/assert/equals_test.go
+++ b/assert/equals_test.go
@@ -1,0 +1,123 @@
+package assert
+
+import (
+	"testing"
+	"time"
+)
+
+type equalT struct {
+	main  int
+	trash int
+}
+
+func (v1 equalT) Equal(v2 equalT) bool {
+	return v1.main == v2.main
+}
+
+type invalidEqualArgT struct {
+	v int
+}
+
+func (v1 invalidEqualArgT) Equal(i equalT) bool {
+	return true
+}
+
+type invalidEqualResultT struct {
+	v int
+}
+
+func (v1 invalidEqualResultT) Equal(i equalT) (bool, bool) {
+	return true, true
+}
+
+type allT struct {
+	b    bool
+	i    int
+	i8   int8
+	i16  int16
+	i32  int32
+	i64  int64
+	u    uint
+	u8   uint8
+	u16  uint16
+	u32  uint32
+	u64  uint64
+	f32  float32
+	f64  float64
+	c64  complex64
+	c128 complex128
+	s    string
+	ba   [2]byte
+	rs   []rune
+	m    map[int]int
+	f    func() int
+}
+
+func TestDeepEqual(t *testing.T) {
+	v1 := equalT{1, 1}
+	v2 := equalT{1, 2}
+	if !deepEqual(v1, v2) {
+		t.Error("deepEqual should return true: equalT{1, 1} equals equalT{1, 2}")
+	}
+	if !deepEqual(&v1, &v2) {
+		t.Error("deepEqual should return true: &equalT{1, 1} equals &equalT{1, 2}")
+	}
+	t1 := time.Now()
+	if !deepEqual(t1, t1.In(time.UTC)) {
+		t.Error("deepEqual should return true: 't1' equals 't1.In(UTC)'")
+	}
+	if deepEqual(t1, time.Time{}) {
+		t.Error("deepEqual should return false: 't1' does not equal zero time")
+	}
+	if deepEqual(invalidEqualArgT{1}, invalidEqualArgT{2}) {
+		t.Error("deepEqual should return false: 'invalidEqualArgT{1}' does not equal 'invalidEqualArgT{2}'")
+	}
+	if deepEqual(invalidEqualResultT{1}, invalidEqualResultT{2}) {
+		t.Error("deepEqual should return false: 'invalidEqualResultT{1}' does not equal 'invalidEqualResultT{2}'")
+	}
+
+	a1 := allT{
+		true,
+		-1, -2, -3, -4, -5,
+		1, 2, 3, 4, 5,
+		0.1, 0.2,
+		complex(6, 3), complex(4, 4),
+		"string",
+		[2]byte{'b', 'n'},
+		[]rune{'a', 'e', 'i'},
+		map[int]int{31: 5},
+		nil,
+	}
+	a2 := allT{
+		true,
+		-1, -2, -3, -4, -5,
+		1, 2, 3, 4, 5,
+		0.1, 0.2,
+		complex(6, 3), complex(4, 4),
+		"string",
+		[2]byte{'b', 'n'},
+		[]rune{'a', 'e', 'i'},
+		map[int]int{31: 5},
+		nil,
+	}
+	if !deepEqual(a1, a2) {
+		t.Error("deepEqual should return true: a1 equals a2")
+	}
+	if deepEqual(a1, allT{}) {
+		t.Error("deepEqual should return false: a1 does not equal allT{}")
+	}
+
+	ch1 := make(chan int)
+	if !deepEqual(ch1, ch1) {
+		t.Error("deepEqual should return true: ch1 equals ch1")
+	}
+	if deepEqual(ch1, make(chan int)) {
+		t.Error("deepEqual should return false: ch1 does not equal make(chan int)")
+	}
+
+	var nch1 <-chan int
+	var nch2 <-chan int
+	if !deepEqual(nch1, nch2) {
+		t.Error("deepEqual should return true: null channel is equal to null channel of same type)")
+	}
+}


### PR DESCRIPTION
If struct implements Equal method it should be used instead of
recursively compare fields, because in some cases recursively
comparing fields returns false result. for example type decimal.Decimal
can have different internal representation for the same values.