### PR TITLE
add a few function types to assist table driven tests

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -27,6 +27,22 @@ type TestingT interface {
 	Errorf(format string, args ...interface{})
 }
 
+// ComparisonAssertionFunc is a common function prototype when comparing two values.  Can be useful
+// for table driven tests.
+type ComparisonAssertionFunc func(TestingT, interface{}, interface{}, ...interface{}) bool
+
+// ValueAssertionFunc is a common function prototype when validating a single value.  Can be useful
+// for table driven tests.
+type ValueAssertionFunc func(TestingT, interface{}, ...interface{}) bool
+
+// BoolAssertionFunc is a common function prototype when validating a bool value.  Can be useful
+// for table driven tests.
+type BoolAssertionFunc func(TestingT, bool, ...interface{}) bool
+
+// ValuesAssertionFunc is a common function prototype when validating an error value.  Can be useful
+// for table driven tests.
+type ErrorAssertionFunc func(TestingT, error, ...interface{}) bool
+
 // Comparison a custom function that returns true on success and false on failure
 type Comparison func() (success bool)
 

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -2,6 +2,7 @@ package assert
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -1578,4 +1579,200 @@ func BenchmarkBytesEqual(b *testing.B) {
 func TestEqualArgsValidation(t *testing.T) {
 	err := validateEqualArgs(time.Now, time.Now)
 	EqualError(t, err, "cannot take func type as argument")
+}
+
+func ExampleComparisonAssertionFunc() {
+	t := &testing.T{} // provided by test
+
+	adder := func(x, y int) int {
+		return x + y
+	}
+
+	type args struct {
+		x int
+		y int
+	}
+
+	tests := []struct {
+		name      string
+		args      args
+		expect    int
+		assertion ComparisonAssertionFunc
+	}{
+		{"2+2=4", args{2, 2}, 4, Equal},
+		{"2+2!=5", args{2, 2}, 5, NotEqual},
+		{"2+3==5", args{2, 3}, 5, Exactly},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.assertion(t, tt.expect, adder(tt.args.x, tt.args.y))
+		})
+	}
+}
+
+func TestComparisonAssertionFunc(t *testing.T) {
+	type iface interface {
+		Name() string
+	}
+
+	tests := []struct {
+		name      string
+		expect    interface{}
+		got       interface{}
+		assertion ComparisonAssertionFunc
+	}{
+		{"implements", (*iface)(nil), t, Implements},
+		{"isType", (*testing.T)(nil), t, IsType},
+		{"equal", t, t, Equal},
+		{"equalValues", t, t, EqualValues},
+		{"exactly", t, t, Exactly},
+		{"notEqual", t, nil, NotEqual},
+		{"notContains", []int{1, 2, 3}, 4, NotContains},
+		{"subset", []int{1, 2, 3, 4}, []int{2, 3}, Subset},
+		{"notSubset", []int{1, 2, 3, 4}, []int{0, 3}, NotSubset},
+		{"elementsMatch", []byte("abc"), []byte("bac"), ElementsMatch},
+		{"regexp", "^t.*y$", "testify", Regexp},
+		{"notRegexp", "^t.*y$", "Testify", NotRegexp},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.assertion(t, tt.expect, tt.got)
+		})
+	}
+}
+
+func ExampleValueAssertionFunc() {
+	t := &testing.T{} // provided by test
+
+	dumbParse := func(input string) interface{} {
+		var x interface{}
+		json.Unmarshal([]byte(input), &x)
+		return x
+	}
+
+	tests := []struct {
+		name      string
+		arg       string
+		assertion ValueAssertionFunc
+	}{
+		{"true is not nil", "true", NotNil},
+		{"empty string is nil", "", Nil},
+		{"zero is not nil", "0", NotNil},
+		{"zero is zero", "0", Zero},
+		{"false is zero", "false", Zero},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.assertion(t, dumbParse(tt.arg))
+		})
+	}
+}
+
+func TestValueAssertionFunc(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     interface{}
+		assertion ValueAssertionFunc
+	}{
+		{"notNil", true, NotNil},
+		{"nil", nil, Nil},
+		{"empty", []int{}, Empty},
+		{"notEmpty", []int{1}, NotEmpty},
+		{"zero", false, Zero},
+		{"notZero", 42, NotZero},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.assertion(t, tt.value)
+		})
+	}
+}
+
+func ExampleBoolAssertionFunc() {
+	t := &testing.T{} // provided by test
+
+	isOkay := func(x int) bool {
+		return x >= 42
+	}
+
+	tests := []struct {
+		name      string
+		arg       int
+		assertion BoolAssertionFunc
+	}{
+		{"-1 is bad", -1, False},
+		{"42 is good", 42, True},
+		{"41 is bad", 41, False},
+		{"45 is cool", 45, True},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.assertion(t, isOkay(tt.arg))
+		})
+	}
+}
+
+func TestBoolAssertionFunc(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     bool
+		assertion BoolAssertionFunc
+	}{
+		{"true", true, True},
+		{"false", false, False},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.assertion(t, tt.value)
+		})
+	}
+}
+
+func ExampleErrorAssertionFunc() {
+	t := &testing.T{} // provided by test
+
+	dumbParseNum := func(input string, v interface{}) error {
+		return json.Unmarshal([]byte(input), v)
+	}
+
+	tests := []struct {
+		name      string
+		arg       string
+		assertion ErrorAssertionFunc
+	}{
+		{"1.2 is number", "1.2", NoError},
+		{"1.2.3 not number", "1.2.3", Error},
+		{"true is not number", "true", Error},
+		{"3 is number", "3", NoError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var x float64
+			tt.assertion(t, dumbParseNum(tt.arg, &x))
+		})
+	}
+}
+
+func TestErrorAssertionFunc(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		assertion ErrorAssertionFunc
+	}{
+		{"noError", nil, NoError},
+		{"error", errors.New("whoops"), Error},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.assertion(t, tt.err)
+		})
+	}
 }

