### PR TITLE
Check number of provided arguments vs mocked

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -715,6 +715,10 @@ func typeAndKind(v interface{}) (reflect.Type, reflect.Kind) {
 }
 
 func diffArguments(expected Arguments, actual Arguments) string {
+	if len(expected) != len(actual) {
+		return fmt.Sprintf("Provided %v arguments, mocked for %v arguments", len(expected), len(actual))
+	}
+
 	for x := range expected {
 		if diffString := diff(expected[x], actual[x]); diffString != "" {
 			return fmt.Sprintf("Difference found in argument %v:\n\n%s", x, diffString)


### PR DESCRIPTION
Pre-diff:
```
panic: runtime error: index out of range
```

Post-diff:
```
panic:

mock: Unexpected Method Call
-----------------------------

MyFunction(string,string,string)
		0: string,
		1: string,
		2: string

The closest call I have is:

MyFunction(string,string)
		0: "mock.Anything"
		1: "mock.Anything"

Provided 3 arguments, mocked for 2 arguments
```