### PR TITLE
Fixing issue of passing varargs and string to Sprintf. Closes #619

### DIFF
--- a/suite/suite.go
+++ b/suite/suite.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"regexp"
 	"runtime/debug"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -80,11 +81,12 @@ func (suite *Suite) Run(name string, subtest func()) bool {
 // Run takes a testing suite and runs all of the tests attached
 // to it.
 func Run(t *testing.T, suite TestingSuite) {
+	testsSync := &sync.WaitGroup{}
 	suite.SetT(t)
 	defer failOnPanic(t)
 
 	suiteSetupDone := false
-	
+
 	methodFinder := reflect.TypeOf(suite)
 	tests := []testing.InternalTest{}
 	for index := 0; index < methodFinder.NumMethod(); index++ {
@@ -103,6 +105,7 @@ func Run(t *testing.T, suite TestingSuite) {
 			}
 			defer func() {
 				if tearDownAllSuite, ok := suite.(TearDownAllSuite); ok {
+					testsSync.Wait()
 					tearDownAllSuite.TearDownSuite()
 				}
 			}()
@@ -111,6 +114,9 @@ func Run(t *testing.T, suite TestingSuite) {
 		test := testing.InternalTest{
 			Name: method.Name,
 			F: func(t *testing.T) {
+				defer func() {
+					testsSync.Done()
+				}()
 				parentT := suite.T()
 				suite.SetT(t)
 				defer failOnPanic(t)
@@ -134,6 +140,7 @@ func Run(t *testing.T, suite TestingSuite) {
 			},
 		}
 		tests = append(tests, test)
+		testsSync.Add(1)
 	}
 	runTests(t, tests)
 }

--- a/suite/suite_order_test.go
+++ b/suite/suite_order_test.go
@@ -1,8 +1,10 @@
 package suite
 
 import (
+	"math/rand"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -13,9 +15,7 @@ type CallOrderSuite struct {
 }
 
 func (s *CallOrderSuite) call(method string) {
-	//	s.Mutex.Lock()
-	// defer s.Mutex.Unlock()
-
+	time.Sleep(time.Duration(rand.Intn(300)) * time.Millisecond)
 	s.callOrder = append(s.callOrder, method)
 }
 
@@ -28,10 +28,9 @@ func (s *CallOrderSuite) SetupSuite() {
 
 func (s *CallOrderSuite) TearDownSuite() {
 	s.call("TearDownSuite")
-	assert.Equal(s.T(), "SetupSuite;SetupTest;Test A;TearDownTest;TearDownSuite", strings.Join(s.callOrder, ";"))
+	assert.Equal(s.T(), "SetupSuite;SetupTest;Test A;TearDownTest;SetupTest;Test B;TearDownTest;TearDownSuite", strings.Join(s.callOrder, ";"))
 }
 func (s *CallOrderSuite) SetupTest() {
-	s.T().Parallel()
 	s.call("SetupTest")
 }
 
@@ -43,7 +42,6 @@ func (s *CallOrderSuite) Test_A() {
 	s.call("Test A")
 }
 
-//func (s *CallOrderSuite) Test_B() {
-//	time.Sleep(time.Second)
-//	s.call("Test B")
-//}
+func (s *CallOrderSuite) Test_B() {
+	s.call("Test B")
+}

--- a/suite/suite_order_test.go
+++ b/suite/suite_order_test.go
@@ -1,0 +1,49 @@
+package suite
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type CallOrderSuite struct {
+	Suite
+	callOrder []string
+}
+
+func (s *CallOrderSuite) call(method string) {
+	//	s.Mutex.Lock()
+	// defer s.Mutex.Unlock()
+
+	s.callOrder = append(s.callOrder, method)
+}
+
+func TestSuiteCallOrder(t *testing.T) {
+	Run(t, new(CallOrderSuite))
+}
+func (s *CallOrderSuite) SetupSuite() {
+	s.call("SetupSuite")
+}
+
+func (s *CallOrderSuite) TearDownSuite() {
+	s.call("TearDownSuite")
+	assert.Equal(s.T(), "SetupSuite;SetupTest;Test A;TearDownTest;TearDownSuite", strings.Join(s.callOrder, ";"))
+}
+func (s *CallOrderSuite) SetupTest() {
+	s.T().Parallel()
+	s.call("SetupTest")
+}
+
+func (s *CallOrderSuite) TearDownTest() {
+	s.call("TearDownTest")
+}
+
+func (s *CallOrderSuite) Test_A() {
+	s.call("Test A")
+}
+
+//func (s *CallOrderSuite) Test_B() {
+//	time.Sleep(time.Second)
+//	s.call("Test B")
+//}


### PR DESCRIPTION
Build fails with recent go version in mock package.
```
./mock.go:506: missing ... in args forwarded to printf-like function
./mock.go:523: missing ... in args forwarded to printf-like function
```

This fixes #619.