### PR TITLE
Fix go generate for Go Modules

### DIFF
--- a/.travis.gogenerate.sh
+++ b/.travis.gogenerate.sh
@@ -3,7 +3,7 @@
 # If GOMOD is defined we are running with Go Modules enabled, either
 # automatically or via the GO111MODULE=on environment variable. Codegen only
 # works with modules, so skip generation if modules is not in use.
-if [[ ! -z "$(go env GOMOD)" ]]; then
+if [[ -z "$(go env GOMOD)" ]]; then
   exit 0
 fi
 

--- a/.travis.gogenerate.sh
+++ b/.travis.gogenerate.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-go generate ./...
+GO111MODULE=on go generate ./...
 if [ -n "$(git diff)" ]; then
   echo "Go generate had not been run"
   git diff

--- a/.travis.gogenerate.sh
+++ b/.travis.gogenerate.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 
-if [[ "$TRAVIS_GO_VERSION" =~ ^1\.(12|13)(\..*)?$ ]]; then
+# If GOMOD is defined we are running with Go Modules enabled, either
+# automatically or via the GO111MODULE=on environment variable. Codegen only
+# works with modules, so skip generation if modules is not in use.
+if [[ ! -z "$(go env GOMOD)" ]]; then
   exit 0
 fi
 
-GO111MODULE=on go generate ./...
+go generate ./...
 if [ -n "$(git diff)" ]; then
   echo "Go generate had not been run"
   git diff

--- a/.travis.gogenerate.sh
+++ b/.travis.gogenerate.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-if [[ "$TRAVIS_GO_VERSION" =~ ^1\.[45](\..*)?$ ]]; then
-  exit 0
-fi
-
-go get github.com/ernesto-jimenez/gogen/imports
 go generate ./...
 if [ -n "$(git diff)" ]; then
   echo "Go generate had not been run"

--- a/.travis.gogenerate.sh
+++ b/.travis.gogenerate.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+if [[ "$TRAVIS_GO_VERSION" =~ ^1\.(12|13)(\..*)?$ ]]; then
+  exit 0
+fi
+
 GO111MODULE=on go generate ./...
 if [ -n "$(git diff)" ]; then
   echo "Go generate had not been run"

--- a/.travis.gogenerate.sh
+++ b/.travis.gogenerate.sh
@@ -4,6 +4,7 @@
 # automatically or via the GO111MODULE=on environment variable. Codegen only
 # works with modules, so skip generation if modules is not in use.
 if [[ -z "$(go env GOMOD)" ]]; then
+  echo "Skipping go generate because modules not enabled and required"
   exit 0
 fi
 

--- a/.travis.govet.sh
+++ b/.travis.govet.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-cd "$(dirname $0)"
-DIRS=". assert require mock _codegen"
 set -e
-for subdir in $DIRS; do
-  pushd $subdir
-  go vet
-  popd
-done
+
+go vet ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,14 @@ matrix:
       env: GO111MODULE=off
     - go: "1.11.x"
       env: GO111MODULE=on
+    - go: "1.12.x"
+      env: GO111MODULE=off
+    - go: "1.12.x"
+      env: GO111MODULE=on
+    - go: "1.13.x"
+      env: GO111MODULE=off
+    - go: "1.13.x"
+      env: GO111MODULE=on
     - go: tip
   script:
     - ./.travis.gogenerate.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ matrix:
     - go: "1.13.x"
       env: GO111MODULE=on
     - go: tip
-script:
-  - ./.travis.gogenerate.sh
-  - ./.travis.gofmt.sh
-  - ./.travis.govet.sh
-  - go test -v -race $(go list ./... | grep -v vendor)
+  script:
+    - ./.travis.gogenerate.sh
+    - ./.travis.gofmt.sh
+    - ./.travis.govet.sh
+    - go test -v -race $(go list ./... | grep -v vendor)

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,4 @@ script:
   - ./.travis.gogenerate.sh
   - ./.travis.gofmt.sh
   - ./.travis.govet.sh
-  - go test -v -race $(go list ./... | grep -v vendor)
+  - go test -v -race ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ matrix:
     - go: "1.13.x"
       env: GO111MODULE=on
     - go: tip
