### PR TITLE
Improve  error message for over-repeating calls

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -350,6 +350,7 @@ func (m *Mock) MethodCalled(methodName string, arguments ...interface{}) Argumen
 	if found < 0 {
 		// expected call found but it has already been called with repeatable times
 		if call != nil {
+			m.mutex.Unlock()
 			m.fail("\nassert: mock: The method has been called over %d times.\n\tEither do one more Mock.On(\"%s\").Return(...), or remove extra call.\n\tThis call was unexpected:\n\t\t%s\n\tat: %s", call.totalCalls, methodName, callString(methodName, arguments, true), assert.CallerInfo())
 		}
 		// we have to fail here - because we don't know what to do

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -262,17 +262,21 @@ func (m *Mock) On(methodName string, arguments ...interface{}) *Call {
 // */
 
 func (m *Mock) findExpectedCall(method string, arguments ...interface{}) (int, *Call) {
-	for i, call := range m.ExpectedCalls {
-		if call.Method == method && call.Repeatability > -1 {
+	var expectedCall *Call
 
+	for i, call := range m.ExpectedCalls {
+		if call.Method == method {
 			_, diffCount := call.Arguments.Diff(arguments)
 			if diffCount == 0 {
-				return i, call
+				expectedCall = call
+				if call.Repeatability > -1 {
+					return i, call
+				}
 			}
-
 		}
 	}
-	return -1, nil
+
+	return -1, expectedCall
 }
 
 func (m *Mock) findClosestCall(method string, arguments ...interface{}) (*Call, string) {
@@ -344,13 +348,16 @@ func (m *Mock) MethodCalled(methodName string, arguments ...interface{}) Argumen
 	found, call := m.findExpectedCall(methodName, arguments...)
 
 	if found < 0 {
+		// expected call found but it has already been called with repeatable times
+		if call != nil {
+			m.fail("\nassert: mock: The method has been called over %d times.\n\tEither do one more Mock.On(\"%s\").Return(...), or remove extra call.\n\tThis call was unexpected:\n\t\t%s\n\tat: %s", call.totalCalls, methodName, callString(methodName, arguments, true), assert.CallerInfo())
+		}
 		// we have to fail here - because we don't know what to do
 		// as the return arguments.  This is because:
 		//
 		//   a) this is a totally unexpected call to this method,
 		//   b) the arguments are not what was expected, or
 		//   c) the developer has forgotten to add an accompanying On...Return pair.
-
 		closestCall, mismatch := m.findClosestCall(methodName, arguments...)
 		m.mutex.Unlock()
 

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -740,6 +740,16 @@ func Test_Mock_findExpectedCall_Respects_Repeatability(t *testing.T) {
 		}
 	}
 
+	c = m.On("Once", 1).Return("one").Once()
+	c.Repeatability = -1
+	f, c = m.findExpectedCall("Once", 1)
+	if assert.Equal(t, -1, f) {
+		if assert.NotNil(t, c) {
+			assert.Equal(t, "Once", c.Method)
+			assert.Equal(t, 1, c.Arguments[0])
+			assert.Equal(t, "one", c.ReturnArguments[0])
+		}
+	}
 }
 
 func Test_callString(t *testing.T) {


### PR DESCRIPTION
## Problem

the error message is confusing for over-repeating calls.

test code:
```Go
package tests

import (
	"testing"

	"github.com/stretchr/testify/mock"
)

type myMock struct {
	mock.Mock
}

func (m *myMock) DoSomething(num int) error {
	return m.Called(num).Error(0)
}

func Test_call(t *testing.T) {
	var tMock = new(myMock)
	tMock.On("DoSomething", 0).Return(nil).Once()
	tMock.DoSomething(0)
	tMock.DoSomething(0)
	tMock.AssertExpectations(t)
}
```

Current test fail message:
```
mock: Unexpected Method Call
-----------------------------

DoSomething(int)
		0: 0

The closest call I have is: 

DoSomething(int)
		0: 0


Diff: No differences.

goroutine 19 [running]:
testing.tRunner.func1(0xc000120100)
	/usr/local/go/src/testing/testing.go:792 +0x387
panic(0x13209a0, 0xc000095130)
	/usr/local/go/src/runtime/panic.go:513 +0x1b9
github.com/stretchr/testify/mock.(*Mock).fail(0xc0000d22d0, 0x13b6a57, 0x6f, 0xc0000a0a80, 0x4, 0x4)
....
```

More helpful message with the change:
```
assert: mock: The method has been called over 1 times.
	Either do one more Mock.On("DoSomething").Return(...), or remove extra call.
	This call was unexpected:
		DoSomething(int)
		0: 0
	at: [mock_test.go:14 mock_test.go:21]

goroutine 5 [running]:
testing.tRunner.func1(0xc000100100)
	/usr/local/go/src/testing/testing.go:792 +0x387
panic(0x1320c40, 0xc00005b130)
	/usr/local/go/src/runtime/panic.go:513 +0x1b9
github.com/stretchr/testify/mock.(*Mock).fail(0xc0000b42d0, 0x13b7219, 0xa5, 0xc000022b80, 0x4, 0x4)
	/Users/xiaoleiliu/go/src/github.com/stretchr/testify/mock/mock.go:236 +0x16d
```