### PR TITLE
Add warning in log when no tests are run within a suite

### DIFF
--- a/suite/suite.go
+++ b/suite/suite.go
@@ -179,16 +179,20 @@ func Run(t *testing.T, suite TestingSuite) {
 }
 
 func runTests(t testing.TB, tests []testing.InternalTest) {
-	r, ok := t.(runner)
-	if !ok { // backwards compatibility with Go 1.6 and below
-		if !testing.RunTests(allTestsFilter, tests) {
-			t.Fail()
+	if len(tests) == 0 {
+		t.Log("warning: no tests to run")
+	} else {
+		r, ok := t.(runner)
+		if !ok { // backwards compatibility with Go 1.6 and below
+			if !testing.RunTests(allTestsFilter, tests) {
+				t.Fail()
+			}
+			return
 		}
-		return
-	}
 
-	for _, test := range tests {
-		r.Run(test.Name, test.F)
+		for _, test := range tests {
+			r.Run(test.Name, test.F)
+		}
 	}
 }
 

--- a/suite/suite.go
+++ b/suite/suite.go
@@ -181,18 +181,19 @@ func Run(t *testing.T, suite TestingSuite) {
 func runTests(t testing.TB, tests []testing.InternalTest) {
 	if len(tests) == 0 {
 		t.Log("warning: no tests to run")
-	} else {
-		r, ok := t.(runner)
-		if !ok { // backwards compatibility with Go 1.6 and below
-			if !testing.RunTests(allTestsFilter, tests) {
-				t.Fail()
-			}
-			return
-		}
+		return
+	}
 
-		for _, test := range tests {
-			r.Run(test.Name, test.F)
+	r, ok := t.(runner)
+	if !ok { // backwards compatibility with Go 1.6 and below
+		if !testing.RunTests(allTestsFilter, tests) {
+			t.Fail()
 		}
+		return
+	}
+
+	for _, test := range tests {
+		r.Run(test.Name, test.F)
 	}
 }
 


### PR DESCRIPTION
## Summary
Add a warning message when no tests are run within a suite. Before this change it would just report passed with no indication that nothing was actually run.

## Changes
Added a check that there are tests to actually run and a warning to testing.Log if there are not

## Motivation
See issue 862. It is easy to assume that all your tests have passed when in fact you didn't run any because of perhaps a typo in your regex.

## Related issues
Closes #862 
