### PR TITLE
Allow a method call to be optional

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -48,6 +48,9 @@ type Call struct {
 	// Amount of times this call has been called
 	totalCalls int
 
+	// Call to this method can be optional
+	optional bool
+
 	// Holds a channel that will be used to block the Return until it either
 	// receives a message or is closed. nil means it returns immediately.
 	WaitFor <-chan time.Time
@@ -145,6 +148,15 @@ func (c *Call) Run(fn func(args Arguments)) *Call {
 	c.lock()
 	defer c.unlock()
 	c.RunFn = fn
+	return c
+}
+
+// Maybe allows the method call to be optional. Not calling an optional method
+// will not cause an error while asserting expectations
+func (c *Call) Maybe() *Call {
+	c.lock()
+	defer c.unlock()
+	c.optional = true
 	return c
 }
 
@@ -380,7 +392,7 @@ func (m *Mock) AssertExpectations(t TestingT) bool {
 	// iterate through each expectation
 	expectedCalls := m.expectedCalls()
 	for _, expectedCall := range expectedCalls {
-		if !m.methodWasCalled(expectedCall.Method, expectedCall.Arguments) && expectedCall.totalCalls == 0 {
+		if !expectedCall.optional && !m.methodWasCalled(expectedCall.Method, expectedCall.Arguments) && expectedCall.totalCalls == 0 {
 			somethingMissing = true
 			failedExpectations++
 			t.Logf("\u274C\t%s(%s)", expectedCall.Method, expectedCall.Arguments.String())

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -998,6 +998,18 @@ func Test_Mock_AssertNotCalled(t *testing.T) {
 
 }
 
+func Test_Mock_AssertOptional(t *testing.T) {
+	for _, isOptional := range []bool{false, true} {
+		var mockedService = new(TestExampleImplementation)
+		mc := mockedService.On("TheExampleMethod", 1, 2, 3).Return(4, nil)
+		if isOptional {
+			mc.Maybe()
+		}
+		tt := new(testing.T)
+		assert.Equal(t, isOptional, mockedService.AssertExpectations(tt))
+	}
+}
+
 /*
 	Arguments helper methods
 */


### PR DESCRIPTION
Sometimes when we are testing a large and complex method, some of its dependencies on a utility level might or might not be called depends on whether the dependee has encountered an error and bails out early.

I added a Maybe() method on the Call struct so we mark a method call optional so when AssertExpectations is called it wouldn't trigger an error.