### PR TITLE
return error from MethodCalled if call is not expected

### DIFF
--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -1190,7 +1190,11 @@ func Test_MockMethodCalled(t *testing.T) {
 	m := new(Mock)
 	m.On("foo", "hello").Return("world")
 
-	retArgs := m.MethodCalled("foo", "hello")
+	retArgs, err := m.MethodCalled("bar", "hello")
+	require.NotNil(t, err)
+
+	retArgs, err = m.MethodCalled("foo", "hello")
+	require.NoError(t, err)
 	require.True(t, len(retArgs) == 1)
 	require.Equal(t, "world", retArgs[0])
 	m.AssertExpectations(t)


### PR DESCRIPTION
This is a second option to address the left over issue to https://github.com/stretchr/testify/pull/444
Instead of panic from MethodCalled() if the call is not expected, it will return error.
We need a way to be able to safely call the MethodCalled(). Either via API to check if the call is expected, or the MethodCalled() returns error instead of panic. 

Also open to any suggestion on other options to achieve the goal.