### PR TITLE
Add prefix and suffix assertions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 *.a
 *.so
 
+# Binaries
+codegen
+
 # Folders
 _obj
 _test

--- a/.travis.gofmt.sh
+++ b/.travis.gofmt.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+echo ".travis.gofmt.sh"
+
 if [ -n "$(gofmt -l .)" ]; then
   echo "Go code is not formatted:"
   gofmt -d .

--- a/.travis.gogenerate.sh
+++ b/.travis.gogenerate.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 
-if [[ "$TRAVIS_GO_VERSION" =~ ^1\.[45](\..*)?$ ]]; then
-  exit 0
-fi
+echo ".travis.gogenerate.sh"
 
+go build -o codegen ./_codegen
 go get github.com/ernesto-jimenez/gogen/imports
 go generate ./...
-if [ -n "$(git diff)" ]; then
+if [ -n "$(git diff assert/ mock/ require/ suite/)" ]; then
   echo "Go generate had not been run"
   git diff
   exit 1
+else
+  echo "Go generate had been run"
 fi
+

--- a/.travis.gogenerate.sh
+++ b/.travis.gogenerate.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
 
+set -e
+set -o pipefail
+
 if [[ "$TRAVIS_GO_VERSION" =~ ^1\.[45](\..*)?$ ]]; then
   exit 0
 fi
 
 go get github.com/ernesto-jimenez/gogen/imports
+go build -o codegen ./_codegen
 go generate ./...
 if [ -n "$(git diff)" ]; then
   echo "Go generate had not been run"

--- a/.travis.govet.sh
+++ b/.travis.govet.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 
+echo ".travis.govet.sh"
+
 cd "$(dirname $0)"
-DIRS=". assert require mock _codegen"
+DIRS=". assert require mock suite _codegen"
 set -e
 for subdir in $DIRS; do
   pushd $subdir
   go vet
   popd
 done
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,16 @@ matrix:
       env: GO111MODULE=off
     - go: "1.11.x"
       env: GO111MODULE=on
+    - go: "1.12.x"
+      env: GO111MODULE=off
+    - go: "1.12.x"
+      env: GO111MODULE=on
     - go: tip
-  script:
-    - ./.travis.gogenerate.sh
-    - ./.travis.gofmt.sh
-    - ./.travis.govet.sh
-    - go test -v -race $(go list ./... | grep -v vendor)
+      env: GO111MODULE=off
+    - go: tip
+      env: GO111MODULE=on
+script:
+  - ./.travis.gogenerate.sh
+  - ./.travis.gofmt.sh
+  - ./.travis.govet.sh
+  - go test -v -race $(go list ./... | grep -v vendor)

--- a/_codegen/importer_new.go
+++ b/_codegen/importer_new.go
@@ -1,0 +1,5 @@
+// +build go1.9
+
+package main
+
+const SOURCE_IMPORTER = true

--- a/_codegen/importer_old.go
+++ b/_codegen/importer_old.go
@@ -1,0 +1,5 @@
+// +build !go1.9
+
+package main
+
+const SOURCE_IMPORTER = false

--- a/_codegen/main.go
+++ b/_codegen/main.go
@@ -193,8 +193,15 @@ func parsePackageSource(pkg string) (*types.Scope, *doc.Package, error) {
 		fileList[i] = f
 	}
 
