### PR TITLE
Issue #469 fix

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -449,9 +449,7 @@ func isEmpty(object interface{}) bool {
 	objValue := reflect.ValueOf(object)
 
 	switch objValue.Kind() {
-	case reflect.Map:
-		fallthrough
-	case reflect.Slice, reflect.Chan:
+	case reflect.Array, reflect.Chan, reflect.Map, reflect.Slice, reflect.String:
 		{
 			return (objValue.Len() == 0)
 		}


### PR DESCRIPTION
reflect.Value.Len() can cover more types, per godoc:
> Len returns v's length. It panics if v's Kind is not Array, Chan, Map, Slice, or String.