### PR TITLE
Fix docs and output for LessOrEqual and friends

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,8 @@ Please feel free to submit issues, fork the repository and send pull requests!
 
 When submitting an issue, we ask that you please include a complete test function that demonstrates the issue.  Extra credit for those using Testify to write the test code that demonstrates it.
 
+Code generation is used. Look for `CODE GENERATED AUTOMATICALLY` at the top of some files. Run `go generate ./...` to update generated files.
+
 ------
 
 License

--- a/assert/assertion_format.go
+++ b/assert/assertion_format.go
@@ -169,7 +169,7 @@ func Greaterf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...in
 	return Greater(t, e1, e2, append([]interface{}{msg}, args...)...)
 }
 
-// GreaterOrEqualf asserts that the first element in greater or equal than the second
+// GreaterOrEqualf asserts that the first element is greater than or equal to the second
 //
 //    assert.GreaterOrEqualf(t, 2, 1, "error message %s", "formatted")
 //    assert.GreaterOrEqualf(t, 2, 2, "error message %s", "formatted")
@@ -325,7 +325,7 @@ func Lenf(t TestingT, object interface{}, length int, msg string, args ...interf
 	return Len(t, object, length, append([]interface{}{msg}, args...)...)
 }
 
-// Lessf asserts that the first element in less than the second
+// Lessf asserts that the first element is less than the second
 //
 //    assert.Lessf(t, 1, 2, "error message %s", "formatted")
 //    assert.Lessf(t, float64(1, "error message %s", "formatted"), float64(2))
@@ -337,7 +337,7 @@ func Lessf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...inter
 	return Less(t, e1, e2, append([]interface{}{msg}, args...)...)
 }
 
-// LessOrEqualf asserts that the first element in greater or equal than the second
+// LessOrEqualf asserts that the first element is less than or equal to the second
 //
 //    assert.LessOrEqualf(t, 1, 2, "error message %s", "formatted")
 //    assert.LessOrEqualf(t, 2, 2, "error message %s", "formatted")

--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -315,7 +315,7 @@ func (a *Assertions) Greater(e1 interface{}, e2 interface{}, msgAndArgs ...inter
 	return Greater(a.t, e1, e2, msgAndArgs...)
 }
 
-// GreaterOrEqual asserts that the first element in greater or equal than the second
+// GreaterOrEqual asserts that the first element is greater than or equal to the second
 //
 //    a.GreaterOrEqual(2, 1)
 //    a.GreaterOrEqual(2, 2)
@@ -328,7 +328,7 @@ func (a *Assertions) GreaterOrEqual(e1 interface{}, e2 interface{}, msgAndArgs .
 	return GreaterOrEqual(a.t, e1, e2, msgAndArgs...)
 }
 
-// GreaterOrEqualf asserts that the first element in greater or equal than the second
+// GreaterOrEqualf asserts that the first element is greater than or equal to the second
 //
 //    a.GreaterOrEqualf(2, 1, "error message %s", "formatted")
 //    a.GreaterOrEqualf(2, 2, "error message %s", "formatted")
@@ -639,7 +639,7 @@ func (a *Assertions) Lenf(object interface{}, length int, msg string, args ...in
 	return Lenf(a.t, object, length, msg, args...)
 }
 
-// Less asserts that the first element in less than the second
+// Less asserts that the first element is less than the second
 //
 //    a.Less(1, 2)
 //    a.Less(float64(1), float64(2))
@@ -651,7 +651,7 @@ func (a *Assertions) Less(e1 interface{}, e2 interface{}, msgAndArgs ...interfac
 	return Less(a.t, e1, e2, msgAndArgs...)
 }
 
-// LessOrEqual asserts that the first element in greater or equal than the second
+// LessOrEqual asserts that the first element is less than or equal to the second
 //
 //    a.LessOrEqual(1, 2)
 //    a.LessOrEqual(2, 2)
@@ -664,7 +664,7 @@ func (a *Assertions) LessOrEqual(e1 interface{}, e2 interface{}, msgAndArgs ...i
 	return LessOrEqual(a.t, e1, e2, msgAndArgs...)
 }
 
-// LessOrEqualf asserts that the first element in greater or equal than the second
+// LessOrEqualf asserts that the first element is less than or equal to the second
 //
 //    a.LessOrEqualf(1, 2, "error message %s", "formatted")
 //    a.LessOrEqualf(2, 2, "error message %s", "formatted")
