### PR TITLE
add MethodCalled to the mock

### DIFF
--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -2,10 +2,11 @@ package mock
 
 import (
 	"errors"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 /*
@@ -1183,4 +1184,14 @@ func Test_WaitUntil_Parallel(t *testing.T) {
 
 	// Allow the first call to execute, so the second one executes afterwards
 	ch2 <- time.Now()
+}
+
+func Test_MockMethodCalled(t *testing.T) {
+	m := new(Mock)
+	m.On("foo", "hello").Return("world")
+
+	retArgs := m.MethodCalled("foo", "hello")
+	require.True(t, len(retArgs) == 1)
+	require.Equal(t, "world", retArgs[0])
+	m.AssertExpectations(t)
 }


### PR DESCRIPTION
This is a second try to address issue https://github.com/stretchr/testify/issues/437
The original PR https://github.com/stretchr/testify/pull/439 was merged then reverted.
This PR avoid exposing internal function which is the reason pull #439 was reverted.
Really hope this could be merged as this would support a very useful use case.
Please put comments if you see anything that needs to be changed for this PR to be merged.
Thanks.