### PR TITLE
Fix equality assertion panic for values of aliased string type

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1349,8 +1349,8 @@ func diff(expected interface{}, actual interface{}) string {
 		e = spewConfig.Sdump(expected)
 		a = spewConfig.Sdump(actual)
 	} else {
-		e = expected.(string)
-		a = actual.(string)
+		e = reflect.ValueOf(expected).String()
+		a = reflect.ValueOf(actual).String()
 	}
 
 	diff, _ := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{


### PR DESCRIPTION
Please consider this small patch that fixes panic in this egde-case:

```go
type wrapper string

func TestWrappedString(t *testing.T) {
	x := wrapper("x")
	y := wrapper("y")
	assert.Equal(t, x, y)
}
```
results in:

```
=== RUN   TestWrappedString
--- FAIL: TestWrappedString (0.00s)
panic: interface conversion: interface {} is main.wrapper, not string [recovered]
	panic: interface conversion: interface {} is main.wrapper, not string

goroutine 5 [running]:
testing.tRunner.func1(0xc4201260f0)
	/usr/local/go/src/testing/testing.go:742 +0x29d
panic(0x685740, 0xc4200688c0)
	/usr/local/go/src/runtime/panic.go:502 +0x229
github.com/stretchr/testify/assert.diff(0x66b7e0, 0xc42004ec60, 0x66b7e0, 0xc42004ec70, 0x0, 0x0)
	/home/vitaly/go/src/github.com/stretchr/testify/assert/assertions.go:1352 +0x453
github.com/stretchr/testify/assert.Equal(0x709f40, 0xc4201260f0, 0x66b7e0, 0xc42004ec60, 0x66b7e0, 0xc42004ec70, 0x0, 0x0, 0x0, 0x3174eb3300793a18)
	/home/vitaly/go/src/github.com/stretchr/testify/assert/assertions.go:338 +0x26a
_/tmp/dada.TestWrappedString(0xc4201260f0)
	/tmp/check/wrapper_test.go:14 +0xf7
testing.tRunner(0xc4201260f0, 0x6e9370)
	/usr/local/go/src/testing/testing.go:777 +0xd0
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:824 +0x2e0
FAIL	_/tmp/dada	0.005s

```

The problem is that not only values of `string` type satisfy condition `if reflect.TypeOf(value).Kind() == reflect.String`: aliased string types fall under this condition too. 