### PR TITLE
diffArguments: remove unnecessary range-for

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -715,10 +715,8 @@ func typeAndKind(v interface{}) (reflect.Type, reflect.Kind) {
 }
 
 func diffArguments(expected Arguments, actual Arguments) string {
-	for x := range expected {
-		if diffString := diff(expected[x], actual[x]); diffString != "" {
-			return fmt.Sprintf("Difference found in argument %v:\n\n%s", x, diffString)
-		}
+	if diffString := diff(expected, actual); diffString != "" {
+		return fmt.Sprintf("Difference found in arguments:\n\n%s", diffString)
 	}
 
 	return ""


### PR DESCRIPTION
When `len(actual) > len(expected)`, this for loop would cause a panic.

Alternative to this implementation, there could be a check for
`if len(actual) != len(expected)`, but generating a meaningful message
describing that is already provided by `diff()`. So we defer to diff in
every case.

Fixes #393