### PR TITLE
missing )

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -150,7 +150,7 @@ func (c *Call) After(d time.Duration) *Call {
 // mocking a method (such as an unmarshaler) that takes a pointer to a struct and
 // sets properties in such struct
 //
-//    Mock.On("Unmarshal", AnythingOfType("*map[string]interface{}").Return().Run(func(args Arguments) {
+//    Mock.On("Unmarshal", AnythingOfType("*map[string]interface{}")).Return().Run(func(args Arguments) {
 //    	arg := args.Get(0).(*map[string]interface{})
 //    	arg["foo"] = "bar"
 //    })


### PR DESCRIPTION

add `)` to the example of the function`Run`.

[GoDoc](https://godoc.org/github.com/stretchr/testify/mock#Call.Run)