-  script:
-    - ./.travis.gogenerate.sh
-    - ./.travis.gofmt.sh
-    - ./.travis.govet.sh
-    - go test -v -race $(go list ./... | grep -v vendor)
+script:
+  - ./.travis.gogenerate.sh
+  - ./.travis.gofmt.sh
+  - ./.travis.govet.sh
+  - go test -v -race $(go list ./... | grep -v vendor)

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ To update Testify to the latest version, use `go get -u github.com/stretchr/test
 Supported go versions
 ==================
 
-We support the three major Go versions, which are 1.9, 1.10, and 1.11 at the moment.
+We support the three major Go versions, which are 1.11, 1.12, and 1.13 at the moment.
 
 ------
 

--- a/_codegen/.gitignore
+++ b/_codegen/.gitignore
@@ -1,0 +1,1 @@
+_codegen

--- a/_codegen/go.mod
+++ b/_codegen/go.mod
@@ -1,5 +1,5 @@
 module github.com/stretchr/testify/_codegen
 
-go 1.13
+go 1.11
 
 require github.com/ernesto-jimenez/gogen v0.0.0-20180125220232-d7d4131e6607

--- a/_codegen/go.mod
+++ b/_codegen/go.mod
@@ -1,0 +1,5 @@
+module github.com/stretchr/testify/_codegen
+
+go 1.13
+
+require github.com/ernesto-jimenez/gogen v0.0.0-20180125220232-d7d4131e6607

--- a/_codegen/go.sum
+++ b/_codegen/go.sum
@@ -1,0 +1,2 @@
+github.com/ernesto-jimenez/gogen v0.0.0-20180125220232-d7d4131e6607 h1:cTavhURetDkezJCvxFggiyLeP40Mrk/TtVg2+ycw1Es=
+github.com/ernesto-jimenez/gogen v0.0.0-20180125220232-d7d4131e6607/go.mod h1:Cg4fM0vhYWOZdgM7RIOSTRNIc8/VT7CXClC3Ni86lu4=

--- a/_codegen/main.go
+++ b/_codegen/main.go
@@ -194,7 +194,7 @@ func parsePackageSource(pkg string) (*types.Scope, *doc.Package, error) {
 	}
 
 	cfg := types.Config{
-		Importer: importer.ForCompiler(fset, "source", nil),
+		Importer: importer.For("source", nil),
 	}
 	info := types.Info{
 		Defs: make(map[*ast.Ident]types.Object),

--- a/_codegen/main.go
+++ b/_codegen/main.go
@@ -181,7 +181,7 @@ func parsePackageSource(pkg string) (*types.Scope, *doc.Package, error) {
 	files := make(map[string]*ast.File)
 	fileList := make([]*ast.File, len(pd.GoFiles))
 	for i, fname := range pd.GoFiles {
-		src, err := ioutil.ReadFile(path.Join(pd.SrcRoot, pd.ImportPath, fname))
+		src, err := ioutil.ReadFile(path.Join(pd.Dir, fname))
 		if err != nil {
 			return nil, nil, err
 		}
@@ -194,7 +194,7 @@ func parsePackageSource(pkg string) (*types.Scope, *doc.Package, error) {
 	}
 
 	cfg := types.Config{
-		Importer: importer.Default(),
+		Importer: importer.ForCompiler(fset, "source", nil),
 	}
 	info := types.Info{
 		Defs: make(map[*ast.Ident]types.Object),

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -22,7 +22,7 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
-//go:generate go run ../_codegen/main.go -output-package=assert -template=assertion_format.go.tmpl
+//go:generate sh -c "cd ../_codegen && go build && cd - && ../_codegen/_codegen -output-package=assert -template=assertion_format.go.tmpl"
 
 // TestingT is an interface wrapper around *testing.T
 type TestingT interface {

--- a/assert/forward_assertions.go
+++ b/assert/forward_assertions.go
@@ -13,4 +13,4 @@ func New(t TestingT) *Assertions {
 	}
 }
 
-//go:generate go run ../_codegen/main.go -output-package=assert -template=assertion_forward.go.tmpl -include-format-funcs
+//go:generate sh -c "cd ../_codegen && go build && cd - && ../_codegen/_codegen -output-package=assert -template=assertion_forward.go.tmpl -include-format-funcs"

--- a/require/forward_requirements.go
+++ b/require/forward_requirements.go
@@ -13,4 +13,4 @@ func New(t TestingT) *Assertions {
 	}
 }
 
-//go:generate go run ../_codegen/main.go -output-package=require -template=require_forward.go.tmpl -include-format-funcs
+//go:generate sh -c "cd ../_codegen && go build && cd - && ../_codegen/_codegen -output-package=require -template=require_forward.go.tmpl -include-format-funcs"

--- a/require/requirements.go
+++ b/require/requirements.go
@@ -26,4 +26,4 @@ type BoolAssertionFunc func(TestingT, bool, ...interface{})
 // for table driven tests.
 type ErrorAssertionFunc func(TestingT, error, ...interface{})
 
-//go:generate go run ../_codegen/main.go -output-package=require -template=require.go.tmpl -include-format-funcs
+//go:generate sh -c "cd ../_codegen && go build && cd - && ../_codegen/_codegen -output-package=require -template=require.go.tmpl -include-format-funcs"

--- a/suite/suite.go
+++ b/suite/suite.go
@@ -84,7 +84,7 @@ func Run(t *testing.T, suite TestingSuite) {
 	defer failOnPanic(t)
 
 	suiteSetupDone := false
-	
+
 	methodFinder := reflect.TypeOf(suite)
 	tests := []testing.InternalTest{}
 	for index := 0; index < methodFinder.NumMethod(); index++ {

--- a/suite/suite_test.go
+++ b/suite/suite_test.go
@@ -350,7 +350,7 @@ func TestRunSuite(t *testing.T) {
 type SuiteSetupSkipTester struct {
 	Suite
 
-	setUp bool
+	setUp    bool
 	toreDown bool
 }
 


### PR DESCRIPTION
Fix two issues with codegen that cause it not to work with Go Modules.

1. Changed `SrcRoot` and `ImportPath` to `Dir`. When parsing the code files the package SrcRoot and ImportPath were being joined which assumes the package is hosted inside a GOPATH src directory. Using those two fields is unnecessary because Dir tells us where the package lives.

2. When checking the types in the source files the default importer is being used. Unfortunately the default importer has not been updated to work with Go Modules and it only looks in the GOPATH for imports. Luckily the Go team were convinced to backport some logic from the newer go/packages package to go/build, and we can make use of the go/build importer which supports Go Modules.

In the future codegen should be rewritten to use go/packages once it is included in the stdlib. go/packages currently lives at golang.org/x/tools/go/packages and is under development.

I've confirmed this works on 1.11, 1.12, 1.13 with modules on, inside and outside of a GOPATH. Testify itself will still work in older versions of Go, but the codegen will need to be done in a version of Go supporting modules.

I tested the codegen with this Dockerfile:
<details><summary>Test Dockerfile</summary>

```Dockerfile
ARG REPO=https://github.com/leighmcculloch/stretchr--testify.git
ARG BRANCH=fix-go-generate-for-modules