+	var imp types.Importer
+	if SOURCE_IMPORTER {
+		imp = importer.For("source", nil)
+	} else {
+		imp = importer.Default()
+	}
+
 	cfg := types.Config{
-		Importer: importer.Default(),
+		Importer: imp,
 	}
 	info := types.Info{
 		Defs: make(map[*ast.Ident]types.Object),

--- a/_codegen/main.go
+++ b/_codegen/main.go
@@ -196,7 +196,7 @@ func parsePackageSource(pkg string) (*types.Scope, *doc.Package, error) {
 
 	var imp types.Importer
 	if SOURCE_IMPORTER {
-		imp = importer.ForCompiler(fset, "source", nil)
+		imp = importer.For("source", nil)
 	} else {
 		imp = importer.Default()
 	}

--- a/assert/assertion_format.go
+++ b/assert/assertion_format.go
@@ -244,6 +244,30 @@ func HTTPSuccessf(t TestingT, handler http.HandlerFunc, method string, url strin
 	return HTTPSuccess(t, handler, method, url, values, append([]interface{}{msg}, args...)...)
 }
 
+// HasPrefixf asserts that the specified string or list(array, slice...) begins with the
+// specified substring or sequence of elements.
+//
+//    assert.HasPrefixf(t, "Hello World", "Hello", "error message %s", "formatted")
+//    assert.HasPrefixf(t, ["Hello", "there", "World"], ["Hello", "there"], "error message %s", "formatted")
+func HasPrefixf(t TestingT, s interface{}, prefix interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return HasPrefix(t, s, prefix, append([]interface{}{msg}, args...)...)
+}
+
+// HasSuffixf asserts that the specified string or list(array, slice...) ends with the
+// specified substring or sequence of elements.
+//
+//    assert.HasSuffixf(t, "Hello World", "World", "error message %s", "formatted")
+//    assert.HasSuffixf(t, ["Hello", "there", "World"], ["there", "World"], "error message %s", "formatted")
+func HasSuffixf(t TestingT, s interface{}, suffix interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return HasSuffix(t, s, suffix, append([]interface{}{msg}, args...)...)
+}
+
 // Implementsf asserts that an object is implemented by the specified interface.
 //
 //    assert.Implementsf(t, (*MyInterface, "error message %s", "formatted")(nil), new(MyObject))
@@ -410,6 +434,22 @@ func NotEqualf(t TestingT, expected interface{}, actual interface{}, msg string,
 		h.Helper()
 	}
 	return NotEqual(t, expected, actual, append([]interface{}{msg}, args...)...)
+}
+
+// NotHasPrefixf asserts the negation of HasPrefix.
+func NotHasPrefixf(t TestingT, s interface{}, prefix interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotHasPrefix(t, s, prefix, append([]interface{}{msg}, args...)...)
+}
+
+// NotHasSuffixf asserts the negation of HasSuffix.
+func NotHasSuffixf(t TestingT, s interface{}, suffix interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotHasSuffix(t, s, suffix, append([]interface{}{msg}, args...)...)
 }
 
 // NotNilf asserts that the specified object is not nil.

--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -477,6 +477,54 @@ func (a *Assertions) HTTPSuccessf(handler http.HandlerFunc, method string, url s
 	return HTTPSuccessf(a.t, handler, method, url, values, msg, args...)
 }
 
+// HasPrefix asserts that the specified string or list(array, slice...) begins with the
+// specified substring or sequence of elements.
+//
+//    a.HasPrefix("Hello World", "Hello")
+//    a.HasPrefix(["Hello", "there", "World"], ["Hello", "there"])
+func (a *Assertions) HasPrefix(s interface{}, prefix interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return HasPrefix(a.t, s, prefix, msgAndArgs...)
+}
+
+// HasPrefixf asserts that the specified string or list(array, slice...) begins with the
+// specified substring or sequence of elements.
+//
+//    a.HasPrefixf("Hello World", "Hello", "error message %s", "formatted")
+//    a.HasPrefixf(["Hello", "there", "World"], ["Hello", "there"], "error message %s", "formatted")
+func (a *Assertions) HasPrefixf(s interface{}, prefix interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return HasPrefixf(a.t, s, prefix, msg, args...)
+}
+
+// HasSuffix asserts that the specified string or list(array, slice...) ends with the
+// specified substring or sequence of elements.
+//
+//    a.HasSuffix("Hello World", "World")
+//    a.HasSuffix(["Hello", "there", "World"], ["there", "World"])
+func (a *Assertions) HasSuffix(s interface{}, suffix interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return HasSuffix(a.t, s, suffix, msgAndArgs...)
+}
+
+// HasSuffixf asserts that the specified string or list(array, slice...) ends with the
+// specified substring or sequence of elements.
+//
+//    a.HasSuffixf("Hello World", "World", "error message %s", "formatted")
+//    a.HasSuffixf(["Hello", "there", "World"], ["there", "World"], "error message %s", "formatted")
+func (a *Assertions) HasSuffixf(s interface{}, suffix interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return HasSuffixf(a.t, s, suffix, msg, args...)
+}
+
 // Implements asserts that an object is implemented by the specified interface.
 //
 //    a.Implements((*MyInterface)(nil), new(MyObject))
@@ -811,6 +859,38 @@ func (a *Assertions) NotEqualf(expected interface{}, actual interface{}, msg str
 		h.Helper()
 	}
 	return NotEqualf(a.t, expected, actual, msg, args...)
+}
+
+// NotHasPrefix asserts the negation of HasPrefix.
+func (a *Assertions) NotHasPrefix(s interface{}, prefix interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotHasPrefix(a.t, s, prefix, msgAndArgs...)
+}
+
+// NotHasPrefixf asserts the negation of HasPrefix.
+func (a *Assertions) NotHasPrefixf(s interface{}, prefix interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotHasPrefixf(a.t, s, prefix, msg, args...)
+}
+
+// NotHasSuffix asserts the negation of HasSuffix.
+func (a *Assertions) NotHasSuffix(s interface{}, suffix interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotHasSuffix(a.t, s, suffix, msgAndArgs...)
+}
+
+// NotHasSuffixf asserts the negation of HasSuffix.
+func (a *Assertions) NotHasSuffixf(s interface{}, suffix interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotHasSuffixf(a.t, s, suffix, msg, args...)
 }
 
 // NotNil asserts that the specified object is not nil.

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -20,7 +20,7 @@ import (
 	"github.com/pmezard/go-difflib/difflib"
 )
 
