### PR TITLE
invalid assertion result in NoError and Error is fixed using reflect value

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1259,7 +1259,7 @@ func NoError(t TestingT, err error, msgAndArgs ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	if err != nil {
+	if err != nil || !reflect.ValueOf(err).IsNil() {
 		return Fail(t, fmt.Sprintf("Received unexpected error:\n%+v", err), msgAndArgs...)
 	}
 
@@ -1277,7 +1277,7 @@ func Error(t TestingT, err error, msgAndArgs ...interface{}) bool {
 		h.Helper()
 	}
 
-	if err == nil {
+	if err == nil || reflect.ValueOf(err).IsNil() {
 		return Fail(t, "An error is expected but got nil.", msgAndArgs...)
 	}
 


### PR DESCRIPTION

```
func Check() {
	checkNil((*Error)(nil))
}

type Error struct{}

func (*Error) Error() string {
	return "check ptr error"
}

func checkNil(err error) {
	if err == nil {
		fmt.Println("error is nil")
		return
	}

	fmt.Println("this is not nil")

}
```
**OUTPUT:** this is not nil

when we pass any object as any interface it creates pointer which points the data of that object.
when i pass my customised error to the error interface this error interface becomes the pointer to that nil object (which pointer is not considered as nil).

so to handle this i have added a nil check with reflect also which gives the desiered output.