### PR TITLE
Helper is called before assert function in require.* functions

### DIFF
--- a/require/require.go
+++ b/require/require.go
@@ -14,22 +14,22 @@ import (
 
 // Condition uses a Comparison to assert a complex condition.
 func Condition(t TestingT, comp assert.Comparison, msgAndArgs ...interface{}) {
-	if assert.Condition(t, comp, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.Condition(t, comp, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
 
 // Conditionf uses a Comparison to assert a complex condition.
 func Conditionf(t TestingT, comp assert.Comparison, msg string, args ...interface{}) {
-	if assert.Conditionf(t, comp, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.Conditionf(t, comp, msg, args...) {
+		return
 	}
 	t.FailNow()
 }
@@ -41,11 +41,11 @@ func Conditionf(t TestingT, comp assert.Comparison, msg string, args ...interfac
 //    assert.Contains(t, ["Hello", "World"], "World")
 //    assert.Contains(t, {"Hello": "World"}, "Hello")
 func Contains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
-	if assert.Contains(t, s, contains, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.Contains(t, s, contains, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
@@ -57,33 +57,33 @@ func Contains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...int
 //    assert.Containsf(t, ["Hello", "World"], "World", "error message %s", "formatted")
 //    assert.Containsf(t, {"Hello": "World"}, "Hello", "error message %s", "formatted")
 func Containsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) {
-	if assert.Containsf(t, s, contains, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.Containsf(t, s, contains, msg, args...) {
+		return
 	}
 	t.FailNow()
 }
 
 // DirExists checks whether a directory exists in the given path. It also fails if the path is a file rather a directory or there is an error checking whether it exists.
 func DirExists(t TestingT, path string, msgAndArgs ...interface{}) {
-	if assert.DirExists(t, path, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.DirExists(t, path, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
 
 // DirExistsf checks whether a directory exists in the given path. It also fails if the path is a file rather a directory or there is an error checking whether it exists.
 func DirExistsf(t TestingT, path string, msg string, args ...interface{}) {
-	if assert.DirExistsf(t, path, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.DirExistsf(t, path, msg, args...) {
+		return
 	}
 	t.FailNow()
 }
@@ -94,11 +94,11 @@ func DirExistsf(t TestingT, path string, msg string, args ...interface{}) {
 //
 // assert.ElementsMatch(t, [1, 3, 2, 3], [1, 3, 3, 2])
 func ElementsMatch(t TestingT, listA interface{}, listB interface{}, msgAndArgs ...interface{}) {
-	if assert.ElementsMatch(t, listA, listB, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.ElementsMatch(t, listA, listB, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
@@ -109,11 +109,11 @@ func ElementsMatch(t TestingT, listA interface{}, listB interface{}, msgAndArgs 
 //
 // assert.ElementsMatchf(t, [1, 3, 2, 3], [1, 3, 3, 2], "error message %s", "formatted")
 func ElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string, args ...interface{}) {
-	if assert.ElementsMatchf(t, listA, listB, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.ElementsMatchf(t, listA, listB, msg, args...) {
+		return
 	}
 	t.FailNow()
 }
@@ -123,11 +123,11 @@ func ElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string
 //
 //  assert.Empty(t, obj)
 func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
-	if assert.Empty(t, object, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.Empty(t, object, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
@@ -137,11 +137,11 @@ func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 //
 //  assert.Emptyf(t, obj, "error message %s", "formatted")
 func Emptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
-	if assert.Emptyf(t, object, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.Emptyf(t, object, msg, args...) {
+		return
 	}
 	t.FailNow()
 }
@@ -154,11 +154,11 @@ func Emptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
 // referenced values (as opposed to the memory addresses). Function equality
 // cannot be determined and will always fail.
 func Equal(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
-	if assert.Equal(t, expected, actual, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.Equal(t, expected, actual, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
@@ -169,11 +169,11 @@ func Equal(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...i
 //   actualObj, err := SomeFunction()
 //   assert.EqualError(t, err,  expectedErrorString)
 func EqualError(t TestingT, theError error, errString string, msgAndArgs ...interface{}) {
-	if assert.EqualError(t, theError, errString, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.EqualError(t, theError, errString, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
@@ -184,11 +184,11 @@ func EqualError(t TestingT, theError error, errString string, msgAndArgs ...inte
 //   actualObj, err := SomeFunction()
 //   assert.EqualErrorf(t, err,  expectedErrorString, "error message %s", "formatted")
 func EqualErrorf(t TestingT, theError error, errString string, msg string, args ...interface{}) {
-	if assert.EqualErrorf(t, theError, errString, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.EqualErrorf(t, theError, errString, msg, args...) {
+		return
 	}
 	t.FailNow()
 }
@@ -198,11 +198,11 @@ func EqualErrorf(t TestingT, theError error, errString string, msg string, args 
 //
 //    assert.EqualValues(t, uint32(123), int32(123))
 func EqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
-	if assert.EqualValues(t, expected, actual, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.EqualValues(t, expected, actual, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
@@ -212,11 +212,11 @@ func EqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArg
 //
 //    assert.EqualValuesf(t, uint32(123, "error message %s", "formatted"), int32(123))
 func EqualValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
-	if assert.EqualValuesf(t, expected, actual, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.EqualValuesf(t, expected, actual, msg, args...) {
+		return
 	}
 	t.FailNow()
 }
@@ -229,11 +229,11 @@ func EqualValuesf(t TestingT, expected interface{}, actual interface{}, msg stri
 // referenced values (as opposed to the memory addresses). Function equality
 // cannot be determined and will always fail.
 func Equalf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
-	if assert.Equalf(t, expected, actual, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.Equalf(t, expected, actual, msg, args...) {
+		return
 	}
 	t.FailNow()
 }
@@ -245,11 +245,11 @@ func Equalf(t TestingT, expected interface{}, actual interface{}, msg string, ar
 // 	   assert.Equal(t, expectedError, err)
 //   }
 func Error(t TestingT, err error, msgAndArgs ...interface{}) {
-	if assert.Error(t, err, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.Error(t, err, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
@@ -261,11 +261,11 @@ func Error(t TestingT, err error, msgAndArgs ...interface{}) {
 // 	   assert.Equal(t, expectedErrorf, err)
 //   }
 func Errorf(t TestingT, err error, msg string, args ...interface{}) {
-	if assert.Errorf(t, err, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.Errorf(t, err, msg, args...) {
+		return
 	}
 	t.FailNow()
 }
@@ -274,11 +274,11 @@ func Errorf(t TestingT, err error, msg string, args ...interface{}) {
 //
 //    assert.Exactly(t, int32(123), int64(123))
 func Exactly(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
-	if assert.Exactly(t, expected, actual, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.Exactly(t, expected, actual, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
@@ -287,55 +287,55 @@ func Exactly(t TestingT, expected interface{}, actual interface{}, msgAndArgs ..
 //
 //    assert.Exactlyf(t, int32(123, "error message %s", "formatted"), int64(123))
 func Exactlyf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
-	if assert.Exactlyf(t, expected, actual, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.Exactlyf(t, expected, actual, msg, args...) {
+		return
 	}
 	t.FailNow()
 }
 
 // Fail reports a failure through
 func Fail(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
-	if assert.Fail(t, failureMessage, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.Fail(t, failureMessage, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
 
 // FailNow fails test
 func FailNow(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
-	if assert.FailNow(t, failureMessage, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.FailNow(t, failureMessage, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
 
 // FailNowf fails test
 func FailNowf(t TestingT, failureMessage string, msg string, args ...interface{}) {
-	if assert.FailNowf(t, failureMessage, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.FailNowf(t, failureMessage, msg, args...) {
+		return
 	}
 	t.FailNow()
 }
 
 // Failf reports a failure through
 func Failf(t TestingT, failureMessage string, msg string, args ...interface{}) {
-	if assert.Failf(t, failureMessage, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.Failf(t, failureMessage, msg, args...) {
+		return
 	}
 	t.FailNow()
 }
@@ -344,11 +344,11 @@ func Failf(t TestingT, failureMessage string, msg string, args ...interface{}) {
 //
 //    assert.False(t, myBool)
 func False(t TestingT, value bool, msgAndArgs ...interface{}) {
-	if assert.False(t, value, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.False(t, value, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
@@ -357,33 +357,33 @@ func False(t TestingT, value bool, msgAndArgs ...interface{}) {
 //
 //    assert.Falsef(t, myBool, "error message %s", "formatted")
 func Falsef(t TestingT, value bool, msg string, args ...interface{}) {
-	if assert.Falsef(t, value, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.Falsef(t, value, msg, args...) {
+		return
 	}
 	t.FailNow()
 }
 
 // FileExists checks whether a file exists in the given path. It also fails if the path points to a directory or there is an error when trying to check the file.
 func FileExists(t TestingT, path string, msgAndArgs ...interface{}) {
-	if assert.FileExists(t, path, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.FileExists(t, path, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
 
 // FileExistsf checks whether a file exists in the given path. It also fails if the path points to a directory or there is an error when trying to check the file.
 func FileExistsf(t TestingT, path string, msg string, args ...interface{}) {
-	if assert.FileExistsf(t, path, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.FileExistsf(t, path, msg, args...) {
+		return
 	}
 	t.FailNow()
 }
@@ -395,11 +395,11 @@ func FileExistsf(t TestingT, path string, msg string, args ...interface{}) {
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPBodyContains(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
-	if assert.HTTPBodyContains(t, handler, method, url, values, str, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.HTTPBodyContains(t, handler, method, url, values, str, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
@@ -411,11 +411,11 @@ func HTTPBodyContains(t TestingT, handler http.HandlerFunc, method string, url s
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPBodyContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
-	if assert.HTTPBodyContainsf(t, handler, method, url, values, str, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.HTTPBodyContainsf(t, handler, method, url, values, str, msg, args...) {
+		return
 	}
 	t.FailNow()
 }
@@ -427,11 +427,11 @@ func HTTPBodyContainsf(t TestingT, handler http.HandlerFunc, method string, url 
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPBodyNotContains(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
-	if assert.HTTPBodyNotContains(t, handler, method, url, values, str, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.HTTPBodyNotContains(t, handler, method, url, values, str, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
@@ -443,11 +443,11 @@ func HTTPBodyNotContains(t TestingT, handler http.HandlerFunc, method string, ur
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPBodyNotContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
-	if assert.HTTPBodyNotContainsf(t, handler, method, url, values, str, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.HTTPBodyNotContainsf(t, handler, method, url, values, str, msg, args...) {
+		return
 	}
 	t.FailNow()
 }
@@ -458,11 +458,11 @@ func HTTPBodyNotContainsf(t TestingT, handler http.HandlerFunc, method string, u
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPError(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
-	if assert.HTTPError(t, handler, method, url, values, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.HTTPError(t, handler, method, url, values, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
@@ -473,11 +473,11 @@ func HTTPError(t TestingT, handler http.HandlerFunc, method string, url string, 
 //
 // Returns whether the assertion was successful (true, "error message %s", "formatted") or not (false).
 func HTTPErrorf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
-	if assert.HTTPErrorf(t, handler, method, url, values, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.HTTPErrorf(t, handler, method, url, values, msg, args...) {
+		return
 	}
 	t.FailNow()
 }
@@ -488,11 +488,11 @@ func HTTPErrorf(t TestingT, handler http.HandlerFunc, method string, url string,
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPRedirect(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
-	if assert.HTTPRedirect(t, handler, method, url, values, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.HTTPRedirect(t, handler, method, url, values, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
@@ -503,11 +503,11 @@ func HTTPRedirect(t TestingT, handler http.HandlerFunc, method string, url strin
 //
 // Returns whether the assertion was successful (true, "error message %s", "formatted") or not (false).
 func HTTPRedirectf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
-	if assert.HTTPRedirectf(t, handler, method, url, values, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.HTTPRedirectf(t, handler, method, url, values, msg, args...) {
+		return
 	}
 	t.FailNow()
 }
@@ -518,11 +518,11 @@ func HTTPRedirectf(t TestingT, handler http.HandlerFunc, method string, url stri
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPSuccess(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
-	if assert.HTTPSuccess(t, handler, method, url, values, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.HTTPSuccess(t, handler, method, url, values, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
@@ -533,11 +533,11 @@ func HTTPSuccess(t TestingT, handler http.HandlerFunc, method string, url string
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPSuccessf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
-	if assert.HTTPSuccessf(t, handler, method, url, values, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.HTTPSuccessf(t, handler, method, url, values, msg, args...) {
+		return
 	}
 	t.FailNow()
 }
@@ -546,11 +546,11 @@ func HTTPSuccessf(t TestingT, handler http.HandlerFunc, method string, url strin
 //
 //    assert.Implements(t, (*MyInterface)(nil), new(MyObject))
 func Implements(t TestingT, interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
-	if assert.Implements(t, interfaceObject, object, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.Implements(t, interfaceObject, object, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
@@ -559,11 +559,11 @@ func Implements(t TestingT, interfaceObject interface{}, object interface{}, msg
 //
 //    assert.Implementsf(t, (*MyInterface, "error message %s", "formatted")(nil), new(MyObject))
 func Implementsf(t TestingT, interfaceObject interface{}, object interface{}, msg string, args ...interface{}) {
-	if assert.Implementsf(t, interfaceObject, object, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.Implementsf(t, interfaceObject, object, msg, args...) {
+		return
 	}
 	t.FailNow()
 }
@@ -572,55 +572,55 @@ func Implementsf(t TestingT, interfaceObject interface{}, object interface{}, ms
 //
 // 	 assert.InDelta(t, math.Pi, (22 / 7.0), 0.01)
 func InDelta(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
-	if assert.InDelta(t, expected, actual, delta, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.InDelta(t, expected, actual, delta, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
 
 // InDeltaMapValues is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
 func InDeltaMapValues(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
-	if assert.InDeltaMapValues(t, expected, actual, delta, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.InDeltaMapValues(t, expected, actual, delta, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
 
 // InDeltaMapValuesf is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
 func InDeltaMapValuesf(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
-	if assert.InDeltaMapValuesf(t, expected, actual, delta, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.InDeltaMapValuesf(t, expected, actual, delta, msg, args...) {
+		return
 	}
 	t.FailNow()
 }
 
 // InDeltaSlice is the same as InDelta, except it compares two slices.
 func InDeltaSlice(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
-	if assert.InDeltaSlice(t, expected, actual, delta, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.InDeltaSlice(t, expected, actual, delta, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
 
 // InDeltaSlicef is the same as InDelta, except it compares two slices.
 func InDeltaSlicef(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
-	if assert.InDeltaSlicef(t, expected, actual, delta, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.InDeltaSlicef(t, expected, actual, delta, msg, args...) {
+		return
 	}
 	t.FailNow()
 }
@@ -629,77 +629,77 @@ func InDeltaSlicef(t TestingT, expected interface{}, actual interface{}, delta f
 //
 // 	 assert.InDeltaf(t, math.Pi, (22 / 7.0, "error message %s", "formatted"), 0.01)
 func InDeltaf(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
-	if assert.InDeltaf(t, expected, actual, delta, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.InDeltaf(t, expected, actual, delta, msg, args...) {
+		return
 	}
 	t.FailNow()
 }
 
 // InEpsilon asserts that expected and actual have a relative error less than epsilon
 func InEpsilon(t TestingT, expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
-	if assert.InEpsilon(t, expected, actual, epsilon, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.InEpsilon(t, expected, actual, epsilon, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
 
 // InEpsilonSlice is the same as InEpsilon, except it compares each value from two slices.
 func InEpsilonSlice(t TestingT, expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
-	if assert.InEpsilonSlice(t, expected, actual, epsilon, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.InEpsilonSlice(t, expected, actual, epsilon, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
 
 // InEpsilonSlicef is the same as InEpsilon, except it compares each value from two slices.
 func InEpsilonSlicef(t TestingT, expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
-	if assert.InEpsilonSlicef(t, expected, actual, epsilon, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.InEpsilonSlicef(t, expected, actual, epsilon, msg, args...) {
+		return
 	}
 	t.FailNow()
 }
 
 // InEpsilonf asserts that expected and actual have a relative error less than epsilon
 func InEpsilonf(t TestingT, expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
-	if assert.InEpsilonf(t, expected, actual, epsilon, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.InEpsilonf(t, expected, actual, epsilon, msg, args...) {
+		return
 	}
 	t.FailNow()
 }
 
 // IsType asserts that the specified objects are of the same type.
 func IsType(t TestingT, expectedType interface{}, object interface{}, msgAndArgs ...interface{}) {
-	if assert.IsType(t, expectedType, object, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.IsType(t, expectedType, object, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
 
 // IsTypef asserts that the specified objects are of the same type.
 func IsTypef(t TestingT, expectedType interface{}, object interface{}, msg string, args ...interface{}) {
-	if assert.IsTypef(t, expectedType, object, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.IsTypef(t, expectedType, object, msg, args...) {
+		return
 	}
 	t.FailNow()
 }
@@ -708,11 +708,11 @@ func IsTypef(t TestingT, expectedType interface{}, object interface{}, msg strin
 //
 //  assert.JSONEq(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
 func JSONEq(t TestingT, expected string, actual string, msgAndArgs ...interface{}) {
-	if assert.JSONEq(t, expected, actual, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.JSONEq(t, expected, actual, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
@@ -721,11 +721,11 @@ func JSONEq(t TestingT, expected string, actual string, msgAndArgs ...interface{
 //
 //  assert.JSONEqf(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
 func JSONEqf(t TestingT, expected string, actual string, msg string, args ...interface{}) {
-	if assert.JSONEqf(t, expected, actual, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.JSONEqf(t, expected, actual, msg, args...) {
+		return
 	}
 	t.FailNow()
 }
@@ -735,11 +735,11 @@ func JSONEqf(t TestingT, expected string, actual string, msg string, args ...int
 //
 //    assert.Len(t, mySlice, 3)
 func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) {
-	if assert.Len(t, object, length, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.Len(t, object, length, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
@@ -749,11 +749,11 @@ func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) 
 //
 //    assert.Lenf(t, mySlice, 3, "error message %s", "formatted")
 func Lenf(t TestingT, object interface{}, length int, msg string, args ...interface{}) {
-	if assert.Lenf(t, object, length, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.Lenf(t, object, length, msg, args...) {
+		return
 	}
 	t.FailNow()
 }
@@ -762,11 +762,11 @@ func Lenf(t TestingT, object interface{}, length int, msg string, args ...interf
 //
 //    assert.Nil(t, err)
 func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
-	if assert.Nil(t, object, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.Nil(t, object, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
@@ -775,11 +775,11 @@ func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 //
 //    assert.Nilf(t, err, "error message %s", "formatted")
 func Nilf(t TestingT, object interface{}, msg string, args ...interface{}) {
-	if assert.Nilf(t, object, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.Nilf(t, object, msg, args...) {
+		return
 	}
 	t.FailNow()
 }
@@ -791,11 +791,11 @@ func Nilf(t TestingT, object interface{}, msg string, args ...interface{}) {
 // 	   assert.Equal(t, expectedObj, actualObj)
 //   }
 func NoError(t TestingT, err error, msgAndArgs ...interface{}) {
-	if assert.NoError(t, err, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.NoError(t, err, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
@@ -807,11 +807,11 @@ func NoError(t TestingT, err error, msgAndArgs ...interface{}) {
 // 	   assert.Equal(t, expectedObj, actualObj)
 //   }
 func NoErrorf(t TestingT, err error, msg string, args ...interface{}) {
-	if assert.NoErrorf(t, err, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.NoErrorf(t, err, msg, args...) {
+		return
 	}
 	t.FailNow()
 }
@@ -823,11 +823,11 @@ func NoErrorf(t TestingT, err error, msg string, args ...interface{}) {
 //    assert.NotContains(t, ["Hello", "World"], "Earth")
 //    assert.NotContains(t, {"Hello": "World"}, "Earth")
 func NotContains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
-	if assert.NotContains(t, s, contains, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.NotContains(t, s, contains, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
@@ -839,11 +839,11 @@ func NotContains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...
 //    assert.NotContainsf(t, ["Hello", "World"], "Earth", "error message %s", "formatted")
 //    assert.NotContainsf(t, {"Hello": "World"}, "Earth", "error message %s", "formatted")
 func NotContainsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) {
-	if assert.NotContainsf(t, s, contains, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.NotContainsf(t, s, contains, msg, args...) {
+		return
 	}
 	t.FailNow()
 }
@@ -855,11 +855,11 @@ func NotContainsf(t TestingT, s interface{}, contains interface{}, msg string, a
 //    assert.Equal(t, "two", obj[1])
 //  }
 func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
-	if assert.NotEmpty(t, object, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.NotEmpty(t, object, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
@@ -871,11 +871,11 @@ func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 //    assert.Equal(t, "two", obj[1])
 //  }
 func NotEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
-	if assert.NotEmptyf(t, object, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.NotEmptyf(t, object, msg, args...) {
+		return
 	}
 	t.FailNow()
 }
@@ -887,11 +887,11 @@ func NotEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) 
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
 func NotEqual(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
-	if assert.NotEqual(t, expected, actual, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.NotEqual(t, expected, actual, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
@@ -903,11 +903,11 @@ func NotEqual(t TestingT, expected interface{}, actual interface{}, msgAndArgs .
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
 func NotEqualf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
-	if assert.NotEqualf(t, expected, actual, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.NotEqualf(t, expected, actual, msg, args...) {
+		return
 	}
 	t.FailNow()
 }
@@ -916,11 +916,11 @@ func NotEqualf(t TestingT, expected interface{}, actual interface{}, msg string,
 //
 //    assert.NotNil(t, err)
 func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
-	if assert.NotNil(t, object, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.NotNil(t, object, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
@@ -929,11 +929,11 @@ func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 //
 //    assert.NotNilf(t, err, "error message %s", "formatted")
 func NotNilf(t TestingT, object interface{}, msg string, args ...interface{}) {
-	if assert.NotNilf(t, object, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.NotNilf(t, object, msg, args...) {
+		return
 	}
 	t.FailNow()
 }
@@ -942,11 +942,11 @@ func NotNilf(t TestingT, object interface{}, msg string, args ...interface{}) {
 //
 //   assert.NotPanics(t, func(){ RemainCalm() })
 func NotPanics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
-	if assert.NotPanics(t, f, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.NotPanics(t, f, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
@@ -955,11 +955,11 @@ func NotPanics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 //
 //   assert.NotPanicsf(t, func(){ RemainCalm() }, "error message %s", "formatted")
 func NotPanicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}) {
-	if assert.NotPanicsf(t, f, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.NotPanicsf(t, f, msg, args...) {
+		return
 	}
 	t.FailNow()
 }
@@ -969,11 +969,11 @@ func NotPanicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interfac
 //  assert.NotRegexp(t, regexp.MustCompile("starts"), "it's starting")
 //  assert.NotRegexp(t, "^start", "it's not starting")
 func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
-	if assert.NotRegexp(t, rx, str, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.NotRegexp(t, rx, str, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
@@ -983,11 +983,11 @@ func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interf
 //  assert.NotRegexpf(t, regexp.MustCompile("starts", "error message %s", "formatted"), "it's starting")
 //  assert.NotRegexpf(t, "^start", "it's not starting", "error message %s", "formatted")
 func NotRegexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) {
-	if assert.NotRegexpf(t, rx, str, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.NotRegexpf(t, rx, str, msg, args...) {
+		return
 	}
 	t.FailNow()
 }
@@ -997,11 +997,11 @@ func NotRegexpf(t TestingT, rx interface{}, str interface{}, msg string, args ..
 //
 //    assert.NotSubset(t, [1, 3, 4], [1, 2], "But [1, 3, 4] does not contain [1, 2]")
 func NotSubset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...interface{}) {
-	if assert.NotSubset(t, list, subset, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.NotSubset(t, list, subset, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
@@ -1011,33 +1011,33 @@ func NotSubset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...i
 //
 //    assert.NotSubsetf(t, [1, 3, 4], [1, 2], "But [1, 3, 4] does not contain [1, 2]", "error message %s", "formatted")
 func NotSubsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) {
-	if assert.NotSubsetf(t, list, subset, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.NotSubsetf(t, list, subset, msg, args...) {
+		return
 	}
 	t.FailNow()
 }
 
 // NotZero asserts that i is not the zero value for its type.
 func NotZero(t TestingT, i interface{}, msgAndArgs ...interface{}) {
-	if assert.NotZero(t, i, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.NotZero(t, i, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
 
 // NotZerof asserts that i is not the zero value for its type.
 func NotZerof(t TestingT, i interface{}, msg string, args ...interface{}) {
-	if assert.NotZerof(t, i, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.NotZerof(t, i, msg, args...) {
+		return
 	}
 	t.FailNow()
 }
@@ -1046,11 +1046,11 @@ func NotZerof(t TestingT, i interface{}, msg string, args ...interface{}) {
 //
 //   assert.Panics(t, func(){ GoCrazy() })
 func Panics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
-	if assert.Panics(t, f, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.Panics(t, f, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
@@ -1060,11 +1060,11 @@ func Panics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 //
 //   assert.PanicsWithValue(t, "crazy error", func(){ GoCrazy() })
 func PanicsWithValue(t TestingT, expected interface{}, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
-	if assert.PanicsWithValue(t, expected, f, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.PanicsWithValue(t, expected, f, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
@@ -1074,11 +1074,11 @@ func PanicsWithValue(t TestingT, expected interface{}, f assert.PanicTestFunc, m
 //
 //   assert.PanicsWithValuef(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
 func PanicsWithValuef(t TestingT, expected interface{}, f assert.PanicTestFunc, msg string, args ...interface{}) {
-	if assert.PanicsWithValuef(t, expected, f, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.PanicsWithValuef(t, expected, f, msg, args...) {
+		return
 	}
 	t.FailNow()
 }
@@ -1087,11 +1087,11 @@ func PanicsWithValuef(t TestingT, expected interface{}, f assert.PanicTestFunc, 
 //
 //   assert.Panicsf(t, func(){ GoCrazy() }, "error message %s", "formatted")
 func Panicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}) {
-	if assert.Panicsf(t, f, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.Panicsf(t, f, msg, args...) {
+		return
 	}
 	t.FailNow()
 }
@@ -1101,11 +1101,11 @@ func Panicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}
 //  assert.Regexp(t, regexp.MustCompile("start"), "it's starting")
 //  assert.Regexp(t, "start...$", "it's not starting")
 func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
-	if assert.Regexp(t, rx, str, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.Regexp(t, rx, str, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
@@ -1115,11 +1115,11 @@ func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface
 //  assert.Regexpf(t, regexp.MustCompile("start", "error message %s", "formatted"), "it's starting")
 //  assert.Regexpf(t, "start...$", "it's not starting", "error message %s", "formatted")
 func Regexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) {
-	if assert.Regexpf(t, rx, str, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.Regexpf(t, rx, str, msg, args...) {
+		return
 	}
 	t.FailNow()
 }
@@ -1129,11 +1129,11 @@ func Regexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...in
 //
 //    assert.Subset(t, [1, 2, 3], [1, 2], "But [1, 2, 3] does contain [1, 2]")
 func Subset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...interface{}) {
-	if assert.Subset(t, list, subset, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.Subset(t, list, subset, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
@@ -1143,11 +1143,11 @@ func Subset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...inte
 //
 //    assert.Subsetf(t, [1, 2, 3], [1, 2], "But [1, 2, 3] does contain [1, 2]", "error message %s", "formatted")
 func Subsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) {
-	if assert.Subsetf(t, list, subset, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.Subsetf(t, list, subset, msg, args...) {
+		return
 	}
 	t.FailNow()
 }
@@ -1156,11 +1156,11 @@ func Subsetf(t TestingT, list interface{}, subset interface{}, msg string, args 
 //
 //    assert.True(t, myBool)
 func True(t TestingT, value bool, msgAndArgs ...interface{}) {
-	if assert.True(t, value, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.True(t, value, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
@@ -1169,11 +1169,11 @@ func True(t TestingT, value bool, msgAndArgs ...interface{}) {
 //
 //    assert.Truef(t, myBool, "error message %s", "formatted")
 func Truef(t TestingT, value bool, msg string, args ...interface{}) {
-	if assert.Truef(t, value, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.Truef(t, value, msg, args...) {
+		return
 	}
 	t.FailNow()
 }
@@ -1182,11 +1182,11 @@ func Truef(t TestingT, value bool, msg string, args ...interface{}) {
 //
 //   assert.WithinDuration(t, time.Now(), time.Now(), 10*time.Second)
 func WithinDuration(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) {
-	if assert.WithinDuration(t, expected, actual, delta, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.WithinDuration(t, expected, actual, delta, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
@@ -1195,33 +1195,33 @@ func WithinDuration(t TestingT, expected time.Time, actual time.Time, delta time
 //
 //   assert.WithinDurationf(t, time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
 func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msg string, args ...interface{}) {
-	if assert.WithinDurationf(t, expected, actual, delta, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.WithinDurationf(t, expected, actual, delta, msg, args...) {
+		return
 	}
 	t.FailNow()
 }
 
 // Zero asserts that i is the zero value for its type.
 func Zero(t TestingT, i interface{}, msgAndArgs ...interface{}) {
-	if assert.Zero(t, i, msgAndArgs...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.Zero(t, i, msgAndArgs...) {
+		return
 	}
 	t.FailNow()
 }
 
 // Zerof asserts that i is the zero value for its type.
 func Zerof(t TestingT, i interface{}, msg string, args ...interface{}) {
-	if assert.Zerof(t, i, msg, args...) {
-		return
-	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
+	}
+	if assert.Zerof(t, i, msg, args...) {
+		return
 	}
 	t.FailNow()
 }

--- a/require/require.go.tmpl
+++ b/require/require.go.tmpl
@@ -1,6 +1,6 @@
 {{.Comment}}
 func {{.DocInfo.Name}}(t TestingT, {{.Params}}) {
-	if assert.{{.DocInfo.Name}}(t, {{.ForwardedParams}}) { return }
 	if h, ok := t.(tHelper); ok { h.Helper() }
+	if assert.{{.DocInfo.Name}}(t, {{.ForwardedParams}}) { return }
 	t.FailNow()
 }


### PR DESCRIPTION
In order for line numbers to be displayed correctly when printing errors from a require.* function, h.Helper() needs to be called before the assert.* test. Otherwise all line numbers will point to require.go