### PR TITLE
Simple validation of Equal/NotEqual assertion arguments

### DIFF
--- a/assert/assertion_format.go
+++ b/assert/assertion_format.go
@@ -45,7 +45,8 @@ func Emptyf(t TestingT, object interface{}, msg string, args ...interface{}) boo
 // Returns whether the assertion was successful (true) or not (false).
 //
 // Pointer variable equality is determined based on the equality of the
-// referenced values (as opposed to the memory addresses).
+// referenced values (as opposed to the memory addresses). Function equality
+// cannot be determined and will always fail.
 func Equalf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
 	return Equal(t, expected, actual, append([]interface{}{msg}, args...)...)
 }

--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -72,7 +72,8 @@ func (a *Assertions) Emptyf(object interface{}, msg string, args ...interface{})
 // Returns whether the assertion was successful (true) or not (false).
 //
 // Pointer variable equality is determined based on the equality of the
-// referenced values (as opposed to the memory addresses).
+// referenced values (as opposed to the memory addresses). Function equality
+// cannot be determined and will always fail.
 func (a *Assertions) Equal(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
 	return Equal(a.t, expected, actual, msgAndArgs...)
 }
@@ -126,7 +127,8 @@ func (a *Assertions) EqualValuesf(expected interface{}, actual interface{}, msg 
 // Returns whether the assertion was successful (true) or not (false).
 //
 // Pointer variable equality is determined based on the equality of the
-// referenced values (as opposed to the memory addresses).
+// referenced values (as opposed to the memory addresses). Function equality
+// cannot be determined and will always fail.
 func (a *Assertions) Equalf(expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
 	return Equalf(a.t, expected, actual, msg, args...)
 }

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -396,8 +396,8 @@ func TestNotEqual(t *testing.T) {
 	}
 	funcA := func() int { return 23 }
 	funcB := func() int { return 42 }
-	if !NotEqual(mockT, funcA, funcB) {
-		t.Error("NotEqual should return true")
+	if NotEqual(mockT, funcA, funcB) {
+		t.Error("NotEqual should return false")
 	}
 
 	if NotEqual(mockT, "Hello World", "Hello World") {
@@ -1374,4 +1374,9 @@ func BenchmarkBytesEqual(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		Equal(mockT, s, s2)
 	}
+}
+
+func TestEqualArgsValidation(t *testing.T) {
+	err := validateEqualArgs(time.Now, time.Now)
+	EqualError(t, err, "cannot take func type as argument")
 }

--- a/require/require.go
+++ b/require/require.go
@@ -85,7 +85,8 @@ func Emptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
 // Returns whether the assertion was successful (true) or not (false).
 //
 // Pointer variable equality is determined based on the equality of the
-// referenced values (as opposed to the memory addresses).
+// referenced values (as opposed to the memory addresses). Function equality
+// cannot be determined and will always fail.
 func Equal(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if !assert.Equal(t, expected, actual, msgAndArgs...) {
 		t.FailNow()
@@ -149,7 +150,8 @@ func EqualValuesf(t TestingT, expected interface{}, actual interface{}, msg stri
 // Returns whether the assertion was successful (true) or not (false).
 //
 // Pointer variable equality is determined based on the equality of the
-// referenced values (as opposed to the memory addresses).
+// referenced values (as opposed to the memory addresses). Function equality
+// cannot be determined and will always fail.
 func Equalf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if !assert.Equalf(t, expected, actual, msg, args...) {
 		t.FailNow()

--- a/require/require_forward.go
+++ b/require/require_forward.go
@@ -73,7 +73,8 @@ func (a *Assertions) Emptyf(object interface{}, msg string, args ...interface{})
 // Returns whether the assertion was successful (true) or not (false).
 //
 // Pointer variable equality is determined based on the equality of the
-// referenced values (as opposed to the memory addresses).
+// referenced values (as opposed to the memory addresses). Function equality
+// cannot be determined and will always fail.
 func (a *Assertions) Equal(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	Equal(a.t, expected, actual, msgAndArgs...)
 }
@@ -127,7 +128,8 @@ func (a *Assertions) EqualValuesf(expected interface{}, actual interface{}, msg 
 // Returns whether the assertion was successful (true) or not (false).
 //
 // Pointer variable equality is determined based on the equality of the
-// referenced values (as opposed to the memory addresses).
+// referenced values (as opposed to the memory addresses). Function equality
+// cannot be determined and will always fail.
 func (a *Assertions) Equalf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	Equalf(a.t, expected, actual, msg, args...)
 }


### PR DESCRIPTION
It resolves #286 by providing a simple validation function for Equal/NotEqual assertions. I have no idea how to test error messages produced by go testing framework, so I moved part of the logic to a helper function.