### PR TITLE
Add HTTPStatusCode assertion

### DIFF
--- a/assert/assertion_format.go
+++ b/assert/assertion_format.go
@@ -245,6 +245,18 @@ func HTTPRedirectf(t TestingT, handler http.HandlerFunc, method string, url stri
 	return HTTPRedirect(t, handler, method, url, values, append([]interface{}{msg}, args...)...)
 }
 
+// HTTPStatusCodef asserts that a specified handler returns a specified status code.
+//
+//  assert.HTTPStatusCodef(t, myHandler, "GET", "/notImplemented", nil, 501, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPStatusCodef(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return HTTPStatusCode(t, handler, method, url, values, statuscode, append([]interface{}{msg}, args...)...)
+}
+
 // HTTPSuccessf asserts that a specified handler returns a success status code.
 //
 //  assert.HTTPSuccessf(t, myHandler, "POST", "http://www.google.com", nil, "error message %s", "formatted")

--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -479,6 +479,30 @@ func (a *Assertions) HTTPRedirectf(handler http.HandlerFunc, method string, url 
 	return HTTPRedirectf(a.t, handler, method, url, values, msg, args...)
 }
 
+// HTTPStatusCode asserts that a specified handler returns a specified status code.
+//
+//  a.HTTPStatusCode(myHandler, "GET", "/notImplemented", nil, 501)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPStatusCode(handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return HTTPStatusCode(a.t, handler, method, url, values, statuscode, msgAndArgs...)
+}
+
+// HTTPStatusCodef asserts that a specified handler returns a specified status code.
+//
+//  a.HTTPStatusCodef(myHandler, "GET", "/notImplemented", nil, 501, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPStatusCodef(handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return HTTPStatusCodef(a.t, handler, method, url, values, statuscode, msg, args...)
+}
+
 // HTTPSuccess asserts that a specified handler returns a success status code.
 //
 //  a.HTTPSuccess(myHandler, "POST", "http://www.google.com", nil)

--- a/assert/http_assertions.go
+++ b/assert/http_assertions.go
@@ -90,6 +90,29 @@ func HTTPError(t TestingT, handler http.HandlerFunc, method, url string, values 
 	return isErrorCode
 }
 
