### PR TITLE
Remove returns info from assertion docs

### DIFF
--- a/assert/assertion_format.go
+++ b/assert/assertion_format.go
@@ -22,8 +22,6 @@ func Conditionf(t TestingT, comp Comparison, msg string, args ...interface{}) bo
 //    assert.Containsf(t, "Hello World", "World", "error message %s", "formatted")
 //    assert.Containsf(t, ["Hello", "World"], "World", "error message %s", "formatted")
 //    assert.Containsf(t, {"Hello": "World"}, "Hello", "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func Containsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) bool {
 	return Contains(t, s, contains, append([]interface{}{msg}, args...)...)
 }
@@ -38,8 +36,6 @@ func DirExistsf(t TestingT, path string, msg string, args ...interface{}) bool {
 // the number of appearances of each of them in both lists should match.
 //
 // assert.ElementsMatchf(t, [1, 3, 2, 3], [1, 3, 3, 2], "error message %s", "formatted"))
-//
-// Returns whether the assertion was successful (true) or not (false).
 func ElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string, args ...interface{}) bool {
 	return ElementsMatch(t, listA, listB, append([]interface{}{msg}, args...)...)
 }
@@ -48,8 +44,6 @@ func ElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string
 // a slice or a channel with len == 0.
 //
 //  assert.Emptyf(t, obj, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func Emptyf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
 	return Empty(t, object, append([]interface{}{msg}, args...)...)
 }
@@ -57,8 +51,6 @@ func Emptyf(t TestingT, object interface{}, msg string, args ...interface{}) boo
 // Equalf asserts that two objects are equal.
 //
 //    assert.Equalf(t, 123, 123, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses). Function equality
@@ -72,8 +64,6 @@ func Equalf(t TestingT, expected interface{}, actual interface{}, msg string, ar
 //
 //   actualObj, err := SomeFunction()
 //   assert.EqualErrorf(t, err,  expectedErrorString, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func EqualErrorf(t TestingT, theError error, errString string, msg string, args ...interface{}) bool {
 	return EqualError(t, theError, errString, append([]interface{}{msg}, args...)...)
 }
@@ -82,8 +72,6 @@ func EqualErrorf(t TestingT, theError error, errString string, msg string, args 
 // and equal.
 //
 //    assert.EqualValuesf(t, uint32(123, "error message %s", "formatted"), int32(123))
-//
-// Returns whether the assertion was successful (true) or not (false).
 func EqualValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
 	return EqualValues(t, expected, actual, append([]interface{}{msg}, args...)...)
 }
@@ -94,8 +82,6 @@ func EqualValuesf(t TestingT, expected interface{}, actual interface{}, msg stri
 //   if assert.Errorf(t, err, "error message %s", "formatted") {
 // 	   assert.Equal(t, expectedErrorf, err)
 //   }
-//
-// Returns whether the assertion was successful (true) or not (false).
 func Errorf(t TestingT, err error, msg string, args ...interface{}) bool {
 	return Error(t, err, append([]interface{}{msg}, args...)...)
 }
@@ -103,8 +89,6 @@ func Errorf(t TestingT, err error, msg string, args ...interface{}) bool {
 // Exactlyf asserts that two objects are equal in value and type.
 //
 //    assert.Exactlyf(t, int32(123, "error message %s", "formatted"), int64(123))
-//
-// Returns whether the assertion was successful (true) or not (false).
 func Exactlyf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
 	return Exactly(t, expected, actual, append([]interface{}{msg}, args...)...)
 }
@@ -122,8 +106,6 @@ func FailNowf(t TestingT, failureMessage string, msg string, args ...interface{}
 // Falsef asserts that the specified value is false.
 //
 //    assert.Falsef(t, myBool, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func Falsef(t TestingT, value bool, msg string, args ...interface{}) bool {
 	return False(t, value, append([]interface{}{msg}, args...)...)
 }
@@ -190,8 +172,6 @@ func Implementsf(t TestingT, interfaceObject interface{}, object interface{}, ms
 // InDeltaf asserts that the two numerals are within delta of each other.
 //
 // 	 assert.InDeltaf(t, math.Pi, (22 / 7.0, "error message %s", "formatted"), 0.01)
-//
-// Returns whether the assertion was successful (true) or not (false).
 func InDeltaf(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) bool {
 	return InDelta(t, expected, actual, delta, append([]interface{}{msg}, args...)...)
 }
@@ -207,8 +187,6 @@ func InDeltaSlicef(t TestingT, expected interface{}, actual interface{}, delta f
 }
 
 // InEpsilonf asserts that expected and actual have a relative error less than epsilon
-//
-// Returns whether the assertion was successful (true) or not (false).
 func InEpsilonf(t TestingT, expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) bool {
 	return InEpsilon(t, expected, actual, epsilon, append([]interface{}{msg}, args...)...)
 }
@@ -226,8 +204,6 @@ func IsTypef(t TestingT, expectedType interface{}, object interface{}, msg strin
 // JSONEqf asserts that two JSON strings are equivalent.
 //
 //  assert.JSONEqf(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func JSONEqf(t TestingT, expected string, actual string, msg string, args ...interface{}) bool {
 	return JSONEq(t, expected, actual, append([]interface{}{msg}, args...)...)
 }
@@ -236,8 +212,6 @@ func JSONEqf(t TestingT, expected string, actual string, msg string, args ...int
 // Lenf also fails if the object has a type that len() not accept.
 //
 //    assert.Lenf(t, mySlice, 3, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func Lenf(t TestingT, object interface{}, length int, msg string, args ...interface{}) bool {
 	return Len(t, object, length, append([]interface{}{msg}, args...)...)
 }
@@ -245,8 +219,6 @@ func Lenf(t TestingT, object interface{}, length int, msg string, args ...interf
 // Nilf asserts that the specified object is nil.
 //
 //    assert.Nilf(t, err, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func Nilf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
 	return Nil(t, object, append([]interface{}{msg}, args...)...)
 }
@@ -257,8 +229,6 @@ func Nilf(t TestingT, object interface{}, msg string, args ...interface{}) bool 
 //   if assert.NoErrorf(t, err, "error message %s", "formatted") {
 // 	   assert.Equal(t, expectedObj, actualObj)
 //   }
-//
-// Returns whether the assertion was successful (true) or not (false).
 func NoErrorf(t TestingT, err error, msg string, args ...interface{}) bool {
 	return NoError(t, err, append([]interface{}{msg}, args...)...)
 }
@@ -269,8 +239,6 @@ func NoErrorf(t TestingT, err error, msg string, args ...interface{}) bool {
 //    assert.NotContainsf(t, "Hello World", "Earth", "error message %s", "formatted")
 //    assert.NotContainsf(t, ["Hello", "World"], "Earth", "error message %s", "formatted")
 //    assert.NotContainsf(t, {"Hello": "World"}, "Earth", "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func NotContainsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) bool {
 	return NotContains(t, s, contains, append([]interface{}{msg}, args...)...)
 }
@@ -281,8 +249,6 @@ func NotContainsf(t TestingT, s interface{}, contains interface{}, msg string, a
 //  if assert.NotEmptyf(t, obj, "error message %s", "formatted") {
 //    assert.Equal(t, "two", obj[1])
 //  }
-//
-// Returns whether the assertion was successful (true) or not (false).
 func NotEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
 	return NotEmpty(t, object, append([]interface{}{msg}, args...)...)
 }
@@ -290,8 +256,6 @@ func NotEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) 
 // NotEqualf asserts that the specified values are NOT equal.
 //
 //    assert.NotEqualf(t, obj1, obj2, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
@@ -302,8 +266,6 @@ func NotEqualf(t TestingT, expected interface{}, actual interface{}, msg string,
 // NotNilf asserts that the specified object is not nil.
 //
 //    assert.NotNilf(t, err, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func NotNilf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
 	return NotNil(t, object, append([]interface{}{msg}, args...)...)
 }
@@ -311,8 +273,6 @@ func NotNilf(t TestingT, object interface{}, msg string, args ...interface{}) bo
 // NotPanicsf asserts that the code inside the specified PanicTestFunc does NOT panic.
 //
 //   assert.NotPanicsf(t, func(){ RemainCalm() }, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func NotPanicsf(t TestingT, f PanicTestFunc, msg string, args ...interface{}) bool {
 	return NotPanics(t, f, append([]interface{}{msg}, args...)...)
 }
@@ -321,8 +281,6 @@ func NotPanicsf(t TestingT, f PanicTestFunc, msg string, args ...interface{}) bo
 //
 //  assert.NotRegexpf(t, regexp.MustCompile("starts", "error message %s", "formatted"), "it's starting")
 //  assert.NotRegexpf(t, "^start", "it's not starting", "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func NotRegexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) bool {
 	return NotRegexp(t, rx, str, append([]interface{}{msg}, args...)...)
 }
@@ -331,13 +289,11 @@ func NotRegexpf(t TestingT, rx interface{}, str interface{}, msg string, args ..
 // elements given in the specified subset(array, slice...).
 //
 //    assert.NotSubsetf(t, [1, 3, 4], [1, 2], "But [1, 3, 4] does not contain [1, 2]", "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func NotSubsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) bool {
 	return NotSubset(t, list, subset, append([]interface{}{msg}, args...)...)
 }
 
-// NotZerof asserts that i is not the zero value for its type and returns the truth.
+// NotZerof asserts that i is not the zero value for its type.
 func NotZerof(t TestingT, i interface{}, msg string, args ...interface{}) bool {
 	return NotZero(t, i, append([]interface{}{msg}, args...)...)
 }
@@ -345,8 +301,6 @@ func NotZerof(t TestingT, i interface{}, msg string, args ...interface{}) bool {
 // Panicsf asserts that the code inside the specified PanicTestFunc panics.
 //
 //   assert.Panicsf(t, func(){ GoCrazy() }, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func Panicsf(t TestingT, f PanicTestFunc, msg string, args ...interface{}) bool {
 	return Panics(t, f, append([]interface{}{msg}, args...)...)
 }
@@ -355,8 +309,6 @@ func Panicsf(t TestingT, f PanicTestFunc, msg string, args ...interface{}) bool 
 // the recovered panic value equals the expected panic value.
 //
 //   assert.PanicsWithValuef(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func PanicsWithValuef(t TestingT, expected interface{}, f PanicTestFunc, msg string, args ...interface{}) bool {
 	return PanicsWithValue(t, expected, f, append([]interface{}{msg}, args...)...)
 }
@@ -365,8 +317,6 @@ func PanicsWithValuef(t TestingT, expected interface{}, f PanicTestFunc, msg str
 //
 //  assert.Regexpf(t, regexp.MustCompile("start", "error message %s", "formatted"), "it's starting")
 //  assert.Regexpf(t, "start...$", "it's not starting", "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func Regexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) bool {
 	return Regexp(t, rx, str, append([]interface{}{msg}, args...)...)
 }
@@ -375,8 +325,6 @@ func Regexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...in
 // elements given in the specified subset(array, slice...).
 //
 //    assert.Subsetf(t, [1, 2, 3], [1, 2], "But [1, 2, 3] does contain [1, 2]", "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func Subsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) bool {
 	return Subset(t, list, subset, append([]interface{}{msg}, args...)...)
 }
@@ -384,8 +332,6 @@ func Subsetf(t TestingT, list interface{}, subset interface{}, msg string, args 
 // Truef asserts that the specified value is true.
 //
 //    assert.Truef(t, myBool, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func Truef(t TestingT, value bool, msg string, args ...interface{}) bool {
 	return True(t, value, append([]interface{}{msg}, args...)...)
 }
