### PR TITLE
add mock.MethodCalled(methodName, args...)

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -213,7 +213,7 @@ func (m *Mock) On(methodName string, arguments ...interface{}) *Call {
 // 	Recording and responding to activity
 // */
 
-func (m *Mock) findExpectedCall(method string, arguments ...interface{}) (int, *Call) {
+func (m *Mock) FindExpectedCall(method string, arguments ...interface{}) (int, *Call) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	for i, call := range m.ExpectedCalls {
@@ -287,8 +287,11 @@ func (m *Mock) Called(arguments ...interface{}) Arguments {
 	}
 	parts := strings.Split(functionPath, ".")
 	functionName := parts[len(parts)-1]
+	return m.MethodCalled(functionName, arguments...)
+}
 
-	found, call := m.findExpectedCall(functionName, arguments...)
+func (m *Mock) MethodCalled(functionName string, arguments ...interface{}) Arguments {
+	found, call := m.FindExpectedCall(functionName, arguments...)
 
 	if found < 0 {
 		// we have to fail here - because we don't know what to do

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -2,10 +2,11 @@ package mock
 
 import (
 	"errors"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 /*
@@ -533,7 +534,7 @@ func Test_Mock_findExpectedCall(t *testing.T) {
 	m.On("Two", 2).Return("two")
 	m.On("Two", 3).Return("three")
 
-	f, c := m.findExpectedCall("Two", 3)
+	f, c := m.FindExpectedCall("Two", 3)
 
 	if assert.Equal(t, 2, f) {
 		if assert.NotNil(t, c) {
@@ -552,7 +553,7 @@ func Test_Mock_findExpectedCall_For_Unknown_Method(t *testing.T) {
 	m.On("Two", 2).Return("two")
 	m.On("Two", 3).Return("three")
 
-	f, _ := m.findExpectedCall("Two")
+	f, _ := m.FindExpectedCall("Two")
 
 	assert.Equal(t, -1, f)
 
@@ -566,7 +567,7 @@ func Test_Mock_findExpectedCall_Respects_Repeatability(t *testing.T) {
 	m.On("Two", 3).Return("three").Twice()
 	m.On("Two", 3).Return("three").Times(8)
 
-	f, c := m.findExpectedCall("Two", 3)
+	f, c := m.FindExpectedCall("Two", 3)
 
 	if assert.Equal(t, 2, f) {
 		if assert.NotNil(t, c) {
@@ -1155,4 +1156,16 @@ func Test_WaitUntil_Parallel(t *testing.T) {
 
 	// Allow the first call to execute, so the second one executes afterwards
 	ch2 <- time.Now()
+}
+
+func Test_MethodCalled(t *testing.T) {
+	m := new(Mock)
+	m.On("foo", "hello").Return("world")
+
+	found, _ := m.FindExpectedCall("foo", "hello")
+	require.True(t, found >= 0)
+	retArgs := m.MethodCalled("foo", "hello")
+	require.True(t, len(retArgs) == 1)
+	require.Equal(t, "world", retArgs[0])
+	m.AssertExpectations(t)
 }


### PR DESCRIPTION
Current Mock.Called(args...) records a method call, but the method name is the calling method. This limits a very useful use case. We are working on a library, where user could register function with a name. Then those registered functions could be invoked by name from some workflow code. The library is using reflect to get the function and passing in arguments to those registered functions. We don't know the function signature at our library's compile time. In code, it is conceptually like:
lib.Register("foo", func(...) {...})
lib.Register("bar", func(...) {...})
Then, the workflow code is something conceptually like:
result1 := lib.Invoke("foo", args...)
result2 := lib.Invoke("bar", args...)
processResult(result1, result2).
Now, we want our test suite to be able to test those workflow code,and allow user to mock any registered function. User's test code would look like:
m.On("foo", args...).Return(some_static_result)
m.On("bar", args...).Return(func(...) {...})
Then user assign this mock object m to our test suite, and in our library test framework, before we pass the arguments via reflect to the actual registered function, we want to check if a mock is available by:
found, _ := m.findExpectedCall(registeredFnName, arguments)
if found {
retArgs := m.MethodCalled(functionName, args...)
// deal with the mock call...
} else {
// no mock call found, call the actual registered function.
}