+// HTTPStatusCode asserts that a specified handler returns a specified status code.
+//
+//  assert.HTTPStatusCode(t, myHandler, "GET", "/notImplemented", nil, 501)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPStatusCode(t TestingT, handler http.HandlerFunc, method, url string, values url.Values, statuscode int, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	code, err := httpCode(handler, method, url, values)
+	if err != nil {
+		Fail(t, fmt.Sprintf("Failed to build test request, got error: %s", err))
+		return false
+	}
+
+	successful := code == statuscode
+	if !successful {
+		Fail(t, fmt.Sprintf("Expected HTTP status code %d for %q but received %d", statuscode, url+"?"+values.Encode(), code))
+	}
+
+	return successful
+}
+
 // HTTPBody is a helper that returns HTTP body of the response. It returns
 // empty string if building a new request fails.
 func HTTPBody(handler http.HandlerFunc, method, url string, values url.Values) string {

--- a/assert/http_assertions.go
+++ b/assert/http_assertions.go
@@ -33,7 +33,6 @@ func HTTPSuccess(t TestingT, handler http.HandlerFunc, method, url string, value
 	code, err := httpCode(handler, method, url, values)
 	if err != nil {
 		Fail(t, fmt.Sprintf("Failed to build test request, got error: %s", err))
-		return false
 	}
 
 	isSuccessCode := code >= http.StatusOK && code <= http.StatusPartialContent
@@ -56,7 +55,6 @@ func HTTPRedirect(t TestingT, handler http.HandlerFunc, method, url string, valu
 	code, err := httpCode(handler, method, url, values)
 	if err != nil {
 		Fail(t, fmt.Sprintf("Failed to build test request, got error: %s", err))
-		return false
 	}
 
 	isRedirectCode := code >= http.StatusMultipleChoices && code <= http.StatusTemporaryRedirect
@@ -79,7 +77,6 @@ func HTTPError(t TestingT, handler http.HandlerFunc, method, url string, values 
 	code, err := httpCode(handler, method, url, values)
 	if err != nil {
 		Fail(t, fmt.Sprintf("Failed to build test request, got error: %s", err))
-		return false
 	}
 
 	isErrorCode := code >= http.StatusBadRequest
@@ -102,7 +99,6 @@ func HTTPStatusCode(t TestingT, handler http.HandlerFunc, method, url string, va
 	code, err := httpCode(handler, method, url, values)
 	if err != nil {
 		Fail(t, fmt.Sprintf("Failed to build test request, got error: %s", err))
-		return false
 	}
 
 	successful := code == statuscode

--- a/assert/http_assertions_test.go
+++ b/assert/http_assertions_test.go
@@ -37,7 +37,7 @@ func TestHTTPSuccess(t *testing.T) {
 	mockT3 := new(testing.T)
 	assert.Equal(HTTPSuccess(mockT3, httpError, "GET", "/", nil), false)
 	assert.True(mockT3.Failed())
-	
+
 	mockT4 := new(testing.T)
 	assert.Equal(HTTPSuccess(mockT4, httpStatusCode, "GET", "/", nil), false)
 	assert.True(mockT4.Failed())
@@ -57,7 +57,7 @@ func TestHTTPRedirect(t *testing.T) {
 	mockT3 := new(testing.T)
 	assert.Equal(HTTPRedirect(mockT3, httpError, "GET", "/", nil), false)
 	assert.True(mockT3.Failed())
-	
+
 	mockT4 := new(testing.T)
 	assert.Equal(HTTPRedirect(mockT4, httpStatusCode, "GET", "/", nil), false)
 	assert.True(mockT4.Failed())
@@ -77,7 +77,7 @@ func TestHTTPError(t *testing.T) {
 	mockT3 := new(testing.T)
 	assert.Equal(HTTPError(mockT3, httpError, "GET", "/", nil), true)
 	assert.False(mockT3.Failed())
-	
+
 	mockT4 := new(testing.T)
 	assert.Equal(HTTPError(mockT4, httpStatusCode, "GET", "/", nil), false)
 	assert.True(mockT4.Failed())
@@ -97,10 +97,10 @@ func TestHTTPStatusCode(t *testing.T) {
 	mockT3 := new(testing.T)
 	assert.Equal(HTTPStatusCode(mockT3, httpError, "GET", "/", nil, http.StatusSwitchingProtocols), false)
 	assert.True(mockT3.Failed())
-	
+
 	mockT4 := new(testing.T)
 	assert.Equal(HTTPStatusCode(mockT4, httpStatusCode, "GET", "/", nil, http.StatusSwitchingProtocols), true)
-	assert.False(mockT4.Failed())	
+	assert.False(mockT4.Failed())
 }
 
 func TestHTTPStatusesWrapper(t *testing.T) {

--- a/assert/http_assertions_test.go
+++ b/assert/http_assertions_test.go
@@ -19,6 +19,10 @@ func httpError(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusInternalServerError)
 }
 
+func httpStatusCode(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusSwitchingProtocols)
+}
+
 func TestHTTPSuccess(t *testing.T) {
 	assert := New(t)
 
@@ -33,6 +37,10 @@ func TestHTTPSuccess(t *testing.T) {
 	mockT3 := new(testing.T)
 	assert.Equal(HTTPSuccess(mockT3, httpError, "GET", "/", nil), false)
 	assert.True(mockT3.Failed())
+	
+	mockT4 := new(testing.T)
+	assert.Equal(HTTPSuccess(mockT4, httpStatusCode, "GET", "/", nil), false)
+	assert.True(mockT4.Failed())
 }
 
 func TestHTTPRedirect(t *testing.T) {
@@ -49,6 +57,10 @@ func TestHTTPRedirect(t *testing.T) {
 	mockT3 := new(testing.T)
 	assert.Equal(HTTPRedirect(mockT3, httpError, "GET", "/", nil), false)
 	assert.True(mockT3.Failed())
+	
+	mockT4 := new(testing.T)
+	assert.Equal(HTTPRedirect(mockT4, httpStatusCode, "GET", "/", nil), false)
+	assert.True(mockT4.Failed())
 }
 
 func TestHTTPError(t *testing.T) {
@@ -65,6 +77,30 @@ func TestHTTPError(t *testing.T) {
 	mockT3 := new(testing.T)
 	assert.Equal(HTTPError(mockT3, httpError, "GET", "/", nil), true)
 	assert.False(mockT3.Failed())
+	
+	mockT4 := new(testing.T)
+	assert.Equal(HTTPError(mockT4, httpStatusCode, "GET", "/", nil), false)
+	assert.True(mockT4.Failed())
+}
+
+func TestHTTPStatusCode(t *testing.T) {
+	assert := New(t)
+
+	mockT1 := new(testing.T)
+	assert.Equal(HTTPStatusCode(mockT1, httpOK, "GET", "/", nil, http.StatusSwitchingProtocols), false)
+	assert.True(mockT1.Failed())
+
+	mockT2 := new(testing.T)
+	assert.Equal(HTTPStatusCode(mockT2, httpRedirect, "GET", "/", nil, http.StatusSwitchingProtocols), false)
+	assert.True(mockT2.Failed())
+
+	mockT3 := new(testing.T)
+	assert.Equal(HTTPStatusCode(mockT3, httpError, "GET", "/", nil, http.StatusSwitchingProtocols), false)
+	assert.True(mockT3.Failed())
+	
+	mockT4 := new(testing.T)
+	assert.Equal(HTTPStatusCode(mockT4, httpStatusCode, "GET", "/", nil, http.StatusSwitchingProtocols), true)
+	assert.False(mockT4.Failed())	
 }
 
 func TestHTTPStatusesWrapper(t *testing.T) {

--- a/require/require.go
+++ b/require/require.go
@@ -606,6 +606,36 @@ func HTTPRedirectf(t TestingT, handler http.HandlerFunc, method string, url stri
 	t.FailNow()
 }
 
+// HTTPStatusCode asserts that a specified handler returns a specified status code.
+//
+//  assert.HTTPStatusCode(t, myHandler, "GET", "/notImplemented", nil, 501)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPStatusCode(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPStatusCode(t, handler, method, url, values, statuscode, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPStatusCodef asserts that a specified handler returns a specified status code.
+//
+//  assert.HTTPStatusCodef(t, myHandler, "GET", "/notImplemented", nil, 501, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPStatusCodef(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPStatusCodef(t, handler, method, url, values, statuscode, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
 // HTTPSuccess asserts that a specified handler returns a success status code.
 //
 //  assert.HTTPSuccess(t, myHandler, "POST", "http://www.google.com", nil)

--- a/require/require_forward.go
+++ b/require/require_forward.go
@@ -480,6 +480,30 @@ func (a *Assertions) HTTPRedirectf(handler http.HandlerFunc, method string, url 
 	HTTPRedirectf(a.t, handler, method, url, values, msg, args...)
 }
 
+// HTTPStatusCode asserts that a specified handler returns a specified status code.
+//
+//  a.HTTPStatusCode(myHandler, "GET", "/notImplemented", nil, 501)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPStatusCode(handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPStatusCode(a.t, handler, method, url, values, statuscode, msgAndArgs...)
+}
+
+// HTTPStatusCodef asserts that a specified handler returns a specified status code.
+//
+//  a.HTTPStatusCodef(myHandler, "GET", "/notImplemented", nil, 501, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPStatusCodef(handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPStatusCodef(a.t, handler, method, url, values, statuscode, msg, args...)
+}
+
 // HTTPSuccess asserts that a specified handler returns a success status code.
 //
 //  a.HTTPSuccess(myHandler, "POST", "http://www.google.com", nil)


### PR DESCRIPTION
@glesica @boyan-soubachov  Please consider this PR for merging.

**Motivation**
The current set of HTTP asserts do not cover the full range of status codes. This addition would allow a user to test for a specific status code.

As such it would cover the full range of status codes, including for example: `http.StatusSwitchingProtocols`.

**Example usage**
`assert.HTTPStatusCode(t, myHandler, "GET", "/", nil, http.StatusSwitchingProtocols)`

**Whether you intend to add / change behaviour or fix a bug**
Adds behaviour.

**Additionally**
- Would also close #824 
- Includes test
- Tests ran successfully