### PR TITLE
ErrorIs assertion; go1.13 feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,10 @@ Please feel free to submit issues, fork the repository and send pull requests!
 When submitting an issue, we ask that you please include a complete test function that demonstrates the issue. Extra credit for those using Testify to write the test code that demonstrates it.
 
 Code generation is used. Look for `CODE GENERATED AUTOMATICALLY` at the top of some files. Run `go generate ./...` to update generated files.
+Assertions are added to `assert/assertions.go` file and then code generated to all other forms including `require.*` as
+```bash
+go generate ./assert/ ./require/
+```
 
 We also chat on the [Gophers Slack](https://gophers.slack.com) group in the `#testify` and `#testify-dev` channels.
 

--- a/assert/assertion_format.go
+++ b/assert/assertion_format.go
@@ -114,6 +114,18 @@ func Errorf(t TestingT, err error, msg string, args ...interface{}) bool {
 	return Error(t, err, append([]interface{}{msg}, args...)...)
 }
 
+// ErrorIsf asserts that a specified error is an another error wrapper as defined by go1.13 errors package.
+//
+//   actualObj, err := SomeFunction()
+//   assert.ErrorIsf(t, err, ErrNotFound, "error message %s", "formatted")
+//   assert.Nil(t, actualObj)
+func ErrorIsf(t TestingT, theError error, theTarget error, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return ErrorIs(t, theError, theTarget, append([]interface{}{msg}, args...)...)
+}
+
 // Eventuallyf asserts that given condition will be met in waitFor time,
 // periodically checking target function each tick.
 //

--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -204,6 +204,30 @@ func (a *Assertions) Error(err error, msgAndArgs ...interface{}) bool {
 	return Error(a.t, err, msgAndArgs...)
 }
 
+// ErrorIs asserts that a specified error is an another error wrapper as defined by go1.13 errors package.
+//
+//   actualObj, err := SomeFunction()
+//   a.ErrorIs(err, ErrNotFound)
+//   assert.Nil(t, actualObj)
+func (a *Assertions) ErrorIs(theError error, theTarget error, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return ErrorIs(a.t, theError, theTarget, msgAndArgs...)
+}
+
+// ErrorIsf asserts that a specified error is an another error wrapper as defined by go1.13 errors package.
+//
+//   actualObj, err := SomeFunction()
+//   a.ErrorIsf(err, ErrNotFound, "error message %s", "formatted")
+//   assert.Nil(t, actualObj)
+func (a *Assertions) ErrorIsf(theError error, theTarget error, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return ErrorIsf(a.t, theError, theTarget, msg, args...)
+}
+
 // Errorf asserts that a function returned an error (i.e. not `nil`).
 //
 //   actualObj, err := SomeFunction()

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1307,6 +1307,23 @@ func EqualError(t TestingT, theError error, errString string, msgAndArgs ...inte
 	return true
 }
 
+// ErrorIs asserts that a specified error is an another error wrapper as defined by go1.13 errors package.
+//
+//   actualObj, err := SomeFunction()
+//   assert.ErrorIs(t, err, ErrNotFound)
+//   assert.Nil(t, actualObj)
+func ErrorIs(t TestingT, theError, theTarget error, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	if errors.Is(theError, theTarget) {
+		return true
+	}
+
+	return Fail(t, fmt.Sprintf("Error is not %v, but %v", theTarget, theError), msgAndArgs...)
+}
+
 // matchRegexp return true if a specified regexp matches a string.
 func matchRegexp(rx interface{}, str interface{}) bool {
 

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -983,6 +983,36 @@ func TestEqualError(t *testing.T) {
 		"EqualError should return true")
 }
 
+type unwrappableError struct {
+	base error
+}
+
+func (e unwrappableError) Error() string { return fmt.Sprintf("wrapper: %v", e.base) }
+
+func (e unwrappableError) Unwrap() error { return e.base }
+
+func TestErrorIs(t *testing.T) {
+	mockT := new(testing.T)
+
+	var err error
+	False(t, ErrorIs(mockT, err, os.ErrExist), "nil is not any error wrapper")
+
+	False(t, ErrorIs(mockT, errors.New("not any error wrapper"), os.ErrExist), "New error is not any error wrapper")
+
+	False(t, ErrorIs(mockT, fmt.Errorf("wrapper: %v", os.ErrExist), os.ErrExist), "getting err.Error is not wrapping")
+
+	// go 1.13 new verb
+	True(t, ErrorIs(mockT, fmt.Errorf("wrapper: %w", os.ErrExist), os.ErrExist), "annotating with %%w must be wrapper")
+
+	False(t, ErrorIs(mockT, unwrappableError{base: errors.New("something")}, os.ErrNotExist), "not matching unwrap")
+
+	False(t, ErrorIs(mockT, unwrappableError{base: os.ErrClosed}, os.ErrNotExist), "not matching unwrap")
+
+	False(t, ErrorIs(mockT, unwrappableError{base: errors.New(os.ErrNotExist.Error())}, os.ErrNotExist), "not matching unwrap")
+
+	True(t, ErrorIs(mockT, unwrappableError{base: os.ErrNotExist}, os.ErrNotExist), "matching unwrap")
+}
+
 func Test_isEmpty(t *testing.T) {
 
 	chWithValue := make(chan struct{}, 1)

--- a/require/require.go
+++ b/require/require.go
@@ -256,6 +256,36 @@ func Error(t TestingT, err error, msgAndArgs ...interface{}) {
 	t.FailNow()
 }
 
+// ErrorIs asserts that a specified error is an another error wrapper as defined by go1.13 errors package.
+//
+//   actualObj, err := SomeFunction()
+//   assert.ErrorIs(t, err, ErrNotFound)
+//   assert.Nil(t, actualObj)
+func ErrorIs(t TestingT, theError error, theTarget error, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ErrorIs(t, theError, theTarget, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// ErrorIsf asserts that a specified error is an another error wrapper as defined in go1.13+ errors package.
+//
+//   actualObj, err := SomeFunction()
+//   assert.ErrorIsf(t, err, ErrNotFound, "error message %s", "formatted")
+//   assert.Nil(t, actualObj)
+func ErrorIsf(t TestingT, theError error, theTarget error, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ErrorIsf(t, theError, theTarget, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
 // Errorf asserts that a function returned an error (i.e. not `nil`).
 //
 //   actualObj, err := SomeFunction()

--- a/require/require_forward.go
+++ b/require/require_forward.go
@@ -205,6 +205,30 @@ func (a *Assertions) Error(err error, msgAndArgs ...interface{}) {
 	Error(a.t, err, msgAndArgs...)
 }
 
+// ErrorIs asserts that a specified error is an another error wrapper as defined by go1.13 errors package.
+//
+//   actualObj, err := SomeFunction()
+//   a.ErrorIs(err, ErrNotFound)
+//   assert.Nil(t, actualObj)
+func (a *Assertions) ErrorIs(theError error, theTarget error, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ErrorIs(a.t, theError, theTarget, msgAndArgs...)
+}
+
+// ErrorIsf asserts that a specified error is an another error wrapper as defined in go1.13+ errors package.
+//
+//   actualObj, err := SomeFunction()
+//   a.ErrorIsf(err, ErrNotFound, "error message %s", "formatted")
+//   assert.Nil(t, actualObj)
+func (a *Assertions) ErrorIsf(theError error, theTarget error, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ErrorIsf(a.t, theError, theTarget, msg, args...)
+}
+
 // Errorf asserts that a function returned an error (i.e. not `nil`).
 //
 //   actualObj, err := SomeFunction()


### PR DESCRIPTION
ErrorIs assertion to check errors as recommended to do in go1.13 release.

In addition to
```go
assert.EqualError(t, err, "error text")
```
I've added support for new assertion
```go
assert.ErrorIs(t, err, pkg.ErrBaseError)
```
to follow recommendations from [errors](https://golang.org/pkg/errors/) package.

I've also added small comment on how to contribute to assertions because it took some time from me to find where to add code.