### PR TITLE
refactoring of assertion_order

### DIFF
--- a/assert/assertion_order.go
+++ b/assert/assertion_order.go
@@ -5,6 +5,12 @@ import (
 	"reflect"
 )
 
+const(
+	greater = 1
+	equal = 0
+	less = -1
+)
+
 func compare(obj1, obj2 interface{}, kind reflect.Kind) (int, bool) {
 	switch kind {
 	case reflect.Int:
@@ -12,13 +18,13 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (int, bool) {
 			intobj1 := obj1.(int)
 			intobj2 := obj2.(int)
 			if intobj1 > intobj2 {
-				return -1, true
+				return greater, true
 			}
 			if intobj1 == intobj2 {
-				return 0, true
+				return equal, true
 			}
 			if intobj1 < intobj2 {
-				return 1, true
+				return less, true
 			}
 		}
 	case reflect.Int8:
@@ -26,13 +32,13 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (int, bool) {
 			int8obj1 := obj1.(int8)
 			int8obj2 := obj2.(int8)
 			if int8obj1 > int8obj2 {
-				return -1, true
+				return greater, true
 			}
 			if int8obj1 == int8obj2 {
-				return 0, true
+				return equal, true
 			}
 			if int8obj1 < int8obj2 {
-				return 1, true
+				return less, true
 			}
 		}
 	case reflect.Int16:
@@ -40,13 +46,13 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (int, bool) {
 			int16obj1 := obj1.(int16)
 			int16obj2 := obj2.(int16)
 			if int16obj1 > int16obj2 {
-				return -1, true
+				return greater, true
 			}
 			if int16obj1 == int16obj2 {
-				return 0, true
+				return equal, true
 			}
 			if int16obj1 < int16obj2 {
-				return 1, true
+				return less, true
 			}
 		}
 	case reflect.Int32:
@@ -54,13 +60,13 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (int, bool) {
 			int32obj1 := obj1.(int32)
 			int32obj2 := obj2.(int32)
 			if int32obj1 > int32obj2 {
-				return -1, true
+				return greater, true
 			}
 			if int32obj1 == int32obj2 {
-				return 0, true
+				return equal, true
 			}
 			if int32obj1 < int32obj2 {
-				return 1, true
+				return less, true
 			}
 		}
 	case reflect.Int64:
@@ -68,13 +74,13 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (int, bool) {
 			int64obj1 := obj1.(int64)
 			int64obj2 := obj2.(int64)
 			if int64obj1 > int64obj2 {
-				return -1, true
+				return greater, true
 			}
 			if int64obj1 == int64obj2 {
-				return 0, true
+				return equal, true
 			}
 			if int64obj1 < int64obj2 {
-				return 1, true
+				return less, true
 			}
 		}
 	case reflect.Uint:
@@ -82,13 +88,13 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (int, bool) {
 			uintobj1 := obj1.(uint)
 			uintobj2 := obj2.(uint)
 			if uintobj1 > uintobj2 {
-				return -1, true
+				return greater, true
 			}
 			if uintobj1 == uintobj2 {
-				return 0, true
+				return equal, true
 			}
 			if uintobj1 < uintobj2 {
-				return 1, true
+				return less, true
 			}
 		}
 	case reflect.Uint8:
@@ -96,13 +102,13 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (int, bool) {
 			uint8obj1 := obj1.(uint8)
 			uint8obj2 := obj2.(uint8)
 			if uint8obj1 > uint8obj2 {
-				return -1, true
+				return greater, true
 			}
 			if uint8obj1 == uint8obj2 {
-				return 0, true
+				return equal, true
 			}
 			if uint8obj1 < uint8obj2 {
-				return 1, true
+				return less, true
 			}
 		}
 	case reflect.Uint16:
@@ -110,13 +116,13 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (int, bool) {
 			uint16obj1 := obj1.(uint16)
 			uint16obj2 := obj2.(uint16)
 			if uint16obj1 > uint16obj2 {
-				return -1, true
+				return greater, true
 			}
 			if uint16obj1 == uint16obj2 {
-				return 0, true
+				return equal, true
 			}
 			if uint16obj1 < uint16obj2 {
-				return 1, true
+				return less, true
 			}
 		}
 	case reflect.Uint32:
@@ -124,13 +130,13 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (int, bool) {
 			uint32obj1 := obj1.(uint32)
 			uint32obj2 := obj2.(uint32)
 			if uint32obj1 > uint32obj2 {
-				return -1, true
+				return greater, true
 			}
 			if uint32obj1 == uint32obj2 {
-				return 0, true
+				return equal, true
 			}
 			if uint32obj1 < uint32obj2 {
-				return 1, true
+				return less, true
 			}
 		}
 	case reflect.Uint64:
@@ -138,13 +144,13 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (int, bool) {
 			uint64obj1 := obj1.(uint64)
 			uint64obj2 := obj2.(uint64)
 			if uint64obj1 > uint64obj2 {
-				return -1, true
+				return greater, true
 			}
 			if uint64obj1 == uint64obj2 {
-				return 0, true
+				return equal, true
 			}
 			if uint64obj1 < uint64obj2 {
-				return 1, true
+				return less, true
 			}
 		}
 	case reflect.Float32:
@@ -152,13 +158,13 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (int, bool) {
 			float32obj1 := obj1.(float32)
 			float32obj2 := obj2.(float32)
 			if float32obj1 > float32obj2 {
-				return -1, true
+				return greater, true
 			}
 			if float32obj1 == float32obj2 {
-				return 0, true
+				return equal, true
 			}
 			if float32obj1 < float32obj2 {
-				return 1, true
+				return less, true
 			}
 		}
 	case reflect.Float64:
@@ -166,13 +172,13 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (int, bool) {
 			float64obj1 := obj1.(float64)
 			float64obj2 := obj2.(float64)
 			if float64obj1 > float64obj2 {
-				return -1, true
+				return greater, true
 			}
 			if float64obj1 == float64obj2 {
-				return 0, true
+				return equal, true
 			}
 			if float64obj1 < float64obj2 {
-				return 1, true
+				return less, true
 			}
 		}
 	case reflect.String:
@@ -180,18 +186,18 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (int, bool) {
 			stringobj1 := obj1.(string)
 			stringobj2 := obj2.(string)
 			if stringobj1 > stringobj2 {
-				return -1, true
+				return greater, true
 			}
 			if stringobj1 == stringobj2 {
-				return 0, true
+				return equal, true
 			}
 			if stringobj1 < stringobj2 {
-				return 1, true
+				return less, true
 			}
 		}
 	}
 
-	return 0, false
+	return equal, false
 }
 
 // Greater asserts that the first element is greater than the second
