### PR TITLE
Add ContainsValue for maps

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -739,7 +739,25 @@ func Contains(t TestingT, s, contains interface{}, msgAndArgs ...interface{}) bo
 	}
 
 	return true
+}
 
+// ContainsValue asserts that the specified map contains the specified element as a value.
+//
+//    assert.Contains(t, map[string]string{"Hello":"World"}, "World")
+func ContainsValue(t TestingT, list interface{}, elem interface{}, msgAndArgs ...interface{}) bool {
+	listValue := reflect.ValueOf(list)
+	listKind := reflect.TypeOf(list).Kind()
+	if listKind != reflect.Map {
+		return Fail(t, fmt.Sprintf("\"%s\" must be a map", list), msgAndArgs...)
+	}
+	iter := listValue.MapRange()
+	for iter.Next() {
+		if ObjectsAreEqual(iter.Value().Interface(), elem) {
+			return true
+		}
+	}
+
+	return Fail(t, fmt.Sprintf("\"%s\" does not contain \"%s\"", list, elem), msgAndArgs...)
 }
 
 // NotContains asserts that the specified string, list(array, slice...) or map does NOT contain the
@@ -762,7 +780,6 @@ func NotContains(t TestingT, s, contains interface{}, msgAndArgs ...interface{})
 	}
 
 	return true
-
 }
 
 // Subset asserts that the specified list(array, slice...) contains all

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -743,7 +743,7 @@ func Contains(t TestingT, s, contains interface{}, msgAndArgs ...interface{}) bo
 
 // ContainsValue asserts that the specified map contains the specified element as a value.
 //
-//    assert.Contains(t, map[string]string{"Hello":"World"}, "World")
+//    assert.ContainsValue(t, map[string]string{"Hello":"World"}, "World")
 func ContainsValue(t TestingT, list interface{}, elem interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -745,14 +745,18 @@ func Contains(t TestingT, s, contains interface{}, msgAndArgs ...interface{}) bo
 //
 //    assert.Contains(t, map[string]string{"Hello":"World"}, "World")
 func ContainsValue(t TestingT, list interface{}, elem interface{}, msgAndArgs ...interface{}) bool {
-	listValue := reflect.ValueOf(list)
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
 	listKind := reflect.TypeOf(list).Kind()
 	if listKind != reflect.Map {
 		return Fail(t, fmt.Sprintf("\"%s\" must be a map", list), msgAndArgs...)
 	}
-	iter := listValue.MapRange()
-	for iter.Next() {
-		if ObjectsAreEqual(iter.Value().Interface(), elem) {
+	listValue := reflect.ValueOf(list)
+	mapKeys := listValue.MapKeys()
+	for i := 0; i < len(mapKeys); i++ {
+		if ObjectsAreEqual(listValue.MapIndex(mapKeys[i]).Interface(), elem) {
 			return true
 		}
 	}

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -582,6 +582,19 @@ func TestContains(t *testing.T) {
 	}
 }
 
+func TestContainsValue(t *testing.T) {
+
+	mockT := new(testing.T)
+	simpleMap := map[interface{}]interface{}{"Foo": "Bar"}
+
+	if ContainsValue(mockT, simpleMap, "Foo") {
+		t.Error("Contains should return false: \"{\"Foo\": \"Bar\"}\" does not contains \"Foo\" value")
+	}
+	if !ContainsValue(mockT, simpleMap, "Bar") {
+		t.Error("Contains should return true: \"{\"Foo\": \"Bar\"}\" contains \"Bar\" value")
+	}
+}
+
 func TestNotContains(t *testing.T) {
 
 	mockT := new(testing.T)


### PR DESCRIPTION
The current `Contains` func doesn't allow to check for specific values within a map.

Having an easy way to check for map values is really useful.
Especially when map keys are random or can't be known inside the test.
I added it outside of the current `Contains` func. 