### PR TITLE
Check go generate on builds

### DIFF
--- a/.travis.gofmt.sh
+++ b/.travis.gofmt.sh
@@ -5,3 +5,10 @@ if [ -n "$(gofmt -l .)" ]; then
   gofmt -d .
   exit 1
 fi
+
+go generate ./...
+if [ -n "$(git status -s -uno)" ]; then
+  echo "Go generate output does not match commit."
+  echo "Did you forget to run go generate ./... ?"
+  exit 1
+fi


### PR DESCRIPTION
* Check if we have mismatching `go generate ./...` output on builds

Fixes #874 