### PR TITLE
Support uint in InDelta and InEpsilon

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -992,6 +992,8 @@ func toFloat(x interface{}) (float64, bool) {
 	xok := true
 
 	switch xn := x.(type) {
+	case uint:
+		xf = float64(xn)
 	case uint8:
 		xf = float64(xn)
 	case uint16:

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -1115,6 +1115,7 @@ func TestInDelta(t *testing.T) {
 		a, b  interface{}
 		delta float64
 	}{
+		{uint(2), uint(1), 1},
 		{uint8(2), uint8(1), 1},
 		{uint16(2), uint16(1), 1},
 		{uint32(2), uint32(1), 1},


### PR DESCRIPTION
InDelta and InEpsilon assertions on uint values would fail with
the error "Parameters must be numerical".