### PR TITLE
Fix CI script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ matrix:
     - go: "1.11.x"
       env: GO111MODULE=on
     - go: tip
-  script:
-    - ./.travis.gogenerate.sh
-    - ./.travis.gofmt.sh
-    - ./.travis.govet.sh
-    - go test -v -race $(go list ./... | grep -v vendor)
+script:
+  - ./.travis.gogenerate.sh
+  - ./.travis.gofmt.sh
+  - ./.travis.govet.sh
+  - go test -v -race $(go list ./... | grep -v vendor)


### PR DESCRIPTION
The script isn't running properly in Travis. This appears to be because the `script` block was indented incorrectly.