@@ -393,13 +339,11 @@ func Truef(t TestingT, value bool, msg string, args ...interface{}) bool {
 // WithinDurationf asserts that the two times are within duration delta of each other.
 //
 //   assert.WithinDurationf(t, time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msg string, args ...interface{}) bool {
 	return WithinDuration(t, expected, actual, delta, append([]interface{}{msg}, args...)...)
 }
 
-// Zerof asserts that i is the zero value for its type and returns the truth.
+// Zerof asserts that i is the zero value for its type.
 func Zerof(t TestingT, i interface{}, msg string, args ...interface{}) bool {
 	return Zero(t, i, append([]interface{}{msg}, args...)...)
 }

--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -27,8 +27,6 @@ func (a *Assertions) Conditionf(comp Comparison, msg string, args ...interface{}
 //    a.Contains("Hello World", "World")
 //    a.Contains(["Hello", "World"], "World")
 //    a.Contains({"Hello": "World"}, "Hello")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Contains(s interface{}, contains interface{}, msgAndArgs ...interface{}) bool {
 	return Contains(a.t, s, contains, msgAndArgs...)
 }
@@ -39,8 +37,6 @@ func (a *Assertions) Contains(s interface{}, contains interface{}, msgAndArgs ..
 //    a.Containsf("Hello World", "World", "error message %s", "formatted")
 //    a.Containsf(["Hello", "World"], "World", "error message %s", "formatted")
 //    a.Containsf({"Hello": "World"}, "Hello", "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Containsf(s interface{}, contains interface{}, msg string, args ...interface{}) bool {
 	return Containsf(a.t, s, contains, msg, args...)
 }
@@ -60,8 +56,6 @@ func (a *Assertions) DirExistsf(path string, msg string, args ...interface{}) bo
 // the number of appearances of each of them in both lists should match.
 //
 // a.ElementsMatch([1, 3, 2, 3], [1, 3, 3, 2]))
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) ElementsMatch(listA interface{}, listB interface{}, msgAndArgs ...interface{}) bool {
 	return ElementsMatch(a.t, listA, listB, msgAndArgs...)
 }
@@ -71,8 +65,6 @@ func (a *Assertions) ElementsMatch(listA interface{}, listB interface{}, msgAndA
 // the number of appearances of each of them in both lists should match.
 //
 // a.ElementsMatchf([1, 3, 2, 3], [1, 3, 3, 2], "error message %s", "formatted"))
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) ElementsMatchf(listA interface{}, listB interface{}, msg string, args ...interface{}) bool {
 	return ElementsMatchf(a.t, listA, listB, msg, args...)
 }
@@ -81,8 +73,6 @@ func (a *Assertions) ElementsMatchf(listA interface{}, listB interface{}, msg st
 // a slice or a channel with len == 0.
 //
 //  a.Empty(obj)
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Empty(object interface{}, msgAndArgs ...interface{}) bool {
 	return Empty(a.t, object, msgAndArgs...)
 }
@@ -91,8 +81,6 @@ func (a *Assertions) Empty(object interface{}, msgAndArgs ...interface{}) bool {
 // a slice or a channel with len == 0.
 //
 //  a.Emptyf(obj, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Emptyf(object interface{}, msg string, args ...interface{}) bool {
 	return Emptyf(a.t, object, msg, args...)
 }
@@ -100,8 +88,6 @@ func (a *Assertions) Emptyf(object interface{}, msg string, args ...interface{})
 // Equal asserts that two objects are equal.
 //
 //    a.Equal(123, 123)
-//
-// Returns whether the assertion was successful (true) or not (false).
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses). Function equality
@@ -115,8 +101,6 @@ func (a *Assertions) Equal(expected interface{}, actual interface{}, msgAndArgs 
 //
 //   actualObj, err := SomeFunction()
 //   a.EqualError(err,  expectedErrorString)
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...interface{}) bool {
 	return EqualError(a.t, theError, errString, msgAndArgs...)
 }
@@ -126,8 +110,6 @@ func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...
 //
 //   actualObj, err := SomeFunction()
 //   a.EqualErrorf(err,  expectedErrorString, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) EqualErrorf(theError error, errString string, msg string, args ...interface{}) bool {
 	return EqualErrorf(a.t, theError, errString, msg, args...)
 }
@@ -136,8 +118,6 @@ func (a *Assertions) EqualErrorf(theError error, errString string, msg string, a
 // and equal.
 //
 //    a.EqualValues(uint32(123), int32(123))
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) EqualValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
 	return EqualValues(a.t, expected, actual, msgAndArgs...)
 }
@@ -146,8 +126,6 @@ func (a *Assertions) EqualValues(expected interface{}, actual interface{}, msgAn
 // and equal.
 //
 //    a.EqualValuesf(uint32(123, "error message %s", "formatted"), int32(123))
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) EqualValuesf(expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
 	return EqualValuesf(a.t, expected, actual, msg, args...)
 }
