### PR TITLE
Include methodName in AssertNumberOfCalls error

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -477,7 +477,7 @@ func (m *Mock) AssertNumberOfCalls(t TestingT, methodName string, expectedCalls 
 			actualCalls++
 		}
 	}
-	return assert.Equal(t, expectedCalls, actualCalls, fmt.Sprintf("Expected number of calls (%d) does not match the actual number of calls (%d).", expectedCalls, actualCalls))
+	return assert.Equal(t, expectedCalls, actualCalls, fmt.Sprintf("Expected %q to be called %d time(s), but it was called %d time(s).", methodName, expectedCalls, actualCalls))
 }
 
 // AssertCalled asserts that the method was called.


### PR DESCRIPTION
Other method assertions include the method name. It would be nice if `AssertNumberOfCalls` did as well.