### PR TITLE
HTTP code status assertions now fail tests

### DIFF
--- a/assert/http_assertions.go
+++ b/assert/http_assertions.go
@@ -8,16 +8,16 @@ import (
 	"strings"
 )
 
-// httpCode is a helper that returns HTTP code of the response. It returns -1
-// if building a new request fails.
-func httpCode(handler http.HandlerFunc, method, url string, values url.Values) int {
+// httpCode is a helper that returns HTTP code of the response. It returns -1 and
+// an error if building a new request fails.
+func httpCode(handler http.HandlerFunc, method, url string, values url.Values) (int, error) {
 	w := httptest.NewRecorder()
 	req, err := http.NewRequest(method, url+"?"+values.Encode(), nil)
 	if err != nil {
-		return -1
+		return -1, err
 	}
 	handler(w, req)
-	return w.Code
+	return w.Code, nil
 }
 
 // HTTPSuccess asserts that a specified handler returns a success status code.
@@ -26,11 +26,18 @@ func httpCode(handler http.HandlerFunc, method, url string, values url.Values) i
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPSuccess(t TestingT, handler http.HandlerFunc, method, url string, values url.Values) bool {
-	code := httpCode(handler, method, url, values)
-	if code == -1 {
+	code, err := httpCode(handler, method, url, values)
+	if err != nil {
+		Fail(t, fmt.Sprintf("Failed to build test request, got error: %s", err))
 		return false
 	}
-	return code >= http.StatusOK && code <= http.StatusPartialContent
+
+	isSuccessCode := code >= http.StatusOK && code <= http.StatusPartialContent
+	if !isSuccessCode {
+		Fail(t, fmt.Sprintf("Expected HTTP success status code for \"%s\" but received \"%d\"", url+"?"+values.Encode(), code))
+	}
+
+	return isSuccessCode
 }
 
 // HTTPRedirect asserts that a specified handler returns a redirect status code.
@@ -39,11 +46,18 @@ func HTTPSuccess(t TestingT, handler http.HandlerFunc, method, url string, value
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPRedirect(t TestingT, handler http.HandlerFunc, method, url string, values url.Values) bool {
-	code := httpCode(handler, method, url, values)
-	if code == -1 {
+	code, err := httpCode(handler, method, url, values)
+	if err != nil {
+		Fail(t, fmt.Sprintf("Failed to build test request, got error: %s", err))
 		return false
 	}
-	return code >= http.StatusMultipleChoices && code <= http.StatusTemporaryRedirect
+
+	isRedirectCode := code >= http.StatusMultipleChoices && code <= http.StatusTemporaryRedirect
+	if !isRedirectCode {
+		Fail(t, fmt.Sprintf("Expected HTTP redirect status code for \"%s\" but received \"%d\"", url+"?"+values.Encode(), code))
+	}
+
+	return isRedirectCode
 }
 
 // HTTPError asserts that a specified handler returns an error status code.
@@ -52,11 +66,18 @@ func HTTPRedirect(t TestingT, handler http.HandlerFunc, method, url string, valu
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPError(t TestingT, handler http.HandlerFunc, method, url string, values url.Values) bool {
-	code := httpCode(handler, method, url, values)
-	if code == -1 {
+	code, err := httpCode(handler, method, url, values)
+	if err != nil {
+		Fail(t, fmt.Sprintf("Failed to build test request, got error: %s", err))
 		return false
 	}
-	return code >= http.StatusBadRequest
+
+	isErrorCode := code >= http.StatusBadRequest
+	if !isErrorCode {
+		Fail(t, fmt.Sprintf("Expected HTTP error status code for \"%s\" but received \"%d\"", url+"?"+values.Encode(), code))
+	}
+
+	return isErrorCode
 }
 
 // HTTPBody is a helper that returns HTTP body of the response. It returns

--- a/assert/http_assertions.go
+++ b/assert/http_assertions.go
@@ -34,7 +34,7 @@ func HTTPSuccess(t TestingT, handler http.HandlerFunc, method, url string, value
 
 	isSuccessCode := code >= http.StatusOK && code <= http.StatusPartialContent
 	if !isSuccessCode {
-		Fail(t, fmt.Sprintf("Expected HTTP success status code for \"%s\" but received \"%d\"", url+"?"+values.Encode(), code))
+		Fail(t, fmt.Sprintf("Expected HTTP success status code for %q but received %d", url+"?"+values.Encode(), code))
 	}
 
 	return isSuccessCode
@@ -54,7 +54,7 @@ func HTTPRedirect(t TestingT, handler http.HandlerFunc, method, url string, valu
 
 	isRedirectCode := code >= http.StatusMultipleChoices && code <= http.StatusTemporaryRedirect
 	if !isRedirectCode {
-		Fail(t, fmt.Sprintf("Expected HTTP redirect status code for \"%s\" but received \"%d\"", url+"?"+values.Encode(), code))
+		Fail(t, fmt.Sprintf("Expected HTTP redirect status code for %q but received %d", url+"?"+values.Encode(), code))
 	}
 
 	return isRedirectCode
@@ -74,7 +74,7 @@ func HTTPError(t TestingT, handler http.HandlerFunc, method, url string, values 
 
 	isErrorCode := code >= http.StatusBadRequest
 	if !isErrorCode {
-		Fail(t, fmt.Sprintf("Expected HTTP error status code for \"%s\" but received \"%d\"", url+"?"+values.Encode(), code))
+		Fail(t, fmt.Sprintf("Expected HTTP error status code for %q but received %d", url+"?"+values.Encode(), code))
 	}
 
 	return isErrorCode

--- a/assert/http_assertions_test.go
+++ b/assert/http_assertions_test.go
@@ -19,21 +19,52 @@ func httpError(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusInternalServerError)
 }
 
-func TestHTTPStatuses(t *testing.T) {
+func TestHTTPSuccess(t *testing.T) {
 	assert := New(t)
-	mockT := new(testing.T)
 
-	assert.Equal(HTTPSuccess(mockT, httpOK, "GET", "/", nil), true)
-	assert.Equal(HTTPSuccess(mockT, httpRedirect, "GET", "/", nil), false)
-	assert.Equal(HTTPSuccess(mockT, httpError, "GET", "/", nil), false)
+	mockT1 := new(testing.T)
+	assert.Equal(HTTPSuccess(mockT1, httpOK, "GET", "/", nil), true)
+	assert.False(mockT1.Failed())
 
-	assert.Equal(HTTPRedirect(mockT, httpOK, "GET", "/", nil), false)
-	assert.Equal(HTTPRedirect(mockT, httpRedirect, "GET", "/", nil), true)
-	assert.Equal(HTTPRedirect(mockT, httpError, "GET", "/", nil), false)
+	mockT2 := new(testing.T)
+	assert.Equal(HTTPSuccess(mockT2, httpRedirect, "GET", "/", nil), false)
+	assert.True(mockT2.Failed())
 
-	assert.Equal(HTTPError(mockT, httpOK, "GET", "/", nil), false)
-	assert.Equal(HTTPError(mockT, httpRedirect, "GET", "/", nil), false)
-	assert.Equal(HTTPError(mockT, httpError, "GET", "/", nil), true)
+	mockT3 := new(testing.T)
+	assert.Equal(HTTPSuccess(mockT3, httpError, "GET", "/", nil), false)
+	assert.True(mockT3.Failed())
+}
+
+func TestHTTPRedirect(t *testing.T) {
+	assert := New(t)
+
+	mockT1 := new(testing.T)
+	assert.Equal(HTTPRedirect(mockT1, httpOK, "GET", "/", nil), false)
+	assert.True(mockT1.Failed())
+
+	mockT2 := new(testing.T)
+	assert.Equal(HTTPRedirect(mockT2, httpRedirect, "GET", "/", nil), true)
+	assert.False(mockT2.Failed(), "WHAT")
+
+	mockT3 := new(testing.T)
+	assert.Equal(HTTPRedirect(mockT3, httpError, "GET", "/", nil), false)
+	assert.True(mockT3.Failed())
+}
+
+func TestHTTPError(t *testing.T) {
+	assert := New(t)
+
+	mockT1 := new(testing.T)
+	assert.Equal(HTTPError(mockT1, httpOK, "GET", "/", nil), false)
+	assert.True(mockT1.Failed())
+
+	mockT2 := new(testing.T)
+	assert.Equal(HTTPError(mockT2, httpRedirect, "GET", "/", nil), false)
+	assert.True(mockT2.Failed())
+
+	mockT3 := new(testing.T)
+	assert.Equal(HTTPError(mockT3, httpError, "GET", "/", nil), true)
+	assert.False(mockT3.Failed())
 }
 
 func TestHTTPStatusesWrapper(t *testing.T) {

--- a/assert/http_assertions_test.go
+++ b/assert/http_assertions_test.go
@@ -44,7 +44,7 @@ func TestHTTPRedirect(t *testing.T) {
 
 	mockT2 := new(testing.T)
 	assert.Equal(HTTPRedirect(mockT2, httpRedirect, "GET", "/", nil), true)
-	assert.False(mockT2.Failed(), "WHAT")
+	assert.False(mockT2.Failed())
 
 	mockT3 := new(testing.T)
 	assert.Equal(HTTPRedirect(mockT3, httpError, "GET", "/", nil), false)


### PR DESCRIPTION
It resolves #379 by failing tests when assertion is false or is unable to construct HTTP request.