### PR TITLE
mock: consider optional expected calls last

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"regexp"
 	"runtime"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -264,7 +265,7 @@ func (m *Mock) On(methodName string, arguments ...interface{}) *Call {
 func (m *Mock) findExpectedCall(method string, arguments ...interface{}) (int, *Call) {
 	var expectedCall *Call
 
-	for i, call := range m.ExpectedCalls {
+	for i, call := range m.expectedCalls() {
 		if call.Method == method {
 			_, diffCount := call.Arguments.Diff(arguments)
 			if diffCount == 0 {
@@ -584,7 +585,12 @@ func (m *Mock) methodWasCalled(methodName string, expected []interface{}) bool {
 }
 
 func (m *Mock) expectedCalls() []*Call {
-	return append([]*Call{}, m.ExpectedCalls...)
+	expectedCalls := append([]*Call{}, m.ExpectedCalls...)
+	sort.Slice(expectedCalls, func(i, j int) bool {
+		return !expectedCalls[i].optional && expectedCalls[j].optional
+	})
+
+	return expectedCalls
 }
 
 func (m *Mock) calls() []Call {

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -1203,6 +1203,24 @@ func Test_Mock_AssertOptional(t *testing.T) {
 	assert.Equal(t, true, ms3.AssertExpectations(tt3))
 }
 
+func Test_Mock_Optional_Last(t *testing.T) {
+	var ms1 = new(TestExampleImplementation)
+	ms1.On("TheExampleMethod", Anything, Anything, Anything).Maybe().Return(0, nil)
+	ms1.On("TheExampleMethod", 1, 2, 3).Return(4, nil)
+
+	r1, _ := ms1.TheExampleMethod(1, 2, 3)
+	assert.Equal(t, 4, r1)
+
+	tt1 := new(testing.T)
+	assert.Equal(t, true, ms1.AssertExpectations(tt1))
+
+	r2, _ := ms1.TheExampleMethod(0, 0, 0)
+	assert.Equal(t, 0, r2)
+
+	tt2 := new(testing.T)
+	assert.Equal(t, true, ms1.AssertExpectations(tt2))
+}
+
 /*
 	Arguments helper methods
 */


### PR DESCRIPTION
For a lot of our testsuite we're using mocks as a replacement of some services which in most tests we just want to return something simple and not care too much about them,  
except for the tests where we're actually testing if the service is being used properly.

So we had the idea to put some `On().Maybe()` calls with `Anything` params on the mocks using the helper which we're already using to build up the various services needed.

However that conflicts with the tests which actually want to mock and assert some method calls themselves because the optional calls are first in the `.ExpectedCalls` and the more specific calls are never actually reached.

eg;
```
	var ms1 = new(TestExampleImplementation)
	ms1.On("TheExampleMethod", Anything, Anything, Anything).Maybe().Return(0, nil)
	ms1.On("TheExampleMethod", 1, 2, 3).Return(4, nil)
```

I think this kinda breaks backwards compatibility, anyone who uses `.Maybe()` with `Anything` params and `.Times()` and has subsequent expected calls could have the methods called in a different other with this change ... 