-//go:generate go run ../_codegen/main.go -output-package=assert -template=assertion_format.go.tmpl
+//go:generate ../codegen -output-package=assert -template=assertion_format.go.tmpl
 
 // TestingT is an interface wrapper around *testing.T
 type TestingT interface {

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -476,8 +476,191 @@ type A struct {
 	Name, Value string
 }
 
-func TestContains(t *testing.T) {
+func TestHasPrefix(t *testing.T) {
+	mockT := new(testing.T)
 
+	list := []string{"Foo", "Bar", "Baz"}
+	listPrefix := []string{list[0], list[1]}
+	listSuffix := []string{list[1], list[2]}
+
+	complexList := []*A{
+		{"b", "c"},
+		{"d", "e"},
+		{"g", "h"},
+		{"j", "k"},
+	}
+	complexListPrefix := []*A{complexList[0], complexList[1]}
+	complexListSuffix := []*A{complexList[2], complexList[3]}
+
+	if !HasPrefix(mockT, "", "") {
+		t.Error("HasPrefix should return true: the empty string is a prefix of the empty string")
+	}
+
+	if !HasPrefix(mockT, "Hello World", "Hello") {
+		t.Error("HasPrefix should return true: \"Hello World\" starts with \"Hello\"")
+	}
+	if HasPrefix(mockT, "Hello World", "World") {
+		t.Error("HasPrefix should return false: \"Hello World\" does not start with \"World\"")
+	}
+
+	if !HasPrefix(mockT, []string{}, []string{}) {
+		t.Error("HasPrefix should return true: the empty list is a prefix of the empty list")
+	}
+
+	if !HasPrefix(mockT, list, listPrefix) {
+		t.Errorf("HasPrefix should return true: %v starts with %v", list, listPrefix)
+	}
+	if HasPrefix(mockT, list, listSuffix) {
+		t.Errorf("HasPrefix should return false: %v does not start with %v", list, listSuffix)
+	}
+
+	if !HasPrefix(mockT, complexList, complexListPrefix) {
+		t.Errorf("HasPrefix should return true: %v starts with %v", complexList, complexListPrefix)
+	}
+	if HasPrefix(mockT, complexList, complexListSuffix) {
+		t.Errorf("HasPrefix should return false: %v does not start with %v", complexList, complexListSuffix)
+	}
+}
+
+func TestNotHasPrefix(t *testing.T) {
+	mockT := new(testing.T)
+
+	list := []string{"Foo", "Bar", "Baz"}
+	listPrefix := []string{list[0], list[1]}
+	listSuffix := []string{list[1], list[2]}
+
+	complexList := []*A{
+		{"b", "c"},
+		{"d", "e"},
+		{"g", "h"},
+		{"j", "k"},
+	}
+	complexListPrefix := []*A{complexList[0], complexList[1]}
+	complexListSuffix := []*A{complexList[2], complexList[3]}
+
+	if NotHasPrefix(mockT, "", "") {
+		t.Error("NotHasPrefix should return false: the empty string is a prefix of the empty string")
+	}
+
+	if NotHasPrefix(mockT, "Hello World", "Hello") {
+		t.Error("NotHasPrefix should return false: \"Hello World\" starts with \"Hello\"")
+	}
+	if !NotHasPrefix(mockT, "Hello World", "World") {
+		t.Error("NotHasPrefix should return true: \"Hello World\" does not start with \"World\"")
+	}
+
+	if NotHasPrefix(mockT, []string{}, []string{}) {
+		t.Error("NotHasPrefix should return false: the empty list is a prefix of the empty list")
+	}
+
+	if NotHasPrefix(mockT, list, listPrefix) {
+		t.Errorf("NotHasPrefix should return false: %v starts with %v", list, listPrefix)
+	}
+	if !NotHasPrefix(mockT, list, listSuffix) {
+		t.Errorf("NotHasPrefix should return true: %v does not start with %v", list, listSuffix)
+	}
+
+	if NotHasPrefix(mockT, complexList, complexListPrefix) {
+		t.Errorf("NotHasPrefix should return false: %v starts with %v", complexList, complexListPrefix)
+	}
+	if !NotHasPrefix(mockT, complexList, complexListSuffix) {
+		t.Errorf("NotHasPrefix should return true: %v does not start with %v", complexList, complexListSuffix)
+	}
+}
+
+func TestHasSuffix(t *testing.T) {
+	mockT := new(testing.T)
+
+	list := []string{"Foo", "Bar", "Baz"}
+	listPrefix := []string{list[0], list[1]}
+	listSuffix := []string{list[1], list[2]}
+
+	complexList := []*A{
+		{"b", "c"},
+		{"d", "e"},
+		{"g", "h"},
+		{"j", "k"},
+	}
+	complexListPrefix := []*A{complexList[0], complexList[1]}
+	complexListSuffix := []*A{complexList[2], complexList[3]}
+
+	if !HasSuffix(mockT, "", "") {
+		t.Error("HasSuffix should return true: the empty string is a suffix of the empty string")
+	}
+
+	if !HasSuffix(mockT, "Hello World", "World") {
+		t.Error("HasSuffix should return true: \"Hello World\" ends with \"World\"")
+	}
+	if HasSuffix(mockT, "Hello World", "Hello") {
+		t.Error("HasSuffix should return false: \"Hello World\" does not end with \"Hello\"")
+	}
+
+	if !HasSuffix(mockT, []string{}, []string{}) {
+		t.Error("HasSuffix should return true: the empty list is a suffix of the empty list")
+	}
+
+	if !HasSuffix(mockT, list, listSuffix) {
+		t.Errorf("HasSuffix should return true: %v ends with %v", list, listSuffix)
+	}
+	if HasSuffix(mockT, list, listPrefix) {
+		t.Errorf("HasSuffix should return false: %v does not end with %v", list, listPrefix)
+	}
+
+	if !HasSuffix(mockT, complexList, complexListSuffix) {
+		t.Errorf("HasSuffix should return true: %v ends with %v", complexList, complexListSuffix)
+	}
+	if HasSuffix(mockT, complexList, complexListPrefix) {
+		t.Errorf("HasSuffix should return false: %v does not end with %v", complexList, complexListPrefix)
+	}
+}
+
+func TestNotHasSuffix(t *testing.T) {
+	mockT := new(testing.T)
+
+	list := []string{"Foo", "Bar", "Baz"}
+	listPrefix := []string{list[0], list[1]}
+	listSuffix := []string{list[1], list[2]}
+
+	complexList := []*A{
+		{"b", "c"},
+		{"d", "e"},
+		{"g", "h"},
+		{"j", "k"},
+	}
+	complexListPrefix := []*A{complexList[0], complexList[1]}
+	complexListSuffix := []*A{complexList[2], complexList[3]}
+
+	if NotHasSuffix(mockT, "", "") {
+		t.Error("NotHasSuffix should return false: the empty string is a suffix of the empty string")
+	}
+
+	if NotHasSuffix(mockT, "Hello World", "World") {
+		t.Error("NotHasSuffix should return false: \"Hello World\" ends with \"World\"")
+	}
+	if !NotHasSuffix(mockT, "Hello World", "Hello") {
+		t.Error("NotHasSuffix should return true: \"Hello World\" does not end with \"Hello\"")
+	}
+
+	if NotHasSuffix(mockT, []string{}, []string{}) {
+		t.Error("NotHasSuffix should return false: the empty list is a suffix of the empty list")
+	}
+
+	if NotHasSuffix(mockT, list, listSuffix) {
+		t.Errorf("NotHasSuffix should return false: %v ends with %v", list, listSuffix)
+	}
+	if !NotHasSuffix(mockT, list, listPrefix) {
+		t.Errorf("NotHasSuffix should return true: %v does not end with %v", list, listPrefix)
+	}
+
+	if NotHasSuffix(mockT, complexList, complexListSuffix) {
+		t.Errorf("NotHasSuffix should return false: %v ends with %v", complexList, complexListSuffix)
+	}
+	if !NotHasSuffix(mockT, complexList, complexListPrefix) {
+		t.Errorf("NotHasSuffix should return true: %v does not end with %v", complexList, complexListPrefix)
+	}
+}
+
+func TestContains(t *testing.T) {
 	mockT := new(testing.T)
 	list := []string{"Foo", "Bar"}
 	complexList := []*A{
@@ -1676,6 +1859,11 @@ func TestComparisonAssertionFunc(t *testing.T) {
 		{"equalValues", t, t, EqualValues},
 		{"exactly", t, t, Exactly},
 		{"notEqual", t, nil, NotEqual},
+		{"hasPrefix", "abcd", "ab", HasPrefix},
+		{"notHasPrefix", "abcd", "bc", NotHasPrefix},
+		{"hasSuffix", "abcd", "cd", HasSuffix},
+		{"notHasSuffix", "abcd", "bc", NotHasSuffix},
+		{"contains", []int{1, 2, 3}, 2, Contains},
 		{"notContains", []int{1, 2, 3}, 4, NotContains},
 		{"subset", []int{1, 2, 3, 4}, []int{2, 3}, Subset},
 		{"notSubset", []int{1, 2, 3, 4}, []int{0, 3}, NotSubset},

--- a/assert/forward_assertions.go
+++ b/assert/forward_assertions.go
@@ -13,4 +13,4 @@ func New(t TestingT) *Assertions {
 	}
 }
 
-//go:generate go run ../_codegen/main.go -output-package=assert -template=assertion_forward.go.tmpl -include-format-funcs
+//go:generate ../codegen -output-package=assert -template=assertion_forward.go.tmpl -include-format-funcs

--- a/require/forward_requirements.go
+++ b/require/forward_requirements.go
@@ -13,4 +13,4 @@ func New(t TestingT) *Assertions {
 	}
 }
 
-//go:generate go run ../_codegen/main.go -output-package=require -template=require_forward.go.tmpl -include-format-funcs
+//go:generate ../codegen -output-package=require -template=require_forward.go.tmpl -include-format-funcs

--- a/require/require.go
+++ b/require/require.go
@@ -604,6 +604,66 @@ func HTTPSuccessf(t TestingT, handler http.HandlerFunc, method string, url strin
 	t.FailNow()
 }
 
+// HasPrefix asserts that the specified string or list(array, slice...) begins with the
+// specified substring or sequence of elements.
+//
+//    assert.HasPrefix(t, "Hello World", "Hello")
+//    assert.HasPrefix(t, ["Hello", "there", "World"], ["Hello", "there"])
+func HasPrefix(t TestingT, s interface{}, prefix interface{}, msgAndArgs ...interface{}) {
+	if assert.HasPrefix(t, s, prefix, msgAndArgs...) {
+		return
+	}
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	t.FailNow()
+}
+
+// HasPrefixf asserts that the specified string or list(array, slice...) begins with the
+// specified substring or sequence of elements.
+//
+//    assert.HasPrefixf(t, "Hello World", "Hello", "error message %s", "formatted")
+//    assert.HasPrefixf(t, ["Hello", "there", "World"], ["Hello", "there"], "error message %s", "formatted")
+func HasPrefixf(t TestingT, s interface{}, prefix interface{}, msg string, args ...interface{}) {
+	if assert.HasPrefixf(t, s, prefix, msg, args...) {
+		return
+	}
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	t.FailNow()
+}
+
+// HasSuffix asserts that the specified string or list(array, slice...) ends with the
+// specified substring or sequence of elements.
+//
+//    assert.HasSuffix(t, "Hello World", "World")
+//    assert.HasSuffix(t, ["Hello", "there", "World"], ["there", "World"])
+func HasSuffix(t TestingT, s interface{}, suffix interface{}, msgAndArgs ...interface{}) {
+	if assert.HasSuffix(t, s, suffix, msgAndArgs...) {
+		return
+	}
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	t.FailNow()
+}
+
+// HasSuffixf asserts that the specified string or list(array, slice...) ends with the
+// specified substring or sequence of elements.
+//
+//    assert.HasSuffixf(t, "Hello World", "World", "error message %s", "formatted")
+//    assert.HasSuffixf(t, ["Hello", "there", "World"], ["there", "World"], "error message %s", "formatted")
+func HasSuffixf(t TestingT, s interface{}, suffix interface{}, msg string, args ...interface{}) {
+	if assert.HasSuffixf(t, s, suffix, msg, args...) {
+		return
+	}
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	t.FailNow()
+}
+
 // Implements asserts that an object is implemented by the specified interface.
 //
 //    assert.Implements(t, (*MyInterface)(nil), new(MyObject))
@@ -1032,6 +1092,50 @@ func NotEqualf(t TestingT, expected interface{}, actual interface{}, msg string,
 	}
 	if assert.NotEqualf(t, expected, actual, msg, args...) {
 		return
+	}
+	t.FailNow()
+}
+
+// NotHasPrefix asserts the negation of HasPrefix.
+func NotHasPrefix(t TestingT, s interface{}, prefix interface{}, msgAndArgs ...interface{}) {
+	if assert.NotHasPrefix(t, s, prefix, msgAndArgs...) {
+		return
+	}
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	t.FailNow()
+}
+
+// NotHasPrefixf asserts the negation of HasPrefix.
+func NotHasPrefixf(t TestingT, s interface{}, prefix interface{}, msg string, args ...interface{}) {
+	if assert.NotHasPrefixf(t, s, prefix, msg, args...) {
+		return
+	}
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	t.FailNow()
+}
+
+// NotHasSuffix asserts the negation of HasSuffix.
+func NotHasSuffix(t TestingT, s interface{}, suffix interface{}, msgAndArgs ...interface{}) {
+	if assert.NotHasSuffix(t, s, suffix, msgAndArgs...) {
+		return
+	}
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	t.FailNow()
+}
+
+// NotHasSuffixf asserts the negation of HasSuffix.
+func NotHasSuffixf(t TestingT, s interface{}, suffix interface{}, msg string, args ...interface{}) {
+	if assert.NotHasSuffixf(t, s, suffix, msg, args...) {
+		return
+	}
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
 	}
 	t.FailNow()
 }

--- a/require/require.go
+++ b/require/require.go
@@ -610,11 +610,11 @@ func HTTPSuccessf(t TestingT, handler http.HandlerFunc, method string, url strin
 //    assert.HasPrefix(t, "Hello World", "Hello")
 //    assert.HasPrefix(t, ["Hello", "there", "World"], ["Hello", "there"])
 func HasPrefix(t TestingT, s interface{}, prefix interface{}, msgAndArgs ...interface{}) {
-	if assert.HasPrefix(t, s, prefix, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.HasPrefix(t, s, prefix, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
@@ -625,11 +625,11 @@ func HasPrefix(t TestingT, s interface{}, prefix interface{}, msgAndArgs ...inte
 //    assert.HasPrefixf(t, "Hello World", "Hello", "error message %s", "formatted")
 //    assert.HasPrefixf(t, ["Hello", "there", "World"], ["Hello", "there"], "error message %s", "formatted")
 func HasPrefixf(t TestingT, s interface{}, prefix interface{}, msg string, args ...interface{}) {
-	if assert.HasPrefixf(t, s, prefix, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.HasPrefixf(t, s, prefix, msg, args...) {
+		return
 	}
 	t.FailNow()
 }
@@ -640,11 +640,11 @@ func HasPrefixf(t TestingT, s interface{}, prefix interface{}, msg string, args 
 //    assert.HasSuffix(t, "Hello World", "World")
 //    assert.HasSuffix(t, ["Hello", "there", "World"], ["there", "World"])
 func HasSuffix(t TestingT, s interface{}, suffix interface{}, msgAndArgs ...interface{}) {
-	if assert.HasSuffix(t, s, suffix, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.HasSuffix(t, s, suffix, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
@@ -655,11 +655,11 @@ func HasSuffix(t TestingT, s interface{}, suffix interface{}, msgAndArgs ...inte
 //    assert.HasSuffixf(t, "Hello World", "World", "error message %s", "formatted")
 //    assert.HasSuffixf(t, ["Hello", "there", "World"], ["there", "World"], "error message %s", "formatted")
 func HasSuffixf(t TestingT, s interface{}, suffix interface{}, msg string, args ...interface{}) {
-	if assert.HasSuffixf(t, s, suffix, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.HasSuffixf(t, s, suffix, msg, args...) {
+		return
 	}
 	t.FailNow()
 }
@@ -1098,44 +1098,44 @@ func NotEqualf(t TestingT, expected interface{}, actual interface{}, msg string,
 
 // NotHasPrefix asserts the negation of HasPrefix.
 func NotHasPrefix(t TestingT, s interface{}, prefix interface{}, msgAndArgs ...interface{}) {
-	if assert.NotHasPrefix(t, s, prefix, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.NotHasPrefix(t, s, prefix, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
 
 // NotHasPrefixf asserts the negation of HasPrefix.
 func NotHasPrefixf(t TestingT, s interface{}, prefix interface{}, msg string, args ...interface{}) {
-	if assert.NotHasPrefixf(t, s, prefix, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.NotHasPrefixf(t, s, prefix, msg, args...) {
+		return
 	}
 	t.FailNow()
 }
 
 // NotHasSuffix asserts the negation of HasSuffix.
 func NotHasSuffix(t TestingT, s interface{}, suffix interface{}, msgAndArgs ...interface{}) {
-	if assert.NotHasSuffix(t, s, suffix, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.NotHasSuffix(t, s, suffix, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
 
 // NotHasSuffixf asserts the negation of HasSuffix.
 func NotHasSuffixf(t TestingT, s interface{}, suffix interface{}, msg string, args ...interface{}) {
-	if assert.NotHasSuffixf(t, s, suffix, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.NotHasSuffixf(t, s, suffix, msg, args...) {
+		return
 	}
 	t.FailNow()
 }

--- a/require/require_forward.go
+++ b/require/require_forward.go
@@ -478,6 +478,54 @@ func (a *Assertions) HTTPSuccessf(handler http.HandlerFunc, method string, url s
 	HTTPSuccessf(a.t, handler, method, url, values, msg, args...)
 }
 
+// HasPrefix asserts that the specified string or list(array, slice...) begins with the
+// specified substring or sequence of elements.
+//
+//    a.HasPrefix("Hello World", "Hello")
+//    a.HasPrefix(["Hello", "there", "World"], ["Hello", "there"])
+func (a *Assertions) HasPrefix(s interface{}, prefix interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HasPrefix(a.t, s, prefix, msgAndArgs...)
+}
+
+// HasPrefixf asserts that the specified string or list(array, slice...) begins with the
+// specified substring or sequence of elements.
+//
+//    a.HasPrefixf("Hello World", "Hello", "error message %s", "formatted")
+//    a.HasPrefixf(["Hello", "there", "World"], ["Hello", "there"], "error message %s", "formatted")
+func (a *Assertions) HasPrefixf(s interface{}, prefix interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HasPrefixf(a.t, s, prefix, msg, args...)
+}
+
+// HasSuffix asserts that the specified string or list(array, slice...) ends with the
+// specified substring or sequence of elements.
+//
+//    a.HasSuffix("Hello World", "World")
+//    a.HasSuffix(["Hello", "there", "World"], ["there", "World"])
+func (a *Assertions) HasSuffix(s interface{}, suffix interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HasSuffix(a.t, s, suffix, msgAndArgs...)
+}
+
+// HasSuffixf asserts that the specified string or list(array, slice...) ends with the
+// specified substring or sequence of elements.
+//
+//    a.HasSuffixf("Hello World", "World", "error message %s", "formatted")
+//    a.HasSuffixf(["Hello", "there", "World"], ["there", "World"], "error message %s", "formatted")
+func (a *Assertions) HasSuffixf(s interface{}, suffix interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HasSuffixf(a.t, s, suffix, msg, args...)
+}
+
 // Implements asserts that an object is implemented by the specified interface.
 //
 //    a.Implements((*MyInterface)(nil), new(MyObject))
@@ -812,6 +860,38 @@ func (a *Assertions) NotEqualf(expected interface{}, actual interface{}, msg str
 		h.Helper()
 	}
 	NotEqualf(a.t, expected, actual, msg, args...)
+}
+
+// NotHasPrefix asserts the negation of HasPrefix.
+func (a *Assertions) NotHasPrefix(s interface{}, prefix interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotHasPrefix(a.t, s, prefix, msgAndArgs...)
+}
+
+// NotHasPrefixf asserts the negation of HasPrefix.
+func (a *Assertions) NotHasPrefixf(s interface{}, prefix interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotHasPrefixf(a.t, s, prefix, msg, args...)
+}
+
+// NotHasSuffix asserts the negation of HasSuffix.
+func (a *Assertions) NotHasSuffix(s interface{}, suffix interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotHasSuffix(a.t, s, suffix, msgAndArgs...)
+}
+
+// NotHasSuffixf asserts the negation of HasSuffix.
+func (a *Assertions) NotHasSuffixf(s interface{}, suffix interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotHasSuffixf(a.t, s, suffix, msg, args...)
 }
 
 // NotNil asserts that the specified object is not nil.

--- a/require/requirements.go
+++ b/require/requirements.go
@@ -26,4 +26,4 @@ type BoolAssertionFunc func(TestingT, bool, ...interface{})
 // for table driven tests.
 type ErrorAssertionFunc func(TestingT, error, ...interface{})
 
-//go:generate go run ../_codegen/main.go -output-package=require -template=require.go.tmpl -include-format-funcs
+//go:generate ../codegen -output-package=require -template=require.go.tmpl -include-format-funcs

--- a/suite/suite.go
+++ b/suite/suite.go
@@ -84,7 +84,7 @@ func Run(t *testing.T, suite TestingSuite) {
 	defer failOnPanic(t)
 
 	suiteSetupDone := false
-	
+
 	methodFinder := reflect.TypeOf(suite)
 	tests := []testing.InternalTest{}
 	for index := 0; index < methodFinder.NumMethod(); index++ {

--- a/suite/suite_test.go
+++ b/suite/suite_test.go
@@ -350,7 +350,7 @@ func TestRunSuite(t *testing.T) {
 type SuiteSetupSkipTester struct {
 	Suite
 
-	setUp bool
+	setUp    bool
 	toreDown bool
 }
 


### PR DESCRIPTION
I found myself wanting to make assertions about string and slice prefixes and suffixes so I thought these might make sense for others as well.

I modeled the new assertions off of the existing `Contains` assertion, but I am open to changing it if the maintainers have other preferences.

I also changed the code generation script a bit to try to make it pass reliably across all relevant Go versions. If these issues can be resolved some better way I'd be happy to revert my changes.