@@ -155,8 +133,6 @@ func (a *Assertions) EqualValuesf(expected interface{}, actual interface{}, msg 
 // Equalf asserts that two objects are equal.
 //
 //    a.Equalf(123, 123, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses). Function equality
@@ -171,8 +147,6 @@ func (a *Assertions) Equalf(expected interface{}, actual interface{}, msg string
 //   if a.Error(err) {
 // 	   assert.Equal(t, expectedError, err)
 //   }
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Error(err error, msgAndArgs ...interface{}) bool {
 	return Error(a.t, err, msgAndArgs...)
 }
@@ -183,8 +157,6 @@ func (a *Assertions) Error(err error, msgAndArgs ...interface{}) bool {
 //   if a.Errorf(err, "error message %s", "formatted") {
 // 	   assert.Equal(t, expectedErrorf, err)
 //   }
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Errorf(err error, msg string, args ...interface{}) bool {
 	return Errorf(a.t, err, msg, args...)
 }
@@ -192,8 +164,6 @@ func (a *Assertions) Errorf(err error, msg string, args ...interface{}) bool {
 // Exactly asserts that two objects are equal in value and type.
 //
 //    a.Exactly(int32(123), int64(123))
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Exactly(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
 	return Exactly(a.t, expected, actual, msgAndArgs...)
 }
@@ -201,8 +171,6 @@ func (a *Assertions) Exactly(expected interface{}, actual interface{}, msgAndArg
 // Exactlyf asserts that two objects are equal in value and type.
 //
 //    a.Exactlyf(int32(123, "error message %s", "formatted"), int64(123))
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Exactlyf(expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
 	return Exactlyf(a.t, expected, actual, msg, args...)
 }
@@ -230,8 +198,6 @@ func (a *Assertions) Failf(failureMessage string, msg string, args ...interface{
 // False asserts that the specified value is false.
 //
 //    a.False(myBool)
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) False(value bool, msgAndArgs ...interface{}) bool {
 	return False(a.t, value, msgAndArgs...)
 }
@@ -239,8 +205,6 @@ func (a *Assertions) False(value bool, msgAndArgs ...interface{}) bool {
 // Falsef asserts that the specified value is false.
 //
 //    a.Falsef(myBool, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Falsef(value bool, msg string, args ...interface{}) bool {
 	return Falsef(a.t, value, msg, args...)
 }
@@ -366,8 +330,6 @@ func (a *Assertions) Implementsf(interfaceObject interface{}, object interface{}
 // InDelta asserts that the two numerals are within delta of each other.
 //
 // 	 a.InDelta(math.Pi, (22 / 7.0), 0.01)
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) InDelta(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) bool {
 	return InDelta(a.t, expected, actual, delta, msgAndArgs...)
 }
@@ -395,15 +357,11 @@ func (a *Assertions) InDeltaSlicef(expected interface{}, actual interface{}, del
 // InDeltaf asserts that the two numerals are within delta of each other.
 //
 // 	 a.InDeltaf(math.Pi, (22 / 7.0, "error message %s", "formatted"), 0.01)
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) InDeltaf(expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) bool {
 	return InDeltaf(a.t, expected, actual, delta, msg, args...)
 }
 
 // InEpsilon asserts that expected and actual have a relative error less than epsilon
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) InEpsilon(expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) bool {
 	return InEpsilon(a.t, expected, actual, epsilon, msgAndArgs...)
 }
@@ -419,8 +377,6 @@ func (a *Assertions) InEpsilonSlicef(expected interface{}, actual interface{}, e
 }
 
 // InEpsilonf asserts that expected and actual have a relative error less than epsilon
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) InEpsilonf(expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) bool {
 	return InEpsilonf(a.t, expected, actual, epsilon, msg, args...)
 }
@@ -438,8 +394,6 @@ func (a *Assertions) IsTypef(expectedType interface{}, object interface{}, msg s
 // JSONEq asserts that two JSON strings are equivalent.
 //
 //  a.JSONEq(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) JSONEq(expected string, actual string, msgAndArgs ...interface{}) bool {
 	return JSONEq(a.t, expected, actual, msgAndArgs...)
 }
@@ -447,8 +401,6 @@ func (a *Assertions) JSONEq(expected string, actual string, msgAndArgs ...interf
 // JSONEqf asserts that two JSON strings are equivalent.
 //
 //  a.JSONEqf(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) JSONEqf(expected string, actual string, msg string, args ...interface{}) bool {
 	return JSONEqf(a.t, expected, actual, msg, args...)
 }
@@ -457,8 +409,6 @@ func (a *Assertions) JSONEqf(expected string, actual string, msg string, args ..
 // Len also fails if the object has a type that len() not accept.
 //
 //    a.Len(mySlice, 3)
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Len(object interface{}, length int, msgAndArgs ...interface{}) bool {
 	return Len(a.t, object, length, msgAndArgs...)
 }
@@ -467,8 +417,6 @@ func (a *Assertions) Len(object interface{}, length int, msgAndArgs ...interface
 // Lenf also fails if the object has a type that len() not accept.
 //
 //    a.Lenf(mySlice, 3, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Lenf(object interface{}, length int, msg string, args ...interface{}) bool {
 	return Lenf(a.t, object, length, msg, args...)
 }
@@ -476,8 +424,6 @@ func (a *Assertions) Lenf(object interface{}, length int, msg string, args ...in
 // Nil asserts that the specified object is nil.
 //
 //    a.Nil(err)
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Nil(object interface{}, msgAndArgs ...interface{}) bool {
 	return Nil(a.t, object, msgAndArgs...)
 }
@@ -485,8 +431,6 @@ func (a *Assertions) Nil(object interface{}, msgAndArgs ...interface{}) bool {
 // Nilf asserts that the specified object is nil.
 //
 //    a.Nilf(err, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Nilf(object interface{}, msg string, args ...interface{}) bool {
 	return Nilf(a.t, object, msg, args...)
 }
@@ -497,8 +441,6 @@ func (a *Assertions) Nilf(object interface{}, msg string, args ...interface{}) b
 //   if a.NoError(err) {
 // 	   assert.Equal(t, expectedObj, actualObj)
 //   }
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NoError(err error, msgAndArgs ...interface{}) bool {
 	return NoError(a.t, err, msgAndArgs...)
 }
@@ -509,8 +451,6 @@ func (a *Assertions) NoError(err error, msgAndArgs ...interface{}) bool {
 //   if a.NoErrorf(err, "error message %s", "formatted") {
 // 	   assert.Equal(t, expectedObj, actualObj)
 //   }
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NoErrorf(err error, msg string, args ...interface{}) bool {
 	return NoErrorf(a.t, err, msg, args...)
 }
@@ -521,8 +461,6 @@ func (a *Assertions) NoErrorf(err error, msg string, args ...interface{}) bool {
 //    a.NotContains("Hello World", "Earth")
 //    a.NotContains(["Hello", "World"], "Earth")
 //    a.NotContains({"Hello": "World"}, "Earth")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotContains(s interface{}, contains interface{}, msgAndArgs ...interface{}) bool {
 	return NotContains(a.t, s, contains, msgAndArgs...)
 }
@@ -533,8 +471,6 @@ func (a *Assertions) NotContains(s interface{}, contains interface{}, msgAndArgs
 //    a.NotContainsf("Hello World", "Earth", "error message %s", "formatted")
 //    a.NotContainsf(["Hello", "World"], "Earth", "error message %s", "formatted")
 //    a.NotContainsf({"Hello": "World"}, "Earth", "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotContainsf(s interface{}, contains interface{}, msg string, args ...interface{}) bool {
 	return NotContainsf(a.t, s, contains, msg, args...)
 }
@@ -545,8 +481,6 @@ func (a *Assertions) NotContainsf(s interface{}, contains interface{}, msg strin
 //  if a.NotEmpty(obj) {
 //    assert.Equal(t, "two", obj[1])
 //  }
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) bool {
 	return NotEmpty(a.t, object, msgAndArgs...)
 }
@@ -557,8 +491,6 @@ func (a *Assertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) boo
 //  if a.NotEmptyf(obj, "error message %s", "formatted") {
 //    assert.Equal(t, "two", obj[1])
 //  }
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotEmptyf(object interface{}, msg string, args ...interface{}) bool {
 	return NotEmptyf(a.t, object, msg, args...)
 }
@@ -566,8 +498,6 @@ func (a *Assertions) NotEmptyf(object interface{}, msg string, args ...interface
 // NotEqual asserts that the specified values are NOT equal.
 //
 //    a.NotEqual(obj1, obj2)
-//
-// Returns whether the assertion was successful (true) or not (false).
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
@@ -579,8 +509,6 @@ func (a *Assertions) NotEqual(expected interface{}, actual interface{}, msgAndAr
 //
 //    a.NotEqualf(obj1, obj2, "error message %s", "formatted")
 //
-// Returns whether the assertion was successful (true) or not (false).
-//
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
 func (a *Assertions) NotEqualf(expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
@@ -590,8 +518,6 @@ func (a *Assertions) NotEqualf(expected interface{}, actual interface{}, msg str
 // NotNil asserts that the specified object is not nil.
 //
 //    a.NotNil(err)
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotNil(object interface{}, msgAndArgs ...interface{}) bool {
 	return NotNil(a.t, object, msgAndArgs...)
 }
@@ -599,8 +525,6 @@ func (a *Assertions) NotNil(object interface{}, msgAndArgs ...interface{}) bool 
 // NotNilf asserts that the specified object is not nil.
 //
 //    a.NotNilf(err, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotNilf(object interface{}, msg string, args ...interface{}) bool {
 	return NotNilf(a.t, object, msg, args...)
 }
@@ -608,8 +532,6 @@ func (a *Assertions) NotNilf(object interface{}, msg string, args ...interface{}
 // NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
 //
 //   a.NotPanics(func(){ RemainCalm() })
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotPanics(f PanicTestFunc, msgAndArgs ...interface{}) bool {
 	return NotPanics(a.t, f, msgAndArgs...)
 }
@@ -617,8 +539,6 @@ func (a *Assertions) NotPanics(f PanicTestFunc, msgAndArgs ...interface{}) bool 
 // NotPanicsf asserts that the code inside the specified PanicTestFunc does NOT panic.
 //
 //   a.NotPanicsf(func(){ RemainCalm() }, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotPanicsf(f PanicTestFunc, msg string, args ...interface{}) bool {
 	return NotPanicsf(a.t, f, msg, args...)
 }
@@ -627,8 +547,6 @@ func (a *Assertions) NotPanicsf(f PanicTestFunc, msg string, args ...interface{}
 //
 //  a.NotRegexp(regexp.MustCompile("starts"), "it's starting")
 //  a.NotRegexp("^start", "it's not starting")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) bool {
 	return NotRegexp(a.t, rx, str, msgAndArgs...)
 }
@@ -637,8 +555,6 @@ func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...in
 //
 //  a.NotRegexpf(regexp.MustCompile("starts", "error message %s", "formatted"), "it's starting")
 //  a.NotRegexpf("^start", "it's not starting", "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotRegexpf(rx interface{}, str interface{}, msg string, args ...interface{}) bool {
 	return NotRegexpf(a.t, rx, str, msg, args...)
 }
@@ -647,8 +563,6 @@ func (a *Assertions) NotRegexpf(rx interface{}, str interface{}, msg string, arg
 // elements given in the specified subset(array, slice...).
 //
 //    a.NotSubset([1, 3, 4], [1, 2], "But [1, 3, 4] does not contain [1, 2]")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotSubset(list interface{}, subset interface{}, msgAndArgs ...interface{}) bool {
 	return NotSubset(a.t, list, subset, msgAndArgs...)
 }
@@ -657,18 +571,16 @@ func (a *Assertions) NotSubset(list interface{}, subset interface{}, msgAndArgs 
 // elements given in the specified subset(array, slice...).
 //
 //    a.NotSubsetf([1, 3, 4], [1, 2], "But [1, 3, 4] does not contain [1, 2]", "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotSubsetf(list interface{}, subset interface{}, msg string, args ...interface{}) bool {
 	return NotSubsetf(a.t, list, subset, msg, args...)
 }
 
-// NotZero asserts that i is not the zero value for its type and returns the truth.
+// NotZero asserts that i is not the zero value for its type.
 func (a *Assertions) NotZero(i interface{}, msgAndArgs ...interface{}) bool {
 	return NotZero(a.t, i, msgAndArgs...)
 }
 
-// NotZerof asserts that i is not the zero value for its type and returns the truth.
+// NotZerof asserts that i is not the zero value for its type.
 func (a *Assertions) NotZerof(i interface{}, msg string, args ...interface{}) bool {
 	return NotZerof(a.t, i, msg, args...)
 }
@@ -676,8 +588,6 @@ func (a *Assertions) NotZerof(i interface{}, msg string, args ...interface{}) bo
 // Panics asserts that the code inside the specified PanicTestFunc panics.
 //
 //   a.Panics(func(){ GoCrazy() })
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Panics(f PanicTestFunc, msgAndArgs ...interface{}) bool {
 	return Panics(a.t, f, msgAndArgs...)
 }
@@ -686,8 +596,6 @@ func (a *Assertions) Panics(f PanicTestFunc, msgAndArgs ...interface{}) bool {
 // the recovered panic value equals the expected panic value.
 //
 //   a.PanicsWithValue("crazy error", func(){ GoCrazy() })
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) PanicsWithValue(expected interface{}, f PanicTestFunc, msgAndArgs ...interface{}) bool {
 	return PanicsWithValue(a.t, expected, f, msgAndArgs...)
 }
@@ -696,8 +604,6 @@ func (a *Assertions) PanicsWithValue(expected interface{}, f PanicTestFunc, msgA
 // the recovered panic value equals the expected panic value.
 //
 //   a.PanicsWithValuef("crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) PanicsWithValuef(expected interface{}, f PanicTestFunc, msg string, args ...interface{}) bool {
 	return PanicsWithValuef(a.t, expected, f, msg, args...)
 }
@@ -705,8 +611,6 @@ func (a *Assertions) PanicsWithValuef(expected interface{}, f PanicTestFunc, msg
 // Panicsf asserts that the code inside the specified PanicTestFunc panics.
 //
 //   a.Panicsf(func(){ GoCrazy() }, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Panicsf(f PanicTestFunc, msg string, args ...interface{}) bool {
 	return Panicsf(a.t, f, msg, args...)
 }
@@ -715,8 +619,6 @@ func (a *Assertions) Panicsf(f PanicTestFunc, msg string, args ...interface{}) b
 //
 //  a.Regexp(regexp.MustCompile("start"), "it's starting")
 //  a.Regexp("start...$", "it's not starting")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) bool {
 	return Regexp(a.t, rx, str, msgAndArgs...)
 }
@@ -725,8 +627,6 @@ func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...inter
 //
 //  a.Regexpf(regexp.MustCompile("start", "error message %s", "formatted"), "it's starting")
 //  a.Regexpf("start...$", "it's not starting", "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Regexpf(rx interface{}, str interface{}, msg string, args ...interface{}) bool {
 	return Regexpf(a.t, rx, str, msg, args...)
 }
@@ -735,8 +635,6 @@ func (a *Assertions) Regexpf(rx interface{}, str interface{}, msg string, args .
 // elements given in the specified subset(array, slice...).
 //
 //    a.Subset([1, 2, 3], [1, 2], "But [1, 2, 3] does contain [1, 2]")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Subset(list interface{}, subset interface{}, msgAndArgs ...interface{}) bool {
 	return Subset(a.t, list, subset, msgAndArgs...)
 }
@@ -745,8 +643,6 @@ func (a *Assertions) Subset(list interface{}, subset interface{}, msgAndArgs ...
 // elements given in the specified subset(array, slice...).
 //
 //    a.Subsetf([1, 2, 3], [1, 2], "But [1, 2, 3] does contain [1, 2]", "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Subsetf(list interface{}, subset interface{}, msg string, args ...interface{}) bool {
 	return Subsetf(a.t, list, subset, msg, args...)
 }
@@ -754,8 +650,6 @@ func (a *Assertions) Subsetf(list interface{}, subset interface{}, msg string, a
 // True asserts that the specified value is true.
 //
 //    a.True(myBool)
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) True(value bool, msgAndArgs ...interface{}) bool {
 	return True(a.t, value, msgAndArgs...)
 }
@@ -763,8 +657,6 @@ func (a *Assertions) True(value bool, msgAndArgs ...interface{}) bool {
 // Truef asserts that the specified value is true.
 //
 //    a.Truef(myBool, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Truef(value bool, msg string, args ...interface{}) bool {
 	return Truef(a.t, value, msg, args...)
 }
@@ -772,8 +664,6 @@ func (a *Assertions) Truef(value bool, msg string, args ...interface{}) bool {
 // WithinDuration asserts that the two times are within duration delta of each other.
 //
 //   a.WithinDuration(time.Now(), time.Now(), 10*time.Second)
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) WithinDuration(expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) bool {
 	return WithinDuration(a.t, expected, actual, delta, msgAndArgs...)
 }
@@ -781,18 +671,16 @@ func (a *Assertions) WithinDuration(expected time.Time, actual time.Time, delta 
 // WithinDurationf asserts that the two times are within duration delta of each other.
 //
 //   a.WithinDurationf(time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) WithinDurationf(expected time.Time, actual time.Time, delta time.Duration, msg string, args ...interface{}) bool {
 	return WithinDurationf(a.t, expected, actual, delta, msg, args...)
 }
 
-// Zero asserts that i is the zero value for its type and returns the truth.
+// Zero asserts that i is the zero value for its type.
 func (a *Assertions) Zero(i interface{}, msgAndArgs ...interface{}) bool {
 	return Zero(a.t, i, msgAndArgs...)
 }
 
-// Zerof asserts that i is the zero value for its type and returns the truth.
+// Zerof asserts that i is the zero value for its type.
 func (a *Assertions) Zerof(i interface{}, msg string, args ...interface{}) bool {
 	return Zerof(a.t, i, msg, args...)
 }

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -307,8 +307,6 @@ func IsType(t TestingT, expectedType interface{}, object interface{}, msgAndArgs
 //
 //    assert.Equal(t, 123, 123)
 //
-// Returns whether the assertion was successful (true) or not (false).
-//
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses). Function equality
 // cannot be determined and will always fail.
@@ -350,8 +348,6 @@ func formatUnequalValues(expected, actual interface{}) (e string, a string) {
 // and equal.
 //
 //    assert.EqualValues(t, uint32(123), int32(123))
-//
-// Returns whether the assertion was successful (true) or not (false).
 func EqualValues(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool {
 
 	if !ObjectsAreEqualValues(expected, actual) {
@@ -369,8 +365,6 @@ func EqualValues(t TestingT, expected, actual interface{}, msgAndArgs ...interfa
 // Exactly asserts that two objects are equal in value and type.
 //
 //    assert.Exactly(t, int32(123), int64(123))
-//
-// Returns whether the assertion was successful (true) or not (false).
 func Exactly(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool {
 
 	aType := reflect.TypeOf(expected)
@@ -387,8 +381,6 @@ func Exactly(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}
 // NotNil asserts that the specified object is not nil.
 //
 //    assert.NotNil(t, err)
-//
-// Returns whether the assertion was successful (true) or not (false).
 func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
 	if !isNil(object) {
 		return true
@@ -414,8 +406,6 @@ func isNil(object interface{}) bool {
 // Nil asserts that the specified object is nil.
 //
 //    assert.Nil(t, err)
-//
-// Returns whether the assertion was successful (true) or not (false).
 func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
 	if isNil(object) {
 		return true
@@ -455,8 +445,6 @@ func isEmpty(object interface{}) bool {
 // a slice or a channel with len == 0.
 //
 //  assert.Empty(t, obj)
-//
-// Returns whether the assertion was successful (true) or not (false).
 func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
 
 	pass := isEmpty(object)
@@ -474,8 +462,6 @@ func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
 //  if assert.NotEmpty(t, obj) {
 //    assert.Equal(t, "two", obj[1])
 //  }
-//
-// Returns whether the assertion was successful (true) or not (false).
 func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
 
 	pass := !isEmpty(object)
@@ -503,8 +489,6 @@ func getLen(x interface{}) (ok bool, length int) {
 // Len also fails if the object has a type that len() not accept.
 //
 //    assert.Len(t, mySlice, 3)
-//
-// Returns whether the assertion was successful (true) or not (false).
 func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) bool {
 	ok, l := getLen(object)
 	if !ok {
@@ -520,8 +504,6 @@ func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) 
 // True asserts that the specified value is true.
 //
 //    assert.True(t, myBool)
-//
-// Returns whether the assertion was successful (true) or not (false).
 func True(t TestingT, value bool, msgAndArgs ...interface{}) bool {
 
 	if value != true {
@@ -535,8 +517,6 @@ func True(t TestingT, value bool, msgAndArgs ...interface{}) bool {
 // False asserts that the specified value is false.
 //
 //    assert.False(t, myBool)
-//
-// Returns whether the assertion was successful (true) or not (false).
 func False(t TestingT, value bool, msgAndArgs ...interface{}) bool {
 
 	if value != false {
@@ -550,8 +530,6 @@ func False(t TestingT, value bool, msgAndArgs ...interface{}) bool {
 // NotEqual asserts that the specified values are NOT equal.
 //
 //    assert.NotEqual(t, obj1, obj2)
-//
-// Returns whether the assertion was successful (true) or not (false).
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
@@ -613,8 +591,6 @@ func includeElement(list interface{}, element interface{}) (ok, found bool) {
 //    assert.Contains(t, "Hello World", "World")
 //    assert.Contains(t, ["Hello", "World"], "World")
 //    assert.Contains(t, {"Hello": "World"}, "Hello")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func Contains(t TestingT, s, contains interface{}, msgAndArgs ...interface{}) bool {
 
 	ok, found := includeElement(s, contains)
@@ -635,8 +611,6 @@ func Contains(t TestingT, s, contains interface{}, msgAndArgs ...interface{}) bo
 //    assert.NotContains(t, "Hello World", "Earth")
 //    assert.NotContains(t, ["Hello", "World"], "Earth")
 //    assert.NotContains(t, {"Hello": "World"}, "Earth")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func NotContains(t TestingT, s, contains interface{}, msgAndArgs ...interface{}) bool {
 
 	ok, found := includeElement(s, contains)
@@ -655,8 +629,6 @@ func NotContains(t TestingT, s, contains interface{}, msgAndArgs ...interface{})
 // elements given in the specified subset(array, slice...).
 //
 //    assert.Subset(t, [1, 2, 3], [1, 2], "But [1, 2, 3] does contain [1, 2]")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func Subset(t TestingT, list, subset interface{}, msgAndArgs ...interface{}) (ok bool) {
 	if subset == nil {
 		return true // we consider nil to be equal to the nil set
@@ -698,8 +670,6 @@ func Subset(t TestingT, list, subset interface{}, msgAndArgs ...interface{}) (ok
 // elements given in the specified subset(array, slice...).
 //
 //    assert.NotSubset(t, [1, 3, 4], [1, 2], "But [1, 3, 4] does not contain [1, 2]")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func NotSubset(t TestingT, list, subset interface{}, msgAndArgs ...interface{}) (ok bool) {
 	if subset == nil {
 		return Fail(t, fmt.Sprintf("nil is the empty set which is a subset of every set"), msgAndArgs...)
@@ -742,8 +712,6 @@ func NotSubset(t TestingT, list, subset interface{}, msgAndArgs ...interface{}) 
 // the number of appearances of each of them in both lists should match.
 //
 // assert.ElementsMatch(t, [1, 3, 2, 3], [1, 3, 3, 2]))
-//
-// Returns whether the assertion was successful (true) or not (false).
 func ElementsMatch(t TestingT, listA, listB interface{}, msgAndArgs ...interface{}) (ok bool) {
 	if isEmpty(listA) && isEmpty(listB) {
 		return true
@@ -831,8 +799,6 @@ func didPanic(f PanicTestFunc) (bool, interface{}) {
 // Panics asserts that the code inside the specified PanicTestFunc panics.
 //
 //   assert.Panics(t, func(){ GoCrazy() })
-//
-// Returns whether the assertion was successful (true) or not (false).
 func Panics(t TestingT, f PanicTestFunc, msgAndArgs ...interface{}) bool {
 
 	if funcDidPanic, panicValue := didPanic(f); !funcDidPanic {
@@ -846,8 +812,6 @@ func Panics(t TestingT, f PanicTestFunc, msgAndArgs ...interface{}) bool {
 // the recovered panic value equals the expected panic value.
 //
 //   assert.PanicsWithValue(t, "crazy error", func(){ GoCrazy() })
-//
-// Returns whether the assertion was successful (true) or not (false).
 func PanicsWithValue(t TestingT, expected interface{}, f PanicTestFunc, msgAndArgs ...interface{}) bool {
 
 	funcDidPanic, panicValue := didPanic(f)
@@ -864,8 +828,6 @@ func PanicsWithValue(t TestingT, expected interface{}, f PanicTestFunc, msgAndAr
 // NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
 //
 //   assert.NotPanics(t, func(){ RemainCalm() })
-//
-// Returns whether the assertion was successful (true) or not (false).
 func NotPanics(t TestingT, f PanicTestFunc, msgAndArgs ...interface{}) bool {
 
 	if funcDidPanic, panicValue := didPanic(f); funcDidPanic {
@@ -878,8 +840,6 @@ func NotPanics(t TestingT, f PanicTestFunc, msgAndArgs ...interface{}) bool {
 // WithinDuration asserts that the two times are within duration delta of each other.
 //
 //   assert.WithinDuration(t, time.Now(), time.Now(), 10*time.Second)
-//
-// Returns whether the assertion was successful (true) or not (false).
 func WithinDuration(t TestingT, expected, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) bool {
 
 	dt := expected.Sub(actual)
@@ -929,8 +889,6 @@ func toFloat(x interface{}) (float64, bool) {
 // InDelta asserts that the two numerals are within delta of each other.
 //
 // 	 assert.InDelta(t, math.Pi, (22 / 7.0), 0.01)
-//
-// Returns whether the assertion was successful (true) or not (false).
 func InDelta(t TestingT, expected, actual interface{}, delta float64, msgAndArgs ...interface{}) bool {
 
 	af, aok := toFloat(expected)
@@ -1035,8 +993,6 @@ func calcRelativeError(expected, actual interface{}) (float64, error) {
 }
 
 // InEpsilon asserts that expected and actual have a relative error less than epsilon
-//
-// Returns whether the assertion was successful (true) or not (false).
 func InEpsilon(t TestingT, expected, actual interface{}, epsilon float64, msgAndArgs ...interface{}) bool {
 	actualEpsilon, err := calcRelativeError(expected, actual)
 	if err != nil {
@@ -1081,8 +1037,6 @@ func InEpsilonSlice(t TestingT, expected, actual interface{}, epsilon float64, m
 //   if assert.NoError(t, err) {
 //	   assert.Equal(t, expectedObj, actualObj)
 //   }
-//
-// Returns whether the assertion was successful (true) or not (false).
 func NoError(t TestingT, err error, msgAndArgs ...interface{}) bool {
 	if err != nil {
 		return Fail(t, fmt.Sprintf("Received unexpected error:\n%+v", err), msgAndArgs...)
@@ -1097,8 +1051,6 @@ func NoError(t TestingT, err error, msgAndArgs ...interface{}) bool {
 //   if assert.Error(t, err) {
 //	   assert.Equal(t, expectedError, err)
 //   }
-//
-// Returns whether the assertion was successful (true) or not (false).
 func Error(t TestingT, err error, msgAndArgs ...interface{}) bool {
 
 	if err == nil {
@@ -1113,8 +1065,6 @@ func Error(t TestingT, err error, msgAndArgs ...interface{}) bool {
 //
 //   actualObj, err := SomeFunction()
 //   assert.EqualError(t, err,  expectedErrorString)
-//
-// Returns whether the assertion was successful (true) or not (false).
 func EqualError(t TestingT, theError error, errString string, msgAndArgs ...interface{}) bool {
 	if !Error(t, theError, msgAndArgs...) {
 		return false
@@ -1148,8 +1098,6 @@ func matchRegexp(rx interface{}, str interface{}) bool {
 //
 //  assert.Regexp(t, regexp.MustCompile("start"), "it's starting")
 //  assert.Regexp(t, "start...$", "it's not starting")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) bool {
 
 	match := matchRegexp(rx, str)
@@ -1165,8 +1113,6 @@ func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface
 //
 //  assert.NotRegexp(t, regexp.MustCompile("starts"), "it's starting")
 //  assert.NotRegexp(t, "^start", "it's not starting")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) bool {
 	match := matchRegexp(rx, str)
 
@@ -1178,7 +1124,7 @@ func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interf
 
 }
 
-// Zero asserts that i is the zero value for its type and returns the truth.
+// Zero asserts that i is the zero value for its type.
 func Zero(t TestingT, i interface{}, msgAndArgs ...interface{}) bool {
 	if i != nil && !reflect.DeepEqual(i, reflect.Zero(reflect.TypeOf(i)).Interface()) {
 		return Fail(t, fmt.Sprintf("Should be zero, but was %v", i), msgAndArgs...)
@@ -1186,7 +1132,7 @@ func Zero(t TestingT, i interface{}, msgAndArgs ...interface{}) bool {
 	return true
 }
 
-// NotZero asserts that i is not the zero value for its type and returns the truth.
+// NotZero asserts that i is not the zero value for its type.
 func NotZero(t TestingT, i interface{}, msgAndArgs ...interface{}) bool {
 	if i == nil || reflect.DeepEqual(i, reflect.Zero(reflect.TypeOf(i)).Interface()) {
 		return Fail(t, fmt.Sprintf("Should not be zero, but was %v", i), msgAndArgs...)
@@ -1227,8 +1173,6 @@ func DirExists(t TestingT, path string, msgAndArgs ...interface{}) bool {
 // JSONEq asserts that two JSON strings are equivalent.
 //
 //  assert.JSONEq(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
-//
-// Returns whether the assertion was successful (true) or not (false).
 func JSONEq(t TestingT, expected string, actual string, msgAndArgs ...interface{}) bool {
 	var expectedJSONAsInterface, actualJSONAsInterface interface{}
 

--- a/require/require.go
+++ b/require/require.go
@@ -32,8 +32,6 @@ func Conditionf(t TestingT, comp assert.Comparison, msg string, args ...interfac
 //    assert.Contains(t, "Hello World", "World")
 //    assert.Contains(t, ["Hello", "World"], "World")
 //    assert.Contains(t, {"Hello": "World"}, "Hello")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func Contains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
 	if !assert.Contains(t, s, contains, msgAndArgs...) {
 		t.FailNow()
@@ -46,8 +44,6 @@ func Contains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...int
 //    assert.Containsf(t, "Hello World", "World", "error message %s", "formatted")
 //    assert.Containsf(t, ["Hello", "World"], "World", "error message %s", "formatted")
 //    assert.Containsf(t, {"Hello": "World"}, "Hello", "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func Containsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) {
 	if !assert.Containsf(t, s, contains, msg, args...) {
 		t.FailNow()
@@ -73,8 +69,6 @@ func DirExistsf(t TestingT, path string, msg string, args ...interface{}) {
 // the number of appearances of each of them in both lists should match.
 //
 // assert.ElementsMatch(t, [1, 3, 2, 3], [1, 3, 3, 2]))
-//
-// Returns whether the assertion was successful (true) or not (false).
 func ElementsMatch(t TestingT, listA interface{}, listB interface{}, msgAndArgs ...interface{}) {
 	if !assert.ElementsMatch(t, listA, listB, msgAndArgs...) {
 		t.FailNow()
@@ -86,8 +80,6 @@ func ElementsMatch(t TestingT, listA interface{}, listB interface{}, msgAndArgs 
 // the number of appearances of each of them in both lists should match.
 //
 // assert.ElementsMatchf(t, [1, 3, 2, 3], [1, 3, 3, 2], "error message %s", "formatted"))
-//
-// Returns whether the assertion was successful (true) or not (false).
 func ElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string, args ...interface{}) {
 	if !assert.ElementsMatchf(t, listA, listB, msg, args...) {
 		t.FailNow()
@@ -98,8 +90,6 @@ func ElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string
 // a slice or a channel with len == 0.
 //
 //  assert.Empty(t, obj)
-//
-// Returns whether the assertion was successful (true) or not (false).
 func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if !assert.Empty(t, object, msgAndArgs...) {
 		t.FailNow()
@@ -110,8 +100,6 @@ func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 // a slice or a channel with len == 0.
 //
 //  assert.Emptyf(t, obj, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func Emptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if !assert.Emptyf(t, object, msg, args...) {
 		t.FailNow()
@@ -121,8 +109,6 @@ func Emptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
 // Equal asserts that two objects are equal.
 //
 //    assert.Equal(t, 123, 123)
-//
-// Returns whether the assertion was successful (true) or not (false).
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses). Function equality
@@ -138,8 +124,6 @@ func Equal(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...i
 //
 //   actualObj, err := SomeFunction()
 //   assert.EqualError(t, err,  expectedErrorString)
-//
-// Returns whether the assertion was successful (true) or not (false).
 func EqualError(t TestingT, theError error, errString string, msgAndArgs ...interface{}) {
 	if !assert.EqualError(t, theError, errString, msgAndArgs...) {
 		t.FailNow()
@@ -151,8 +135,6 @@ func EqualError(t TestingT, theError error, errString string, msgAndArgs ...inte
 //
 //   actualObj, err := SomeFunction()
 //   assert.EqualErrorf(t, err,  expectedErrorString, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func EqualErrorf(t TestingT, theError error, errString string, msg string, args ...interface{}) {
 	if !assert.EqualErrorf(t, theError, errString, msg, args...) {
 		t.FailNow()
@@ -163,8 +145,6 @@ func EqualErrorf(t TestingT, theError error, errString string, msg string, args 
 // and equal.
 //
 //    assert.EqualValues(t, uint32(123), int32(123))
-//
-// Returns whether the assertion was successful (true) or not (false).
 func EqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if !assert.EqualValues(t, expected, actual, msgAndArgs...) {
 		t.FailNow()
@@ -175,8 +155,6 @@ func EqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArg
 // and equal.
 //
 //    assert.EqualValuesf(t, uint32(123, "error message %s", "formatted"), int32(123))
-//
-// Returns whether the assertion was successful (true) or not (false).
 func EqualValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if !assert.EqualValuesf(t, expected, actual, msg, args...) {
 		t.FailNow()
@@ -186,8 +164,6 @@ func EqualValuesf(t TestingT, expected interface{}, actual interface{}, msg stri
 // Equalf asserts that two objects are equal.
 //
 //    assert.Equalf(t, 123, 123, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses). Function equality
@@ -204,8 +180,6 @@ func Equalf(t TestingT, expected interface{}, actual interface{}, msg string, ar
 //   if assert.Error(t, err) {
 // 	   assert.Equal(t, expectedError, err)
 //   }
-//
-// Returns whether the assertion was successful (true) or not (false).
 func Error(t TestingT, err error, msgAndArgs ...interface{}) {
 	if !assert.Error(t, err, msgAndArgs...) {
 		t.FailNow()
@@ -218,8 +192,6 @@ func Error(t TestingT, err error, msgAndArgs ...interface{}) {
 //   if assert.Errorf(t, err, "error message %s", "formatted") {
 // 	   assert.Equal(t, expectedErrorf, err)
 //   }
-//
-// Returns whether the assertion was successful (true) or not (false).
 func Errorf(t TestingT, err error, msg string, args ...interface{}) {
 	if !assert.Errorf(t, err, msg, args...) {
 		t.FailNow()
@@ -229,8 +201,6 @@ func Errorf(t TestingT, err error, msg string, args ...interface{}) {
 // Exactly asserts that two objects are equal in value and type.
 //
 //    assert.Exactly(t, int32(123), int64(123))
-//
-// Returns whether the assertion was successful (true) or not (false).
 func Exactly(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if !assert.Exactly(t, expected, actual, msgAndArgs...) {
 		t.FailNow()
@@ -240,8 +210,6 @@ func Exactly(t TestingT, expected interface{}, actual interface{}, msgAndArgs ..
 // Exactlyf asserts that two objects are equal in value and type.
 //
 //    assert.Exactlyf(t, int32(123, "error message %s", "formatted"), int64(123))
-//
-// Returns whether the assertion was successful (true) or not (false).
 func Exactlyf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if !assert.Exactlyf(t, expected, actual, msg, args...) {
 		t.FailNow()
@@ -279,8 +247,6 @@ func Failf(t TestingT, failureMessage string, msg string, args ...interface{}) {
 // False asserts that the specified value is false.
 //
 //    assert.False(t, myBool)
-//
-// Returns whether the assertion was successful (true) or not (false).
 func False(t TestingT, value bool, msgAndArgs ...interface{}) {
 	if !assert.False(t, value, msgAndArgs...) {
 		t.FailNow()
@@ -290,8 +256,6 @@ func False(t TestingT, value bool, msgAndArgs ...interface{}) {
 // Falsef asserts that the specified value is false.
 //
 //    assert.Falsef(t, myBool, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func Falsef(t TestingT, value bool, msg string, args ...interface{}) {
 	if !assert.Falsef(t, value, msg, args...) {
 		t.FailNow()
@@ -447,8 +411,6 @@ func Implementsf(t TestingT, interfaceObject interface{}, object interface{}, ms
 // InDelta asserts that the two numerals are within delta of each other.
 //
 // 	 assert.InDelta(t, math.Pi, (22 / 7.0), 0.01)
-//
-// Returns whether the assertion was successful (true) or not (false).
 func InDelta(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
 	if !assert.InDelta(t, expected, actual, delta, msgAndArgs...) {
 		t.FailNow()
@@ -486,8 +448,6 @@ func InDeltaSlicef(t TestingT, expected interface{}, actual interface{}, delta f
 // InDeltaf asserts that the two numerals are within delta of each other.
 //
 // 	 assert.InDeltaf(t, math.Pi, (22 / 7.0, "error message %s", "formatted"), 0.01)
-//
-// Returns whether the assertion was successful (true) or not (false).
 func InDeltaf(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
 	if !assert.InDeltaf(t, expected, actual, delta, msg, args...) {
 		t.FailNow()
@@ -495,8 +455,6 @@ func InDeltaf(t TestingT, expected interface{}, actual interface{}, delta float6
 }
 
 // InEpsilon asserts that expected and actual have a relative error less than epsilon
-//
-// Returns whether the assertion was successful (true) or not (false).
 func InEpsilon(t TestingT, expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
 	if !assert.InEpsilon(t, expected, actual, epsilon, msgAndArgs...) {
 		t.FailNow()
@@ -518,8 +476,6 @@ func InEpsilonSlicef(t TestingT, expected interface{}, actual interface{}, epsil
 }
 
 // InEpsilonf asserts that expected and actual have a relative error less than epsilon
-//
-// Returns whether the assertion was successful (true) or not (false).
 func InEpsilonf(t TestingT, expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
 	if !assert.InEpsilonf(t, expected, actual, epsilon, msg, args...) {
 		t.FailNow()
@@ -543,8 +499,6 @@ func IsTypef(t TestingT, expectedType interface{}, object interface{}, msg strin
 // JSONEq asserts that two JSON strings are equivalent.
 //
 //  assert.JSONEq(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
-//
-// Returns whether the assertion was successful (true) or not (false).
 func JSONEq(t TestingT, expected string, actual string, msgAndArgs ...interface{}) {
 	if !assert.JSONEq(t, expected, actual, msgAndArgs...) {
 		t.FailNow()
@@ -554,8 +508,6 @@ func JSONEq(t TestingT, expected string, actual string, msgAndArgs ...interface{
 // JSONEqf asserts that two JSON strings are equivalent.
 //
 //  assert.JSONEqf(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func JSONEqf(t TestingT, expected string, actual string, msg string, args ...interface{}) {
 	if !assert.JSONEqf(t, expected, actual, msg, args...) {
 		t.FailNow()
@@ -566,8 +518,6 @@ func JSONEqf(t TestingT, expected string, actual string, msg string, args ...int
 // Len also fails if the object has a type that len() not accept.
 //
 //    assert.Len(t, mySlice, 3)
-//
-// Returns whether the assertion was successful (true) or not (false).
 func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) {
 	if !assert.Len(t, object, length, msgAndArgs...) {
 		t.FailNow()
@@ -578,8 +528,6 @@ func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) 
 // Lenf also fails if the object has a type that len() not accept.
 //
 //    assert.Lenf(t, mySlice, 3, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func Lenf(t TestingT, object interface{}, length int, msg string, args ...interface{}) {
 	if !assert.Lenf(t, object, length, msg, args...) {
 		t.FailNow()
@@ -589,8 +537,6 @@ func Lenf(t TestingT, object interface{}, length int, msg string, args ...interf
 // Nil asserts that the specified object is nil.
 //
 //    assert.Nil(t, err)
-//
-// Returns whether the assertion was successful (true) or not (false).
 func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if !assert.Nil(t, object, msgAndArgs...) {
 		t.FailNow()
@@ -600,8 +546,6 @@ func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 // Nilf asserts that the specified object is nil.
 //
 //    assert.Nilf(t, err, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func Nilf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if !assert.Nilf(t, object, msg, args...) {
 		t.FailNow()
@@ -614,8 +558,6 @@ func Nilf(t TestingT, object interface{}, msg string, args ...interface{}) {
 //   if assert.NoError(t, err) {
 // 	   assert.Equal(t, expectedObj, actualObj)
 //   }
-//
-// Returns whether the assertion was successful (true) or not (false).
 func NoError(t TestingT, err error, msgAndArgs ...interface{}) {
 	if !assert.NoError(t, err, msgAndArgs...) {
 		t.FailNow()
@@ -628,8 +570,6 @@ func NoError(t TestingT, err error, msgAndArgs ...interface{}) {
 //   if assert.NoErrorf(t, err, "error message %s", "formatted") {
 // 	   assert.Equal(t, expectedObj, actualObj)
 //   }
-//
-// Returns whether the assertion was successful (true) or not (false).
 func NoErrorf(t TestingT, err error, msg string, args ...interface{}) {
 	if !assert.NoErrorf(t, err, msg, args...) {
 		t.FailNow()
@@ -642,8 +582,6 @@ func NoErrorf(t TestingT, err error, msg string, args ...interface{}) {
 //    assert.NotContains(t, "Hello World", "Earth")
 //    assert.NotContains(t, ["Hello", "World"], "Earth")
 //    assert.NotContains(t, {"Hello": "World"}, "Earth")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func NotContains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
 	if !assert.NotContains(t, s, contains, msgAndArgs...) {
 		t.FailNow()
@@ -656,8 +594,6 @@ func NotContains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...
 //    assert.NotContainsf(t, "Hello World", "Earth", "error message %s", "formatted")
 //    assert.NotContainsf(t, ["Hello", "World"], "Earth", "error message %s", "formatted")
 //    assert.NotContainsf(t, {"Hello": "World"}, "Earth", "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func NotContainsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) {
 	if !assert.NotContainsf(t, s, contains, msg, args...) {
 		t.FailNow()
@@ -670,8 +606,6 @@ func NotContainsf(t TestingT, s interface{}, contains interface{}, msg string, a
 //  if assert.NotEmpty(t, obj) {
 //    assert.Equal(t, "two", obj[1])
 //  }
-//
-// Returns whether the assertion was successful (true) or not (false).
 func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if !assert.NotEmpty(t, object, msgAndArgs...) {
 		t.FailNow()
@@ -684,8 +618,6 @@ func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 //  if assert.NotEmptyf(t, obj, "error message %s", "formatted") {
 //    assert.Equal(t, "two", obj[1])
 //  }
-//
-// Returns whether the assertion was successful (true) or not (false).
 func NotEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if !assert.NotEmptyf(t, object, msg, args...) {
 		t.FailNow()
@@ -695,8 +627,6 @@ func NotEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) 
 // NotEqual asserts that the specified values are NOT equal.
 //
 //    assert.NotEqual(t, obj1, obj2)
-//
-// Returns whether the assertion was successful (true) or not (false).
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
@@ -710,8 +640,6 @@ func NotEqual(t TestingT, expected interface{}, actual interface{}, msgAndArgs .
 //
 //    assert.NotEqualf(t, obj1, obj2, "error message %s", "formatted")
 //
-// Returns whether the assertion was successful (true) or not (false).
-//
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
 func NotEqualf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
@@ -723,8 +651,6 @@ func NotEqualf(t TestingT, expected interface{}, actual interface{}, msg string,
 // NotNil asserts that the specified object is not nil.
 //
 //    assert.NotNil(t, err)
-//
-// Returns whether the assertion was successful (true) or not (false).
 func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if !assert.NotNil(t, object, msgAndArgs...) {
 		t.FailNow()
@@ -734,8 +660,6 @@ func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 // NotNilf asserts that the specified object is not nil.
 //
 //    assert.NotNilf(t, err, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func NotNilf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if !assert.NotNilf(t, object, msg, args...) {
 		t.FailNow()
@@ -745,8 +669,6 @@ func NotNilf(t TestingT, object interface{}, msg string, args ...interface{}) {
 // NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
 //
 //   assert.NotPanics(t, func(){ RemainCalm() })
-//
-// Returns whether the assertion was successful (true) or not (false).
 func NotPanics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	if !assert.NotPanics(t, f, msgAndArgs...) {
 		t.FailNow()
@@ -756,8 +678,6 @@ func NotPanics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 // NotPanicsf asserts that the code inside the specified PanicTestFunc does NOT panic.
 //
 //   assert.NotPanicsf(t, func(){ RemainCalm() }, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func NotPanicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}) {
 	if !assert.NotPanicsf(t, f, msg, args...) {
 		t.FailNow()
@@ -768,8 +688,6 @@ func NotPanicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interfac
 //
 //  assert.NotRegexp(t, regexp.MustCompile("starts"), "it's starting")
 //  assert.NotRegexp(t, "^start", "it's not starting")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
 	if !assert.NotRegexp(t, rx, str, msgAndArgs...) {
 		t.FailNow()
@@ -780,8 +698,6 @@ func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interf
 //
 //  assert.NotRegexpf(t, regexp.MustCompile("starts", "error message %s", "formatted"), "it's starting")
 //  assert.NotRegexpf(t, "^start", "it's not starting", "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func NotRegexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) {
 	if !assert.NotRegexpf(t, rx, str, msg, args...) {
 		t.FailNow()
@@ -792,8 +708,6 @@ func NotRegexpf(t TestingT, rx interface{}, str interface{}, msg string, args ..
 // elements given in the specified subset(array, slice...).
 //
 //    assert.NotSubset(t, [1, 3, 4], [1, 2], "But [1, 3, 4] does not contain [1, 2]")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func NotSubset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...interface{}) {
 	if !assert.NotSubset(t, list, subset, msgAndArgs...) {
 		t.FailNow()
@@ -804,22 +718,20 @@ func NotSubset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...i
 // elements given in the specified subset(array, slice...).
 //
 //    assert.NotSubsetf(t, [1, 3, 4], [1, 2], "But [1, 3, 4] does not contain [1, 2]", "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func NotSubsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) {
 	if !assert.NotSubsetf(t, list, subset, msg, args...) {
 		t.FailNow()
 	}
 }
 
-// NotZero asserts that i is not the zero value for its type and returns the truth.
+// NotZero asserts that i is not the zero value for its type.
 func NotZero(t TestingT, i interface{}, msgAndArgs ...interface{}) {
 	if !assert.NotZero(t, i, msgAndArgs...) {
 		t.FailNow()
 	}
 }
 
-// NotZerof asserts that i is not the zero value for its type and returns the truth.
+// NotZerof asserts that i is not the zero value for its type.
 func NotZerof(t TestingT, i interface{}, msg string, args ...interface{}) {
 	if !assert.NotZerof(t, i, msg, args...) {
 		t.FailNow()
@@ -829,8 +741,6 @@ func NotZerof(t TestingT, i interface{}, msg string, args ...interface{}) {
 // Panics asserts that the code inside the specified PanicTestFunc panics.
 //
 //   assert.Panics(t, func(){ GoCrazy() })
-//
-// Returns whether the assertion was successful (true) or not (false).
 func Panics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	if !assert.Panics(t, f, msgAndArgs...) {
 		t.FailNow()
@@ -841,8 +751,6 @@ func Panics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 // the recovered panic value equals the expected panic value.
 //
 //   assert.PanicsWithValue(t, "crazy error", func(){ GoCrazy() })
-//
-// Returns whether the assertion was successful (true) or not (false).
 func PanicsWithValue(t TestingT, expected interface{}, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	if !assert.PanicsWithValue(t, expected, f, msgAndArgs...) {
 		t.FailNow()
@@ -853,8 +761,6 @@ func PanicsWithValue(t TestingT, expected interface{}, f assert.PanicTestFunc, m
 // the recovered panic value equals the expected panic value.
 //
 //   assert.PanicsWithValuef(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func PanicsWithValuef(t TestingT, expected interface{}, f assert.PanicTestFunc, msg string, args ...interface{}) {
 	if !assert.PanicsWithValuef(t, expected, f, msg, args...) {
 		t.FailNow()
@@ -864,8 +770,6 @@ func PanicsWithValuef(t TestingT, expected interface{}, f assert.PanicTestFunc, 
 // Panicsf asserts that the code inside the specified PanicTestFunc panics.
 //
 //   assert.Panicsf(t, func(){ GoCrazy() }, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func Panicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}) {
 	if !assert.Panicsf(t, f, msg, args...) {
 		t.FailNow()
@@ -876,8 +780,6 @@ func Panicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}
 //
 //  assert.Regexp(t, regexp.MustCompile("start"), "it's starting")
 //  assert.Regexp(t, "start...$", "it's not starting")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
 	if !assert.Regexp(t, rx, str, msgAndArgs...) {
 		t.FailNow()
@@ -888,8 +790,6 @@ func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface
 //
 //  assert.Regexpf(t, regexp.MustCompile("start", "error message %s", "formatted"), "it's starting")
 //  assert.Regexpf(t, "start...$", "it's not starting", "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func Regexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) {
 	if !assert.Regexpf(t, rx, str, msg, args...) {
 		t.FailNow()
@@ -900,8 +800,6 @@ func Regexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...in
 // elements given in the specified subset(array, slice...).
 //
 //    assert.Subset(t, [1, 2, 3], [1, 2], "But [1, 2, 3] does contain [1, 2]")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func Subset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...interface{}) {
 	if !assert.Subset(t, list, subset, msgAndArgs...) {
 		t.FailNow()
@@ -912,8 +810,6 @@ func Subset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...inte
 // elements given in the specified subset(array, slice...).
 //
 //    assert.Subsetf(t, [1, 2, 3], [1, 2], "But [1, 2, 3] does contain [1, 2]", "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func Subsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) {
 	if !assert.Subsetf(t, list, subset, msg, args...) {
 		t.FailNow()
@@ -923,8 +819,6 @@ func Subsetf(t TestingT, list interface{}, subset interface{}, msg string, args 
 // True asserts that the specified value is true.
 //
 //    assert.True(t, myBool)
-//
-// Returns whether the assertion was successful (true) or not (false).
 func True(t TestingT, value bool, msgAndArgs ...interface{}) {
 	if !assert.True(t, value, msgAndArgs...) {
 		t.FailNow()
@@ -934,8 +828,6 @@ func True(t TestingT, value bool, msgAndArgs ...interface{}) {
 // Truef asserts that the specified value is true.
 //
 //    assert.Truef(t, myBool, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func Truef(t TestingT, value bool, msg string, args ...interface{}) {
 	if !assert.Truef(t, value, msg, args...) {
 		t.FailNow()
@@ -945,8 +837,6 @@ func Truef(t TestingT, value bool, msg string, args ...interface{}) {
 // WithinDuration asserts that the two times are within duration delta of each other.
 //
 //   assert.WithinDuration(t, time.Now(), time.Now(), 10*time.Second)
-//
-// Returns whether the assertion was successful (true) or not (false).
 func WithinDuration(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) {
 	if !assert.WithinDuration(t, expected, actual, delta, msgAndArgs...) {
 		t.FailNow()
@@ -956,22 +846,20 @@ func WithinDuration(t TestingT, expected time.Time, actual time.Time, delta time
 // WithinDurationf asserts that the two times are within duration delta of each other.
 //
 //   assert.WithinDurationf(t, time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msg string, args ...interface{}) {
 	if !assert.WithinDurationf(t, expected, actual, delta, msg, args...) {
 		t.FailNow()
 	}
 }
 
-// Zero asserts that i is the zero value for its type and returns the truth.
+// Zero asserts that i is the zero value for its type.
 func Zero(t TestingT, i interface{}, msgAndArgs ...interface{}) {
 	if !assert.Zero(t, i, msgAndArgs...) {
 		t.FailNow()
 	}
 }
 
-// Zerof asserts that i is the zero value for its type and returns the truth.
+// Zerof asserts that i is the zero value for its type.
 func Zerof(t TestingT, i interface{}, msg string, args ...interface{}) {
 	if !assert.Zerof(t, i, msg, args...) {
 		t.FailNow()

--- a/require/require_forward.go
+++ b/require/require_forward.go
@@ -28,8 +28,6 @@ func (a *Assertions) Conditionf(comp assert.Comparison, msg string, args ...inte
 //    a.Contains("Hello World", "World")
 //    a.Contains(["Hello", "World"], "World")
 //    a.Contains({"Hello": "World"}, "Hello")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Contains(s interface{}, contains interface{}, msgAndArgs ...interface{}) {
 	Contains(a.t, s, contains, msgAndArgs...)
 }
@@ -40,8 +38,6 @@ func (a *Assertions) Contains(s interface{}, contains interface{}, msgAndArgs ..
 //    a.Containsf("Hello World", "World", "error message %s", "formatted")
 //    a.Containsf(["Hello", "World"], "World", "error message %s", "formatted")
 //    a.Containsf({"Hello": "World"}, "Hello", "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Containsf(s interface{}, contains interface{}, msg string, args ...interface{}) {
 	Containsf(a.t, s, contains, msg, args...)
 }
@@ -61,8 +57,6 @@ func (a *Assertions) DirExistsf(path string, msg string, args ...interface{}) {
 // the number of appearances of each of them in both lists should match.
 //
 // a.ElementsMatch([1, 3, 2, 3], [1, 3, 3, 2]))
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) ElementsMatch(listA interface{}, listB interface{}, msgAndArgs ...interface{}) {
 	ElementsMatch(a.t, listA, listB, msgAndArgs...)
 }
@@ -72,8 +66,6 @@ func (a *Assertions) ElementsMatch(listA interface{}, listB interface{}, msgAndA
 // the number of appearances of each of them in both lists should match.
 //
 // a.ElementsMatchf([1, 3, 2, 3], [1, 3, 3, 2], "error message %s", "formatted"))
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) ElementsMatchf(listA interface{}, listB interface{}, msg string, args ...interface{}) {
 	ElementsMatchf(a.t, listA, listB, msg, args...)
 }
@@ -82,8 +74,6 @@ func (a *Assertions) ElementsMatchf(listA interface{}, listB interface{}, msg st
 // a slice or a channel with len == 0.
 //
 //  a.Empty(obj)
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Empty(object interface{}, msgAndArgs ...interface{}) {
 	Empty(a.t, object, msgAndArgs...)
 }
@@ -92,8 +82,6 @@ func (a *Assertions) Empty(object interface{}, msgAndArgs ...interface{}) {
 // a slice or a channel with len == 0.
 //
 //  a.Emptyf(obj, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Emptyf(object interface{}, msg string, args ...interface{}) {
 	Emptyf(a.t, object, msg, args...)
 }
@@ -101,8 +89,6 @@ func (a *Assertions) Emptyf(object interface{}, msg string, args ...interface{})
 // Equal asserts that two objects are equal.
 //
 //    a.Equal(123, 123)
-//
-// Returns whether the assertion was successful (true) or not (false).
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses). Function equality
@@ -116,8 +102,6 @@ func (a *Assertions) Equal(expected interface{}, actual interface{}, msgAndArgs 
 //
 //   actualObj, err := SomeFunction()
 //   a.EqualError(err,  expectedErrorString)
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...interface{}) {
 	EqualError(a.t, theError, errString, msgAndArgs...)
 }
@@ -127,8 +111,6 @@ func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...
 //
 //   actualObj, err := SomeFunction()
 //   a.EqualErrorf(err,  expectedErrorString, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) EqualErrorf(theError error, errString string, msg string, args ...interface{}) {
 	EqualErrorf(a.t, theError, errString, msg, args...)
 }
@@ -137,8 +119,6 @@ func (a *Assertions) EqualErrorf(theError error, errString string, msg string, a
 // and equal.
 //
 //    a.EqualValues(uint32(123), int32(123))
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) EqualValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	EqualValues(a.t, expected, actual, msgAndArgs...)
 }
@@ -147,8 +127,6 @@ func (a *Assertions) EqualValues(expected interface{}, actual interface{}, msgAn
 // and equal.
 //
 //    a.EqualValuesf(uint32(123, "error message %s", "formatted"), int32(123))
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) EqualValuesf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	EqualValuesf(a.t, expected, actual, msg, args...)
 }
@@ -156,8 +134,6 @@ func (a *Assertions) EqualValuesf(expected interface{}, actual interface{}, msg 
 // Equalf asserts that two objects are equal.
 //
 //    a.Equalf(123, 123, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses). Function equality
@@ -172,8 +148,6 @@ func (a *Assertions) Equalf(expected interface{}, actual interface{}, msg string
 //   if a.Error(err) {
 // 	   assert.Equal(t, expectedError, err)
 //   }
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Error(err error, msgAndArgs ...interface{}) {
 	Error(a.t, err, msgAndArgs...)
 }
@@ -184,8 +158,6 @@ func (a *Assertions) Error(err error, msgAndArgs ...interface{}) {
 //   if a.Errorf(err, "error message %s", "formatted") {
 // 	   assert.Equal(t, expectedErrorf, err)
 //   }
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Errorf(err error, msg string, args ...interface{}) {
 	Errorf(a.t, err, msg, args...)
 }
@@ -193,8 +165,6 @@ func (a *Assertions) Errorf(err error, msg string, args ...interface{}) {
 // Exactly asserts that two objects are equal in value and type.
 //
 //    a.Exactly(int32(123), int64(123))
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Exactly(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	Exactly(a.t, expected, actual, msgAndArgs...)
 }
@@ -202,8 +172,6 @@ func (a *Assertions) Exactly(expected interface{}, actual interface{}, msgAndArg
 // Exactlyf asserts that two objects are equal in value and type.
 //
 //    a.Exactlyf(int32(123, "error message %s", "formatted"), int64(123))
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Exactlyf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	Exactlyf(a.t, expected, actual, msg, args...)
 }
@@ -231,8 +199,6 @@ func (a *Assertions) Failf(failureMessage string, msg string, args ...interface{
 // False asserts that the specified value is false.
 //
 //    a.False(myBool)
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) False(value bool, msgAndArgs ...interface{}) {
 	False(a.t, value, msgAndArgs...)
 }
@@ -240,8 +206,6 @@ func (a *Assertions) False(value bool, msgAndArgs ...interface{}) {
 // Falsef asserts that the specified value is false.
 //
 //    a.Falsef(myBool, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Falsef(value bool, msg string, args ...interface{}) {
 	Falsef(a.t, value, msg, args...)
 }
@@ -367,8 +331,6 @@ func (a *Assertions) Implementsf(interfaceObject interface{}, object interface{}
 // InDelta asserts that the two numerals are within delta of each other.
 //
 // 	 a.InDelta(math.Pi, (22 / 7.0), 0.01)
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) InDelta(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
 	InDelta(a.t, expected, actual, delta, msgAndArgs...)
 }
@@ -396,15 +358,11 @@ func (a *Assertions) InDeltaSlicef(expected interface{}, actual interface{}, del
 // InDeltaf asserts that the two numerals are within delta of each other.
 //
 // 	 a.InDeltaf(math.Pi, (22 / 7.0, "error message %s", "formatted"), 0.01)
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) InDeltaf(expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
 	InDeltaf(a.t, expected, actual, delta, msg, args...)
 }
 
 // InEpsilon asserts that expected and actual have a relative error less than epsilon
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) InEpsilon(expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
 	InEpsilon(a.t, expected, actual, epsilon, msgAndArgs...)
 }
@@ -420,8 +378,6 @@ func (a *Assertions) InEpsilonSlicef(expected interface{}, actual interface{}, e
 }
 
 // InEpsilonf asserts that expected and actual have a relative error less than epsilon
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) InEpsilonf(expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
 	InEpsilonf(a.t, expected, actual, epsilon, msg, args...)
 }
@@ -439,8 +395,6 @@ func (a *Assertions) IsTypef(expectedType interface{}, object interface{}, msg s
 // JSONEq asserts that two JSON strings are equivalent.
 //
 //  a.JSONEq(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) JSONEq(expected string, actual string, msgAndArgs ...interface{}) {
 	JSONEq(a.t, expected, actual, msgAndArgs...)
 }
@@ -448,8 +402,6 @@ func (a *Assertions) JSONEq(expected string, actual string, msgAndArgs ...interf
 // JSONEqf asserts that two JSON strings are equivalent.
 //
 //  a.JSONEqf(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) JSONEqf(expected string, actual string, msg string, args ...interface{}) {
 	JSONEqf(a.t, expected, actual, msg, args...)
 }
@@ -458,8 +410,6 @@ func (a *Assertions) JSONEqf(expected string, actual string, msg string, args ..
 // Len also fails if the object has a type that len() not accept.
 //
 //    a.Len(mySlice, 3)
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Len(object interface{}, length int, msgAndArgs ...interface{}) {
 	Len(a.t, object, length, msgAndArgs...)
 }
@@ -468,8 +418,6 @@ func (a *Assertions) Len(object interface{}, length int, msgAndArgs ...interface
 // Lenf also fails if the object has a type that len() not accept.
 //
 //    a.Lenf(mySlice, 3, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Lenf(object interface{}, length int, msg string, args ...interface{}) {
 	Lenf(a.t, object, length, msg, args...)
 }
@@ -477,8 +425,6 @@ func (a *Assertions) Lenf(object interface{}, length int, msg string, args ...in
 // Nil asserts that the specified object is nil.
 //
 //    a.Nil(err)
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Nil(object interface{}, msgAndArgs ...interface{}) {
 	Nil(a.t, object, msgAndArgs...)
 }
@@ -486,8 +432,6 @@ func (a *Assertions) Nil(object interface{}, msgAndArgs ...interface{}) {
 // Nilf asserts that the specified object is nil.
 //
 //    a.Nilf(err, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Nilf(object interface{}, msg string, args ...interface{}) {
 	Nilf(a.t, object, msg, args...)
 }
@@ -498,8 +442,6 @@ func (a *Assertions) Nilf(object interface{}, msg string, args ...interface{}) {
 //   if a.NoError(err) {
 // 	   assert.Equal(t, expectedObj, actualObj)
 //   }
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NoError(err error, msgAndArgs ...interface{}) {
 	NoError(a.t, err, msgAndArgs...)
 }
@@ -510,8 +452,6 @@ func (a *Assertions) NoError(err error, msgAndArgs ...interface{}) {
 //   if a.NoErrorf(err, "error message %s", "formatted") {
 // 	   assert.Equal(t, expectedObj, actualObj)
 //   }
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NoErrorf(err error, msg string, args ...interface{}) {
 	NoErrorf(a.t, err, msg, args...)
 }
@@ -522,8 +462,6 @@ func (a *Assertions) NoErrorf(err error, msg string, args ...interface{}) {
 //    a.NotContains("Hello World", "Earth")
 //    a.NotContains(["Hello", "World"], "Earth")
 //    a.NotContains({"Hello": "World"}, "Earth")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotContains(s interface{}, contains interface{}, msgAndArgs ...interface{}) {
 	NotContains(a.t, s, contains, msgAndArgs...)
 }
@@ -534,8 +472,6 @@ func (a *Assertions) NotContains(s interface{}, contains interface{}, msgAndArgs
 //    a.NotContainsf("Hello World", "Earth", "error message %s", "formatted")
 //    a.NotContainsf(["Hello", "World"], "Earth", "error message %s", "formatted")
 //    a.NotContainsf({"Hello": "World"}, "Earth", "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotContainsf(s interface{}, contains interface{}, msg string, args ...interface{}) {
 	NotContainsf(a.t, s, contains, msg, args...)
 }
@@ -546,8 +482,6 @@ func (a *Assertions) NotContainsf(s interface{}, contains interface{}, msg strin
 //  if a.NotEmpty(obj) {
 //    assert.Equal(t, "two", obj[1])
 //  }
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) {
 	NotEmpty(a.t, object, msgAndArgs...)
 }
@@ -558,8 +492,6 @@ func (a *Assertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) {
 //  if a.NotEmptyf(obj, "error message %s", "formatted") {
 //    assert.Equal(t, "two", obj[1])
 //  }
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotEmptyf(object interface{}, msg string, args ...interface{}) {
 	NotEmptyf(a.t, object, msg, args...)
 }
@@ -567,8 +499,6 @@ func (a *Assertions) NotEmptyf(object interface{}, msg string, args ...interface
 // NotEqual asserts that the specified values are NOT equal.
 //
 //    a.NotEqual(obj1, obj2)
-//
-// Returns whether the assertion was successful (true) or not (false).
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
@@ -580,8 +510,6 @@ func (a *Assertions) NotEqual(expected interface{}, actual interface{}, msgAndAr
 //
 //    a.NotEqualf(obj1, obj2, "error message %s", "formatted")
 //
-// Returns whether the assertion was successful (true) or not (false).
-//
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
 func (a *Assertions) NotEqualf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
@@ -591,8 +519,6 @@ func (a *Assertions) NotEqualf(expected interface{}, actual interface{}, msg str
 // NotNil asserts that the specified object is not nil.
 //
 //    a.NotNil(err)
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotNil(object interface{}, msgAndArgs ...interface{}) {
 	NotNil(a.t, object, msgAndArgs...)
 }
@@ -600,8 +526,6 @@ func (a *Assertions) NotNil(object interface{}, msgAndArgs ...interface{}) {
 // NotNilf asserts that the specified object is not nil.
 //
 //    a.NotNilf(err, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotNilf(object interface{}, msg string, args ...interface{}) {
 	NotNilf(a.t, object, msg, args...)
 }
@@ -609,8 +533,6 @@ func (a *Assertions) NotNilf(object interface{}, msg string, args ...interface{}
 // NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
 //
 //   a.NotPanics(func(){ RemainCalm() })
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotPanics(f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	NotPanics(a.t, f, msgAndArgs...)
 }
@@ -618,8 +540,6 @@ func (a *Assertions) NotPanics(f assert.PanicTestFunc, msgAndArgs ...interface{}
 // NotPanicsf asserts that the code inside the specified PanicTestFunc does NOT panic.
 //
 //   a.NotPanicsf(func(){ RemainCalm() }, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotPanicsf(f assert.PanicTestFunc, msg string, args ...interface{}) {
 	NotPanicsf(a.t, f, msg, args...)
 }
@@ -628,8 +548,6 @@ func (a *Assertions) NotPanicsf(f assert.PanicTestFunc, msg string, args ...inte
 //
 //  a.NotRegexp(regexp.MustCompile("starts"), "it's starting")
 //  a.NotRegexp("^start", "it's not starting")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) {
 	NotRegexp(a.t, rx, str, msgAndArgs...)
 }
@@ -638,8 +556,6 @@ func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...in
 //
 //  a.NotRegexpf(regexp.MustCompile("starts", "error message %s", "formatted"), "it's starting")
 //  a.NotRegexpf("^start", "it's not starting", "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotRegexpf(rx interface{}, str interface{}, msg string, args ...interface{}) {
 	NotRegexpf(a.t, rx, str, msg, args...)
 }
@@ -648,8 +564,6 @@ func (a *Assertions) NotRegexpf(rx interface{}, str interface{}, msg string, arg
 // elements given in the specified subset(array, slice...).
 //
 //    a.NotSubset([1, 3, 4], [1, 2], "But [1, 3, 4] does not contain [1, 2]")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotSubset(list interface{}, subset interface{}, msgAndArgs ...interface{}) {
 	NotSubset(a.t, list, subset, msgAndArgs...)
 }
@@ -658,18 +572,16 @@ func (a *Assertions) NotSubset(list interface{}, subset interface{}, msgAndArgs 
 // elements given in the specified subset(array, slice...).
 //
 //    a.NotSubsetf([1, 3, 4], [1, 2], "But [1, 3, 4] does not contain [1, 2]", "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) NotSubsetf(list interface{}, subset interface{}, msg string, args ...interface{}) {
 	NotSubsetf(a.t, list, subset, msg, args...)
 }
 
-// NotZero asserts that i is not the zero value for its type and returns the truth.
+// NotZero asserts that i is not the zero value for its type.
 func (a *Assertions) NotZero(i interface{}, msgAndArgs ...interface{}) {
 	NotZero(a.t, i, msgAndArgs...)
 }
 
-// NotZerof asserts that i is not the zero value for its type and returns the truth.
+// NotZerof asserts that i is not the zero value for its type.
 func (a *Assertions) NotZerof(i interface{}, msg string, args ...interface{}) {
 	NotZerof(a.t, i, msg, args...)
 }
@@ -677,8 +589,6 @@ func (a *Assertions) NotZerof(i interface{}, msg string, args ...interface{}) {
 // Panics asserts that the code inside the specified PanicTestFunc panics.
 //
 //   a.Panics(func(){ GoCrazy() })
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Panics(f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	Panics(a.t, f, msgAndArgs...)
 }
@@ -687,8 +597,6 @@ func (a *Assertions) Panics(f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 // the recovered panic value equals the expected panic value.
 //
 //   a.PanicsWithValue("crazy error", func(){ GoCrazy() })
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) PanicsWithValue(expected interface{}, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	PanicsWithValue(a.t, expected, f, msgAndArgs...)
 }
@@ -697,8 +605,6 @@ func (a *Assertions) PanicsWithValue(expected interface{}, f assert.PanicTestFun
 // the recovered panic value equals the expected panic value.
 //
 //   a.PanicsWithValuef("crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) PanicsWithValuef(expected interface{}, f assert.PanicTestFunc, msg string, args ...interface{}) {
 	PanicsWithValuef(a.t, expected, f, msg, args...)
 }
@@ -706,8 +612,6 @@ func (a *Assertions) PanicsWithValuef(expected interface{}, f assert.PanicTestFu
 // Panicsf asserts that the code inside the specified PanicTestFunc panics.
 //
 //   a.Panicsf(func(){ GoCrazy() }, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Panicsf(f assert.PanicTestFunc, msg string, args ...interface{}) {
 	Panicsf(a.t, f, msg, args...)
 }
@@ -716,8 +620,6 @@ func (a *Assertions) Panicsf(f assert.PanicTestFunc, msg string, args ...interfa
 //
 //  a.Regexp(regexp.MustCompile("start"), "it's starting")
 //  a.Regexp("start...$", "it's not starting")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) {
 	Regexp(a.t, rx, str, msgAndArgs...)
 }
@@ -726,8 +628,6 @@ func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...inter
 //
 //  a.Regexpf(regexp.MustCompile("start", "error message %s", "formatted"), "it's starting")
 //  a.Regexpf("start...$", "it's not starting", "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Regexpf(rx interface{}, str interface{}, msg string, args ...interface{}) {
 	Regexpf(a.t, rx, str, msg, args...)
 }
@@ -736,8 +636,6 @@ func (a *Assertions) Regexpf(rx interface{}, str interface{}, msg string, args .
 // elements given in the specified subset(array, slice...).
 //
 //    a.Subset([1, 2, 3], [1, 2], "But [1, 2, 3] does contain [1, 2]")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Subset(list interface{}, subset interface{}, msgAndArgs ...interface{}) {
 	Subset(a.t, list, subset, msgAndArgs...)
 }
@@ -746,8 +644,6 @@ func (a *Assertions) Subset(list interface{}, subset interface{}, msgAndArgs ...
 // elements given in the specified subset(array, slice...).
 //
 //    a.Subsetf([1, 2, 3], [1, 2], "But [1, 2, 3] does contain [1, 2]", "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Subsetf(list interface{}, subset interface{}, msg string, args ...interface{}) {
 	Subsetf(a.t, list, subset, msg, args...)
 }
@@ -755,8 +651,6 @@ func (a *Assertions) Subsetf(list interface{}, subset interface{}, msg string, a
 // True asserts that the specified value is true.
 //
 //    a.True(myBool)
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) True(value bool, msgAndArgs ...interface{}) {
 	True(a.t, value, msgAndArgs...)
 }
@@ -764,8 +658,6 @@ func (a *Assertions) True(value bool, msgAndArgs ...interface{}) {
 // Truef asserts that the specified value is true.
 //
 //    a.Truef(myBool, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) Truef(value bool, msg string, args ...interface{}) {
 	Truef(a.t, value, msg, args...)
 }
@@ -773,8 +665,6 @@ func (a *Assertions) Truef(value bool, msg string, args ...interface{}) {
 // WithinDuration asserts that the two times are within duration delta of each other.
 //
 //   a.WithinDuration(time.Now(), time.Now(), 10*time.Second)
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) WithinDuration(expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) {
 	WithinDuration(a.t, expected, actual, delta, msgAndArgs...)
 }
@@ -782,18 +672,16 @@ func (a *Assertions) WithinDuration(expected time.Time, actual time.Time, delta 
 // WithinDurationf asserts that the two times are within duration delta of each other.
 //
 //   a.WithinDurationf(time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
-//
-// Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) WithinDurationf(expected time.Time, actual time.Time, delta time.Duration, msg string, args ...interface{}) {
 	WithinDurationf(a.t, expected, actual, delta, msg, args...)
 }
 
-// Zero asserts that i is the zero value for its type and returns the truth.
+// Zero asserts that i is the zero value for its type.
 func (a *Assertions) Zero(i interface{}, msgAndArgs ...interface{}) {
 	Zero(a.t, i, msgAndArgs...)
 }
 
-// Zerof asserts that i is the zero value for its type and returns the truth.
+// Zerof asserts that i is the zero value for its type.
 func (a *Assertions) Zerof(i interface{}, msg string, args ...interface{}) {
 	Zerof(a.t, i, msg, args...)
 }


### PR DESCRIPTION
Fixes #525

Return information was propagated to the docs from other wrapper
functions which return nothing.