### PR TITLE
Bump go version to 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ language: go
 sudo: false
 
 go:
-  - 1.7
-  - 1.8
-  - 1.9
+  - "1.8"
+  - "1.9"
+  - "1.10"
   - tip
 
 script:

--- a/README.md
+++ b/README.md
@@ -293,6 +293,13 @@ To update Testify to the latest version, use `go get -u github.com/stretchr/test
 
 ------
 
+Supported go versions
+==================
+
+We support the three major Go versions, which are 1.8, 1.9 and 1.10 at the moment.
+
+------
+
 Contributing
 ============
 


### PR DESCRIPTION
Since go 1.10 go versions must be set as strings

[Building a Go Project \- Travis CI](https://docs.travis-ci.com/user/languages/go/#What-This-Guide-Covers)
> Note that, in order to choose Go 1.10, you must use go: "1.10" (a string), not go: 1.10 (a float). Using a float results in the use of Go 1.1.