### PR TITLE
Add T object and Test method to Mock

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -501,7 +501,7 @@ type Arguments []interface{}
 const (
 	// Anything is used in Diff and Assert when the argument being tested
 	// shouldn't be taken into consideration.
-	Anything string = "mock.Anything"
+	Anything = "mock.Anything"
 )
 
 // AnythingOfTypeArgument is a string that contains the type of an argument

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -191,9 +191,9 @@ type Mock struct {
 	// Holds the calls that were made to this mocked object.
 	Calls []Call
 
-	// T is An optional variable that holds the test struct, to be used when an
+	// test is An optional variable that holds the test struct, to be used when an
 	// invalid mock call was made.
-	T TestingT
+	test TestingT
 
 	// TestData holds any data that might be useful for testing.  Testify ignores
 	// this data completely allowing you to do whatever you like with it.
@@ -221,7 +221,7 @@ func (m *Mock) TestData() objx.Map {
 func (m *Mock) Test(t TestingT) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
-	m.T = t
+	m.test = t
 }
 
 // fail fails the current test with the given formatted format and args.
@@ -231,11 +231,11 @@ func (m *Mock) fail(format string, args ...interface{}) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
-	if m.T == nil {
+	if m.test == nil {
 		panic(fmt.Sprintf(format, args...))
 	}
-	m.T.Errorf(format, args...)
-	m.T.FailNow()
+	m.test.Errorf(format, args...)
+	m.test.FailNow()
 }
 
 // On starts a description of an expectation of the specified method

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -130,14 +130,14 @@ func Test_Mock_Chained_On(t *testing.T) {
 		Return(nil)
 
 	expectedCalls := []*Call{
-		&Call{
+		{
 			Parent:          &mockedService.Mock,
 			Method:          "TheExampleMethod",
 			Arguments:       []interface{}{1, 2, 3},
 			ReturnArguments: []interface{}{0},
 			callerInfo:      []string{fmt.Sprintf("mock_test.go:%d", line+2)},
 		},
-		&Call{
+		{
 			Parent:          &mockedService.Mock,
 			Method:          "TheExampleMethod3",
 			Arguments:       []interface{}{AnythingOfType("*mock.ExampleType")},
@@ -1266,7 +1266,7 @@ func Test_Arguments_Bool(t *testing.T) {
 func Test_WaitUntil_Parallel(t *testing.T) {
 
 	// make a test impl object
-	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+	var mockedService = new(TestExampleImplementation)
 
 	ch1 := make(chan time.Time)
 	ch2 := make(chan time.Time)
@@ -1379,7 +1379,7 @@ func TestAfterTotalWaitTimeWhileExecution(t *testing.T) {
 	elapsedTime := end.Sub(start)
 	assert.True(t, elapsedTime > waitMs, fmt.Sprintf("Total elapsed time:%v should be atleast greater than %v", elapsedTime, waitMs))
 	assert.Equal(t, total, len(results))
-	for i, _ := range results {
+	for i := range results {
 		assert.Equal(t, fmt.Sprintf("Time%d", i), results[i], "Return value of method should be same")
 	}
 }


### PR DESCRIPTION
This makes is possible to fail the test instead of panicing in case
that the method was called with unexpected arguments.

Fixes #489