### PR TITLE
nit: Provide argument name `args` in function signature

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -141,7 +141,7 @@ func (c *Call) After(d time.Duration) *Call {
 //    	arg := args.Get(0).(*map[string]interface{})
 //    	arg["foo"] = "bar"
 //    })
-func (c *Call) Run(fn func(Arguments)) *Call {
+func (c *Call) Run(fn func(args Arguments)) *Call {
 	c.lock()
 	defer c.unlock()
 	c.RunFn = fn


### PR DESCRIPTION
This mainly serves to make code-completion better in IDEs that automatically create the function signature.

Feel free to close this PR if you disagree in anyway. atom + go-plus, will default automation to expand to:
```go
call.Run(func(arg1 mock.Arguments) {		

})
```

With this change it'll instead be:
```go
call.Run(func(args mock.Arguments) {		

})
```