### PR TITLE
suite: call a suite method before panic

### DIFF
--- a/suite/interfaces.go
+++ b/suite/interfaces.go
@@ -44,3 +44,8 @@ type BeforeTest interface {
 type AfterTest interface {
 	AfterTest(suiteName, testName string)
 }
+
+// BeforePanic has a function to be executed if a test panics
+type BeforePanic interface {
+	BeforePanic(suiteName, testName string)
+}

--- a/suite/suite.go
+++ b/suite/suite.go
@@ -91,6 +91,13 @@ func Run(t *testing.T, suite TestingSuite) {
 						beforeTestSuite.BeforeTest(methodFinder.Elem().Name(), method.Name)
 					}
 					defer func() {
+						err := recover()
+						if err != nil {
+							if beforePanicSuite, ok := suite.(BeforePanic); ok {
+								beforePanicSuite.BeforePanic(methodFinder.Elem().Name(), method.Name)
+							}
+							panic(err)
+						}
 						if afterTestSuite, ok := suite.(AfterTest); ok {
 							afterTestSuite.AfterTest(methodFinder.Elem().Name(), method.Name)
 						}


### PR DESCRIPTION
I'm curious if there would be support for adding a suite method that would be called in the case of a test panic.  I know it is dangerous to try to do anything after a panic, but it would be extremely helpful to try to clean up before exiting when a test panics.

In our case, we are using [dockertest](https://github.com/ory/dockertest) to start up Postgres before the tests run.  The suite's lifecycle methods make it convenient to start docker, add data, drop data, and stop docker.  During development, it is unfortunately common to have a test panic.  In these cases, we are left with "orphaned" docker containers running.  An alternative would be to have a separate process start/stop docker, but this is convenient to do all within a single `go test` process.

I'll be happy to rework this, add tests, etc. if there is interest in adding some sort of handling for panics.  The way I've implemented this is conservative: `AfterTest` is still not run in the case of a panic and the panic still causes the process to exit even if you implement `BeforePanic`.  So this doesn't add any panic recovery, just a chance to clean up before exit.