### PR TITLE
Add FileNotExists and DirNotExists assertions

### DIFF
--- a/assert/assertion_format.go
+++ b/assert/assertion_format.go
@@ -32,12 +32,22 @@ func Containsf(t TestingT, s interface{}, contains interface{}, msg string, args
 	return Contains(t, s, contains, append([]interface{}{msg}, args...)...)
 }
 
-// DirExistsf checks whether a directory exists in the given path. It also fails if the path is a file rather a directory or there is an error checking whether it exists.
+// DirExistsf checks whether a directory exists in the given path.
+// It also fails if the path is a file rather a directory or there is an error checking whether it exists.
 func DirExistsf(t TestingT, path string, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
 	return DirExists(t, path, append([]interface{}{msg}, args...)...)
+}
+
+// DirNotExistsf checks whether a directory not exists in the given path.
+// It also fails if the path is a file rather a directory or there is an error checking whether it exists.
+func DirNotExistsf(t TestingT, path string, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return DirNotExists(t, path, append([]interface{}{msg}, args...)...)
 }
 
 // ElementsMatchf asserts that the specified listA(array, slice...) is equal to specified
@@ -160,12 +170,22 @@ func Falsef(t TestingT, value bool, msg string, args ...interface{}) bool {
 	return False(t, value, append([]interface{}{msg}, args...)...)
 }
 
-// FileExistsf checks whether a file exists in the given path. It also fails if the path points to a directory or there is an error when trying to check the file.
+// FileExistsf checks whether a file exists in the given path.
+// It also fails if the path points to a directory or there is an error when trying to check the file.
 func FileExistsf(t TestingT, path string, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
 	return FileExists(t, path, append([]interface{}{msg}, args...)...)
+}
+
+// FileNotExistsf checks whether a file not exists in the given path.
+// It also fails if the path points to a directory or there is an error when trying to check the file.
+func FileNotExistsf(t TestingT, path string, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return FileNotExists(t, path, append([]interface{}{msg}, args...)...)
 }
 
 // Greaterf asserts that the first element is greater than the second

--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -53,7 +53,8 @@ func (a *Assertions) Containsf(s interface{}, contains interface{}, msg string, 
 	return Containsf(a.t, s, contains, msg, args...)
 }
 
