### PR TITLE
mock: callString to handle nil nicely

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -855,7 +855,7 @@ func (args Arguments) String(indexOrNil ...int) string {
 		// normal String() method - return a string representation of the args
 		var argsStr []string
 		for _, arg := range args {
-			argsStr = append(argsStr, reflect.TypeOf(arg).String())
+			argsStr = append(argsStr, fmt.Sprintf("%T", arg)) // handles nil nicely
 		}
 		return strings.Join(argsStr, ",")
 	} else if len(indexOrNil) == 1 {

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -778,6 +778,7 @@ func Test_Mock_findExpectedCall_Respects_Repeatability(t *testing.T) {
 func Test_callString(t *testing.T) {
 
 	assert.Equal(t, `Method(int,bool,string)`, callString("Method", []interface{}{1, true, "something"}, false))
+	assert.Equal(t, `Method(<nil>)`, callString("Method", []interface{}{nil}, false))
 
 }
 


### PR DESCRIPTION
## Summary
Fixes a regression in `testify/mock`.
## Changes
Handle nil in Arguments.String() by employing fmt.Sprint().

## Motivation
A regression introduced while replacing `fmt.Sprint()` with `reflect.TypeOf(arg)` in `Arguments.String()`: `reflect.TypeOf(nil)` returns `nil` which is its documented behaviour. A null pointer dereference is what follows.

A unit test case added.

## Related issues
Closes #936.
