### PR TITLE
Fix TravisCI config

### DIFF
--- a/.travis.gogenerate.sh
+++ b/.travis.gogenerate.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
-if [[ "$TRAVIS_GO_VERSION" =~ ^1\.[45](\..*)?$ ]]; then
+# If GOMOD is defined we are running with Go Modules enabled, either
+# automatically or via the GO111MODULE=on environment variable. If modules is
+# enabled we skip generation because at the moment the codegen only works
+# without modules.
+if [[ -z "$(go env GOMOD)" ]]; then
   exit 0
 fi
 

--- a/.travis.gogenerate.sh
+++ b/.travis.gogenerate.sh
@@ -4,7 +4,7 @@
 # automatically or via the GO111MODULE=on environment variable. If modules is
 # enabled we skip generation because at the moment the codegen only works
 # without modules.
-if [[ -z "$(go env GOMOD)" ]]; then
+if [[ ! -z "$(go env GOMOD)" ]]; then
   echo "Skipping go generate because modules are in use"
   exit 0
 fi

--- a/.travis.gogenerate.sh
+++ b/.travis.gogenerate.sh
@@ -5,6 +5,7 @@
 # enabled we skip generation because at the moment the codegen only works
 # without modules.
 if [[ -z "$(go env GOMOD)" ]]; then
+  echo "Skipping go generate because modules are in use"
   exit 0
 fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ matrix:
     - go: "1.11.x"
       env: GO111MODULE=on
     - go: tip
-  script:
-    - ./.travis.gogenerate.sh
-    - ./.travis.gofmt.sh
-    - ./.travis.govet.sh
-    - go test -v -race $(go list ./... | grep -v vendor)
+script:
+  - ./.travis.gogenerate.sh
+  - ./.travis.gofmt.sh
+  - ./.travis.govet.sh
+  - go test -v -race $(go list ./... | grep -v vendor)

--- a/suite/suite.go
+++ b/suite/suite.go
@@ -84,7 +84,7 @@ func Run(t *testing.T, suite TestingSuite) {
 	defer failOnPanic(t)
 
 	suiteSetupDone := false
-	
+
 	methodFinder := reflect.TypeOf(suite)
 	tests := []testing.InternalTest{}
 	for index := 0; index < methodFinder.NumMethod(); index++ {

--- a/suite/suite_test.go
+++ b/suite/suite_test.go
@@ -350,7 +350,7 @@ func TestRunSuite(t *testing.T) {
 type SuiteSetupSkipTester struct {
 	Suite
 
-	setUp bool
+	setUp    bool
 	toreDown bool
 }
 


### PR DESCRIPTION
Fix the indenting in the TravisCI config that is causing the custom scripts to be ignored by TravisCI. None of the builds on testify are actually using the custom scripts, it's just using the default Go build behavior. This is because the `script` key is supposed to be at the top-level but it is nested under the matrix configs.

Some files are not go fmt'd correctly, so I've fixed them too to make the `.travis.gofmt.sh` script pass.

I also need to change the guard in the `.travis.gogenerate.sh` script so that it only runs when modules is turned off. This is because at the moment the codegen doesn't support modules. That is being fixed separately in #852.