-// DirExists checks whether a directory exists in the given path. It also fails if the path is a file rather a directory or there is an error checking whether it exists.
+// DirExists checks whether a directory exists in the given path.
+// It also fails if the path is a file rather a directory or there is an error checking whether it exists.
 func (a *Assertions) DirExists(path string, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -61,12 +62,31 @@ func (a *Assertions) DirExists(path string, msgAndArgs ...interface{}) bool {
 	return DirExists(a.t, path, msgAndArgs...)
 }
 
-// DirExistsf checks whether a directory exists in the given path. It also fails if the path is a file rather a directory or there is an error checking whether it exists.
+// DirExists checks whether a directory not exists in the given path.
+// It also fails if the path is a file rather a directory or there is an error checking whether it exists.
+func (a *Assertions) DirNotExists(path string, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return DirNotExists(a.t, path, msgAndArgs...)
+}
+
+// DirExistsf checks whether a directory exists in the given path.
+// It also fails if the path is a file rather a directory or there is an error checking whether it exists.
 func (a *Assertions) DirExistsf(path string, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
 	return DirExistsf(a.t, path, msg, args...)
+}
+
+// DirExistsf checks whether a directory not exists in the given path.
+// It also fails if the path is a file rather a directory or there is an error checking whether it exists.
+func (a *Assertions) DirNotExistsf(path string, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return DirNotExistsf(a.t, path, msg, args...)
 }
 
 // ElementsMatch asserts that the specified listA(array, slice...) is equal to specified

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1317,40 +1317,95 @@ func NotZero(t TestingT, i interface{}, msgAndArgs ...interface{}) bool {
 	return true
 }
 
-// FileExists checks whether a file exists in the given path. It also fails if the path points to a directory or there is an error when trying to check the file.
+// FileExists checks whether a file exists in the given path.
+// It also fails if the path points to a directory or there is an error when trying to check the file.
 func FileExists(t TestingT, path string, msgAndArgs ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
+
 	info, err := os.Lstat(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return Fail(t, fmt.Sprintf("unable to find file %q", path), msgAndArgs...)
-		}
+	switch {
+	case os.IsNotExist(err):
+		return Fail(t, fmt.Sprintf("unable to find file %q", path), msgAndArgs...)
+	case err != nil:
 		return Fail(t, fmt.Sprintf("error when running os.Lstat(%q): %s", path, err), msgAndArgs...)
 	}
+
 	if info.IsDir() {
 		return Fail(t, fmt.Sprintf("%q is a directory", path), msgAndArgs...)
 	}
+
 	return true
 }
 
-// DirExists checks whether a directory exists in the given path. It also fails if the path is a file rather a directory or there is an error checking whether it exists.
+// FileNotExists checks whether a file not exists in the given path.
+// It also fails if the path points to a directory or there is an error when trying to check the file.
+func FileNotExists(t TestingT, path string, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	info, err := os.Lstat(path)
+	if err != nil && !os.IsNotExist(err) {
+		return Fail(t, fmt.Sprintf("error when running os.Lstat(%q): %s", path, err), msgAndArgs...)
+	}
+
+	if os.IsNotExist(err) {
+		return true
+	}
+
+	if info.IsDir() {
+		return Fail(t, fmt.Sprintf("%q is a directory", path), msgAndArgs...)
+	}
+
+	return Fail(t, fmt.Sprintf("file %q should not exist", path), msgAndArgs...)
+
+}
+
+// DirExists checks whether a directory exists in the given path.
+// It also fails if the path is a file rather a directory or there is an error checking whether it exists.
 func DirExists(t TestingT, path string, msgAndArgs ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
+
 	info, err := os.Lstat(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return Fail(t, fmt.Sprintf("unable to find file %q", path), msgAndArgs...)
-		}
+	switch {
+	case os.IsNotExist(err):
+		return Fail(t, fmt.Sprintf("unable to find directory %q", path), msgAndArgs...)
+	case err != nil:
 		return Fail(t, fmt.Sprintf("error when running os.Lstat(%q): %s", path, err), msgAndArgs...)
 	}
+
 	if !info.IsDir() {
 		return Fail(t, fmt.Sprintf("%q is a file", path), msgAndArgs...)
 	}
+
 	return true
+}
+
+// DirNotExists checks whether a directory exists in the given path.
+// It also fails if the path is a file rather a directory or there is an error checking whether it exists.
+func DirNotExists(t TestingT, path string, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	info, err := os.Lstat(path)
+	if err != nil && !os.IsNotExist(err) {
+		return Fail(t, fmt.Sprintf("error when running os.Lstat(%q): %s", path, err), msgAndArgs...)
+	}
+
+	if os.IsNotExist(err) {
+		return true
+	}
+
+	if info.IsDir() {
+		return Fail(t, fmt.Sprintf("%q is a file", path), msgAndArgs...)
+	}
+
+	return Fail(t, fmt.Sprintf("directory %q should not exist", path), msgAndArgs...)
 }
 
 // JSONEq asserts that two JSON strings are equivalent.

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -1381,6 +1381,17 @@ func TestFileExists(t *testing.T) {
 	False(t, FileExists(mockT, "../_codegen"))
 }
 
+func TestFileNotExists(t *testing.T) {
+	mockT := new(testing.T)
+	False(t, FileNotExists(mockT, "assertions.go"))
+
+	mockT = new(testing.T)
+	True(t, FileNotExists(mockT, "random_file"))
+
+	mockT = new(testing.T)
+	False(t, FileNotExists(mockT, "../_codegen"))
+}
+
 func TestDirExists(t *testing.T) {
 	mockT := new(testing.T)
 	False(t, DirExists(mockT, "assertions.go"))
@@ -1390,6 +1401,17 @@ func TestDirExists(t *testing.T) {
 
 	mockT = new(testing.T)
 	True(t, DirExists(mockT, "../_codegen"))
+}
+
+func TestDirNotExists(t *testing.T) {
+	mockT := new(testing.T)
+	False(t, DirNotExists(mockT, "assertions.go"))
+
+	mockT = new(testing.T)
+	True(t, DirNotExists(mockT, "random_dir"))
+
+	mockT = new(testing.T)
+	False(t, DirNotExists(mockT, "../_codegen"))
 }
 
 func TestJSONEq_EqualSONString(t *testing.T) {

--- a/require/require.go
+++ b/require/require.go
@@ -66,7 +66,8 @@ func Containsf(t TestingT, s interface{}, contains interface{}, msg string, args
 	t.FailNow()
 }
 
-// DirExists checks whether a directory exists in the given path. It also fails if the path is a file rather a directory or there is an error checking whether it exists.
+// DirExists checks whether a directory exists in the given path.
+// It also fails if the path is a file rather a directory or there is an error checking whether it exists.
 func DirExists(t TestingT, path string, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -77,12 +78,37 @@ func DirExists(t TestingT, path string, msgAndArgs ...interface{}) {
 	t.FailNow()
 }
 
-// DirExistsf checks whether a directory exists in the given path. It also fails if the path is a file rather a directory or there is an error checking whether it exists.
+// DirExistsf checks whether a directory exists in the given path.
+// It also fails if the path is a file rather a directory or there is an error checking whether it exists.
 func DirExistsf(t TestingT, path string, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
 	if assert.DirExistsf(t, path, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// DirNotExists checks whether a directory not exists in the given path.
+// It also fails if the path is a file rather a directory or there is an error checking whether it exists.
+func DirNotExists(t TestingT, path string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.DirNotExists(t, path, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// DirNotExistsf checks whether a directory not exists in the given path.
+// It also fails if the path is a file rather a directory or there is an error checking whether it exists.
+func DirNotExistsf(t TestingT, path string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.DirNotExistsf(t, path, msg, args...) {
 		return
 	}
 	t.FailNow()
@@ -394,7 +420,8 @@ func Falsef(t TestingT, value bool, msg string, args ...interface{}) {
 	t.FailNow()
 }
 
-// FileExists checks whether a file exists in the given path. It also fails if the path points to a directory or there is an error when trying to check the file.
+// FileExists checks whether a file exists in the given path.
+// It also fails if the path points to a directory or there is an error when trying to check the file.
 func FileExists(t TestingT, path string, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -405,12 +432,37 @@ func FileExists(t TestingT, path string, msgAndArgs ...interface{}) {
 	t.FailNow()
 }
 
-// FileExistsf checks whether a file exists in the given path. It also fails if the path points to a directory or there is an error when trying to check the file.
+// FileExistsf checks whether a file not exists in the given path.
+// It also fails if the path points to a directory or there is an error when trying to check the file.
 func FileExistsf(t TestingT, path string, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
 	if assert.FileExistsf(t, path, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// FileExists checks whether a file not exists in the given path.
+// It also fails if the path points to a directory or there is an error when trying to check the file.
+func FileNotExists(t TestingT, path string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.FileNotExists(t, path, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// FileExistsf checks whether a file exists in the given path.
+// It also fails if the path points to a directory or there is an error when trying to check the file.
+func FileNotExistsf(t TestingT, path string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.FileNotExistsf(t, path, msg, args...) {
 		return
 	}
 	t.FailNow()

--- a/require/require_forward.go
+++ b/require/require_forward.go
@@ -54,7 +54,8 @@ func (a *Assertions) Containsf(s interface{}, contains interface{}, msg string, 
 	Containsf(a.t, s, contains, msg, args...)
 }
 
-// DirExists checks whether a directory exists in the given path. It also fails if the path is a file rather a directory or there is an error checking whether it exists.
+// DirExists checks whether a directory exists in the given path.
+// It also fails if the path is a file rather a directory or there is an error checking whether it exists.
 func (a *Assertions) DirExists(path string, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -62,12 +63,31 @@ func (a *Assertions) DirExists(path string, msgAndArgs ...interface{}) {
 	DirExists(a.t, path, msgAndArgs...)
 }
 
-// DirExistsf checks whether a directory exists in the given path. It also fails if the path is a file rather a directory or there is an error checking whether it exists.
+// DirExistsf checks whether a directory exists in the given path.
+// It also fails if the path is a file rather a directory or there is an error checking whether it exists.
 func (a *Assertions) DirExistsf(path string, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
 	DirExistsf(a.t, path, msg, args...)
+}
+
+// DirNotExists checks whether a directory not exists in the given path.
+// It also fails if the path is a file rather a directory or there is an error checking whether it exists.
+func (a *Assertions) DirNotExists(path string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	DirNotExists(a.t, path, msgAndArgs...)
+}
+
+// DirNotExistsf checks whether a directory not exists in the given path.
+// It also fails if the path is a file rather a directory or there is an error checking whether it exists.
+func (a *Assertions) DirNotExistsf(path string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	DirNotExistsf(a.t, path, msg, args...)
 }
 
 // ElementsMatch asserts that the specified listA(array, slice...) is equal to specified
@@ -310,7 +330,8 @@ func (a *Assertions) Falsef(value bool, msg string, args ...interface{}) {
 	Falsef(a.t, value, msg, args...)
 }
 
-// FileExists checks whether a file exists in the given path. It also fails if the path points to a directory or there is an error when trying to check the file.
+// FileExists checks whether a file exists in the given path.
+// It also fails if the path points to a directory or there is an error when trying to check the file.
 func (a *Assertions) FileExists(path string, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -318,12 +339,31 @@ func (a *Assertions) FileExists(path string, msgAndArgs ...interface{}) {
 	FileExists(a.t, path, msgAndArgs...)
 }
 
-// FileExistsf checks whether a file exists in the given path. It also fails if the path points to a directory or there is an error when trying to check the file.
+// FileExistsf checks whether a file exists in the given path.
+// It also fails if the path points to a directory or there is an error when trying to check the file.
 func (a *Assertions) FileExistsf(path string, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
 	FileExistsf(a.t, path, msg, args...)
+}
+
+// FileNotExists checks whether a file not exists in the given path.
+// It also fails if the path points to a directory or there is an error when trying to check the file.
+func (a *Assertions) FileNotExists(path string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	FileNotExists(a.t, path, msgAndArgs...)
+}
+
+// FileNotExistsf checks whether a file not exists in the given path.
+// It also fails if the path points to a directory or there is an error when trying to check the file.
+func (a *Assertions) FileNotExistsf(path string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	FileNotExistsf(a.t, path, msg, args...)
 }
 
 // Greater asserts that the first element is greater than the second


### PR DESCRIPTION
Implement FileNotExists and DirNotExists assertions to check whether file/dir not exist in a given path.

This functions is the opposite of FileExists and DirExists. 

It is very useful in some cases. For example, if your tests creates some files while working, it would be nice to check if this files exist, before test. Or test can remove some files and we have to make sure that files are really removed. 