### PR TITLE
Check length of path before trying to index directory.

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -108,10 +108,12 @@ func CallerInfo() []string {
 		}
 
 		parts := strings.Split(file, "/")
-		dir := parts[len(parts)-2]
 		file = parts[len(parts)-1]
-		if (dir != "assert" && dir != "mock" && dir != "require") || file == "mock_test.go" {
-			callers = append(callers, fmt.Sprintf("%s:%d", file, line))
+		if len(parts) > 1 {
+			dir := parts[len(parts)-2]
+			if (dir != "assert" && dir != "mock" && dir != "require") || file == "mock_test.go" {
+				callers = append(callers, fmt.Sprintf("%s:%d", file, line))
+			}
 		}
 
 		// Drop the package
@@ -181,7 +183,7 @@ func indentMessageLines(message string, longestLabelLen int) string {
 		// no need to align first line because it starts at the correct location (after the label)
 		if i != 0 {
 			// append alignLen+1 spaces to align with "{{longestLabel}}:" before adding tab
-			outBuf.WriteString("\n\r\t" + strings.Repeat(" ", longestLabelLen +1) + "\t")
+			outBuf.WriteString("\n\r\t" + strings.Repeat(" ", longestLabelLen+1) + "\t")
 		}
 		outBuf.WriteString(scanner.Text())
 	}
@@ -229,7 +231,7 @@ func Fail(t TestingT, failureMessage string, msgAndArgs ...interface{}) bool {
 }
 
 type labeledContent struct {
-	label string
+	label   string
 	content string
 }
 


### PR DESCRIPTION
This doesn't normally occur with `go test` which includes absolute paths, but when using `-trimpath` it's possible for the caller's file to simply be `my_test.go`. This might happen with some third-party build tools, e.g. https://github.com/thought-machine/please.

It's not easy to add a test on this without moving the code around. I'm happy to refactor a little if you'd like one though.