### PR TITLE
EqualError: Accept error as expected value as well as string

### DIFF
--- a/assert/assertion_format.go
+++ b/assert/assertion_format.go
@@ -82,11 +82,11 @@ func Equalf(t TestingT, expected interface{}, actual interface{}, msg string, ar
 //
 //   actualObj, err := SomeFunction()
 //   assert.EqualErrorf(t, err,  expectedErrorString, "error message %s", "formatted")
-func EqualErrorf(t TestingT, theError error, errString string, msg string, args ...interface{}) bool {
+func EqualErrorf(t TestingT, theError error, errExpected interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	return EqualError(t, theError, errString, append([]interface{}{msg}, args...)...)
+	return EqualError(t, theError, errExpected, append([]interface{}{msg}, args...)...)
 }
 
 // EqualValuesf asserts that two objects are equal or convertable to the same types

--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -134,11 +134,11 @@ func (a *Assertions) Equal(expected interface{}, actual interface{}, msgAndArgs 
 //
 //   actualObj, err := SomeFunction()
 //   a.EqualError(err,  expectedErrorString)
-func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...interface{}) bool {
+func (a *Assertions) EqualError(theError error, errExpected interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
-	return EqualError(a.t, theError, errString, msgAndArgs...)
+	return EqualError(a.t, theError, errExpected, msgAndArgs...)
 }
 
 // EqualErrorf asserts that a function returned an error (i.e. not `nil`)
@@ -146,11 +146,11 @@ func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...
 //
 //   actualObj, err := SomeFunction()
 //   a.EqualErrorf(err,  expectedErrorString, "error message %s", "formatted")
-func (a *Assertions) EqualErrorf(theError error, errString string, msg string, args ...interface{}) bool {
+func (a *Assertions) EqualErrorf(theError error, errExpected interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
-	return EqualErrorf(a.t, theError, errString, msg, args...)
+	return EqualErrorf(a.t, theError, errExpected, msg, args...)
 }
 
 // EqualValues asserts that two objects are equal or convertable to the same types

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1169,14 +1169,24 @@ func Error(t TestingT, err error, msgAndArgs ...interface{}) bool {
 //
 //   actualObj, err := SomeFunction()
 //   assert.EqualError(t, err,  expectedErrorString)
-func EqualError(t TestingT, theError error, errString string, msgAndArgs ...interface{}) bool {
+func EqualError(t TestingT, theError error, errExpected interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
 	if !Error(t, theError, msgAndArgs...) {
 		return false
 	}
-	expected := errString
+
+	var expected string
+	switch e := errExpected.(type) {
+	case string:
+		expected = e
+	case error:
+		expected = e.Error()
+	default:
+		return Fail(t, "Expected value must be either error or string", msgAndArgs...)
+	}
+
 	actual := theError.Error()
 	// don't need to use deep equals here, we know they are both strings
 	if expected != actual {

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -847,6 +847,8 @@ func TestEqualError(t *testing.T) {
 		"EqualError should return false for different error string")
 	True(t, EqualError(mockT, err, "some error"),
 		"EqualError should return true")
+	True(t, EqualError(mockT, err, err))
+	True(t, EqualError(mockT, err, errors.New("some error")))
 }
 
 func Test_isEmpty(t *testing.T) {

--- a/require/require.go
+++ b/require/require.go
@@ -168,8 +168,8 @@ func Equal(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...i
 //
 //   actualObj, err := SomeFunction()
 //   assert.EqualError(t, err,  expectedErrorString)
-func EqualError(t TestingT, theError error, errString string, msgAndArgs ...interface{}) {
-	if assert.EqualError(t, theError, errString, msgAndArgs...) {
+func EqualError(t TestingT, theError error, errExpected interface{}, msgAndArgs ...interface{}) {
+	if assert.EqualError(t, theError, errExpected, msgAndArgs...) {
 		return
 	}
 	if h, ok := t.(tHelper); ok {
@@ -183,8 +183,8 @@ func EqualError(t TestingT, theError error, errString string, msgAndArgs ...inte
 //
 //   actualObj, err := SomeFunction()
 //   assert.EqualErrorf(t, err,  expectedErrorString, "error message %s", "formatted")
-func EqualErrorf(t TestingT, theError error, errString string, msg string, args ...interface{}) {
-	if assert.EqualErrorf(t, theError, errString, msg, args...) {
+func EqualErrorf(t TestingT, theError error, errExpected interface{}, msg string, args ...interface{}) {
+	if assert.EqualErrorf(t, theError, errExpected, msg, args...) {
 		return
 	}
 	if h, ok := t.(tHelper); ok {

--- a/require/require_forward.go
+++ b/require/require_forward.go
@@ -135,11 +135,11 @@ func (a *Assertions) Equal(expected interface{}, actual interface{}, msgAndArgs 
 //
 //   actualObj, err := SomeFunction()
 //   a.EqualError(err,  expectedErrorString)
-func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...interface{}) {
+func (a *Assertions) EqualError(theError error, errExpected interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
-	EqualError(a.t, theError, errString, msgAndArgs...)
+	EqualError(a.t, theError, errExpected, msgAndArgs...)
 }
 
 // EqualErrorf asserts that a function returned an error (i.e. not `nil`)
@@ -147,11 +147,11 @@ func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...
 //
 //   actualObj, err := SomeFunction()
 //   a.EqualErrorf(err,  expectedErrorString, "error message %s", "formatted")
-func (a *Assertions) EqualErrorf(theError error, errString string, msg string, args ...interface{}) {
+func (a *Assertions) EqualErrorf(theError error, errExpected interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
-	EqualErrorf(a.t, theError, errString, msg, args...)
+	EqualErrorf(a.t, theError, errExpected, msg, args...)
 }
 
 // EqualValues asserts that two objects are equal or convertable to the same types


### PR DESCRIPTION
This modification is useful in cases where we want to assert equality against
some exported error value, e.g. `assert.EqualError(t, err, pkg.ErrSomeError)`,
letting us avoid the unnecessary error "dereference" to string.