@@ -200,26 +206,7 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (int, bool) {
 //    assert.Greater(t, float64(2), float64(1))
 //    assert.Greater(t, "b", "a")
 func Greater(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
-	if h, ok := t.(tHelper); ok {
-		h.Helper()
-	}
-
-	e1Kind := reflect.ValueOf(e1).Kind()
-	e2Kind := reflect.ValueOf(e2).Kind()
-	if e1Kind != e2Kind {
-		return Fail(t, "Elements should be the same type", msgAndArgs...)
-	}
-
-	res, isComparable := compare(e1, e2, e1Kind)
-	if !isComparable {
-		return Fail(t, fmt.Sprintf("Can not compare type \"%s\"", reflect.TypeOf(e1)), msgAndArgs...)
-	}
-
-	if res != -1 {
-		return Fail(t, fmt.Sprintf("\"%v\" is not greater than \"%v\"", e1, e2), msgAndArgs...)
-	}
-
-	return true
+	return compareTwoValues(t, e1, e2, []int {greater}, "\"%s\" is not greater than \"%s\"", msgAndArgs);
 }
 
 // GreaterOrEqual asserts that the first element is greater than or equal to the second
@@ -229,26 +216,7 @@ func Greater(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface
 //    assert.GreaterOrEqual(t, "b", "a")
 //    assert.GreaterOrEqual(t, "b", "b")
 func GreaterOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
-	if h, ok := t.(tHelper); ok {
-		h.Helper()
-	}
-
-	e1Kind := reflect.ValueOf(e1).Kind()
-	e2Kind := reflect.ValueOf(e2).Kind()
-	if e1Kind != e2Kind {
-		return Fail(t, "Elements should be the same type", msgAndArgs...)
-	}
-
-	res, isComparable := compare(e1, e2, e1Kind)
-	if !isComparable {
-		return Fail(t, fmt.Sprintf("Can not compare type \"%s\"", reflect.TypeOf(e1)), msgAndArgs...)
-	}
-
-	if res != -1 && res != 0 {
-		return Fail(t, fmt.Sprintf("\"%v\" is not greater than or equal to \"%v\"", e1, e2), msgAndArgs...)
-	}
-
-	return true
+	return compareTwoValues(t, e1, e2, []int {greater, equal}, "\"%s\" is not greater or equal than \"%s\"", msgAndArgs);
 }
 
 // Less asserts that the first element is less than the second
@@ -257,26 +225,7 @@ func GreaterOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...in
 //    assert.Less(t, float64(1), float64(2))
 //    assert.Less(t, "a", "b")
 func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
-	if h, ok := t.(tHelper); ok {
-		h.Helper()
-	}
-
-	e1Kind := reflect.ValueOf(e1).Kind()
-	e2Kind := reflect.ValueOf(e2).Kind()
-	if e1Kind != e2Kind {
-		return Fail(t, "Elements should be the same type", msgAndArgs...)
-	}
-
-	res, isComparable := compare(e1, e2, e1Kind)
-	if !isComparable {
-		return Fail(t, fmt.Sprintf("Can not compare type \"%s\"", reflect.TypeOf(e1)), msgAndArgs...)
-	}
-
-	if res != 1 {
-		return Fail(t, fmt.Sprintf("\"%v\" is not less than \"%v\"", e1, e2), msgAndArgs...)
-	}
-
-	return true
+	return compareTwoValues(t, e1, e2, []int {less}, "\"%s\" is not less than \"%s\"", msgAndArgs);
 }
 
 // LessOrEqual asserts that the first element is less than or equal to the second