--- a/require/requirements.go
+++ b/require/requirements.go
@@ -10,4 +10,20 @@ type tHelper interface {
 	Helper()
 }
 
+// ComparisonAssertionFunc is a common function prototype when comparing two values.  Can be useful
+// for table driven tests.
+type ComparisonAssertionFunc func(TestingT, interface{}, interface{}, ...interface{})
+
+// ValueAssertionFunc is a common function prototype when validating a single value.  Can be useful
+// for table driven tests.
+type ValueAssertionFunc func(TestingT, interface{}, ...interface{})
+
+// BoolAssertionFunc is a common function prototype when validating a bool value.  Can be useful
+// for table driven tests.
+type BoolAssertionFunc func(TestingT, bool, ...interface{})
+
+// ValuesAssertionFunc is a common function prototype when validating an error value.  Can be useful
+// for table driven tests.
+type ErrorAssertionFunc func(TestingT, error, ...interface{})
+
 //go:generate go run ../_codegen/main.go -output-package=require -template=require.go.tmpl -include-format-funcs

--- a/require/requirements_test.go
+++ b/require/requirements_test.go
@@ -1,6 +1,7 @@
 package require
 
 import (
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -365,5 +366,201 @@ func TestJSONEq_ArraysOfDifferentOrder(t *testing.T) {
 	JSONEq(mockT, `["foo", {"hello": "world", "nested": "hash"}]`, `[{ "hello": "world", "nested": "hash"}, "foo"]`)
 	if !mockT.Failed {
 		t.Error("Check should fail")
+	}
+}
+
+func ExampleComparisonAssertionFunc() {
+	t := &testing.T{} // provided by test
+
+	adder := func(x, y int) int {
+		return x + y
+	}
+
+	type args struct {
+		x int
+		y int
+	}
+
+	tests := []struct {
+		name      string
+		args      args
+		expect    int
+		assertion ComparisonAssertionFunc
+	}{
+		{"2+2=4", args{2, 2}, 4, Equal},
+		{"2+2!=5", args{2, 2}, 5, NotEqual},
+		{"2+3==5", args{2, 3}, 5, Exactly},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.assertion(t, tt.expect, adder(tt.args.x, tt.args.y))
+		})
+	}
+}
+
+func TestComparisonAssertionFunc(t *testing.T) {
+	type iface interface {
+		Name() string
+	}
+
+	tests := []struct {
+		name      string
+		expect    interface{}
+		got       interface{}
+		assertion ComparisonAssertionFunc
+	}{
+		{"implements", (*iface)(nil), t, Implements},
+		{"isType", (*testing.T)(nil), t, IsType},
+		{"equal", t, t, Equal},
+		{"equalValues", t, t, EqualValues},
+		{"exactly", t, t, Exactly},
+		{"notEqual", t, nil, NotEqual},
+		{"notContains", []int{1, 2, 3}, 4, NotContains},
+		{"subset", []int{1, 2, 3, 4}, []int{2, 3}, Subset},
+		{"notSubset", []int{1, 2, 3, 4}, []int{0, 3}, NotSubset},
+		{"elementsMatch", []byte("abc"), []byte("bac"), ElementsMatch},
+		{"regexp", "^t.*y$", "testify", Regexp},
+		{"notRegexp", "^t.*y$", "Testify", NotRegexp},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.assertion(t, tt.expect, tt.got)
+		})
+	}
+}
+
+func ExampleValueAssertionFunc() {
+	t := &testing.T{} // provided by test
+
+	dumbParse := func(input string) interface{} {
+		var x interface{}
+		json.Unmarshal([]byte(input), &x)
+		return x
+	}
+
+	tests := []struct {
+		name      string
+		arg       string
+		assertion ValueAssertionFunc
+	}{
+		{"true is not nil", "true", NotNil},
+		{"empty string is nil", "", Nil},
+		{"zero is not nil", "0", NotNil},
+		{"zero is zero", "0", Zero},
+		{"false is zero", "false", Zero},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.assertion(t, dumbParse(tt.arg))
+		})
+	}
+}
+
+func TestValueAssertionFunc(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     interface{}
+		assertion ValueAssertionFunc
+	}{
+		{"notNil", true, NotNil},
+		{"nil", nil, Nil},
+		{"empty", []int{}, Empty},
+		{"notEmpty", []int{1}, NotEmpty},
+		{"zero", false, Zero},
+		{"notZero", 42, NotZero},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.assertion(t, tt.value)
+		})
+	}
+}
+
+func ExampleBoolAssertionFunc() {
+	t := &testing.T{} // provided by test
+
+	isOkay := func(x int) bool {
+		return x >= 42
+	}
+
+	tests := []struct {
+		name      string
+		arg       int
+		assertion BoolAssertionFunc
+	}{
+		{"-1 is bad", -1, False},
+		{"42 is good", 42, True},
+		{"41 is bad", 41, False},
+		{"45 is cool", 45, True},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.assertion(t, isOkay(tt.arg))
+		})
+	}
+}
+
+func TestBoolAssertionFunc(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     bool
+		assertion BoolAssertionFunc
+	}{
+		{"true", true, True},
+		{"false", false, False},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.assertion(t, tt.value)
+		})
+	}
+}
+
+func ExampleErrorAssertionFunc() {
+	t := &testing.T{} // provided by test
+
+	dumbParseNum := func(input string, v interface{}) error {
+		return json.Unmarshal([]byte(input), v)
+	}
+
+	tests := []struct {
+		name      string
+		arg       string
+		assertion ErrorAssertionFunc
+	}{
+		{"1.2 is number", "1.2", NoError},
+		{"1.2.3 not number", "1.2.3", Error},
+		{"true is not number", "true", Error},
+		{"3 is number", "3", NoError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var x float64
+			tt.assertion(t, dumbParseNum(tt.arg, &x))
+		})
+	}
+}
+
+func TestErrorAssertionFunc(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		assertion ErrorAssertionFunc
+	}{
+		{"noError", nil, NoError},
+		{"error", errors.New("whoops"), Error},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.assertion(t, tt.err)
+		})
 	}
 }


