### PR TITLE
Change how tearDownAllSuite is run to aviod deadlock when running with failfast

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ sudo: false
 
 matrix:
   include:
-    - go: "1.8.x"
-    - go: "1.9.x"
     - go: "1.10.x"
     - go: "1.11.x"
       env: GO111MODULE=off
@@ -28,4 +26,3 @@ script:
   - ./.travis.gofmt.sh
   - ./.travis.govet.sh
   - go test -v -race ./...
-  - go test -v -race -failfast -run TestSuiteWithFailfast

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,3 +28,4 @@ script:
   - ./.travis.gofmt.sh
   - ./.travis.govet.sh
   - go test -v -race ./...
+  - go test -v -race -failfast -run TestSuiteWithFailfast

--- a/suite/suite.go
+++ b/suite/suite.go
@@ -91,7 +91,7 @@ func Run(t *testing.T, suite TestingSuite) {
 	if _, ok := suite.(WithStats); ok {
 		stats = newSuiteInformation()
 	}
-	
+
 	tests := []testing.InternalTest{}
 	methodFinder := reflect.TypeOf(suite)
 	suiteName := methodFinder.Elem().Name()
@@ -160,7 +160,6 @@ func Run(t *testing.T, suite TestingSuite) {
 		}
 		tests = append(tests, test)
 	}
-
 	if suiteSetupDone {
 		defer func() {
 			if tearDownAllSuite, ok := suite.(TearDownAllSuite); ok {

--- a/suite/suite_test.go
+++ b/suite/suite_test.go
@@ -516,7 +516,7 @@ func TestSuiteWithStats(t *testing.T) {
 	assert.True(t, testStats.Passed)
 }
 
-// Suite to test behavior when running with the failfast flag
+// FailfastSuite will test the behavior when running with the failfast flag
 // It logs calls in the callOrder slice which we then use to assert the correct calls were made
 type FailfastSuite struct {
 	Suite

--- a/suite/suite_test.go
+++ b/suite/suite_test.go
@@ -580,7 +580,7 @@ func (s *FailfastSuite) TearDownTest() {
 
 func (s *FailfastSuite) Test_A_Fails() {
 	s.call("Test A Fails")
-	s.Require().True(false)
+	s.T().Error("Test A meant to fail")
 }
 
 func (s *FailfastSuite) Test_B_Passes() {


### PR DESCRIPTION
## Summary
Fixes a deadlock when there is a failing test in a suite when run with failfast

## Changes
This commit https://github.com/stretchr/testify/commit/0d3c8ce9f8c3be984ccd5d2e3438b173ea722267 attempted to fix an ordering issue with suite teardown, but introduced a deadlock when a test fails when running with failfast.

The problem is that the sync.WaitGroup was being incremented for each test which was expected to be run, but with failfast not all of those tests were actually run. Then the first test is trying to run tearDownAllSuite after itself but waiting on the sync.WaitGroup which never wakes up.

I think we can just move the tearDownAllSuite  into a defer which will run after we have run whatever tests are going to be run, without the need for a sync.WaitGroup at all.

## Motivation
Fixes a defect

## Related issues
Closes #917 
