### PR TITLE
Adds a helper to quickly get the calls for a given method

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -463,6 +463,17 @@ func (m *Mock) calls() []Call {
 	return append([]Call{}, m.Calls...)
 }
 
+// CallsForMethod returns a list of call for a given method
+func (m *Mock) CallsForMethod(method string) []Call {
+	calls := []Call{}
+	for _, call := range m.Calls {
+		if call.Method == method {
+			calls = append(calls, call)
+		}
+	}
+	return calls
+}
+
 /*
 	Arguments
 */

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -998,6 +998,28 @@ func Test_Mock_AssertNotCalled(t *testing.T) {
 
 }
 
+func Test_Mock_CallsForMethod(t *testing.T) {
+	var mockedService = new(TestExampleImplementation)
+
+	mockedService.On("TheExampleMethod", Anything, Anything, Anything).Return(0, nil)
+	mockedService.On("TheExampleMethod2", Anything)
+	mockedService.On("TheExampleMethodVariadic", Anything).Return(nil)
+
+	mockedService.TheExampleMethod(0, 0, 0)
+	mockedService.TheExampleMethod(1, 1, 1)
+	mockedService.TheExampleMethod2(true)
+	mockedService.TheExampleMethod2(false)
+	mockedService.TheExampleMethodVariadic(0, 1, 2, 3)
+
+	theExampleMethodCalls := mockedService.CallsForMethod("TheExampleMethod")
+	theExampleMethod2Calls := mockedService.CallsForMethod("TheExampleMethod2")
+	theExampleMethodVariadicCalls := mockedService.CallsForMethod("TheExampleMethodVariadic")
+
+	assert.Len(t, theExampleMethodCalls, 2)
+	assert.Len(t, theExampleMethod2Calls, 2)
+	assert.Len(t, theExampleMethodVariadicCalls, 1)
+}
+
 /*
 	Arguments helper methods
 */


### PR DESCRIPTION
This the same than https://github.com/stretchr/testify/pull/404

I mishandled something that got the previous PR automatically closed, my bad.

@ernesto-jimenez  something like that could be useful if one ever need a quick way to get all the calls for a specific method name. Suppose you want to make sure that some code called the `Warn` method on some mock logger, but you don't want to deal with all the noisy `Info` calls.