### PR TITLE
Fix issue with GoLand debugger using testify

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -676,7 +676,7 @@ func (args Arguments) Diff(objects []interface{}) (string, int) {
 			actualFmt = "(Missing)"
 		} else {
 			actual = objects[i]
-			actualFmt = fmt.Sprintf("(%[1]T=%[1]v)", actual)
+			actualFmt = fmt.Sprintf("(%[1]T=%#[1]v)", actual)
 		}
 
 		if len(args) <= i {
@@ -684,7 +684,7 @@ func (args Arguments) Diff(objects []interface{}) (string, int) {
 			expectedFmt = "(Missing)"
 		} else {
 			expected = args[i]
-			expectedFmt = fmt.Sprintf("(%[1]T=%[1]v)", expected)
+			expectedFmt = fmt.Sprintf("(%[1]T=%#[1]v)", expected)
 		}
 
 		if matcher, ok := expected.(argumentMatcher); ok {

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -1189,7 +1189,7 @@ func Test_Arguments_Diff(t *testing.T) {
 
 	assert.Equal(t, 2, count)
 	assert.Contains(t, diff, `(int=456) != (int=123)`)
-	assert.Contains(t, diff, `(string=false) != (bool=true)`)
+	assert.Contains(t, diff, `(string="false") != (bool=true)`)
 
 }
 
@@ -1201,7 +1201,7 @@ func Test_Arguments_Diff_DifferentNumberOfArgs(t *testing.T) {
 	diff, count = args.Diff([]interface{}{"string", 456, "false", "extra"})
 
 	assert.Equal(t, 3, count)
-	assert.Contains(t, diff, `(string=extra) != (Missing)`)
+	assert.Contains(t, diff, `(string="extra") != (Missing)`)
 
 }
 


### PR DESCRIPTION
GoLand's debugger hangs given *goquery.Document as the value to the Sprintf function
This makes it impossible to debug tests in GoLand which is too bad
%v --> %#v make it so the debugger won't hang