### PR TITLE
Race-free read of Calls list

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -543,6 +543,13 @@ func (m *Mock) calls() []Call {
 	return append([]Call{}, m.Calls...)
 }
 
+// Concurrency-safe way to get a copy of the list of calls made to this mock
+func (m *Mock) GetCalls() []Call {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	return m.calls()
+}
+
 /*
 	Arguments
 */


### PR DESCRIPTION
It does not currently appear possible to read `mock.Calls` under the mutex, meaning you can't do things with the list of calls in a concurrent test - this will fail `go test -race`.

This introduces a tiny proposal for a simple way to just read the list of calls under the mutex, making the go race tester happy. I'm writing this up quickly just in the github editor as a means to make this proposal; please let me know if something like this seems sensible and, if so, what good naming and appropriate tests would be.