### PR TITLE
Add IsCallExpected()

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -209,6 +209,15 @@ func (m *Mock) On(methodName string, arguments ...interface{}) *Call {
 	return c
 }
 
+// IsCallExpected checks whether a method call is expected.
+func (m *Mock) IsCallExpected(method string, arguments ...interface{}) bool {
+	m.mutex.Lock()
+	found, _ := m.findExpectedCall(method, arguments...)
+	m.mutex.Unlock()
+
+	return found >= 0
+}
+
 // /*
 // 	Recording and responding to activity
 // */


### PR DESCRIPTION
This is a follow up to https://github.com/stretchr/testify/pull/444
It expose a way for user to know if a call is expected before calls to the MethodCalled() function. @ernesto-jimenez, I know that you think that this expose some internal state and dis-like this method. But we need a way to make the use case possible. Another way we could do is to return error from MethodCalled() if the call is not expected, right now it will panic. Let me know what do you think, and I will update the PR if you think returning error from MethodCalled is good.