### PR TITLE
Disable using Stringer/error interfaces for diffing

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1553,6 +1553,7 @@ var spewConfig = spew.ConfigState{
 	DisablePointerAddresses: true,
 	DisableCapacities:       true,
 	SortKeys:                true,
+	DisableMethods:          true,
 }
 
 type tHelper interface {

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -1750,6 +1750,15 @@ func TestYAMLEq_ArraysOfDifferentOrder(t *testing.T) {
 	False(t, YAMLEq(mockT, `["foo", {"hello": "world", "nested": "hash"}]`, `[{ "hello": "world", "nested": "hash"}, "foo"]`))
 }
 
+type diffTestingStruct struct {
+	A string
+	B int
+}
+
+func (d *diffTestingStruct) String() string {
+	return d.A
+}
+
 func TestDiff(t *testing.T) {
 	expected := `
 
@@ -1827,6 +1836,42 @@ Diff:
 	actual = diff(
 		map[string]int{"one": 1, "two": 2, "three": 3, "four": 4},
 		map[string]int{"one": 1, "three": 3, "five": 5, "seven": 7},
+	)
+	Equal(t, expected, actual)
+
+	expected = `
+
+Diff:
+--- Expected
++++ Actual
+@@ -1,3 +1,3 @@
+ (*errors.errorString)({
+- s: (string) (len=19) "some expected error"
++ s: (string) (len=12) "actual error"
+ })
+`
+
+	actual = diff(
+		errors.New("some expected error"),
+		errors.New("actual error"),
+	)
+	Equal(t, expected, actual)
+
+	expected = `
+
+Diff:
+--- Expected
++++ Actual
+@@ -2,3 +2,3 @@
+  A: (string) (len=11) "some string",
+- B: (int) 10
++ B: (int) 15
+ }
+`
+
+	actual = diff(
+		diffTestingStruct{A: "some string", B: 10},
+		diffTestingStruct{A: "some string", B: 15},
 	)
 	Equal(t, expected, actual)
 }


### PR DESCRIPTION
*NOTE*: this changes something that is the default behavior. I intentionally am doing this as a proposal to change that behavior because I think the new one is better. If this is a problem, we could also achieve the goal of this PR by making `spewConfig` somewhat accessible so that the user of the library can choose to `DisableMethods` themselves.

`spew`'s default formatter will call `String()` or `Error()` in structs
that implement the `fmt.Stringer` or `error` interfaces. Depending on
the implementation of those, the diff can become quite useless to read
(see the example struct I used for the test case in this commit).

This changes `spew`'s configuration to `DisableMethods` so that it will
always use it's own pretty printer. This makes testing structs less
surprising and generally more useful, without tying the tests to the
implementation of `String()` (the user here can always choose to
`require.Equal(a.String(), b.String())` if testing those is important to
them.