### PR TITLE
Add test status to AfterTest callback

### DIFF
--- a/suite/interfaces.go
+++ b/suite/interfaces.go
@@ -40,7 +40,8 @@ type BeforeTest interface {
 }
 
 // AfterTest has a function to be executed right after the test
-// finishes and receives the suite and test names as input
+// finishes and receives the suite and test names, and also a
+// flag to tell whether the test has passed or not.
 type AfterTest interface {
 	AfterTest(suiteName, testName string, success bool)
 }

--- a/suite/interfaces.go
+++ b/suite/interfaces.go
@@ -42,5 +42,5 @@ type BeforeTest interface {
 // AfterTest has a function to be executed right after the test
 // finishes and receives the suite and test names as input
 type AfterTest interface {
-	AfterTest(suiteName, testName string)
+	AfterTest(suiteName, testName string, success bool)
 }

--- a/suite/suite.go
+++ b/suite/suite.go
@@ -127,8 +127,10 @@ func Run(t *testing.T, suite TestingSuite) {
 				}
 				defer func() {
 					if afterTestSuite, ok := suite.(AfterTest); ok {
-						afterTestSuite.AfterTest(methodFinder.Elem().Name(), method.Name)
+						success := !t.Failed()
+						afterTestSuite.AfterTest(methodFinder.Elem().Name(), method.Name, success)
 					}
+
 					if tearDownTestSuite, ok := suite.(TearDownTestSuite); ok {
 						tearDownTestSuite.TearDownTest()
 					}

--- a/suite/suite_test.go
+++ b/suite/suite_test.go
@@ -79,7 +79,7 @@ func (s *panickingSuite) Test() {
 	}
 }
 
-func (s *panickingSuite) AfterTest(_, _ string) {
+func (s *panickingSuite) AfterTest(_, _ string, _ bool) {
 	if s.panicInAfterTest {
 		panic("oops in after test")
 	}
@@ -165,6 +165,8 @@ type SuiteTester struct {
 
 	TimeBefore []time.Time
 	TimeAfter  []time.Time
+
+	TestSuccess []bool
 }
 
 // The SetupSuite method will be run by testify once, at the very
@@ -179,10 +181,11 @@ func (suite *SuiteTester) BeforeTest(suiteName, testName string) {
 	suite.TimeBefore = append(suite.TimeBefore, time.Now())
 }
 
-func (suite *SuiteTester) AfterTest(suiteName, testName string) {
+func (suite *SuiteTester) AfterTest(suiteName, testName string, success bool) {
 	suite.SuiteNameAfter = append(suite.SuiteNameAfter, suiteName)
 	suite.TestNameAfter = append(suite.TestNameAfter, testName)
 	suite.TimeAfter = append(suite.TimeAfter, time.Now())
+	suite.TestSuccess = append(suite.TestSuccess, success)
 }
 
 // The TearDownSuite method will be run by testify once, at the very
@@ -295,6 +298,7 @@ func TestRunSuite(t *testing.T) {
 	assert.Equal(t, len(suiteTester.SuiteNameBefore), 4)
 	assert.Equal(t, len(suiteTester.TestNameAfter), 4)
 	assert.Equal(t, len(suiteTester.TestNameBefore), 4)
+	assert.Equal(t, len(suiteTester.TestSuccess), 4)
 
 	assert.Contains(t, suiteTester.TestNameAfter, "TestOne")
 	assert.Contains(t, suiteTester.TestNameAfter, "TestTwo")


### PR DESCRIPTION
I wanted to create a log file with suite + test + duration + test status, so I could gather some data about how slow or flaky some tests can be.

I couldn't find an easy way to log if a test has failed, so I revisited this functionality I added a long time ago and changed `AfterTest` to include the test status. It's a breaking change, unfortunately, so it's probably something for a major release. 

Let me know what you think!

**Edit:**

I wrote a small library to extend my testify suites with stats. I plan to use it to store the results in log files, databases etc. 

My `go.mod` is pointing to my fork of testify, so I can use my fork with my new function. I wrote [some code](https://github.com/esdrasbeleza/testify-stats/blob/d321f339ed0f70334442066214bc346a7d243420/suitewithmetrics.go#L38-L44) in it that stores test stats (suite name + test name + duration + success) using this changed version of `AfterTest`.