### PR TITLE
Add a WithinTimes assertion

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -933,6 +933,24 @@ func WithinDuration(t TestingT, expected, actual time.Time, delta time.Duration,
 	return true
 }
 
+// WithinTimes asserts that the actual time is between the two given times.
+//
+//   before := time.Now()
+//   now := time.Now()
+//   after := time.Now()
+//   assert.WithinTimes(t, before, now, after)
+func WithinTimes(t TestingT, before time.Time, actual time.Time, after time.Time, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	if actual.Before(before) || actual.After(after) {
+		return Fail(t, fmt.Sprintf("Actual time %v was not between %v and %v", actual, before, after), msgAndArgs...)
+	}
+
+	return true
+}
+
 func toFloat(x interface{}) (float64, bool) {
 	var xf float64
 	xok := true

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -1074,6 +1074,18 @@ func TestWithinDuration(t *testing.T) {
 	False(t, WithinDuration(mockT, b, a, -11*time.Second), "A 10s difference is not within a 9s time difference")
 }
 
+func TestWithinTimes(t *testing.T) {
+	mockT := new(testing.T)
+
+	before := time.Now()
+	now := time.Now()
+	after := time.Now()
+
+	True(t, WithinTimes(mockT, before, now, after), "Actual was not in range")
+	False(t, WithinTimes(mockT, now.Add(-2*time.Second), now, now.Add(-time.Second)), "Actual was not in range")
+	False(t, WithinTimes(mockT, now.Add(time.Second), now, now.Add(2*time.Second)), "Actual was not in range")
+}
+
 func TestInDelta(t *testing.T) {
 	mockT := new(testing.T)
 


### PR DESCRIPTION
I've been testing some code that generates timestamps and found that I'm often thinking in terms of 'time should be between a and b'. So I think this might be helpful.

Example of how I'd like to write my tests:

```go
before := time.Now()
data := DoSomething()
after := time.Now()

assert.WithinTimes(t, before, data.timestamp, after)
```

Without this, I have to use `WithinDuration`, which I find _slightly_ cumbersome to setup and read.

```go
before := time.Now()
data := DoSomething()
span := time.Since(before) /2
midpoint := before.Add(span)

assert.WithinDuration(t, midpoint, data.timestamp, span)
```