### PR TITLE
Implement assert.NotEmptyThenClear

### DIFF
--- a/assert/assertion_format.go
+++ b/assert/assertion_format.go
@@ -349,6 +349,17 @@ func NotEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) 
 	return NotEmpty(t, object, append([]interface{}{msg}, args...)...)
 }
 
+// NotEmptyThenClearf asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0
+// or either a slice or a channel with len == 0. And then set it to empty.
+//
+//  assert.NotEmptyThenClearf(t, &obj, "error message %s", "formatted")
+func NotEmptyThenClearf(t TestingT, object *interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotEmptyThenClear(t, object, append([]interface{}{msg}, args...)...)
+}
+
 // NotEqualf asserts that the specified values are NOT equal.
 //
 //    assert.NotEqualf(t, obj1, obj2, "error message %s", "formatted")

--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -674,6 +674,28 @@ func (a *Assertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) boo
 	return NotEmpty(a.t, object, msgAndArgs...)
 }
 
+// NotEmptyThenClear asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0
+// or either a slice or a channel with len == 0. And then set it to empty.
+//
+//  a.NotEmptyThenClear(&obj)
+func (a *Assertions) NotEmptyThenClear(object *interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotEmptyThenClear(a.t, object, msgAndArgs...)
+}
+
+// NotEmptyThenClearf asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0
+// or either a slice or a channel with len == 0. And then set it to empty.
+//
+//  a.NotEmptyThenClearf(&obj, "error message %s", "formatted")
+func (a *Assertions) NotEmptyThenClearf(object *interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotEmptyThenClearf(a.t, object, msg, args...)
+}
+
 // NotEmptyf asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or either
 // a slice or a channel with len == 0.
 //

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -487,6 +487,27 @@ func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
 
 }
 
+// NotEmptyThenClear asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0
+// or either a slice or a channel with len == 0. And then set it to empty.
+//
+//  assert.NotEmptyThenClear(t, &obj)
+func NotEmptyThenClear(t TestingT, object *interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	if object == nil {
+		return false
+	}
+	if Empty(t, *object, msgAndArgs...) {
+		return false
+	}
+
+	objValue := reflect.ValueOf(object)
+	objValue.Elem().Set(reflect.Zero(objValue.Type()))
+	return true
+}
+
 // NotEmpty asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or either
 // a slice or a channel with len == 0.
 //

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -925,6 +925,49 @@ func TestNotEmpty(t *testing.T) {
 	True(t, NotEmpty(mockT, chWithValue), "Channel with values is not empty")
 }
 
+func TestNotEmptyThenClear(t *testing.T) {
+	mockT := new(testing.T)
+	chWithValue := make(chan struct{}, 1)
+	chWithValue <- struct{}{}
+
+	cases := []struct {
+		testTitle string
+		value     interface{}
+	}{
+		{
+			testTitle: "String",
+			value:     "something",
+		},
+		{
+			testTitle: "Object",
+			value:     errors.New("something"),
+		},
+		{
+			testTitle: "Slice",
+			value:     []string{"a"},
+		},
+		{
+			testTitle: "Int",
+			value:     1,
+		},
+		{
+			testTitle: "Boolean",
+			value:     true,
+		},
+		{
+			testTitle: "Channel",
+			value:     chWithValue,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.testTitle, func(t *testing.T) {
+			True(t, NotEmptyThenClear(mockT, &tc.value), "Value was already empty before clearing")
+			Empty(t, tc.value, "Value not empty after clearing")
+		})
+	}
+}
+
 func Test_getLen(t *testing.T) {
 	falseCases := []interface{}{
 		nil,

--- a/require/require.go
+++ b/require/require.go
@@ -801,6 +801,32 @@ func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	}
 }
 
+// NotEmptyThenClear asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0
+// or either a slice or a channel with len == 0. And then set it to empty.
+//
+//  assert.NotEmptyThenClear(t, &obj)
+func NotEmptyThenClear(t TestingT, object *interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if !assert.NotEmptyThenClear(t, object, msgAndArgs...) {
+		t.FailNow()
+	}
+}
+
+// NotEmptyThenClearf asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0
+// or either a slice or a channel with len == 0. And then set it to empty.
+//
+//  assert.NotEmptyThenClearf(t, &obj, "error message %s", "formatted")
+func NotEmptyThenClearf(t TestingT, object *interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if !assert.NotEmptyThenClearf(t, object, msg, args...) {
+		t.FailNow()
+	}
+}
+
 // NotEmptyf asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or either
 // a slice or a channel with len == 0.
 //

--- a/require/require_forward.go
+++ b/require/require_forward.go
@@ -675,6 +675,28 @@ func (a *Assertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) {
 	NotEmpty(a.t, object, msgAndArgs...)
 }
 
+// NotEmptyThenClear asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0
+// or either a slice or a channel with len == 0. And then set it to empty.
+//
+//  a.NotEmptyThenClear(&obj)
+func (a *Assertions) NotEmptyThenClear(object *interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotEmptyThenClear(a.t, object, msgAndArgs...)
+}
+
+// NotEmptyThenClearf asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0
+// or either a slice or a channel with len == 0. And then set it to empty.
+//
+//  a.NotEmptyThenClearf(&obj, "error message %s", "formatted")
+func (a *Assertions) NotEmptyThenClearf(object *interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotEmptyThenClearf(a.t, object, msg, args...)
+}
+
 // NotEmptyf asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or either
 // a slice or a channel with len == 0.
 //


### PR DESCRIPTION
This a helper to simplify a pattern that I use often in my everyday work with `testify`.

Generally when an API endpoint returns a struct, I want to assert that it's equal to an expected model, but a some fields have auto-generated values like a timestamps or UUIDs that cannot be predicted.

The options then are
1) Assert fields separately instead of asserting the whole struct, which makes for very verbose code.
2) Check that the unpredictable fields are non-empty and then clear, which is cleaner but also a bit verbose. The PR is trying to achieve this option but in an cleaner way.
