### PR TITLE
Skip vendored packages from tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ script:
   - ./.travis.gogenerate.sh
   - ./.travis.gofmt.sh
   - ./.travis.govet.sh
-  - go test -v -race ./...
+  - go test -v -race $(go list ./... | grep -v vendor)


### PR DESCRIPTION
Until we drop support of Go < 1.9, skip vendored packages manually.

Once Go 1.11 is released, we would be able to just use ./...