@@ -286,6 +235,11 @@ func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{})
 //    assert.LessOrEqual(t, "a", "b")
 //    assert.LessOrEqual(t, "b", "b")
 func LessOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
+	return compareTwoValues(t, e1, e2, []int {less, equal}, "\"%s\" is not less or equal than \"%s\"", msgAndArgs);
+}
+
+
+func compareTwoValues(t TestingT, e1 interface{}, e2 interface{}, allowedComparesResults []int, failMessage string, msgAndArgs ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -296,14 +250,25 @@ func LessOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...inter
 		return Fail(t, "Elements should be the same type", msgAndArgs...)
 	}
 
-	res, isComparable := compare(e1, e2, e1Kind)
+	compareResult, isComparable := compare(e1, e2, e1Kind)
 	if !isComparable {
 		return Fail(t, fmt.Sprintf("Can not compare type \"%s\"", reflect.TypeOf(e1)), msgAndArgs...)
 	}
 
-	if res != 1 && res != 0 {
-		return Fail(t, fmt.Sprintf("\"%v\" is not less than or equal to \"%v\"", e1, e2), msgAndArgs...)
+	if !containsValue(allowedComparesResults, compareResult) {
+		return Fail(t, fmt.Sprintf(failMessage, e1, e2), msgAndArgs...)
 	}
 
 	return true
+}
+
+
+func containsValue(values []int, value int) bool{
+    for _, v := range values {
+        if (v == value) {
+            return true
+        }
+	}
+
+    return false
 }

--- a/assert/assertion_order.go
+++ b/assert/assertion_order.go
@@ -268,7 +268,7 @@ func containsValue(values []int, value int) bool{
         if (v == value) {
             return true
         }
-	}
+    }
 
     return false
 }

--- a/assert/assertion_order.go
+++ b/assert/assertion_order.go
@@ -5,10 +5,10 @@ import (
 	"reflect"
 )
 
