### PR TITLE
fail: add test name for logged output

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -231,6 +231,13 @@ func Fail(t TestingT, failureMessage string, msgAndArgs ...interface{}) bool {
 		{"Error", failureMessage},
 	}
 
+	// Add test name if the Go version supports it
+	if n, ok := t.(interface {
+		Name() string
+	}); ok {
+		content = append(content, labeledContent{"Test", n.Name()})
+	}
+
 	message := messageFromMsgAndArgs(msgAndArgs...)
 	if len(message) > 0 {
 		content = append(content, labeledContent{"Messages", message})


### PR DESCRIPTION
From: https://github.com/stretchr/testify/pull/472

> In case of a test failure, the test name will be logged to the output
> with makes debugging easier, specially in case of table driven tests.

New pr to cleanup history.