### PR TITLE
Support nil arguments to Argument Matchers

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -1,6 +1,7 @@
 package mock
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"regexp"
@@ -512,7 +513,10 @@ func (f argumentMatcher) Matches(argument interface{}) bool {
 		arg = reflect.ValueOf(argument)
 	}
 
-	if (argType == nil && expectTypeNilSupported) || argType.AssignableTo(expectType) {
+	if argType == nil && !expectTypeNilSupported {
+		panic(errors.New("attempting to call matcher with nil for non-nil expected type"))
+	}
+	if argType == nil || argType.AssignableTo(expectType) {
 		result := f.fn.Call([]reflect.Value{arg})
 		return result[0].Bool()
 	}

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -2,6 +2,7 @@ package mock
 
 import (
 	"errors"
+	"reflect"
 	"testing"
 	"time"
 
@@ -1157,6 +1158,15 @@ func Test_Arguments_Bool(t *testing.T) {
 
 	var args = Arguments([]interface{}{"string", 123, true})
 	assert.Equal(t, true, args.Bool(2))
+
+}
+
+func Test_ArgumentMatcher_Matches_Nil(t *testing.T) {
+
+	var matcher = argumentMatcher{fn: reflect.ValueOf(func(v interface{}) bool {
+		return v == nil
+	})}
+	assert.True(t, matcher.Matches(nil))
 
 }
 

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -2,7 +2,6 @@ package mock
 
 import (
 	"errors"
-	"reflect"
 	"testing"
 	"time"
 
@@ -39,6 +38,26 @@ type ExampleType struct {
 
 func (i *TestExampleImplementation) TheExampleMethod3(et *ExampleType) error {
 	args := i.Called(et)
+	return args.Error(0)
+}
+
+func (i *TestExampleImplementation) TheExampleMethod4(v ExampleInterface) error {
+	args := i.Called(v)
+	return args.Error(0)
+}
+
+func (i *TestExampleImplementation) TheExampleMethod5(ch chan struct{}) error {
+	args := i.Called(ch)
+	return args.Error(0)
+}
+
+func (i *TestExampleImplementation) TheExampleMethod6(m map[string]bool) error {
+	args := i.Called(m)
+	return args.Error(0)
+}
+
+func (i *TestExampleImplementation) TheExampleMethod7(slice []bool) error {
+	args := i.Called(slice)
 	return args.Error(0)
 }
 
@@ -181,15 +200,20 @@ func Test_Mock_On_WithPtrArgMatcher(t *testing.T) {
 	var mockedService TestExampleImplementation
 
 	mockedService.On("TheExampleMethod3",
-		MatchedBy(func(a *ExampleType) bool { return a.ran == true }),
+		MatchedBy(func(a *ExampleType) bool { return a != nil && a.ran == true }),
 	).Return(nil)
 
 	mockedService.On("TheExampleMethod3",
-		MatchedBy(func(a *ExampleType) bool { return a.ran == false }),
+		MatchedBy(func(a *ExampleType) bool { return a != nil && a.ran == false }),
 	).Return(errors.New("error"))
+
+	mockedService.On("TheExampleMethod3",
+		MatchedBy(func(a *ExampleType) bool { return a == nil }),
+	).Return(errors.New("error2"))
 
 	assert.Equal(t, mockedService.TheExampleMethod3(&ExampleType{true}), nil)
 	assert.EqualError(t, mockedService.TheExampleMethod3(&ExampleType{false}), "error")
+	assert.EqualError(t, mockedService.TheExampleMethod3(nil), "error2")
 }
 
 func Test_Mock_On_WithFuncArgMatcher(t *testing.T) {
@@ -198,17 +222,62 @@ func Test_Mock_On_WithFuncArgMatcher(t *testing.T) {
 	fixture1, fixture2 := errors.New("fixture1"), errors.New("fixture2")
 
 	mockedService.On("TheExampleMethodFunc",
-		MatchedBy(func(a func(string) error) bool { return a("string") == fixture1 }),
+		MatchedBy(func(a func(string) error) bool { return a != nil && a("string") == fixture1 }),
 	).Return(errors.New("fixture1"))
 
 	mockedService.On("TheExampleMethodFunc",
-		MatchedBy(func(a func(string) error) bool { return a("string") == fixture2 }),
+		MatchedBy(func(a func(string) error) bool { return a != nil && a("string") == fixture2 }),
 	).Return(errors.New("fixture2"))
+
+	mockedService.On("TheExampleMethodFunc",
+		MatchedBy(func(a func(string) error) bool { return a == nil }),
+	).Return(errors.New("fixture3"))
 
 	assert.EqualError(t, mockedService.TheExampleMethodFunc(
 		func(string) error { return fixture1 }), "fixture1")
 	assert.EqualError(t, mockedService.TheExampleMethodFunc(
 		func(string) error { return fixture2 }), "fixture2")
+	assert.EqualError(t, mockedService.TheExampleMethodFunc(nil), "fixture3")
+}
+
+func Test_Mock_On_WithInterfaceArgMatcher(t *testing.T) {
+	var mockedService TestExampleImplementation
+
+	mockedService.On("TheExampleMethod4",
+		MatchedBy(func(a ExampleInterface) bool { return a == nil }),
+	).Return(errors.New("fixture1"))
+
+	assert.EqualError(t, mockedService.TheExampleMethod4(nil), "fixture1")
+}
+
+func Test_Mock_On_WithChannelArgMatcher(t *testing.T) {
+	var mockedService TestExampleImplementation
+
+	mockedService.On("TheExampleMethod5",
+		MatchedBy(func(ch chan struct{}) bool { return ch == nil }),
+	).Return(errors.New("fixture1"))
+
+	assert.EqualError(t, mockedService.TheExampleMethod5(nil), "fixture1")
+}
+
+func Test_Mock_On_WithMapArgMatcher(t *testing.T) {
+	var mockedService TestExampleImplementation
+
+	mockedService.On("TheExampleMethod6",
+		MatchedBy(func(m map[string]bool) bool { return m == nil }),
+	).Return(errors.New("fixture1"))
+
+	assert.EqualError(t, mockedService.TheExampleMethod6(nil), "fixture1")
+}
+
+func Test_Mock_On_WithSliceArgMatcher(t *testing.T) {
+	var mockedService TestExampleImplementation
+
+	mockedService.On("TheExampleMethod7",
+		MatchedBy(func(slice []bool) bool { return slice == nil }),
+	).Return(errors.New("fixture1"))
+
+	assert.EqualError(t, mockedService.TheExampleMethod7(nil), "fixture1")
 }
 
 func Test_Mock_On_WithVariadicFunc(t *testing.T) {
@@ -1158,15 +1227,6 @@ func Test_Arguments_Bool(t *testing.T) {
 
 	var args = Arguments([]interface{}{"string", 123, true})
 	assert.Equal(t, true, args.Bool(2))
-
-}
-
-func Test_ArgumentMatcher_Matches_Nil(t *testing.T) {
-
-	var matcher = argumentMatcher{fn: reflect.ValueOf(func(v interface{}) bool {
-		return v == nil
-	})}
-	assert.True(t, matcher.Matches(nil))
 
 }
 


### PR DESCRIPTION
Currently, this would panic because `reflect.TypeOf(argument)` returns `nil`.

This adds support for:
 - Interfaces
 - Channels
 - Functions
 - Maps
 - Slices
 - Pointers

(basically anything that can have `nil` assigned to it)