### PR TITLE
travis: rm broken go releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ language: go
 sudo: false
 
 go:
-  - 1.1 # broken?
-  - 1.2 # broken?
-  - 1.3 # broken?
   - 1.4
   - 1.5
   - 1.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ language: go
 sudo: false
 
 go:
-  - 1.1
-  - 1.2
-  - 1.3
+  - 1.1 # broken?
+  - 1.2 # broken?
+  - 1.3 # broken?
   - 1.4
   - 1.5
   - 1.6


### PR DESCRIPTION
Some dependencies no longer support go <= 1.3.

github.com/davecgh/go-spew/spew and github.com/stretchr/objx depend on
the "bytes" package, and github.com/pmezard/go-difflib/difflib depends
on the "bufio" package.

This change removes them from tested platforms in travis. It may make
sense to explicitly doc the lack of support elsewhere.