### PR TITLE
Compare bytes with bytes.Equal instead of reflect.DeepEqual

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -38,7 +38,15 @@ func ObjectsAreEqual(expected, actual interface{}) bool {
 	if expected == nil || actual == nil {
 		return expected == actual
 	}
-
+	if exp, ok := expected.([]byte); ok {
+		act, ok := actual.([]byte)
+		if !ok {
+			return false
+		} else if exp == nil || act == nil {
+			return exp == nil && act == nil
+		}
+		return bytes.Equal(exp, act)
+	}
 	return reflect.DeepEqual(expected, actual)
 
 }

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -1283,3 +1283,32 @@ func TestFailNowWithFullTestingT(t *testing.T) {
 		FailNow(mockT, "failed")
 	}, "should call mockT.FailNow() rather than panicking")
 }
+
+func TestBytesEqual(t *testing.T) {
+	var cases = []struct {
+		a, b []byte
+	}{
+		{make([]byte, 2), make([]byte, 2)},
+		{make([]byte, 2), make([]byte, 2, 3)},
+		{nil, make([]byte, 0)},
+	}
+	for i, c := range cases {
+		Equal(t, reflect.DeepEqual(c.a, c.b), ObjectsAreEqual(c.a, c.b), "case %d failed", i+1)
+	}
+}
+
+func BenchmarkBytesEqual(b *testing.B) {
+	const size = 1024 * 8
+	s := make([]byte, size)
+	for i := range s {
+		s[i] = byte(i % 255)
+	}
+	s2 := make([]byte, size)
+	copy(s2, s)
+
+	mockT := &mockFailNowTestingT{}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Equal(mockT, s, s2)
+	}
+}


### PR DESCRIPTION
In some tests we compare ~1M byte slices with testify library, but since it uses `reflect.DeepEqual` this operation is very slow.

This PR adds a `[]byte` as a special case for `ObjectsAreEqual` and uses `bytes.Equal` to make comparison faster.

Benchmark results:
```
benchmark                 old ns/op     new ns/op     delta
BenchmarkBytesEqual-4     695795        261           -99.96%
```