### PR TITLE
assert.Len: print value last

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -553,6 +553,7 @@ func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) 
 	}
 	ok, l := getLen(object)
 	if !ok {
+		//TODO: should it be - \"%s\" could not be applied <to> builtin len() or maybe "len() could not be applied to \"%s\" 
 		return Fail(t, fmt.Sprintf("\"%s\" could not be applied builtin len()", object), msgAndArgs...)
 	}
 

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -553,7 +553,7 @@ func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) 
 	}
 	ok, l := getLen(object)
 	if !ok {
-		return Fail(t, fmt.Sprintf("len() \"%s\" could not be applied builtin len()", object), msgAndArgs...)
+		return Fail(t, fmt.Sprintf("\"%s\" could not be applied builtin len()", object), msgAndArgs...)
 	}
 
 	if l != length {

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -553,11 +553,11 @@ func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) 
 	}
 	ok, l := getLen(object)
 	if !ok {
-		return Fail(t, fmt.Sprintf("\"%s\" could not be applied builtin len()", object), msgAndArgs...)
+		return Fail(t, fmt.Sprintf("len() \"%s\" could not be applied builtin len()", object), msgAndArgs...)
 	}
 
 	if l != length {
-		return Fail(t, fmt.Sprintf("\"%s\" should have %d item(s), but has %d", object, length, l), msgAndArgs...)
+		return Fail(t, fmt.Sprintf("Expected %d item(s), but got %d for \"%s\"",  length, l, object,), msgAndArgs...)
 	}
 	return true
 }


### PR DESCRIPTION
https://github.com/stretchr/testify/issues/207#issuecomment-464956602 - Adjust assert.Len() fail message making the object last so that large object output doesn't obscure the length difference.