### PR TITLE
Add new assertion ErrorContains

### DIFF
--- a/assert/assertion_format.go
+++ b/assert/assertion_format.go
@@ -84,6 +84,17 @@ func Errorf(t TestingT, err error, msg string, args ...interface{}) bool {
 	return Error(t, err, append([]interface{}{msg}, args...)...)
 }
 
+// ErrorContainsf asserts that the error is not-nil and that it contains the
+// expected error string.
+//
+//   actualObj, err := SomeFunction()
+//   assert.ErrorContainsf(t, err,  expectedErrorString, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func ErrorContainsf(t TestingT, theError error, errString string, msg string, args ...interface{}) bool {
+	return ErrorContains(t, theError, errString, append([]interface{}{msg}, args...)...)
+}
+
 // Exactlyf asserts that two objects are equal is value and type.
 //
 //    assert.Exactlyf(t, int32(123, "error message %s", "formatted"), int64(123))

--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -145,6 +145,28 @@ func (a *Assertions) Error(err error, msgAndArgs ...interface{}) bool {
 	return Error(a.t, err, msgAndArgs...)
 }
 
+// ErrorContains asserts that the error is not-nil and that it contains the
+// expected error string.
+//
+//   actualObj, err := SomeFunction()
+//   a.ErrorContains(err,  expectedErrorString)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) ErrorContains(theError error, errString string, msgAndArgs ...interface{}) bool {
+	return ErrorContains(a.t, theError, errString, msgAndArgs...)
+}
+
+// ErrorContainsf asserts that the error is not-nil and that it contains the
+// expected error string.
+//
+//   actualObj, err := SomeFunction()
+//   a.ErrorContainsf(err,  expectedErrorString, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) ErrorContainsf(theError error, errString string, msg string, args ...interface{}) bool {
+	return ErrorContainsf(a.t, theError, errString, msg, args...)
+}
+
 // Errorf asserts that a function returned an error (i.e. not `nil`).
 //
 //   actualObj, err := SomeFunction()

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1058,6 +1058,27 @@ func EqualError(t TestingT, theError error, errString string, msgAndArgs ...inte
 	return true
 }
 
+// ErrorContains asserts that the error is not-nil and that it contains the
+// expected error string.
+//
+//   actualObj, err := SomeFunction()
+//   assert.ErrorContains(t, err,  expectedErrorString)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func ErrorContains(t TestingT, theError error, errString string, msgAndArgs ...interface{}) bool {
+	if !Error(t, theError, msgAndArgs...) {
+		return false
+	}
+	expected := errString
+	actual := theError.Error()
+	if !strings.Contains(actual, expected) {
+		return Fail(t, fmt.Sprintf("Error message does not contain:\n"+
+			"expected: %q\n"+
+			"actual: %q", expected, actual), msgAndArgs...)
+	}
+	return true
+}
+
 // matchRegexp return true if a specified regexp matches a string.
 func matchRegexp(rx interface{}, str interface{}) bool {
 

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -771,6 +771,20 @@ func TestEqualError(t *testing.T) {
 		"EqualError should return true")
 }
 
+func TestErrorContains(t *testing.T) {
+	mockT := new(testing.T)
+
+	var err error
+	False(t, ErrorContains(mockT, err, ""),
+		"EqualError should return false for nil arg")
+
+	err = errors.New("some error occurred")
+	False(t, ErrorContains(mockT, err, "not this text"),
+		"EqualError should return false for different error string")
+	True(t, ErrorContains(mockT, err, "some error"),
+		"EqualError should return true")
+}
+
 func Test_isEmpty(t *testing.T) {
 
 	chWithValue := make(chan struct{}, 1)

--- a/assert/forward_assertions_test.go
+++ b/assert/forward_assertions_test.go
@@ -308,6 +308,21 @@ func TestEqualErrorWrapper(t *testing.T) {
 		"EqualError should return true")
 }
 
