### PR TITLE
Use latest Go master instead of dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
       env: GO111MODULE=off
     - go: "1.13.x"
       env: GO111MODULE=on
-    - go: tip
+    - go: master
 script:
   - ./.travis.gogenerate.sh
   - ./.travis.gofmt.sh


### PR DESCRIPTION
* Changed the latest Go version of the Travis build to be master instead of dev