### PR TITLE
Allow assert.Equal on string type alias without panicking on failure

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1345,7 +1345,7 @@ func diff(expected interface{}, actual interface{}) string {
 	}
 
 	var e, a string
-	if ek != reflect.String {
+	if et != reflect.TypeOf("") {
 		e = spewConfig.Sdump(expected)
 		a = spewConfig.Sdump(actual)
 	} else {

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -175,6 +175,8 @@ func TestIsType(t *testing.T) {
 
 }
 
+type myType string
+
 func TestEqual(t *testing.T) {
 
 	mockT := new(testing.T)
@@ -200,11 +202,17 @@ func TestEqual(t *testing.T) {
 	if !Equal(mockT, uint64(123), uint64(123)) {
 		t.Error("Equal should return true")
 	}
+	if !Equal(mockT, myType("1"), myType("1")) {
+		t.Error("Equal should return true")
+	}
 	if !Equal(mockT, &struct{}{}, &struct{}{}) {
 		t.Error("Equal should return true (pointer equality is based on equality of underlying value)")
 	}
 	var m map[string]interface{}
 	if Equal(mockT, m["bar"], "something") {
+		t.Error("Equal should return false")
+	}
+	if Equal(mockT, myType("1"), myType("2")) {
 		t.Error("Equal should return false")
 	}
 }


### PR DESCRIPTION
@ernesto-jimenez The old comparison against `reflect.String` is true for type aliases of string, but the type coercion panics. So let's compare the type instead of the kind, to avoid the panics.

Fixes https://github.com/stretchr/testify/issues/644
Fixes https://github.com/stretchr/testify/issues/646