### PR TITLE
Prevent misleading test result output

### DIFF
--- a/suite/suite_test.go
+++ b/suite/suite_test.go
@@ -19,6 +19,11 @@ type SuiteRequireTwice struct{ Suite }
 // suite.requirements was not initialised in suite.SetT()
 // A regression would result on these tests panicking rather than failing.
 func TestSuiteRequireTwice(t *testing.T) {
+	stdout := os.Stdout
+	os.Stdout, _ = ioutil.TempFile("", "")
+	defer func() {
+		os.Stdout = stdout
+	}()
 	ok := testing.RunTests(
 		allTestsFilter,
 		[]testing.InternalTest{{
@@ -127,6 +132,12 @@ func TestSuiteRecoverPanic(t *testing.T) {
 			F:    func(t *testing.T) { Run(t, &panickingSuite{panicInTearDownSuite: true}) },
 		},
 	}
+
+	stdout := os.Stdout
+	os.Stdout, _ = ioutil.TempFile("", "")
+	defer func() {
+		os.Stdout = stdout
+	}()
 
 	require.NotPanics(t, func() {
 		ok = testing.RunTests(allTestsFilter, panickingTests)


### PR DESCRIPTION
Some tests intentionally use and let golang `InternalTest` to fail. Those `InternalTest` print "FAIL" messages to stdout, with is confusing readers. This commit redirect `os.Stdout` during those test to suppress the messages and revert original `Stdout` back one done.

---

Before this commit, we got following lines after running `go test -v ./....`

```
...
PASS
ok      github.com/stretchr/testify/require     (cached)
=== RUN   TestSuiteRequireTwice
=== RUN   TestSuiteRequireTwice
=== RUN   TestSuiteRequireTwice/TestRequireOne
=== RUN   TestSuiteRequireTwice/TestRequireTwo
--- FAIL: TestSuiteRequireTwice (0.00s)
    --- FAIL: TestSuiteRequireTwice/TestRequireOne (0.00s)
        require.go:157:
                Error Trace:    suite_test.go:37
                Error:          Not equal:
                                expected: 1
                                actual  : 2
                Test:           TestSuiteRequireTwice/TestRequireOne
    --- FAIL: TestSuiteRequireTwice/TestRequireTwo (0.00s)
        require.go:157:
                Error Trace:    suite_test.go:42
                Error:          Not equal:
                                expected: 1
                                actual  : 2
                Test:           TestSuiteRequireTwice/TestRequireTwo
...
```
I had to debug the source code to know why exit code (`$?`) is still 0.  