### PR TITLE
Add Drop method to Mock

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -238,6 +238,24 @@ func (m *Mock) fail(format string, args ...interface{}) {
 	m.test.FailNow()
 }
 
+// Drop removes any Call matching the methodName and arguments passed in from
+// the slice of ExpectedCalls held by the mock.
+func (m *Mock) Drop(methodName string, arguments ...interface{}) {
+	var expectedCalls []*Call
+	for _, call := range m.expectedCalls() {
+		if call.Method == methodName && call.Repeatability > -1 {
+			_, diffCount := call.Arguments.Diff(arguments)
+			if diffCount > 0 {
+				expectedCalls = append(expectedCalls, call)
+			}
+		} else if call.Repeatability > -1 {
+			expectedCalls = append(expectedCalls, call)
+		}
+	}
+
+	m.ExpectedCalls = expectedCalls
+}
+
 // On starts a description of an expectation of the specified method
 // being called.
 //
@@ -697,11 +715,13 @@ func (args Arguments) Diff(objects []interface{}) (string, int) {
 
 			// type checking
 			if reflect.TypeOf(actual).Name() != string(expected.(AnythingOfTypeArgument)) && reflect.TypeOf(actual).String() != string(expected.(AnythingOfTypeArgument)) {
-				// not match
-				differences++
-				output = fmt.Sprintf("%s\t%d: FAIL:  type %s != type %s - %s\n", output, i, expected, reflect.TypeOf(actual).Name(), actualFmt)
+				// Check that we don't have matching AnythingOfTypeArguments
+				// representing mocks of the same type.
+				if !(reflect.TypeOf(actual).Name() == "AnythingOfTypeArgument" && reflect.TypeOf(actual).Name() == reflect.TypeOf(expected).Name() && string(expected.(AnythingOfTypeArgument)) == string(actual.(AnythingOfTypeArgument))) {
+					differences++
+					output = fmt.Sprintf("%s\t%d: FAIL:  type %s != type %s - %s\n", output, i, expected, reflect.TypeOf(actual).Name(), actualFmt)
+				}
 			}
-
 		} else {
 
 			// normal checking

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -243,9 +243,9 @@ func (m *Mock) fail(format string, args ...interface{}) {
 func (m *Mock) Drop(methodName string, arguments ...interface{}) {
 	var expectedCalls []*Call
 	for _, call := range m.expectedCalls() {
-		if call.Method == methodName && call.Repeatability > -1 {
+		if call.Method != methodName && call.Repeatability > -1 {
 			_, diffCount := call.Arguments.Diff(arguments)
-			if diffCount > 0 {
+			if diffCount > 0 || len(arguments) == 0 {
 				expectedCalls = append(expectedCalls, call)
 			}
 		}
@@ -715,9 +715,11 @@ func (args Arguments) Diff(objects []interface{}) (string, int) {
 			if reflect.TypeOf(actual).Name() != string(expected.(AnythingOfTypeArgument)) && reflect.TypeOf(actual).String() != string(expected.(AnythingOfTypeArgument)) {
 				// Check that we don't have matching AnythingOfTypeArguments
 				// representing mocks of the same type.
-				if !(reflect.TypeOf(actual).Name() == "AnythingOfTypeArgument" && reflect.TypeOf(actual).Name() == reflect.TypeOf(expected).Name() && string(expected.(AnythingOfTypeArgument)) == string(actual.(AnythingOfTypeArgument))) {
-					differences++
-					output = fmt.Sprintf("%s\t%d: FAIL:  type %s != type %s - %s\n", output, i, expected, reflect.TypeOf(actual).Name(), actualFmt)
+				if reflect.TypeOf(actual).Name() == "AnythingOfTypeArgument" && reflect.TypeOf(expected).Name() == "AnythingOfTypeArgument" {
+					if !(reflect.TypeOf(actual).Name() == reflect.TypeOf(expected).Name() && string(expected.(AnythingOfTypeArgument)) == string(actual.(AnythingOfTypeArgument))) {
+						differences++
+						output = fmt.Sprintf("%s\t%d: FAIL:  type %s != type %s - %s\n", output, i, expected, reflect.TypeOf(actual).Name(), actualFmt)
+					}
 				}
 			}
 		} else {

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -3,6 +3,7 @@ package mock
 import (
 	"errors"
 	"fmt"
+	"log"
 	"reflect"
 	"regexp"
 	"runtime"
@@ -716,10 +717,13 @@ func (args Arguments) Diff(objects []interface{}) (string, int) {
 				// Check that we don't have matching AnythingOfTypeArguments
 				// representing mocks of the same type.
 				if reflect.TypeOf(actual).Name() == "AnythingOfTypeArgument" && reflect.TypeOf(expected).Name() == "AnythingOfTypeArgument" {
-					if !(reflect.TypeOf(actual).Name() == reflect.TypeOf(expected).Name() && string(expected.(AnythingOfTypeArgument)) == string(actual.(AnythingOfTypeArgument))) {
-						differences++
-						output = fmt.Sprintf("%s\t%d: FAIL:  type %s != type %s - %s\n", output, i, expected, reflect.TypeOf(actual).Name(), actualFmt)
+					log.Printf("string(expected.(AnythingOfTypeArgument)) = %+v\n", string(expected.(AnythingOfTypeArgument)))
+					log.Printf("string(actual.(AnythingOfTypeArgument)) = %+v\n", string(actual.(AnythingOfTypeArgument)))
+					if string(expected.(AnythingOfTypeArgument)) != string(actual.(AnythingOfTypeArgument)) {
 					}
+				} else {
+					differences++
+					output = fmt.Sprintf("%s\t%d: FAIL:  type %s != type %s - %s\n", output, i, expected, reflect.TypeOf(actual).Name(), actualFmt)
 				}
 			}
 		} else {

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -3,7 +3,6 @@ package mock
 import (
 	"errors"
 	"fmt"
-	"log"
 	"reflect"
 	"regexp"
 	"runtime"
@@ -716,11 +715,9 @@ func (args Arguments) Diff(objects []interface{}) (string, int) {
 			if reflect.TypeOf(actual).Name() != string(expected.(AnythingOfTypeArgument)) && reflect.TypeOf(actual).String() != string(expected.(AnythingOfTypeArgument)) {
 				// Check that we don't have matching AnythingOfTypeArguments
 				// representing mocks of the same type.
-				if reflect.TypeOf(actual).Name() == "AnythingOfTypeArgument" && reflect.TypeOf(expected).Name() == "AnythingOfTypeArgument" {
-					log.Printf("string(expected.(AnythingOfTypeArgument)) = %+v\n", string(expected.(AnythingOfTypeArgument)))
-					log.Printf("string(actual.(AnythingOfTypeArgument)) = %+v\n", string(actual.(AnythingOfTypeArgument)))
-					if string(expected.(AnythingOfTypeArgument)) != string(actual.(AnythingOfTypeArgument)) {
-					}
+				if reflect.TypeOf(actual).Name() == "AnythingOfTypeArgument" &&
+					reflect.TypeOf(expected).Name() == "AnythingOfTypeArgument" &&
+					string(expected.(AnythingOfTypeArgument)) != string(actual.(AnythingOfTypeArgument)) {
 				} else {
 					differences++
 					output = fmt.Sprintf("%s\t%d: FAIL:  type %s != type %s - %s\n", output, i, expected, reflect.TypeOf(actual).Name(), actualFmt)

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -248,8 +248,6 @@ func (m *Mock) Drop(methodName string, arguments ...interface{}) {
 			if diffCount > 0 {
 				expectedCalls = append(expectedCalls, call)
 			}
-		} else if call.Repeatability > -1 {
-			expectedCalls = append(expectedCalls, call)
 		}
 	}
 

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -138,6 +138,7 @@ func Test_Mock_TestData(t *testing.T) {
 func Test_Mock_Drop(t *testing.T) {
 	var mockedService = new(TestExampleImplementation)
 
+	_, _, line, _ := runtime.Caller(0)
 	c := mockedService.On("TheExampleMethod")
 	d := mockedService.On("TheExampleMethodTwo")
 	assert.Equal(t, len(mockedService.ExpectedCalls), 2)
@@ -151,33 +152,33 @@ func Test_Mock_Drop(t *testing.T) {
 	assert.Equal(t, "TheExampleMethodTwo", d.Method)
 	mockedService.Drop("TheExampleMethodTwo")
 
-	_, _, line, _ := runtime.Caller(0)
+	_, _, line, _ = runtime.Caller(0)
 	mockedService.
-		On("TheExampleMethod", 1, 2, 3).
+		On("TheExampleMethodThree", 1, 2, 3).
 		Return(0).
-		On("TheExampleMethod2", AnythingOfType("int")).
+		On("TheExampleMethodFour", AnythingOfType("int")).
 		Return(nil).
-		On("TheExampleMethod3", AnythingOfType("*mock.ExampleType")).
+		On("TheExampleMethodFive", AnythingOfType("*mock.ExampleType")).
 		Return(nil)
 
 	expectedCalls := []*Call{
 		{
 			Parent:          &mockedService.Mock,
-			Method:          "TheExampleMethod",
+			Method:          "TheExampleMethodThree",
 			Arguments:       []interface{}{1, 2, 3},
 			ReturnArguments: []interface{}{0},
 			callerInfo:      []string{fmt.Sprintf("mock_test.go:%d", line+2)},
 		},
 		{
 			Parent:          &mockedService.Mock,
-			Method:          "TheExampleMethod2",
+			Method:          "TheExampleMethodFour",
 			Arguments:       []interface{}{AnythingOfType("int")},
 			ReturnArguments: []interface{}{nil},
 			callerInfo:      []string{fmt.Sprintf("mock_test.go:%d", line+4)},
 		},
 		{
 			Parent:          &mockedService.Mock,
-			Method:          "TheExampleMethod3",
+			Method:          "TheExampleMethodFive",
 			Arguments:       []interface{}{AnythingOfType("*mock.ExampleType")},
 			ReturnArguments: []interface{}{nil},
 			callerInfo:      []string{fmt.Sprintf("mock_test.go:%d", line+6)},
@@ -186,18 +187,18 @@ func Test_Mock_Drop(t *testing.T) {
 
 	assert.Equal(t, expectedCalls, mockedService.ExpectedCalls)
 
-	mockedService.Drop("TheExampleMethod", 1, 2, 3)
+	mockedService.Drop("TheExampleMethodThree", 1, 2, 3)
 	expectedCalls = []*Call{
 		{
 			Parent:          &mockedService.Mock,
-			Method:          "TheExampleMethod2",
+			Method:          "TheExampleMethodFour",
 			Arguments:       []interface{}{AnythingOfType("int")},
 			ReturnArguments: []interface{}{nil},
 			callerInfo:      []string{fmt.Sprintf("mock_test.go:%d", line+4)},
 		},
 		{
 			Parent:          &mockedService.Mock,
-			Method:          "TheExampleMethod3",
+			Method:          "TheExampleMethodFive",
 			Arguments:       []interface{}{AnythingOfType("*mock.ExampleType")},
 			ReturnArguments: []interface{}{nil},
 			callerInfo:      []string{fmt.Sprintf("mock_test.go:%d", line+6)},
@@ -206,7 +207,7 @@ func Test_Mock_Drop(t *testing.T) {
 
 	assert.Equal(t, expectedCalls, mockedService.ExpectedCalls)
 
-	mockedService.Drop("TheExampleMethod3", AnythingOfType("*mock.ExampleType"))
+	mockedService.Drop("TheExampleMethodFive", AnythingOfType("*mock.ExampleType"))
 	expectedCalls = []*Call{
 		{
 			Parent:          &mockedService.Mock,


### PR DESCRIPTION
Mock.Drop removes a Call from the slice of ExpectedCalls on the Mock.

This is helpful when repeatedly mocking the same function with the same
arguments at different points in the test but with different returned
results as at the moment doing this adds new Calls to the ExpectedCalls
slice even if the return arguments are different.