### PR TITLE
Fix unprotected call fields access in MethodCalled()

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -336,11 +336,19 @@ func (m *Mock) MethodCalled(methodName string, arguments ...interface{}) Argumen
 		<-call.WaitFor
 	}
 
-	if call.RunFn != nil {
-		call.RunFn(arguments)
+	m.mutex.Lock()
+	runFn := call.RunFn
+	m.mutex.Unlock()
+
+	if runFn != nil {
+		runFn(arguments)
 	}
 
-	return call.ReturnArguments
+	m.mutex.Lock()
+	returnArgs := call.ReturnArguments
+	m.mutex.Unlock()
+
+	return returnArgs
 }
 
 /*


### PR DESCRIPTION
This change fixes a race condition I discovered when a multithreaded test in a service I work on failed under -race.  The included test case simulates that failure (concurrent mutation of a Call with invocations on the mock).  The test will fail with a data race if run under the race detector; the new locking ensures that call fields are not accessed without the protection of the parent mutex.