### PR TITLE
don't fail the whole build on go-tip failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ matrix:
     - go: "1.11.x"
       env: GO111MODULE=on
     - go: tip
+  allow_failures:
+    - go: tip
   script:
     - ./.travis.gogenerate.sh
     - ./.travis.gofmt.sh


### PR DESCRIPTION
tip:
* Can change at any time
* Has no stability/compatability guarantee
* Is development code & can be broken
* Is out of control of testify contributors

I addition, go versions 1.12 and 1.13 are completely missing from the build matrix, as well as "release", yet "tip" is present...