### PR TITLE
420: Add a default Mock struct

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -176,6 +176,11 @@ type Mock struct {
 	mutex sync.Mutex
 }
 
+// Default Struct definition using Mock
+type MockStruct struct {
+	Mock
+}
+
 // TestData holds any data that might be useful for testing.  Testify ignores
 // this data completely allowing you to do whatever you like with it.
 func (m *Mock) TestData() objx.Map {


### PR DESCRIPTION
I'm not sure what are your thoughts on this addition.

With this, I'd be able to define my mock structs as follow:

```
type (
	mockWriter mock.MockStruct
	mockUsername mock.MockStruct
	elasticSearchMockNoResult mock.MockStruct
	elasticSearchMockOneResult mock.MockStruct
)
```

It's really just syntactic sugar, but it reads better in my opinion.