### PR TITLE
Add go.mod and go.modverify

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,18 @@ language: go
 
 sudo: false
 
-go:
-  - "1.8.x"
-  - "1.9.x"
-  - "1.10.x"
-  - "1.11.x"
-  - tip
-
-script:
-  - ./.travis.gogenerate.sh
-  - ./.travis.gofmt.sh
-  - ./.travis.govet.sh
-  - go test -v -race $(go list ./... | grep -v vendor)
+matrix:
+  include:
+    - go: "1.8.x"
+    - go: "1.9.x"
+    - go: "1.10.x"
+    - go: "1.11.x"
+      env: GO111MODULE=off
+    - go: "1.11.x"
+      env: GO111MODULE=on
+    - go: tip
+  script:
+    - ./.travis.gogenerate.sh
+    - ./.travis.gofmt.sh
+    - ./.travis.govet.sh
+    - go test -v -race $(go list ./... | grep -v vendor)

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module github.com/stretchr/testify
+
+require (
+	github.com/davecgh/go-spew v1.1.0
+	github.com/pmezard/go-difflib v1.0.0
+	github.com/stretchr/objx v0.1.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
What
===
Add `go.mod` and `go.sum`, using `Go 1.11`.

Why
===
Now that golang/go#24301 has been accepted, lets start using go.mod files
alongside Godep, and keep the two in sync.

Notes
===
There are no changes required to testify to support go.mod. The files were
generated by running `go build` and `go mod tidy.

Merging
===
This PR is intended to be merged after #659 which adds Go1.11 to the list of
supported builds.