### PR TITLE
Don't setup suite if no methods satisfy filter

### DIFF
--- a/suite/suite.go
+++ b/suite/suite.go
@@ -82,7 +82,7 @@ func Run(t *testing.T, suite TestingSuite) {
 	suite.SetT(t)
 	defer failOnPanic(t)
 
-	setupDone := false
+	suiteSetupDone := false
 	
 	methodFinder := reflect.TypeOf(suite)
 	tests := []testing.InternalTest{}
@@ -96,7 +96,7 @@ func Run(t *testing.T, suite TestingSuite) {
 		if !ok {
 			continue
 		}
-		if !setupDone {
+		if !suiteSetupDone {
 			if setupAllSuite, ok := suite.(SetupAllSuite); ok {
 				setupAllSuite.SetupSuite()
 			}
@@ -105,7 +105,7 @@ func Run(t *testing.T, suite TestingSuite) {
 					tearDownAllSuite.TearDownSuite()
 				}
 			}()
-			setupDone = true
+			suiteSetupDone = true
 		}
 		test := testing.InternalTest{
 			Name: method.Name,

--- a/suite/suite.go
+++ b/suite/suite.go
@@ -82,15 +82,8 @@ func Run(t *testing.T, suite TestingSuite) {
 	suite.SetT(t)
 	defer failOnPanic(t)
 
-	if setupAllSuite, ok := suite.(SetupAllSuite); ok {
-		setupAllSuite.SetupSuite()
-	}
-	defer func() {
-		if tearDownAllSuite, ok := suite.(TearDownAllSuite); ok {
-			tearDownAllSuite.TearDownSuite()
-		}
-	}()
-
+	setupDone := false
+	
 	methodFinder := reflect.TypeOf(suite)
 	tests := []testing.InternalTest{}
 	for index := 0; index < methodFinder.NumMethod(); index++ {
@@ -100,34 +93,46 @@ func Run(t *testing.T, suite TestingSuite) {
 			fmt.Fprintf(os.Stderr, "testify: invalid regexp for -m: %s\n", err)
 			os.Exit(1)
 		}
-		if ok {
-			test := testing.InternalTest{
-				Name: method.Name,
-				F: func(t *testing.T) {
-					parentT := suite.T()
-					suite.SetT(t)
-					defer failOnPanic(t)
-
-					if setupTestSuite, ok := suite.(SetupTestSuite); ok {
-						setupTestSuite.SetupTest()
-					}
-					if beforeTestSuite, ok := suite.(BeforeTest); ok {
-						beforeTestSuite.BeforeTest(methodFinder.Elem().Name(), method.Name)
-					}
-					defer func() {
-						if afterTestSuite, ok := suite.(AfterTest); ok {
-							afterTestSuite.AfterTest(methodFinder.Elem().Name(), method.Name)
-						}
-						if tearDownTestSuite, ok := suite.(TearDownTestSuite); ok {
-							tearDownTestSuite.TearDownTest()
-						}
-						suite.SetT(parentT)
-					}()
-					method.Func.Call([]reflect.Value{reflect.ValueOf(suite)})
-				},
-			}
-			tests = append(tests, test)
+		if !ok {
+			continue
 		}
+		if !setupDone {
+			if setupAllSuite, ok := suite.(SetupAllSuite); ok {
+				setupAllSuite.SetupSuite()
+			}
+			defer func() {
+				if tearDownAllSuite, ok := suite.(TearDownAllSuite); ok {
+					tearDownAllSuite.TearDownSuite()
+				}
+			}()
+			setupDone = true
+		}
+		test := testing.InternalTest{
+			Name: method.Name,
+			F: func(t *testing.T) {
+				parentT := suite.T()
+				suite.SetT(t)
+				defer failOnPanic(t)
+
+				if setupTestSuite, ok := suite.(SetupTestSuite); ok {
+					setupTestSuite.SetupTest()
+				}
+				if beforeTestSuite, ok := suite.(BeforeTest); ok {
+					beforeTestSuite.BeforeTest(methodFinder.Elem().Name(), method.Name)
+				}
+				defer func() {
+					if afterTestSuite, ok := suite.(AfterTest); ok {
+						afterTestSuite.AfterTest(methodFinder.Elem().Name(), method.Name)
+					}
+					if tearDownTestSuite, ok := suite.(TearDownTestSuite); ok {
+						tearDownTestSuite.TearDownTest()
+					}
+					suite.SetT(parentT)
+				}()
+				method.Func.Call([]reflect.Value{reflect.ValueOf(suite)})
+			},
+		}
+		tests = append(tests, test)
 	}
 	runTests(t, tests)
 }

--- a/suite/suite_test.go
+++ b/suite/suite_test.go
@@ -265,7 +265,7 @@ func (suite *SuiteSkipTester) SetupSuite() {
 }
 
 func (suite *SuiteSkipTester) TestNothing() {
-	// SetupSuite is only called when at least one test satisfies
+	// SetupSuite() is only called when at least one test satisfies
 	// test filter. For this suite to be set up (and then tore down)
 	// it is necessary to add at least one test method.
 }

--- a/suite/suite_test.go
+++ b/suite/suite_test.go
@@ -165,15 +165,6 @@ type SuiteTester struct {
 	TimeAfter  []time.Time
 }
 
-type SuiteSkipTester struct {
-	// Include our basic suite logic.
-	Suite
-
-	// Keep counts of how many times each method is run.
-	SetupSuiteRunCount    int
-	TearDownSuiteRunCount int
-}
-
 // The SetupSuite method will be run by testify once, at the very
 // start of the testing suite, before any tests are run.
 func (suite *SuiteTester) SetupSuite() {
@@ -192,18 +183,9 @@ func (suite *SuiteTester) AfterTest(suiteName, testName string) {
 	suite.TimeAfter = append(suite.TimeAfter, time.Now())
 }
 
-func (suite *SuiteSkipTester) SetupSuite() {
-	suite.SetupSuiteRunCount++
-	suite.T().Skip()
-}
-
 // The TearDownSuite method will be run by testify once, at the very
 // end of the testing suite, after all tests have been run.
 func (suite *SuiteTester) TearDownSuite() {
-	suite.TearDownSuiteRunCount++
-}
-
-func (suite *SuiteSkipTester) TearDownSuite() {
 	suite.TearDownSuiteRunCount++
 }
 
@@ -266,6 +248,30 @@ func (suite *SuiteTester) TestSubtest() {
 		})
 		suite.Equal(suiteT, suite.T())
 	}
+}
+
+type SuiteSkipTester struct {
+	// Include our basic suite logic.
+	Suite
+
+	// Keep counts of how many times each method is run.
+	SetupSuiteRunCount    int
+	TearDownSuiteRunCount int
+}
+
+func (suite *SuiteSkipTester) SetupSuite() {
+	suite.SetupSuiteRunCount++
+	suite.T().Skip()
+}
+
+func (suite *SuiteSkipTester) TestNothing() {
+	// SetupSuite is only called when at least one test satisfies
+	// test filter. For this suite to be set up (and then tore down)
+	// it is necessary to add at least one test method.
+}
+
+func (suite *SuiteSkipTester) TearDownSuite() {
+	suite.TearDownSuiteRunCount++
 }
 
 // TestRunSuite will be run by the 'go test' command, so within it, we

--- a/suite/suite_test.go
+++ b/suite/suite_test.go
@@ -265,7 +265,7 @@ func (suite *SuiteSkipTester) SetupSuite() {
 }
 
 func (suite *SuiteSkipTester) TestNothing() {
-	// SetupSuite() is only called when at least one test satisfies
+	// SetupSuite is only called when at least one test satisfies
 	// test filter. For this suite to be set up (and then tore down)
 	// it is necessary to add at least one test method.
 }
@@ -344,6 +344,33 @@ func TestRunSuite(t *testing.T) {
 	assert.Equal(t, suiteSkipTester.SetupSuiteRunCount, 1)
 	assert.Equal(t, suiteSkipTester.TearDownSuiteRunCount, 1)
 
+}
+
+// This suite has no Test... methods. It's setup and teardown must be skipped.
+type SuiteSetupSkipTester struct {
+	Suite
+
+	setUp bool
+	toreDown bool
+}
+
+func (s *SuiteSetupSkipTester) SetupSuite() {
+	s.setUp = true
+}
+
+func (s *SuiteSetupSkipTester) NonTestMethod() {
+
+}
+
+func (s *SuiteSetupSkipTester) TearDownSuite() {
+	s.toreDown = true
+}
+
+func TestSkippingSuiteSetup(t *testing.T) {
+	suiteTester := new(SuiteSetupSkipTester)
+	Run(t, suiteTester)
+	assert.False(t, suiteTester.setUp)
+	assert.False(t, suiteTester.toreDown)
 }
 
 func TestSuiteGetters(t *testing.T) {


### PR DESCRIPTION
When suite setup is long, the necessity to wait for all suite setups for testing one single method of one of suites bothers a lot. Here's a little fix of that behavior.