### PR TITLE
mock: refactor Diff to reduce risk of triggering race conditions

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -667,7 +667,6 @@ func (args Arguments) Is(objects ...interface{}) bool {
 func (args Arguments) Diff(objects []interface{}) (string, int) {
 	//TODO: could return string as error and nil for No difference
 
-	var output = "\n"
 	var differences int
 
 	var maxArgCount = len(args)
@@ -675,32 +674,23 @@ func (args Arguments) Diff(objects []interface{}) (string, int) {
 		maxArgCount = len(objects)
 	}
 
+	outputFuncs := make([]func() string, maxArgCount)
+
 	for i := 0; i < maxArgCount; i++ {
 		var actual, expected interface{}
-		var actualFmt, expectedFmt string
-
-		if len(objects) <= i {
-			actual = "(Missing)"
-			actualFmt = "(Missing)"
-		} else {
+		if len(objects) > i {
 			actual = objects[i]
-			actualFmt = fmt.Sprintf("(%[1]T=%[1]v)", actual)
 		}
-
-		if len(args) <= i {
-			expected = "(Missing)"
-			expectedFmt = "(Missing)"
-		} else {
+		if len(args) > i {
 			expected = args[i]
-			expectedFmt = fmt.Sprintf("(%[1]T=%[1]v)", expected)
 		}
 
 		if matcher, ok := expected.(argumentMatcher); ok {
 			if matcher.Matches(actual) {
-				output = fmt.Sprintf("%s\t%d: PASS:  %s matched by %s\n", output, i, actualFmt, matcher)
+				outputFuncs[i] = reportFunc(i, true, actual, expected)
 			} else {
 				differences++
-				output = fmt.Sprintf("%s\t%d: FAIL:  %s not matched by %s\n", output, i, actualFmt, matcher)
+				outputFuncs[i] = reportFunc(i, false, actual, expected)
 			}
 		} else if reflect.TypeOf(expected) == reflect.TypeOf((*AnythingOfTypeArgument)(nil)).Elem() {
 
@@ -708,31 +698,99 @@ func (args Arguments) Diff(objects []interface{}) (string, int) {
 			if reflect.TypeOf(actual).Name() != string(expected.(AnythingOfTypeArgument)) && reflect.TypeOf(actual).String() != string(expected.(AnythingOfTypeArgument)) {
 				// not match
 				differences++
-				output = fmt.Sprintf("%s\t%d: FAIL:  type %s != type %s - %s\n", output, i, expected, reflect.TypeOf(actual).Name(), actualFmt)
+				outputFuncs[i] = reportFunc(i, false, actual, expected)
 			}
 
 		} else {
-
 			// normal checking
-
 			if assert.ObjectsAreEqual(expected, Anything) || assert.ObjectsAreEqual(actual, Anything) || assert.ObjectsAreEqual(actual, expected) {
-				// match
-				output = fmt.Sprintf("%s\t%d: PASS:  %s == %s\n", output, i, actualFmt, expectedFmt)
+				outputFuncs[i] = reportFunc(i, true, actual, expected)
+
 			} else {
 				// not match
 				differences++
-				output = fmt.Sprintf("%s\t%d: FAIL:  %s != %s\n", output, i, actualFmt, expectedFmt)
+				outputFuncs[i] = reportFunc(i, false, actual, expected)
 			}
 		}
-
 	}
 
 	if differences == 0 {
 		return "No differences.", differences
 	}
 
-	return output, differences
+	var output = "\n"
 
+	// Generate output, highlighting the failed expectations.
+	for _, f := range outputFuncs {
+		if f != nil {
+			output += f()
+		}
+	}
+
+	return output, differences
+}
+
+// Returns a function that will report on the pass/fail of a specific argument expectation.
+// i is the argument index, pass indicates pass/fail, actual and expected are the argument values.
+func reportFunc(i int, pass bool, actual, expected interface{}) func() string {
+	var actDisplay, expDisplay interface{}
+	if actual == nil {
+		actDisplay = "(Missing)"
+	} else {
+		actDisplay = actual
+	}
+	if expected == nil {
+		expDisplay = "(Missing)"
+	} else {
+		expDisplay = expected
+	}
+
+	if matcher, ok := expected.(argumentMatcher); ok {
+		tvFmt := typeValueFmt(2, actual)
+		switch pass {
+		case true:
+			return func() string { return fmt.Sprintf("\t%d: PASS:  "+tvFmt+" matched by %s\n", i, actDisplay, matcher) }
+		case false:
+			return func() string {
+				return fmt.Sprintf("\t%d: FAIL:  "+tvFmt+" not matched by %s\n", i, actDisplay, matcher)
+			}
+		}
+	}
+
+	if reflect.TypeOf(expected) == reflect.TypeOf((*AnythingOfTypeArgument)(nil)).Elem() {
+		if !pass {
+			tvFmt := typeValueFmt(4, actual)
+			return func() string {
+				return fmt.Sprintf("\t%d: FAIL:  type %s != type %s - "+tvFmt+"\n", i, expected, reflect.TypeOf(actual).Name(), actual)
+			}
+		}
+		return nil
+	}
+
+	actTvFmt := typeValueFmt(2, actual)
+	expTvFmt := typeValueFmt(3, expected)
+
+	switch pass {
+	case true:
+		return func() string {
+			return fmt.Sprintf("\t%d: PASS:  "+actTvFmt+" == "+expTvFmt+"\n", i, actDisplay, expDisplay)
+		}
+	case false:
+		return func() string {
+			return fmt.Sprintf("\t%d: FAIL:  "+actTvFmt+" != "+expTvFmt+"\n", i, actDisplay, expDisplay)
+		}
+	}
+	return nil
+}
+
+// Generates a format string for a type=value pair or, if the value is nil, returns "(Missing)"
+func typeValueFmt(i int, value interface{}) string {
+	switch {
+	case value != nil:
+		return fmt.Sprintf("(%%[%d]T=%%[%d]v)", i, i)
+	default:
+		return "(Missing)"
+	}
 }
 
 // Assert compares the arguments with the specified objects and fails if

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -1,8 +1,11 @@
 package mock
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"regexp"
 	"runtime"
 	"sync"
@@ -1039,6 +1042,35 @@ func Test_Mock_AssertExpectations_With_Repeatability(t *testing.T) {
 	// now assert expectations
 	assert.True(t, mockedService.AssertExpectations(tt))
 
+}
+
+func Test_Mock_AssertExpectationsServerRace(t *testing.T) {
+	// This test reproduces the bug in https://github.com/stretchr/testify/issues/625
+	var mockedService = new(TestExampleImplementation)
+
+	mockedService.On("func1", AnythingOfType("*context.cancelCtx")).Return(nil).Once()
+
+	tt := new(testing.T)
+	assert.False(t, mockedService.AssertExpectations(tt))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// make the call now
+		mockedService.Called(r.Context())
+		w.Write([]byte("some response"))
+	}))
+	defer srv.Close()
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL+"/", nil)
+	assert.NoError(t, err)
+	req = req.WithContext(context.Background())
+
+	res, err := http.DefaultClient.Do(req)
+
+	assert.NoError(t, err)
+	defer res.Body.Close()
+
+	// now assert expectations
+	assert.True(t, mockedService.AssertExpectations(tt))
 }
 
 func Test_Mock_TwoCallsWithDifferentArguments(t *testing.T) {


### PR DESCRIPTION
This is an alternative to https://github.com/stretchr/testify/pull/654
and seeks to address https://github.com/stretchr/testify/issues/625, avoiding triggering race conditions when stringifying arguments.

The Diff method is refactored to decouple the generation of argument pass/fail reports from the argument checks, so that argument stringification only takes place after all arguments have been checked and only if arguments expectations are not met. 

It remains the case that if an argument expectation is not met, the subsequent argument stringification could trigger a race condition which might mask the original argument mismatch.

The changes incorporates the unit test added by  https://github.com/stretchr/testify/pull/654.
Without the changes to the Diff method, I found that race conditions were consistently reported by that test when running:
```
go test -race -count=10 github.com/stretchr/testify/mock
```