### PR DESCRIPTION
Basically this PR is just adding these function aliases:
```
type ValuesChecker func(TestingT, interface{}, interface{}, ...interface{}) bool
type ValueChecker func(TestingT, interface{}, ...interface{}) bool
type BoolChecker func(TestingT, bool, ...interface{}) bool
type ErrorChecker func(TestingT, error, ...interface{}) bool
```
I have added tests and Examples so there will example usage in the docs.

### Why?
I find myself frequently using table driven tests to test various edge cases of my functions, but I generally want to test both the positive and negative cases.

Lets say I have a trival function `func MyFunc(input string) error`, typically the data tests would look something like this (without `testify`):
```
    tests := []struct {
        name    string
        arg     string
        wantErr bool
    }{
        {"good test", "good", false},
        {"bad test", "bad", true},
    }

    for _, tt := range tests {
        t.Run(tt.name, func(t *testing.T) {
            if err := MyFunc(tt.arg); (err != nil) != tt.wantErr {
                t.Errorf("MyFunc() error = %v, wantErr %v", err, tt.wantErr)
            }
        })
    }
```

With `testify` it gets a bit worse with the conditional:
```
    for _, tt := range tests {
        t.Run(tt.name, func(t *testing.T) {
            if err := MyFunc(tt.arg); (err != nil) != tt.wantErr {
                assert.Error(t, err, tt.name)
            } else {
                assert.NoError(t, err, tt.name)
            }
        })
    }
```

But with the function aliases in this PR, I can make more clear what I am testing (in my opinion anyway):
```
    tests := []struct {
        name  string
        arg   string
        check assert.ErrorChecker
    }{
        {"good test", "good", assert.NoError},
        {"bad test", "bad", assert.Error},
    }

    for _, tt := range tests {
        t.Run(tt.name, func(t *testing.T) {
            tt.check(t, MyFunc(tt.arg), tt.name)
        })
    }
```

I could obviously just add the function aliases to my project tests, but I think it useful enough that others might want to use them as well, and it would be nice just having them directly in testify.