### PR TITLE
Add go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module github.com/stretchr/testify
+
+require (
+	github.com/davecgh/go-spew v1.1.0
+	github.com/pmezard/go-difflib v1.0.0
+	github.com/stretchr/objx v0.1.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
Now that modules are (mostly) working on tip, it's probably worth adding
a `go.mod` file to this project. The contents of the file were generated
automatically:

```bash
$ go version
go version devel +8a330454dc Fri Jul 13 03:53:00 2018 +0000 linux/amd64

$ go mod -init -module "github.com/stretchr/testify"
go: creating new go.mod: module github.com/stretchr/testify
go: copying requirements from Gopkg.lock

$ go test ./...
ok  	github.com/stretchr/testify	(cached)
mock/mock.go:498: missing ... in args forwarded to printf-like function
mock/mock.go:516: missing ... in args forwarded to printf-like function
ok  	github.com/stretchr/testify/assert	(cached)
?   	github.com/stretchr/testify/http	[no test files]
FAIL	github.com/stretchr/testify/mock [build failed]
ok  	github.com/stretchr/testify/require	(cached)
ok  	github.com/stretchr/testify/suite	(cached)
```

/cc @DAddYE - I'm not sure how you'd like me to proceed with the test failure on tip.