### PR TITLE
[WIP] Improve local development workflow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,9 @@ matrix:
     - go: "1.11.x"
       env: GO111MODULE=on
     - go: tip
-  script:
-    - ./.travis.gogenerate.sh
-    - ./.travis.gofmt.sh
-    - ./.travis.govet.sh
-    - go test -v -race $(go list ./... | grep -v vendor)
+
+script:
+  - ./.travis.gogenerate.sh
+  - ./.travis.gofmt.sh
+  - ./.travis.govet.sh
+  - go test -v -race $(go list ./... | grep -v vendor)


### PR DESCRIPTION
This is pretty much a WIP. I want to raise it soon to get the maintainers
opinions for below issues and my proposal.

## Issues with current project setup

1. Travis CI build failed for due to `_codegen/main.go` execution (via
   `.traivis.gogenerate.sh`) failed.

   Before
   [c73991d8a147e795e8560222c12be1cfc7f3da9a)](https://github.com/stretchr/testify/pull/722/commits/c73991d8a147e795e8560222c12be1cfc7f3da9a),
   due to wrong indentation, the `script` block is never executed. Tests are
   using default travis setting for golang project. I think that's why noone
   notice this issue.

   After I fix that, another issue pop up. For go1.11, codegen [can't find the
   file to parse](https://travis-ci.org/letientai299/testify/jobs/484202808).

   ```
   2019/01/25 04:06:23 open /home/travis/gopath/src/github.com/stretchr/testify/assert/assertion_format.go: no such file or directory
   ```

2. We might be able to fix `_codegen/main.go` to work with `GO111MODULE=on`, but
   is it a good ideas to set to build result based on `git diff` output? I don't
   think so. With that approach:

   - Source code after cloned is not immediately usable (missing
     `github.com/ernesto-jimenez/gogen/imports` for codegen)

   - It's easy for beginner to accidently commit `go.sum` and `go.mod` changes after
     execute `.travis.gogenerate.sh`.

## Proposal

For easy to develop and encourage best practice, I propose to

- Make `_codegen` anther modules, with its own `go.sum`, `go.mod`.
- Remove `//go:generate` directives. Use bash script or other means to build and
  run codegen against the code.
- Provide a Makefile with some ready prepared targets:

  - `setup`: download development dependencies
  - `codegen`: run codegen
  - `test`: run all tests
  - `testall`: run all test with `-race` and others stricter flags.

- Provide a git-hooks pre-push that will be configured via `make setup`, and
  will run `make test` and prevet push if it fails.
