### PR TITLE
assert: s/rune/r/ to avoid "rune" predeclared ident shadowing

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -170,8 +170,8 @@ func isTest(name, prefix string) bool {
 	if len(name) == len(prefix) { // "Test" is ok
 		return true
 	}
-	rune, _ := utf8.DecodeRuneInString(name[len(prefix):])
-	return !unicode.IsLower(rune)
+	r, _ := utf8.DecodeRuneInString(name[len(prefix):])
+	return !unicode.IsLower(r)
 }
 
 func messageFromMsgAndArgs(msgAndArgs ...interface{}) string {


### PR DESCRIPTION
Found using https://go-critic.github.io/overview#builtinShadow-ref