-const(
+const (
 	greater = 1
-	equal = 0
-	less = -1
+	equal   = 0
+	less    = -1
 )
 
 func compare(obj1, obj2 interface{}, kind reflect.Kind) (int, bool) {
@@ -206,7 +206,7 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (int, bool) {
 //    assert.Greater(t, float64(2), float64(1))
 //    assert.Greater(t, "b", "a")
 func Greater(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
-	return compareTwoValues(t, e1, e2, []int {greater}, "\"%s\" is not greater than \"%s\"", msgAndArgs);
+	return compareTwoValues(t, e1, e2, []int{greater}, "\"%s\" is not greater than \"%s\"", msgAndArgs)
 }
 
 // GreaterOrEqual asserts that the first element is greater than or equal to the second
@@ -216,7 +216,7 @@ func Greater(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface
 //    assert.GreaterOrEqual(t, "b", "a")
 //    assert.GreaterOrEqual(t, "b", "b")
 func GreaterOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
-	return compareTwoValues(t, e1, e2, []int {greater, equal}, "\"%s\" is not greater or equal than \"%s\"", msgAndArgs);
+	return compareTwoValues(t, e1, e2, []int{greater, equal}, "\"%s\" is not greater or equal than \"%s\"", msgAndArgs)
 }
 
 // Less asserts that the first element is less than the second
@@ -225,7 +225,7 @@ func GreaterOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...in
 //    assert.Less(t, float64(1), float64(2))
 //    assert.Less(t, "a", "b")
 func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
-	return compareTwoValues(t, e1, e2, []int {less}, "\"%s\" is not less than \"%s\"", msgAndArgs);
+	return compareTwoValues(t, e1, e2, []int{less}, "\"%s\" is not less than \"%s\"", msgAndArgs)
 }
 
 // LessOrEqual asserts that the first element is less than or equal to the second
@@ -235,9 +235,8 @@ func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{})
 //    assert.LessOrEqual(t, "a", "b")
 //    assert.LessOrEqual(t, "b", "b")
 func LessOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
-	return compareTwoValues(t, e1, e2, []int {less, equal}, "\"%s\" is not less or equal than \"%s\"", msgAndArgs);
+	return compareTwoValues(t, e1, e2, []int{less, equal}, "\"%s\" is not less or equal than \"%s\"", msgAndArgs)
 }
