### PR TITLE
update comment to match function name

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -39,7 +39,7 @@ type ValueAssertionFunc func(TestingT, interface{}, ...interface{}) bool
 // for table driven tests.
 type BoolAssertionFunc func(TestingT, bool, ...interface{}) bool
 
-// ValuesAssertionFunc is a common function prototype when validating an error value.  Can be useful
+// ErrorAssertionFunc is a common function prototype when validating an error value.  Can be useful
 // for table driven tests.
 type ErrorAssertionFunc func(TestingT, error, ...interface{}) bool
 

--- a/require/requirements.go
+++ b/require/requirements.go
@@ -22,7 +22,7 @@ type ValueAssertionFunc func(TestingT, interface{}, ...interface{})
 // for table driven tests.
 type BoolAssertionFunc func(TestingT, bool, ...interface{})
 
-// ValuesAssertionFunc is a common function prototype when validating an error value.  Can be useful
+// ErrorAssertionFunc is a common function prototype when validating an error value.  Can be useful
 // for table driven tests.
 type ErrorAssertionFunc func(TestingT, error, ...interface{})
 


### PR DESCRIPTION
Hey testify friends
This is a small change to fix a mismatch between a comment and the exported function name it describes.