### PR TITLE
#562: assert.NoError() and assert.Error() now behave correctly when a nil error struct is supplied

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1197,7 +1197,7 @@ func NoError(t TestingT, err error, msgAndArgs ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	if err != nil {
+	if !isNil(err) {
 		return Fail(t, fmt.Sprintf("Received unexpected error:\n%+v", err), msgAndArgs...)
 	}
 
@@ -1215,7 +1215,7 @@ func Error(t TestingT, err error, msgAndArgs ...interface{}) bool {
 		h.Helper()
 	}
 
-	if err == nil {
+	if isNil(err)  {
 		return Fail(t, "An error is expected but got nil.", msgAndArgs...)
 	}
 

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -826,7 +826,7 @@ func TestNoError(t *testing.T) {
 		t.Errorf("Error should be nil due to empty interface: %s", err)
 	}
 
-	False(t, NoError(mockT, err), "NoError should fail with empty error interface")
+	True(t, NoError(mockT, err), "NoError should fail with empty error interface")
 }
 
 type customError struct{}
@@ -863,7 +863,7 @@ func TestError(t *testing.T) {
 		t.Errorf("Error should be nil due to empty interface: %s", err)
 	}
 
-	True(t, Error(mockT, err), "Error should pass with empty error interface")
+	False(t, Error(mockT, err), "Error should pass with empty error interface")
 }
 
 func TestEqualError(t *testing.T) {


### PR DESCRIPTION
Fixes #562 

assert.Nil already does this correctly by checking via reflection if the supplied value isn't nil wrapped in an interface in order to not give false results. I think assert.NoError should do the same.
