### PR TITLE
Preserve stack frame for mock parent method call

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -176,6 +176,7 @@ func (c *Call) Maybe() *Call {
 //    Mock.
 //       On("MyMethod", 1).Return(nil).
 //       On("MyOtherMethod", 'a', 'b', 'c').Return(errors.New("Some Error"))
+//go:noinline
 func (c *Call) On(methodName string, arguments ...interface{}) *Call {
 	return c.Parent.On(methodName, arguments...)
 }

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -32,6 +32,7 @@ func (i *TestExampleImplementation) TheExampleMethod(a, b, c int) (int, error) {
 	return args.Int(0), errors.New("Whoops")
 }
 
+//go:noinline
 func (i *TestExampleImplementation) TheExampleMethod2(yesorno bool) {
 	i.Called(yesorno)
 }
@@ -1492,6 +1493,7 @@ func unexpectedCallRegex(method, calledArg, expectedArg, diff string) string {
 		rMethod, calledArg, rMethod, expectedArg, diff)
 }
 
+//go:noinline
 func ConcurrencyTestMethod(m *Mock) {
 	m.Called()
 }


### PR DESCRIPTION
Fixes #705 

Go tip contains following commmit, that inlines function with single
call bodies.

https://github.com/golang/go/commit/13baf4b2cd34dfb41c570e35b48ec287713f4d7f

`(*Call).On()` is the exact target for the improvement in Go repo. Due to
the inlining, assert.CallerInfo() can't not detect the file and line
number of the call to `(*Mock).On()` from `(*Call).On()`. Thus, the test
fails.

Adding the compiler directive `go:noinline` prevent this effect and make
mock package works with go tip as before.