### PR TITLE
Optimise Template

### DIFF
--- a/require/require.go.tmpl
+++ b/require/require.go.tmpl
@@ -1,7 +1,8 @@
 {{.Comment}}
 func {{.DocInfo.Name}}(t TestingT, {{.Params}}) {
-	if h, ok := t.(tHelper); ok { h.Helper() }
-	if !assert.{{.DocInfo.Name}}(t, {{.ForwardedParams}}) {
-		t.FailNow()
+	if assert.{{.DocInfo.Name}}(t, {{.ForwardedParams}}) {
+		return
 	}
+	if h, ok := t.(tHelper); ok { h.Helper() }
+	t.FailNow()
 }


### PR DESCRIPTION
Fixes #602 

Returns early without calling:
```
	if h, ok := t.(tHelper); ok {
		h.Helper()
	}
```
Need to run the code generator on the new template, but couldn't get it to run, just got:
```
2018/05/26 21:53:23 8:1: expected 'IDENT', found 'import'
exit status 1
```