-
 
 func compareTwoValues(t TestingT, e1 interface{}, e2 interface{}, allowedComparesResults []int, failMessage string, msgAndArgs ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
@@ -262,13 +261,12 @@ func compareTwoValues(t TestingT, e1 interface{}, e2 interface{}, allowedCompare
 	return true
 }
 
+func containsValue(values []int, value int) bool {
+	for _, v := range values {
+		if v == value {
+			return true
+		}
+	}
 
-func containsValue(values []int, value int) bool{
-    for _, v := range values {
-        if (v == value) {
-            return true
-        }
-    }
-
-    return false
+	return false
 }

--- a/assert/assertion_order.go
+++ b/assert/assertion_order.go
@@ -5,26 +5,28 @@ import (
 	"reflect"
 )
 
+type CompareType int
+
 const (
-	greater = 1
-	equal   = 0
-	less    = -1
+	compareLess CompareType = iota - 1
+	compareEqual
+	compareGreater
 )
 
-func compare(obj1, obj2 interface{}, kind reflect.Kind) (int, bool) {
+func compare(obj1, obj2 interface{}, kind reflect.Kind) (CompareType, bool) {
 	switch kind {
 	case reflect.Int:
 		{
 			intobj1 := obj1.(int)
 			intobj2 := obj2.(int)
 			if intobj1 > intobj2 {
-				return greater, true
+				return compareGreater, true
 			}
 			if intobj1 == intobj2 {
-				return equal, true
+				return compareEqual, true
 			}
 			if intobj1 < intobj2 {
-				return less, true
+				return compareLess, true
 			}
 		}
 	case reflect.Int8:
@@ -32,13 +34,13 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (int, bool) {
 			int8obj1 := obj1.(int8)
 			int8obj2 := obj2.(int8)
 			if int8obj1 > int8obj2 {
-				return greater, true
+				return compareGreater, true
 			}
 			if int8obj1 == int8obj2 {
-				return equal, true
+				return compareEqual, true
 			}
 			if int8obj1 < int8obj2 {
-				return less, true
+				return compareLess, true
 			}
 		}
 	case reflect.Int16:
@@ -46,13 +48,13 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (int, bool) {
 			int16obj1 := obj1.(int16)
 			int16obj2 := obj2.(int16)
 			if int16obj1 > int16obj2 {
-				return greater, true
+				return compareGreater, true
 			}
 			if int16obj1 == int16obj2 {
-				return equal, true
+				return compareEqual, true
 			}
 			if int16obj1 < int16obj2 {
-				return less, true
+				return compareLess, true
 			}
 		}
 	case reflect.Int32:
@@ -60,13 +62,13 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (int, bool) {
 			int32obj1 := obj1.(int32)
 			int32obj2 := obj2.(int32)
 			if int32obj1 > int32obj2 {
-				return greater, true
+				return compareGreater, true
 			}
 			if int32obj1 == int32obj2 {
-				return equal, true
+				return compareEqual, true
 			}
 			if int32obj1 < int32obj2 {
-				return less, true
+				return compareLess, true
 			}
 		}
 	case reflect.Int64:
@@ -74,13 +76,13 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (int, bool) {
 			int64obj1 := obj1.(int64)
 			int64obj2 := obj2.(int64)
 			if int64obj1 > int64obj2 {
-				return greater, true
+				return compareGreater, true
 			}
 			if int64obj1 == int64obj2 {
-				return equal, true
+				return compareEqual, true
 			}
 			if int64obj1 < int64obj2 {
-				return less, true
+				return compareLess, true
 			}
 		}
 	case reflect.Uint:
@@ -88,13 +90,13 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (int, bool) {
 			uintobj1 := obj1.(uint)
 			uintobj2 := obj2.(uint)
 			if uintobj1 > uintobj2 {
-				return greater, true
+				return compareGreater, true
 			}
 			if uintobj1 == uintobj2 {
-				return equal, true
+				return compareEqual, true
 			}
 			if uintobj1 < uintobj2 {
-				return less, true
+				return compareLess, true
 			}
 		}
 	case reflect.Uint8:
@@ -102,13 +104,13 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (int, bool) {
 			uint8obj1 := obj1.(uint8)
 			uint8obj2 := obj2.(uint8)
 			if uint8obj1 > uint8obj2 {
-				return greater, true
+				return compareGreater, true
 			}
 			if uint8obj1 == uint8obj2 {
-				return equal, true
+				return compareEqual, true
 			}
 			if uint8obj1 < uint8obj2 {
-				return less, true
+				return compareLess, true
 			}
 		}
 	case reflect.Uint16:
@@ -116,13 +118,13 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (int, bool) {
 			uint16obj1 := obj1.(uint16)
 			uint16obj2 := obj2.(uint16)
 			if uint16obj1 > uint16obj2 {
-				return greater, true
+				return compareGreater, true
 			}
 			if uint16obj1 == uint16obj2 {
-				return equal, true
+				return compareEqual, true
 			}
 			if uint16obj1 < uint16obj2 {
-				return less, true
+				return compareLess, true
 			}
 		}
 	case reflect.Uint32:
@@ -130,13 +132,13 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (int, bool) {
 			uint32obj1 := obj1.(uint32)
 			uint32obj2 := obj2.(uint32)
 			if uint32obj1 > uint32obj2 {
-				return greater, true
+				return compareGreater, true
 			}
 			if uint32obj1 == uint32obj2 {
-				return equal, true
+				return compareEqual, true
 			}
 			if uint32obj1 < uint32obj2 {
-				return less, true
+				return compareLess, true
 			}
 		}
 	case reflect.Uint64:
@@ -144,13 +146,13 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (int, bool) {
 			uint64obj1 := obj1.(uint64)
 			uint64obj2 := obj2.(uint64)
 			if uint64obj1 > uint64obj2 {
-				return greater, true
+				return compareGreater, true
 			}
 			if uint64obj1 == uint64obj2 {
-				return equal, true
+				return compareEqual, true
 			}
 			if uint64obj1 < uint64obj2 {
-				return less, true
+				return compareLess, true
 			}
 		}
 	case reflect.Float32:
@@ -158,13 +160,13 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (int, bool) {
 			float32obj1 := obj1.(float32)
 			float32obj2 := obj2.(float32)
 			if float32obj1 > float32obj2 {
-				return greater, true
+				return compareGreater, true
 			}
 			if float32obj1 == float32obj2 {
-				return equal, true
+				return compareEqual, true
 			}
 			if float32obj1 < float32obj2 {
-				return less, true
+				return compareLess, true
 			}
 		}
 	case reflect.Float64:
@@ -172,13 +174,13 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (int, bool) {
 			float64obj1 := obj1.(float64)
 			float64obj2 := obj2.(float64)
 			if float64obj1 > float64obj2 {
-				return greater, true
+				return compareGreater, true
 			}
 			if float64obj1 == float64obj2 {
-				return equal, true
+				return compareEqual, true
 			}
 			if float64obj1 < float64obj2 {
-				return less, true
+				return compareLess, true
 			}
 		}
 	case reflect.String:
@@ -186,18 +188,18 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (int, bool) {
 			stringobj1 := obj1.(string)
 			stringobj2 := obj2.(string)
 			if stringobj1 > stringobj2 {
-				return greater, true
+				return compareGreater, true
 			}
 			if stringobj1 == stringobj2 {
-				return equal, true
+				return compareEqual, true
 			}
 			if stringobj1 < stringobj2 {
-				return less, true
+				return compareLess, true
 			}
 		}
 	}
 
-	return equal, false
+	return compareEqual, false
 }
 
 // Greater asserts that the first element is greater than the second
@@ -206,7 +208,7 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (int, bool) {
 //    assert.Greater(t, float64(2), float64(1))
 //    assert.Greater(t, "b", "a")
 func Greater(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
-	return compareTwoValues(t, e1, e2, []int{greater}, "\"%s\" is not greater than \"%s\"", msgAndArgs)
+	return compareTwoValues(t, e1, e2, []CompareType{compareGreater}, "\"%s\" is not greater than \"%s\"", msgAndArgs)
 }
 
 // GreaterOrEqual asserts that the first element is greater than or equal to the second
@@ -216,7 +218,7 @@ func Greater(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface
 //    assert.GreaterOrEqual(t, "b", "a")
 //    assert.GreaterOrEqual(t, "b", "b")
 func GreaterOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
-	return compareTwoValues(t, e1, e2, []int{greater, equal}, "\"%s\" is not greater or equal than \"%s\"", msgAndArgs)
+	return compareTwoValues(t, e1, e2, []CompareType{compareGreater, compareEqual}, "\"%s\" is not greater or equal than \"%s\"", msgAndArgs)
 }
 
 // Less asserts that the first element is less than the second
@@ -225,7 +227,7 @@ func GreaterOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...in
 //    assert.Less(t, float64(1), float64(2))
 //    assert.Less(t, "a", "b")
 func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
-	return compareTwoValues(t, e1, e2, []int{less}, "\"%s\" is not less than \"%s\"", msgAndArgs)
+	return compareTwoValues(t, e1, e2, []CompareType{compareLess}, "\"%s\" is not less than \"%s\"", msgAndArgs)
 }
 
 // LessOrEqual asserts that the first element is less than or equal to the second
@@ -235,10 +237,10 @@ func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{})
 //    assert.LessOrEqual(t, "a", "b")
 //    assert.LessOrEqual(t, "b", "b")
 func LessOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
-	return compareTwoValues(t, e1, e2, []int{less, equal}, "\"%s\" is not less or equal than \"%s\"", msgAndArgs)
+	return compareTwoValues(t, e1, e2, []CompareType{compareLess, compareEqual}, "\"%s\" is not less or equal than \"%s\"", msgAndArgs)
 }
 
-func compareTwoValues(t TestingT, e1 interface{}, e2 interface{}, allowedComparesResults []int, failMessage string, msgAndArgs ...interface{}) bool {
+func compareTwoValues(t TestingT, e1 interface{}, e2 interface{}, allowedComparesResults []CompareType, failMessage string, msgAndArgs ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -261,7 +263,7 @@ func compareTwoValues(t TestingT, e1 interface{}, e2 interface{}, allowedCompare
 	return true
 }
 
-func containsValue(values []int, value int) bool {
+func containsValue(values []CompareType, value CompareType) bool {
 	for _, v := range values {
 		if v == value {
 			return true

--- a/assert/assertion_order.go
+++ b/assert/assertion_order.go
@@ -218,7 +218,7 @@ func Greater(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface
 //    assert.GreaterOrEqual(t, "b", "a")
 //    assert.GreaterOrEqual(t, "b", "b")
 func GreaterOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
-	return compareTwoValues(t, e1, e2, []CompareType{compareGreater, compareEqual}, "\"%s\" is not greater or equal than \"%s\"", msgAndArgs)
+	return compareTwoValues(t, e1, e2, []CompareType{compareGreater, compareEqual}, "\"%s\" is not greater than or equal to \"%s\"", msgAndArgs)
 }
 
 // Less asserts that the first element is less than the second
@@ -237,7 +237,7 @@ func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{})
 //    assert.LessOrEqual(t, "a", "b")
 //    assert.LessOrEqual(t, "b", "b")
 func LessOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
-	return compareTwoValues(t, e1, e2, []CompareType{compareLess, compareEqual}, "\"%s\" is not less or equal than \"%s\"", msgAndArgs)
+	return compareTwoValues(t, e1, e2, []CompareType{compareLess, compareEqual}, "\"%s\" is not less than or equal to \"%s\"", msgAndArgs)
 }
 
 func compareTwoValues(t TestingT, e1 interface{}, e2 interface{}, allowedComparesResults []CompareType, failMessage string, msgAndArgs ...interface{}) bool {

--- a/assert/assertion_order_test.go
+++ b/assert/assertion_order_test.go
@@ -29,7 +29,7 @@ func TestCompare(t *testing.T) {
 			t.Error("object should be comparable for type " + currCase.cType)
 		}
 
-		if resLess != -1 {
+		if resLess != less {
 			t.Errorf("object less should be less than greater for type " + currCase.cType)
 		}
 
@@ -38,7 +38,7 @@ func TestCompare(t *testing.T) {
 			t.Error("object are comparable for type " + currCase.cType)
 		}
 
-		if resGreater != 1 {
+		if resGreater != greater {
 			t.Errorf("object greater should be greater than less for type " + currCase.cType)
 		}
 

--- a/assert/assertion_order_test.go
+++ b/assert/assertion_order_test.go
@@ -29,7 +29,7 @@ func TestCompare(t *testing.T) {
 			t.Error("object should be comparable for type " + currCase.cType)
 		}
 
-		if resLess != 1 {
+		if resLess != -1 {
 			t.Errorf("object less should be less than greater for type " + currCase.cType)
 		}
 
@@ -38,7 +38,7 @@ func TestCompare(t *testing.T) {
 			t.Error("object are comparable for type " + currCase.cType)
 		}
 
-		if resGreater != -1 {
+		if resGreater != 1 {
 			t.Errorf("object greater should be greater than less for type " + currCase.cType)
 		}
 

--- a/assert/assertion_order_test.go
+++ b/assert/assertion_order_test.go
@@ -131,9 +131,7 @@ func Test_compareTwoValuesDifferentValuesTypes(t *testing.T) {
 		{v1: "float(12)", v2: float64(1)},
 	} {
 		compareResult := compareTwoValues(mockT, currCase.v1, currCase.v2, []CompareType{compareLess, compareEqual, compareGreater}, "testFailMessage")
-		if compareResult {
-			t.Errorf("Values %s and %s should be different kinds", currCase.v1, currCase.v2)
-		}
+		False(t, compareResult)
 	}
 }
 
@@ -152,13 +150,11 @@ func Test_compareTwoValuesNotComparableValues(t *testing.T) {
 		{v1: make([]int, 5, 5), v2: make([]int, 5, 5)},
 	} {
 		compareResult := compareTwoValues(mockT, currCase.v1, currCase.v2, []CompareType{compareLess, compareEqual, compareGreater}, "testFailMessage")
-		if compareResult {
-			t.Errorf("Values %s and %s should be not comparable", currCase.v1, currCase.v2)
-		}
+		False(t, compareResult)
 	}
 }
 
-func Test_compareTwoValuesCrrectCompareResult(t *testing.T) {
+func Test_compareTwoValuesCorrectCompareResult(t *testing.T) {
 	mockT := new(testing.T)
 
 	for _, currCase := range []struct {
@@ -174,9 +170,7 @@ func Test_compareTwoValuesCrrectCompareResult(t *testing.T) {
 		{v1: 2, v2: 1, compareTypes: []CompareType{compareGreater}},
 	} {
 		compareResult := compareTwoValues(mockT, currCase.v1, currCase.v2, currCase.compareTypes, "testFailMessage")
-		if !compareResult {
-			t.Errorf("Values %d and %d is not compared correctly", currCase.v1, currCase.v2)
-		}
+		True(t, compareResult)
 	}
 }
 
@@ -192,8 +186,6 @@ func Test_containsValue(t *testing.T) {
 		{values: []CompareType{compareGreater, compareLess}, value: compareEqual, result: false},
 	} {
 		compareResult := containsValue(currCase.values, currCase.value)
-		if compareResult != currCase.result {
-			t.Error("Value not in list")
-		}
+		Equal(t, currCase.result, compareResult)
 	}
 }

--- a/assert/assertion_order_test.go
+++ b/assert/assertion_order_test.go
@@ -29,7 +29,7 @@ func TestCompare(t *testing.T) {
 			t.Error("object should be comparable for type " + currCase.cType)
 		}
 
-		if resLess != less {
+		if resLess != compareLess {
 			t.Errorf("object less should be less than greater for type " + currCase.cType)
 		}
 
@@ -38,7 +38,7 @@ func TestCompare(t *testing.T) {
 			t.Error("object are comparable for type " + currCase.cType)
 		}
 
-		if resGreater != greater {
+		if resGreater != compareGreater {
 			t.Errorf("object greater should be greater than less for type " + currCase.cType)
 		}
 
@@ -114,5 +114,86 @@ func TestLessOrEqual(t *testing.T) {
 
 	if LessOrEqual(mockT, 2, 1) {
 		t.Error("Greater should return false")
+	}
+}
+
+func Test_compareTwoValuesDifferentValuesTypes(t *testing.T) {
+	mockT := new(testing.T)
+
+	for _, currCase := range []struct {
+		v1            interface{}
+		v2            interface{}
+		compareResult bool
+	}{
+		{v1: 123, v2: "abc"},
+		{v1: "abc", v2: 123456},
+		{v1: float64(12), v2: "123"},
+		{v1: "float(12)", v2: float64(1)},
+	} {
+		compareResult := compareTwoValues(mockT, currCase.v1, currCase.v2, []CompareType{compareLess, compareEqual, compareGreater}, "testFailMessage")
+		if compareResult {
+			t.Errorf("Values %s and %s should be different kinds", currCase.v1, currCase.v2)
+		}
+	}
+}
+
+func Test_compareTwoValuesNotComparableValues(t *testing.T) {
+	mockT := new(testing.T)
+
+	type CompareStruct struct {
+	}
+
+	for _, currCase := range []struct {
+		v1 interface{}
+		v2 interface{}
+	}{
+		{v1: CompareStruct{}, v2: CompareStruct{}},
+		{v1: map[string]int{}, v2: map[string]int{}},
+		{v1: make([]int, 5, 5), v2: make([]int, 5, 5)},
+	} {
+		compareResult := compareTwoValues(mockT, currCase.v1, currCase.v2, []CompareType{compareLess, compareEqual, compareGreater}, "testFailMessage")
+		if compareResult {
+			t.Errorf("Values %s and %s should be not comparable", currCase.v1, currCase.v2)
+		}
+	}
+}
+
+func Test_compareTwoValuesCrrectCompareResult(t *testing.T) {
+	mockT := new(testing.T)
+
+	for _, currCase := range []struct {
+		v1           interface{}
+		v2           interface{}
+		compareTypes []CompareType
+	}{
+		{v1: 1, v2: 2, compareTypes: []CompareType{compareLess}},
+		{v1: 1, v2: 2, compareTypes: []CompareType{compareLess, compareEqual}},
+		{v1: 2, v2: 2, compareTypes: []CompareType{compareGreater, compareEqual}},
+		{v1: 2, v2: 2, compareTypes: []CompareType{compareEqual}},
+		{v1: 2, v2: 1, compareTypes: []CompareType{compareEqual, compareGreater}},
+		{v1: 2, v2: 1, compareTypes: []CompareType{compareGreater}},
+	} {
+		compareResult := compareTwoValues(mockT, currCase.v1, currCase.v2, currCase.compareTypes, "testFailMessage")
+		if !compareResult {
+			t.Errorf("Values %d and %d is not compared correctly", currCase.v1, currCase.v2)
+		}
+	}
+}
+
+func Test_containsValue(t *testing.T) {
+	for _, currCase := range []struct {
+		values []CompareType
+		value  CompareType
+		result bool
+	}{
+		{values: []CompareType{compareGreater}, value: compareGreater, result: true},
+		{values: []CompareType{compareGreater, compareLess}, value: compareGreater, result: true},
+		{values: []CompareType{compareGreater, compareLess}, value: compareLess, result: true},
+		{values: []CompareType{compareGreater, compareLess}, value: compareEqual, result: false},
+	} {
+		compareResult := containsValue(currCase.values, currCase.value)
+		if compareResult != currCase.result {
+			t.Error("Value not in list")
+		}
 	}
 }


### PR DESCRIPTION
Refactoring of the assertion order functionality:
 - Using constants `greater`, `equal`, `less` instead of `-1`, `0`, `1`. Now the code become more readable.
 - Unify working with comparing results. There was almost the same copy-pasted code for `Greater`, `GreaterOrEqual`, `Less`, `LessOrEqual` functions. Now these call one function with all common logic. It could help to change behavior for all of them in future.

Linked issue https://github.com/stretchr/testify/issues/903 .