+func TestErrorContainsWrapper(t *testing.T) {
+	assert := New(t)
+	mockAssert := New(new(testing.T))
+
+	var err error
+	assert.False(mockAssert.ErrorContains(err, ""),
+		"EqualError should return false for nil arg")
+
+	err = errors.New("some error occurred")
+	assert.False(mockAssert.ErrorContains(err, "Not some error"),
+		"EqualError should return false for different error string")
+	assert.True(mockAssert.ErrorContains(err, "some error"),
+		"EqualError should return true")
+}
+
 func TestEmptyWrapper(t *testing.T) {
 	assert := New(t)
 	mockAssert := New(new(testing.T))

--- a/require/require.go
+++ b/require/require.go
@@ -172,6 +172,32 @@ func Error(t TestingT, err error, msgAndArgs ...interface{}) {
 	}
 }
 
+// ErrorContains asserts that the error is not-nil and that it contains the
+// expected error string.
+//
+//   actualObj, err := SomeFunction()
+//   assert.ErrorContains(t, err,  expectedErrorString)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func ErrorContains(t TestingT, theError error, errString string, msgAndArgs ...interface{}) {
+	if !assert.ErrorContains(t, theError, errString, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// ErrorContainsf asserts that the error is not-nil and that it contains the
+// expected error string.
+//
+//   actualObj, err := SomeFunction()
+//   assert.ErrorContainsf(t, err,  expectedErrorString, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func ErrorContainsf(t TestingT, theError error, errString string, msg string, args ...interface{}) {
+	if !assert.ErrorContainsf(t, theError, errString, msg, args...) {
+		t.FailNow()
+	}
+}
+
 // Errorf asserts that a function returned an error (i.e. not `nil`).
 //
 //   actualObj, err := SomeFunction()

--- a/require/require_forward.go
+++ b/require/require_forward.go
@@ -146,6 +146,28 @@ func (a *Assertions) Error(err error, msgAndArgs ...interface{}) {
 	Error(a.t, err, msgAndArgs...)
 }
 
+// ErrorContains asserts that the error is not-nil and that it contains the
+// expected error string.
+//
+//   actualObj, err := SomeFunction()
+//   a.ErrorContains(err,  expectedErrorString)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) ErrorContains(theError error, errString string, msgAndArgs ...interface{}) {
+	ErrorContains(a.t, theError, errString, msgAndArgs...)
+}
+
+// ErrorContainsf asserts that the error is not-nil and that it contains the
+// expected error string.
+//
+//   actualObj, err := SomeFunction()
+//   a.ErrorContainsf(err,  expectedErrorString, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) ErrorContainsf(theError error, errString string, msg string, args ...interface{}) {
+	ErrorContainsf(a.t, theError, errString, msg, args...)
+}
+
 // Errorf asserts that a function returned an error (i.e. not `nil`).
 //
 //   actualObj, err := SomeFunction()

--- a/require/requirements_test.go
+++ b/require/requirements_test.go
@@ -218,6 +218,17 @@ func TestEqualError(t *testing.T) {
 	}
 }
 
+func TestErrorContains(t *testing.T) {
+
+	ErrorContains(t, errors.New("some error occurred"), "some error")
+
+	mockT := new(MockT)
+	ErrorContains(mockT, errors.New("some error"), "Not some error")
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
 func TestEmpty(t *testing.T) {
 
 	Empty(t, "")


### PR DESCRIPTION
Fixes #497

I have found that in many cases an error message isn't entirely predictable. This may be the case when a function wraps an error using`errors.Wrap()`, and the underlying error changes by platform or for some other reason.

I often us an `ErrorContains()` assertion to test these cases. Would you be interested in adding this assertion to `testify` ?

I've named the function `ErrorContains()` which I think reads better than `ContainsError()` but I realize that is less consistent with `EqualError()`. `ErrorContains()` also has the advantage that in godoc it is sorted next to `Error()` so all the error-related assertions are grouped together.