### PR TITLE
assert.Equal: fix a panic when comparing types where the underlying type is string

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1345,7 +1345,7 @@ func diff(expected interface{}, actual interface{}) string {
 	}
 
 	var e, a string
-	if ek != reflect.String {
+	if et.Name() != "string" {
 		e = spewConfig.Sdump(expected)
 		a = spewConfig.Sdump(actual)
 	} else {

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -1791,3 +1791,18 @@ func TestErrorAssertionFunc(t *testing.T) {
 		})
 	}
 }
+
+type notstring string
+
+// The code in the diff func used to check that the type was a kind of string
+// and then do `var.(type)` on the variable containing the expected and actual
+// values. This blew up when the type was a _kind_ of string but not actually
+// a string.
+func TestPanicOnStringLikeType(t *testing.T) {
+	f := func() {
+		mockT := new(testing.T)
+		Equal(mockT, notstring("value"), notstring("value2"))
+	}
+
+	NotPanics(t, f, "Should not panic when comparing string-ish types")
+}


### PR DESCRIPTION
The code was checking if the type's _kind_ was string and then attempting to
do a type assertion of `var.(string)`. However, this assertion only works if
the type actually _is_ a string. If it's some other type (like `type foo
string`) then this ends up giving us a runtime panic.