### PR TITLE
Drop old Go versions from tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ language: go
 sudo: false
 
 go:
-  - 1.4
-  - 1.5
-  - 1.6
   - 1.7
   - 1.8
   - 1.9
@@ -15,4 +12,4 @@ script:
   - ./.travis.gogenerate.sh
   - ./.travis.gofmt.sh
   - ./.travis.govet.sh
-  - go test -v ./...
+  - go test -v -race ./...


### PR DESCRIPTION
From now on, we will support the last 3 major Go versions, which covers
at least one year and a half of Go versions.