# Go 1.13 inside GOPATH
FROM golang:1.13
ARG REPO
ARG BRANCH
ARG DIR=/go/src/github.com/stretchr/testify
RUN git clone --single-branch --branch $BRANCH $REPO $DIR
WORKDIR $DIR
RUN go generate ./...
RUN git diff --exit-code

# Go 1.13 outside GOPATH
FROM golang:1.13
ARG REPO
ARG BRANCH
ARG DIR=/testify
RUN git clone --single-branch --branch $BRANCH $REPO $DIR
WORKDIR $DIR
RUN go generate ./...
RUN git diff --exit-code

# Go 1.12 inside GOPATH with modules enabled
FROM golang:1.12
ARG REPO
ARG BRANCH
ARG DIR=/go/src/github.com/stretchr/testify
ENV GO111MODULE=on
RUN git clone --single-branch --branch $BRANCH $REPO $DIR
WORKDIR $DIR
RUN go generate ./...
RUN git diff --exit-code

# Go 1.12 outside GOPATH
FROM golang:1.12
ARG REPO
ARG BRANCH
ARG DIR=/testify
RUN git clone --single-branch --branch $BRANCH $REPO $DIR
WORKDIR $DIR
RUN go generate ./...
RUN git diff --exit-code

# Go 1.11 inside GOPATH with modules enabled
FROM golang:1.11
ARG REPO
ARG BRANCH
ARG DIR=/go/src/github.com/stretchr/testify
ENV GO111MODULE=on
RUN git clone --single-branch --branch $BRANCH $REPO $DIR
WORKDIR $DIR
RUN go generate ./...
RUN git diff --exit-code

# Go 1.11 outside GOPATH
FROM golang:1.11
ARG REPO
ARG BRANCH
ARG DIR=/testify
RUN git clone --single-branch --branch $BRANCH $REPO $DIR
WORKDIR $DIR
RUN go generate ./...
RUN git diff --exit-code
```
</details>

The codegen will require modules to be on, but you can still use testify itself without modules. Given that modules is always on in the latest version, I don't think this is a huge issue.

I've also fixed TravisCI the config so that it runs the custom scripts.

Fixes #841 
