### PR TITLE
codegen: add flag for additional imports

### DIFF
--- a/_codegen/main.go
+++ b/_codegen/main.go
@@ -28,11 +28,12 @@ import (
 )
 
 var (
-	pkg       = flag.String("assert-path", "github.com/stretchr/testify/assert", "Path to the assert package")
-	includeF  = flag.Bool("include-format-funcs", false, "include format functions such as Errorf and Equalf")
-	outputPkg = flag.String("output-package", "", "package for the resulting code")
-	tmplFile  = flag.String("template", "", "What file to load the function template from")
-	out       = flag.String("out", "", "What file to write the source code to")
+	pkg               = flag.String("assert-path", "github.com/stretchr/testify/assert", "Path to the assert package")
+	includeF          = flag.Bool("include-format-funcs", false, "include format functions such as Errorf and Equalf")
+	outputPkg         = flag.String("output-package", "", "package for the resulting code")
+	tmplFile          = flag.String("template", "", "What file to load the function template from")
+	out               = flag.String("out", "", "What file to write the source code to")
+	additionalImports = flag.String("additional-imports", "", "additional packages to import")
 )
 
 func main() {
@@ -61,13 +62,20 @@ func generateCode(importer imports.Importer, funcs []testFunc) error {
 		return err
 	}
 
+	imports := importer.Imports()
+	if len(*additionalImports) > 0 {
+		for _, pkg := range strings.Split(*additionalImports, ",") {
+			imports[pkg] = path.Base(pkg)
+		}
+	}
+
 	// Generate header
 	if err := tmplHead.Execute(buff, struct {
 		Name    string
 		Imports map[string]string
 	}{
 		*outputPkg,
-		importer.Imports(),
+		imports,
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
Go 1.5 introduced the 'source' compiler. See
https://github.com/golang/go/issues/11415 for details.

This avoids the problem of using out of date information when generating
code. It also means we don't have to have to run `go install` prior to
generating.

I also added the ability to specify additional imports since we use
codegen to generate files that depend on types outside testify.