@@ -677,7 +677,7 @@ func (a *Assertions) LessOrEqualf(e1 interface{}, e2 interface{}, msg string, ar
 	return LessOrEqualf(a.t, e1, e2, msg, args...)
 }
 
-// Lessf asserts that the first element in less than the second
+// Lessf asserts that the first element is less than the second
 //
 //    a.Lessf(1, 2, "error message %s", "formatted")
 //    a.Lessf(float64(1, "error message %s", "formatted"), float64(2))

--- a/assert/assertion_order.go
+++ b/assert/assertion_order.go
@@ -216,13 +216,13 @@ func Greater(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface
 	}
 
 	if res != -1 {
-		return Fail(t, fmt.Sprintf("\"%s\" is not greater than \"%s\"", e1, e2), msgAndArgs...)
+		return Fail(t, fmt.Sprintf("\"%v\" is not greater than \"%v\"", e1, e2), msgAndArgs...)
 	}
 
 	return true
 }
 
-// GreaterOrEqual asserts that the first element in greater or equal than the second
+// GreaterOrEqual asserts that the first element is greater than or equal to the second
 //
 //    assert.GreaterOrEqual(t, 2, 1)
 //    assert.GreaterOrEqual(t, 2, 2)
@@ -245,13 +245,13 @@ func GreaterOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...in
 	}
 
 	if res != -1 && res != 0 {
-		return Fail(t, fmt.Sprintf("\"%s\" is not greater or equal than \"%s\"", e1, e2), msgAndArgs...)
+		return Fail(t, fmt.Sprintf("\"%v\" is not greater than or equal to \"%v\"", e1, e2), msgAndArgs...)
 	}
 
 	return true
 }
 
-// Less asserts that the first element in less than the second
+// Less asserts that the first element is less than the second
 //
 //    assert.Less(t, 1, 2)
 //    assert.Less(t, float64(1), float64(2))
@@ -273,13 +273,13 @@ func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{})
 	}
 
 	if res != 1 {
-		return Fail(t, fmt.Sprintf("\"%s\" is not less than \"%s\"", e1, e2), msgAndArgs...)
+		return Fail(t, fmt.Sprintf("\"%v\" is not less than \"%v\"", e1, e2), msgAndArgs...)
 	}
 
 	return true
 }
 
-// LessOrEqual asserts that the first element in greater or equal than the second
+// LessOrEqual asserts that the first element is less than or equal to the second
 //
 //    assert.LessOrEqual(t, 1, 2)
 //    assert.LessOrEqual(t, 2, 2)
@@ -302,7 +302,7 @@ func LessOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...inter
 	}
 
 	if res != 1 && res != 0 {
-		return Fail(t, fmt.Sprintf("\"%s\" is not less or equal than \"%s\"", e1, e2), msgAndArgs...)
+		return Fail(t, fmt.Sprintf("\"%v\" is not less than or equal to \"%v\"", e1, e2), msgAndArgs...)
 	}
 
 	return true

--- a/require/require.go
+++ b/require/require.go
@@ -403,7 +403,7 @@ func Greater(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface
 	t.FailNow()
 }
 
-// GreaterOrEqual asserts that the first element in greater or equal than the second
+// GreaterOrEqual asserts that the first element is greater than or equal to the second
 //
 //    assert.GreaterOrEqual(t, 2, 1)
 //    assert.GreaterOrEqual(t, 2, 2)
@@ -419,7 +419,7 @@ func GreaterOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...in
 	t.FailNow()
 }
 
-// GreaterOrEqualf asserts that the first element in greater or equal than the second
+// GreaterOrEqualf asserts that the first element is greater than or equal to the second
 //
 //    assert.GreaterOrEqualf(t, 2, 1, "error message %s", "formatted")
 //    assert.GreaterOrEqualf(t, 2, 2, "error message %s", "formatted")
@@ -820,7 +820,7 @@ func Lenf(t TestingT, object interface{}, length int, msg string, args ...interf
 	t.FailNow()
 }
 
-// Less asserts that the first element in less than the second
+// Less asserts that the first element is less than the second
 //
 //    assert.Less(t, 1, 2)
 //    assert.Less(t, float64(1), float64(2))
@@ -835,7 +835,7 @@ func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{})
 	t.FailNow()
 }
 
