### PR TITLE
Allow tests to fail on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,11 @@ go:
   - "1.10"
   - tip
 
+matrix:
+  allow_failures:
+    - go: master
+fast_finish: true
+
 script:
   - ./.travis.gogenerate.sh
   - ./.travis.gofmt.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 language: go
-
-sudo: false
-
 go:
-  - "1.8"
-  - "1.9"
-  - "1.10"
-  - tip
+  - "1.7.x"
+  - "1.8.x"
+  - "1.9.x"
+  - "1.10.x"
+  - master
 
 matrix:
   allow_failures:


### PR DESCRIPTION
When testing against go tip we can allow tests to fail. This PR also ensures that we run test against the newest go version e.g. `1.10.3` instead of `1.10`

Ref #619 