### PR TITLE
assert.Equal: fix panic on user type from string

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1349,8 +1349,15 @@ func diff(expected interface{}, actual interface{}) string {
 		e = spewConfig.Sdump(expected)
 		a = spewConfig.Sdump(actual)
 	} else {
-		e = expected.(string)
-		a = actual.(string)
+		var ok bool
+		e, ok = expected.(string)
+		if !ok {
+			e = spewConfig.Sdump(expected)
+		}
+		a, ok = actual.(string)
+		if !ok {
+			a = spewConfig.Sdump(actual)
+		}
 	}
 
 	diff, _ := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{

--- a/assert/issue_test.go
+++ b/assert/issue_test.go
@@ -1,0 +1,67 @@
+package assert
+
+import (
+	"runtime/debug"
+	"testing"
+)
+
+func TestEqual_Issue(t *testing.T) {
+
+	var stack []byte
+	recovery := func() {
+		if r := recover(); r != nil {
+			stack = debug.Stack()
+			panic(r)
+		}
+	}
+
+	t.Run("User type, string", func(t *testing.T) {
+
+		type MyType string
+
+		const (
+			One   MyType = "one"
+			Two   MyType = "two"
+			Three MyType = "three"
+			Four  MyType = "four"
+		)
+
+		tested := &testing.T{}
+		assert, assertT := New(t), New(tested)
+
+		assertT.Equal(One, One)
+		assert.False(tested.Failed(), "this is ok")
+
+		assertT.Equal(string(One), string(Two))
+		assert.True(tested.Failed(), "should just fail")
+		if !assert.NotPanics(func() {
+			defer recovery()
+			assertT.Equal(Three, Four)
+		}, "shouldn't panic!!") {
+			t.Logf("watchout in `assertions.go:1352`!!\n%s", stack)
+		}
+	})
+
+	t.Run("User type, int", func(t *testing.T) {
+
+		type MyType int
+
+		const (
+			One   MyType = 1
+			Two   MyType = 2
+			Three MyType = 3
+			Four  MyType = 4
+		)
+
+		tested := &testing.T{}
+		assert, assertT := New(t), New(tested)
+
+		assertT.Equal(One, One)
+		assert.False(tested.Failed(), "this is ok")
+
+		assertT.Equal(int(One), int(Two))
+		assert.True(tested.Failed(), "should just fail")
+
+		assert.NotPanics(func() { assertT.Equal(Three, Four) }, "shouldn't panic!!")
+	})
+}


### PR DESCRIPTION
To repro the bug, pull only assert/issue_test.go, then run unit tests and watch the failing output.
If you also want the fix, pull also assert/assertions.go, run the tests again, which all should pass ;)