-// LessOrEqual asserts that the first element in greater or equal than the second
+// LessOrEqual asserts that the first element is less than or equal to the second
 //
 //    assert.LessOrEqual(t, 1, 2)
 //    assert.LessOrEqual(t, 2, 2)
@@ -851,7 +851,7 @@ func LessOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...inter
 	t.FailNow()
 }
 
-// LessOrEqualf asserts that the first element in greater or equal than the second
+// LessOrEqualf asserts that the first element is less than or equal to the second
 //
 //    assert.LessOrEqualf(t, 1, 2, "error message %s", "formatted")
 //    assert.LessOrEqualf(t, 2, 2, "error message %s", "formatted")
@@ -867,7 +867,7 @@ func LessOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args .
 	t.FailNow()
 }
 
-// Lessf asserts that the first element in less than the second
+// Lessf asserts that the first element is less than the second
 //
 //    assert.Lessf(t, 1, 2, "error message %s", "formatted")
 //    assert.Lessf(t, float64(1, "error message %s", "formatted"), float64(2))

--- a/require/require_forward.go
+++ b/require/require_forward.go
@@ -316,7 +316,7 @@ func (a *Assertions) Greater(e1 interface{}, e2 interface{}, msgAndArgs ...inter
 	Greater(a.t, e1, e2, msgAndArgs...)
 }
 
-// GreaterOrEqual asserts that the first element in greater or equal than the second
+// GreaterOrEqual asserts that the first element is greater than or equal to the second
 //
 //    a.GreaterOrEqual(2, 1)
 //    a.GreaterOrEqual(2, 2)
@@ -329,7 +329,7 @@ func (a *Assertions) GreaterOrEqual(e1 interface{}, e2 interface{}, msgAndArgs .
 	GreaterOrEqual(a.t, e1, e2, msgAndArgs...)
 }
 
-// GreaterOrEqualf asserts that the first element in greater or equal than the second
+// GreaterOrEqualf asserts that the first element is greater than or equal to the second
 //
 //    a.GreaterOrEqualf(2, 1, "error message %s", "formatted")
 //    a.GreaterOrEqualf(2, 2, "error message %s", "formatted")
@@ -640,7 +640,7 @@ func (a *Assertions) Lenf(object interface{}, length int, msg string, args ...in
 	Lenf(a.t, object, length, msg, args...)
 }
 
-// Less asserts that the first element in less than the second
+// Less asserts that the first element is less than the second
 //
 //    a.Less(1, 2)
 //    a.Less(float64(1), float64(2))
@@ -652,7 +652,7 @@ func (a *Assertions) Less(e1 interface{}, e2 interface{}, msgAndArgs ...interfac
 	Less(a.t, e1, e2, msgAndArgs...)
 }
 
-// LessOrEqual asserts that the first element in greater or equal than the second
+// LessOrEqual asserts that the first element is less than or equal to the second
 //
 //    a.LessOrEqual(1, 2)
 //    a.LessOrEqual(2, 2)
@@ -665,7 +665,7 @@ func (a *Assertions) LessOrEqual(e1 interface{}, e2 interface{}, msgAndArgs ...i
 	LessOrEqual(a.t, e1, e2, msgAndArgs...)
 }
 
-// LessOrEqualf asserts that the first element in greater or equal than the second
+// LessOrEqualf asserts that the first element is less than or equal to the second
 //
 //    a.LessOrEqualf(1, 2, "error message %s", "formatted")
 //    a.LessOrEqualf(2, 2, "error message %s", "formatted")
@@ -678,7 +678,7 @@ func (a *Assertions) LessOrEqualf(e1 interface{}, e2 interface{}, msg string, ar
 	LessOrEqualf(a.t, e1, e2, msg, args...)
 }
 
-// Lessf asserts that the first element in less than the second
+// Lessf asserts that the first element is less than the second
 //
 //    a.Lessf(1, 2, "error message %s", "formatted")
 //    a.Lessf(float64(1, "error message %s", "formatted"), float64(2))


### PR DESCRIPTION
In documentation change this and other similar entries:
```
- LessOrEqual asserts that the first element in greater or equal than the second
+ LessOrEqual asserts that the first element is less than or equal to the second 
```

In test output for `LessOrEqual(t, 2, 1)` change this and similar:
```
-                Error:          "%!s(int=2)" is not less or equal than "%!s(int=1)"
+                Error:          "2" is not less than or equal to "1"
```