### PR TITLE
Refactor unit tests to table-driven tests

### DIFF
--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -594,6 +594,7 @@ func TestContainsNotContains(t *testing.T) {
 			}
 		}
 	})
+
 	t.Run("TestNotContains", func(t *testing.T) {
 		mockT := new(testing.T)
 
@@ -624,64 +625,55 @@ func TestContainsFailMessage(t *testing.T) {
 	}
 }
 
-func TestSubset(t *testing.T) {
-	mockT := new(testing.T)
-
-	if !Subset(mockT, []int{1, 2, 3}, nil) {
-		t.Error("Subset should return true: given subset is nil")
-	}
-	if !Subset(mockT, []int{1, 2, 3}, []int{}) {
-		t.Error("Subset should return true: any set contains the nil set")
-	}
-	if !Subset(mockT, []int{1, 2, 3}, []int{1, 2}) {
-		t.Error("Subset should return true: [1, 2, 3] contains [1, 2]")
-	}
-	if !Subset(mockT, []int{1, 2, 3}, []int{1, 2, 3}) {
-		t.Error("Subset should return true: [1, 2, 3] contains [1, 2, 3]")
-	}
-	if !Subset(mockT, []string{"hello", "world"}, []string{"hello"}) {
-		t.Error("Subset should return true: [\"hello\", \"world\"] contains [\"hello\"]")
+func TestSubsetNotSubset(t *testing.T) {
+	type MTestCase struct {
+		TestCase
+		message string
 	}
 
-	if Subset(mockT, []string{"hello", "world"}, []string{"hello", "testify"}) {
-		t.Error("Subset should return false: [\"hello\", \"world\"] does not contain [\"hello\", \"testify\"]")
-	}
-	if Subset(mockT, []int{1, 2, 3}, []int{4, 5}) {
-		t.Error("Subset should return false: [1, 2, 3] does not contain [4, 5]")
-	}
-	if Subset(mockT, []int{1, 2, 3}, []int{1, 5}) {
-		t.Error("Subset should return false: [1, 2, 3] does not contain [1, 5]")
-	}
-}
+	cases := []MTestCase{
+		// cases that are expected to contain
+		{TestCase{[]int{1, 2, 3}, nil, true}, "given subset is nil"},
+		{TestCase{[]int{1, 2, 3}, []int{}, true}, "any set contains the nil set"},
+		{TestCase{[]int{1, 2, 3}, []int{1, 2}, true}, "[1, 2, 3] contains [1, 2]"},
+		{TestCase{[]int{1, 2, 3}, []int{1, 2, 3}, true}, "[1, 2, 3] contains [1, 2, 3"},
+		{TestCase{[]string{"hello", "world"}, []string{"hello"}, true}, "[\"hello\", \"world\"] contains [\"hello\"]"},
 
-func TestNotSubset(t *testing.T) {
-	mockT := new(testing.T)
-
-	if NotSubset(mockT, []int{1, 2, 3}, nil) {
-		t.Error("NotSubset should return false: given subset is nil")
-	}
-	if NotSubset(mockT, []int{1, 2, 3}, []int{}) {
-		t.Error("NotSubset should return false: any set contains the nil set")
-	}
-	if NotSubset(mockT, []int{1, 2, 3}, []int{1, 2}) {
-		t.Error("NotSubset should return false: [1, 2, 3] contains [1, 2]")
-	}
-	if NotSubset(mockT, []int{1, 2, 3}, []int{1, 2, 3}) {
-		t.Error("NotSubset should return false: [1, 2, 3] contains [1, 2, 3]")
-	}
-	if NotSubset(mockT, []string{"hello", "world"}, []string{"hello"}) {
-		t.Error("NotSubset should return false: [\"hello\", \"world\"] contains [\"hello\"]")
+		// cases that are expected not to contain
+		{TestCase{[]string{"hello", "world"}, []string{"hello", "testify"}, false}, "[\"hello\", \"world\"] does not contain [\"hello\", \"testify\"]"},
+		{TestCase{[]int{1, 2, 3}, []int{4, 5}, false}, "[1, 2, 3] does not contain [4, 5"},
+		{TestCase{[]int{1, 2, 3}, []int{1, 5}, false}, "[1, 2, 3] does not contain [1, 5]"},
 	}
 
-	if !NotSubset(mockT, []string{"hello", "world"}, []string{"hello", "testify"}) {
-		t.Error("NotSubset should return true: [\"hello\", \"world\"] does not contain [\"hello\", \"testify\"]")
-	}
-	if !NotSubset(mockT, []int{1, 2, 3}, []int{4, 5}) {
-		t.Error("NotSubset should return true: [1, 2, 3] does not contain [4, 5]")
-	}
-	if !NotSubset(mockT, []int{1, 2, 3}, []int{1, 5}) {
-		t.Error("NotSubset should return true: [1, 2, 3] does not contain [1, 5]")
-	}
+	t.Run("TestSubset", func(t *testing.T) {
+		mockT := new(testing.T)
+		for _, c := range cases {
+			res := Subset(mockT, c.expected, c.actual)
+
+			if res != c.result {
+				if res {
+					t.Errorf("Subset should return true: %s", c.message)
+				} else {
+					t.Errorf("Subset should return false: %s", c.message)
+				}
+			}
+		}
+	})
+	t.Run("TestNotSubset", func(t *testing.T) {
+		mockT := new(testing.T)
+		for _, c := range cases {
+			res := NotSubset(mockT, c.expected, c.actual)
+
+			// Not that we negate the result, since we expect the opposite
+			if res != !c.result {
+				if res {
+					t.Errorf("NotSubset should return true: %s", c.message)
+				} else {
+					t.Errorf("NotSubset should return false: %s", c.message)
+				}
+			}
+		}
+	})
 }
 
 func TestNotSubsetNil(t *testing.T) {

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -474,6 +474,12 @@ func TestFalse(t *testing.T) {
 
 }
 
+type TestCase struct {
+	expected interface{}
+	actual   interface{}
+	result   bool
+}
+
 func TestExactly(t *testing.T) {
 
 	mockT := new(testing.T)
@@ -482,30 +488,21 @@ func TestExactly(t *testing.T) {
 	b := float64(1)
 	c := float32(1)
 	d := float32(2)
-
-	if Exactly(mockT, a, b) {
-		t.Error("Exactly should return false")
-	}
-	if Exactly(mockT, a, d) {
-		t.Error("Exactly should return false")
-	}
-	if !Exactly(mockT, a, c) {
-		t.Error("Exactly should return true")
+	cases := []TestCase{
+		{a, b, false},
+		{a, d, false},
+		{a, c, true},
+		{nil, a, false},
+		{a, nil, false},
 	}
 
-	if Exactly(mockT, nil, a) {
-		t.Error("Exactly should return false")
-	}
-	if Exactly(mockT, a, nil) {
-		t.Error("Exactly should return false")
-	}
+	for _, c := range cases {
+		res := Exactly(mockT, c.expected, c.actual)
 
-}
-
-type TestCase struct {
-	expected interface{}
-	actual   interface{}
-	result   bool
+		if res != c.result {
+			t.Errorf("Exactly(%v, %v) should return %v", c.expected, c.actual, c.result)
+		}
+	}
 }
 
 func TestNotEqual(t *testing.T) {

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -631,6 +631,7 @@ func TestSubsetNotSubset(t *testing.T) {
 		message string
 	}
 
+	// MTestCase adds a custom message to the case
 	cases := []MTestCase{
 		// cases that are expected to contain
 		{TestCase{[]int{1, 2, 3}, nil, true}, "given subset is nil"},
@@ -738,51 +739,35 @@ func Test_includeElement(t *testing.T) {
 func TestElementsMatch(t *testing.T) {
 	mockT := new(testing.T)
 
-	if !ElementsMatch(mockT, nil, nil) {
-		t.Error("ElementsMatch should return true")
-	}
-	if !ElementsMatch(mockT, []int{}, []int{}) {
-		t.Error("ElementsMatch should return true")
-	}
-	if !ElementsMatch(mockT, []int{1}, []int{1}) {
-		t.Error("ElementsMatch should return true")
-	}
-	if !ElementsMatch(mockT, []int{1, 1}, []int{1, 1}) {
-		t.Error("ElementsMatch should return true")
-	}
-	if !ElementsMatch(mockT, []int{1, 2}, []int{1, 2}) {
-		t.Error("ElementsMatch should return true")
-	}
-	if !ElementsMatch(mockT, []int{1, 2}, []int{2, 1}) {
-		t.Error("ElementsMatch should return true")
-	}
-	if !ElementsMatch(mockT, [2]int{1, 2}, [2]int{2, 1}) {
-		t.Error("ElementsMatch should return true")
-	}
-	if !ElementsMatch(mockT, []string{"hello", "world"}, []string{"world", "hello"}) {
-		t.Error("ElementsMatch should return true")
-	}
-	if !ElementsMatch(mockT, []string{"hello", "hello"}, []string{"hello", "hello"}) {
-		t.Error("ElementsMatch should return true")
-	}
-	if !ElementsMatch(mockT, []string{"hello", "hello", "world"}, []string{"hello", "world", "hello"}) {
-		t.Error("ElementsMatch should return true")
-	}
-	if !ElementsMatch(mockT, [3]string{"hello", "hello", "world"}, [3]string{"hello", "world", "hello"}) {
-		t.Error("ElementsMatch should return true")
-	}
-	if !ElementsMatch(mockT, []int{}, nil) {
-		t.Error("ElementsMatch should return true")
+	cases := []TestCase{
+		// matching
+		{nil, nil, true},
+
+		{nil, nil, true},
+		{[]int{}, []int{}, true},
+		{[]int{1}, []int{1}, true},
+		{[]int{1, 1}, []int{1, 1}, true},
+		{[]int{1, 2}, []int{1, 2}, true},
+		{[]int{1, 2}, []int{2, 1}, true},
+		{[2]int{1, 2}, [2]int{2, 1}, true},
+		{[]string{"hello", "world"}, []string{"world", "hello"}, true},
+		{[]string{"hello", "hello"}, []string{"hello", "hello"}, true},
+		{[]string{"hello", "hello", "world"}, []string{"hello", "world", "hello"}, true},
+		{[3]string{"hello", "hello", "world"}, [3]string{"hello", "world", "hello"}, true},
+		{[]int{}, nil, true},
+
+		// not matching
+		{[]int{1}, []int{1, 1}, false},
+		{[]int{1, 2}, []int{2, 2}, false},
+		{[]string{"hello", "hello"}, []string{"hello"}, false},
 	}
 
-	if ElementsMatch(mockT, []int{1}, []int{1, 1}) {
-		t.Error("ElementsMatch should return false")
-	}
-	if ElementsMatch(mockT, []int{1, 2}, []int{2, 2}) {
-		t.Error("ElementsMatch should return false")
-	}
-	if ElementsMatch(mockT, []string{"hello", "hello"}, []string{"hello"}) {
-		t.Error("ElementsMatch should return false")
+	for _, c := range cases {
+		res := ElementsMatch(mockT, c.actual, c.expected)
+
+		if res != c.result {
+			t.Errorf("ElementsMatch(%#v, %#v) should return %v", c.actual, c.expected, c.result)
+		}
 	}
 }
 

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -131,7 +131,7 @@ func TestObjectsAreEqual(t *testing.T) {
 		res := ObjectsAreEqual(c.expected, c.actual)
 
 		if res != c.result {
-			t.Errorf("Equal(%v, %v) should return %v", c.expected, c.actual, c.result)
+			t.Errorf("Equal(%#v, %#v) should return %#v", c.expected, c.actual, c.result)
 		}
 	}
 
@@ -206,7 +206,7 @@ func TestEqual(t *testing.T) {
 		res := Equal(mockT, c.expected, c.actual)
 
 		if res != c.result {
-			t.Errorf("Equal(%v, %v) should return %v", c.expected, c.actual, c.result)
+			t.Errorf("Equal(%#v, %#v) should return %#v", c.expected, c.actual, c.result)
 		}
 	}
 }
@@ -477,7 +477,7 @@ func TestExactly(t *testing.T) {
 		res := Exactly(mockT, c.expected, c.actual)
 
 		if res != c.result {
-			t.Errorf("Exactly(%v, %v) should return %v", c.expected, c.actual, c.result)
+			t.Errorf("Exactly(%#v, %#v) should return %#v", c.expected, c.actual, c.result)
 		}
 	}
 }
@@ -511,7 +511,7 @@ func TestNotEqual(t *testing.T) {
 		res := NotEqual(mockT, c.expected, c.actual)
 
 		if res != c.result {
-			t.Errorf("NotEqual(%v, %v) should return %v", c.expected, c.actual, c.result)
+			t.Errorf("NotEqual(%#v, %#v) should return %#v", c.expected, c.actual, c.result)
 		}
 	}
 }
@@ -548,19 +548,18 @@ func TestNotEqualValues(t *testing.T) {
 		res := NotEqualValues(mockT, c.expected, c.actual)
 
 		if res != c.result {
-			t.Errorf("NotEqualValues(%v, %v) should return %v", c.expected, c.actual, c.result)
+			t.Errorf("NotEqualValues(%#v, %#v) should return %#v", c.expected, c.actual, c.result)
 		}
 	}
 }
 
-type A struct {
-	Name, Value string
-}
+func TestContainsNotContains(t *testing.T) {
 
-func TestContains(t *testing.T) {
-
-	mockT := new(testing.T)
+	type A struct {
+		Name, Value string
+	}
 	list := []string{"Foo", "Bar"}
+
 	complexList := []*A{
 		{"b", "c"},
 		{"d", "e"},
@@ -569,34 +568,48 @@ func TestContains(t *testing.T) {
 	}
 	simpleMap := map[interface{}]interface{}{"Foo": "Bar"}
 
-	if !Contains(mockT, "Hello World", "Hello") {
-		t.Error("Contains should return true: \"Hello World\" contains \"Hello\"")
-	}
-	if Contains(mockT, "Hello World", "Salut") {
-		t.Error("Contains should return false: \"Hello World\" does not contain \"Salut\"")
+	cases := []TestCase{
+		{"Hello World", "Hello", true},
+		{"Hello World", "Salut", false},
+		{list, "Bar", true},
+		{list, "Salut", false},
+		{complexList, &A{"g", "h"}, true},
+		{complexList, &A{"g", "e"}, false},
+		{simpleMap, "Foo", true},
+		{simpleMap, "Bar", false},
 	}
 
-	if !Contains(mockT, list, "Bar") {
-		t.Error("Contains should return true: \"[\"Foo\", \"Bar\"]\" contains \"Bar\"")
-	}
-	if Contains(mockT, list, "Salut") {
-		t.Error("Contains should return false: \"[\"Foo\", \"Bar\"]\" does not contain \"Salut\"")
-	}
-	if !Contains(mockT, complexList, &A{"g", "h"}) {
-		t.Error("Contains should return true: complexList contains {\"g\", \"h\"}")
-	}
-	if Contains(mockT, complexList, &A{"g", "e"}) {
-		t.Error("Contains should return false: complexList contains {\"g\", \"e\"}")
-	}
-	if Contains(mockT, complexList, &A{"g", "e"}) {
-		t.Error("Contains should return false: complexList contains {\"g\", \"e\"}")
-	}
-	if !Contains(mockT, simpleMap, "Foo") {
-		t.Error("Contains should return true: \"{\"Foo\": \"Bar\"}\" contains \"Foo\"")
-	}
-	if Contains(mockT, simpleMap, "Bar") {
-		t.Error("Contains should return false: \"{\"Foo\": \"Bar\"}\" does not contains \"Bar\"")
-	}
+	t.Run("TestContains", func(t *testing.T) {
+		mockT := new(testing.T)
+
+		for _, c := range cases {
+			res := Contains(mockT, c.expected, c.actual)
+
+			if res != c.result {
+				if res {
+					t.Errorf("Contains(%#v, %#v) should return true:\n\t%#v contains %#v", c.expected, c.actual, c.expected, c.actual)
+				} else {
+					t.Errorf("Contains(%#v, %#v) should return false:\n\t%#v does not contain %#v", c.expected, c.actual, c.expected, c.actual)
+				}
+			}
+		}
+	})
+	t.Run("TestNotContains", func(t *testing.T) {
+		mockT := new(testing.T)
+
+		for _, c := range cases {
+			res := NotContains(mockT, c.expected, c.actual)
+
+			// Not that we negate the result, since we expect the opposite
+			if res != !c.result {
+				if res {
+					t.Errorf("NotContains(%#v, %#v) should return true:\n\t%#v does not contains %#v", c.expected, c.actual, c.expected, c.actual)
+				} else {
+					t.Errorf("NotContains(%#v, %#v) should return false:\n\t%#v contains %#v", c.expected, c.actual, c.expected, c.actual)
+				}
+			}
+		}
+	})
 }
 
 func TestContainsFailMessage(t *testing.T) {
@@ -608,33 +621,6 @@ func TestContainsFailMessage(t *testing.T) {
 	actualFail := mockT.errorString()
 	if !strings.Contains(actualFail, expectedFail) {
 		t.Errorf("Contains failure should include %q but was %q", expectedFail, actualFail)
-	}
-}
-
-func TestNotContains(t *testing.T) {
-
-	mockT := new(testing.T)
-	list := []string{"Foo", "Bar"}
-	simpleMap := map[interface{}]interface{}{"Foo": "Bar"}
-
-	if !NotContains(mockT, "Hello World", "Hello!") {
-		t.Error("NotContains should return true: \"Hello World\" does not contain \"Hello!\"")
-	}
-	if NotContains(mockT, "Hello World", "Hello") {
-		t.Error("NotContains should return false: \"Hello World\" contains \"Hello\"")
-	}
-
-	if !NotContains(mockT, list, "Foo!") {
-		t.Error("NotContains should return true: \"[\"Foo\", \"Bar\"]\" does not contain \"Foo!\"")
-	}
-	if NotContains(mockT, list, "Foo") {
-		t.Error("NotContains should return false: \"[\"Foo\", \"Bar\"]\" contains \"Foo\"")
-	}
-	if NotContains(mockT, simpleMap, "Foo") {
-		t.Error("Contains should return true: \"{\"Foo\": \"Bar\"}\" contains \"Foo\"")
-	}
-	if !NotContains(mockT, simpleMap, "Bar") {
-		t.Error("Contains should return false: \"{\"Foo\": \"Bar\"}\" does not contains \"Bar\"")
 	}
 }
 

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -182,9 +182,8 @@ func TestIsType(t *testing.T) {
 
 }
 
-type myType string
-
 func TestEqual(t *testing.T) {
+	type myType string
 
 	mockT := new(testing.T)
 

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -125,11 +125,14 @@ func TestObjectsAreEqual(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		res := ObjectsAreEqual(c.expected, c.actual)
+		t.Run(fmt.Sprintf("ObjectsAreEqual(%#v, %#v)", c.expected, c.actual), func(t *testing.T) {
+			res := ObjectsAreEqual(c.expected, c.actual)
 
-		if res != c.result {
-			t.Errorf("Equal(%#v, %#v) should return %#v", c.expected, c.actual, c.result)
-		}
+			if res != c.result {
+				t.Errorf("ObjectsAreEqual(%#v, %#v) should return %#v", c.expected, c.actual, c.result)
+			}
+
+		})
 	}
 
 	// Cases where type differ but values are equal
@@ -184,31 +187,34 @@ func TestEqual(t *testing.T) {
 		expected interface{}
 		actual   interface{}
 		result   bool
+		remark   string
 	}{
-		{"Hello World", "Hello World", true},
-		{123, 123, true},
-		{123.5, 123.5, true},
-		{[]byte("Hello World"), []byte("Hello World"), true},
-		{nil, nil, true},
-		{int32(123), int32(123), true},
-		{uint64(123), uint64(123), true},
-		{myType("1"), myType("1"), true},
-		{&struct{}{}, &struct{}{}, true}, // pointer equality is based on equality of underlying value
+		{"Hello World", "Hello World", true, ""},
+		{123, 123, true, ""},
+		{123.5, 123.5, true, ""},
+		{[]byte("Hello World"), []byte("Hello World"), true, ""},
+		{nil, nil, true, ""},
+		{int32(123), int32(123), true, ""},
+		{uint64(123), uint64(123), true, ""},
+		{myType("1"), myType("1"), true, ""},
+		{&struct{}{}, &struct{}{}, true, "pointer equality is based on equality of underlying value"},
 
 		// Not expected to be equal
-		{m["bar"], "something", false},
-		{myType("1"), myType("2"), false},
+		{m["bar"], "something", false, ""},
+		{myType("1"), myType("2"), false, ""},
 
 		// A case that might be confusing, especially with numeric literals
-		{10, uint(10), false},
+		{10, uint(10), false, ""},
 	}
 
 	for _, c := range cases {
-		res := Equal(mockT, c.expected, c.actual)
+		t.Run(fmt.Sprintf("Equal(%#v, %#v)", c.expected, c.actual), func(t *testing.T) {
+			res := Equal(mockT, c.expected, c.actual)
 
-		if res != c.result {
-			t.Errorf("Equal(%#v, %#v) should return %#v", c.expected, c.actual, c.result)
-		}
+			if res != c.result {
+				t.Errorf("Equal(%#v, %#v) should return %#v: %s", c.expected, c.actual, c.result, c.remark)
+			}
+		})
 	}
 }
 
@@ -479,11 +485,13 @@ func TestExactly(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		res := Exactly(mockT, c.expected, c.actual)
+		t.Run(fmt.Sprintf("Exactly(%#v, %#v)", c.expected, c.actual), func(t *testing.T) {
+			res := Exactly(mockT, c.expected, c.actual)
 
-		if res != c.result {
-			t.Errorf("Exactly(%#v, %#v) should return %#v", c.expected, c.actual, c.result)
-		}
+			if res != c.result {
+				t.Errorf("Exactly(%#v, %#v) should return %#v", c.expected, c.actual, c.result)
+			}
+		})
 	}
 }
 
@@ -517,11 +525,13 @@ func TestNotEqual(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		res := NotEqual(mockT, c.expected, c.actual)
+		t.Run(fmt.Sprintf("NotEqual(%#v, %#v)", c.expected, c.actual), func(t *testing.T) {
+			res := NotEqual(mockT, c.expected, c.actual)
 
-		if res != c.result {
-			t.Errorf("NotEqual(%#v, %#v) should return %#v", c.expected, c.actual, c.result)
-		}
+			if res != c.result {
+				t.Errorf("NotEqual(%#v, %#v) should return %#v", c.expected, c.actual, c.result)
+			}
+		})
 	}
 }
 
@@ -558,11 +568,13 @@ func TestNotEqualValues(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		res := NotEqualValues(mockT, c.expected, c.actual)
+		t.Run(fmt.Sprintf("NotEqualValues(%#v, %#v)", c.expected, c.actual), func(t *testing.T) {
+			res := NotEqualValues(mockT, c.expected, c.actual)
 
-		if res != c.result {
-			t.Errorf("NotEqualValues(%#v, %#v) should return %#v", c.expected, c.actual, c.result)
-		}
+			if res != c.result {
+				t.Errorf("NotEqualValues(%#v, %#v) should return %#v", c.expected, c.actual, c.result)
+			}
+		})
 	}
 }
 
@@ -596,10 +608,9 @@ func TestContainsNotContains(t *testing.T) {
 		{simpleMap, "Bar", false},
 	}
 
-	t.Run("TestContains", func(t *testing.T) {
-		mockT := new(testing.T)
-
-		for _, c := range cases {
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("Contains(%#v, %#v)", c.expected, c.actual), func(t *testing.T) {
+			mockT := new(testing.T)
 			res := Contains(mockT, c.expected, c.actual)
 
 			if res != c.result {
@@ -609,25 +620,24 @@ func TestContainsNotContains(t *testing.T) {
 					t.Errorf("Contains(%#v, %#v) should return false:\n\t%#v does not contain %#v", c.expected, c.actual, c.expected, c.actual)
 				}
 			}
-		}
-	})
+		})
+	}
 
-	t.Run("TestNotContains", func(t *testing.T) {
-		mockT := new(testing.T)
-
-		for _, c := range cases {
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("NotContains(%#v, %#v)", c.expected, c.actual), func(t *testing.T) {
+			mockT := new(testing.T)
 			res := NotContains(mockT, c.expected, c.actual)
 
-			// Not that we negate the result, since we expect the opposite
-			if res != !c.result {
+			// NotContains should be inverse of Contains. If it's not, something is wrong
+			if res == Contains(mockT, c.expected, c.actual) {
 				if res {
 					t.Errorf("NotContains(%#v, %#v) should return true:\n\t%#v does not contains %#v", c.expected, c.actual, c.expected, c.actual)
 				} else {
 					t.Errorf("NotContains(%#v, %#v) should return false:\n\t%#v contains %#v", c.expected, c.actual, c.expected, c.actual)
 				}
 			}
-		}
-	})
+		})
+	}
 }
 
 func TestContainsFailMessage(t *testing.T) {
@@ -664,9 +674,10 @@ func TestSubsetNotSubset(t *testing.T) {
 		{[]int{1, 2, 3}, []int{1, 5}, false, "[1, 2, 3] does not contain [1, 5]"},
 	}
 
-	t.Run("TestSubset", func(t *testing.T) {
-		mockT := new(testing.T)
-		for _, c := range cases {
+	for _, c := range cases {
+		t.Run("SubSet: "+c.message, func(t *testing.T) {
+
+			mockT := new(testing.T)
 			res := Subset(mockT, c.expected, c.actual)
 
 			if res != c.result {
@@ -676,23 +687,23 @@ func TestSubsetNotSubset(t *testing.T) {
 					t.Errorf("Subset should return false: %s", c.message)
 				}
 			}
-		}
-	})
-	t.Run("TestNotSubset", func(t *testing.T) {
-		mockT := new(testing.T)
-		for _, c := range cases {
+		})
+	}
+	for _, c := range cases {
+		t.Run("NotSubSet: "+c.message, func(t *testing.T) {
+			mockT := new(testing.T)
 			res := NotSubset(mockT, c.expected, c.actual)
 
-			// Not that we negate the result, since we expect the opposite
-			if res != !c.result {
+			// NotSubset should match the inverse of Subset. If it doesn't, something is wrong
+			if res == Subset(mockT, c.expected, c.actual) {
 				if res {
 					t.Errorf("NotSubset should return true: %s", c.message)
 				} else {
 					t.Errorf("NotSubset should return false: %s", c.message)
 				}
 			}
-		}
-	})
+		})
+	}
 }
 
 func TestNotSubsetNil(t *testing.T) {
@@ -785,11 +796,13 @@ func TestElementsMatch(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		res := ElementsMatch(mockT, c.actual, c.expected)
+		t.Run(fmt.Sprintf("ElementsMatch(%#v, %#v)", c.expected, c.actual), func(t *testing.T) {
+			res := ElementsMatch(mockT, c.actual, c.expected)
 
-		if res != c.result {
-			t.Errorf("ElementsMatch(%#v, %#v) should return %v", c.actual, c.expected, c.result)
-		}
+			if res != c.result {
+				t.Errorf("ElementsMatch(%#v, %#v) should return %v", c.actual, c.expected, c.result)
+			}
+		})
 	}
 }
 

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -182,48 +182,43 @@ func TestIsType(t *testing.T) {
 
 }
 
+type TestCase struct {
+	expected interface{}
+	actual   interface{}
+	result   bool
+}
+
 func TestEqual(t *testing.T) {
 	type myType string
 
 	mockT := new(testing.T)
-
-	if !Equal(mockT, "Hello World", "Hello World") {
-		t.Error("Equal should return true")
-	}
-	if !Equal(mockT, 123, 123) {
-		t.Error("Equal should return true")
-	}
-	if !Equal(mockT, 123.5, 123.5) {
-		t.Error("Equal should return true")
-	}
-	if !Equal(mockT, []byte("Hello World"), []byte("Hello World")) {
-		t.Error("Equal should return true")
-	}
-	if !Equal(mockT, nil, nil) {
-		t.Error("Equal should return true")
-	}
-	if !Equal(mockT, int32(123), int32(123)) {
-		t.Error("Equal should return true")
-	}
-	if !Equal(mockT, uint64(123), uint64(123)) {
-		t.Error("Equal should return true")
-	}
-	if !Equal(mockT, myType("1"), myType("1")) {
-		t.Error("Equal should return true")
-	}
-	if !Equal(mockT, &struct{}{}, &struct{}{}) {
-		t.Error("Equal should return true (pointer equality is based on equality of underlying value)")
-	}
 	var m map[string]interface{}
-	if Equal(mockT, m["bar"], "something") {
-		t.Error("Equal should return false")
+
+	cases := []TestCase{
+		{"Hello World", "Hello World", true},
+		{123, 123, true},
+		{123.5, 123.5, true},
+		{[]byte("Hello World"), []byte("Hello World"), true},
+		{nil, nil, true},
+		{int32(123), int32(123), true},
+		{uint64(123), uint64(123), true},
+		{myType("1"), myType("1"), true},
+		{&struct{}{}, &struct{}{}, true}, // pointer equality is based on equality of underlying value
+
+		// Not expected to be equal
+		{m["bar"], "something", false},
+		{myType("1"), myType("2"), false},
+
+		// A case that might be confusing, especially with numeric literals
+		{10, uint(10), false},
 	}
-	if Equal(mockT, myType("1"), myType("2")) {
-		t.Error("Equal should return false")
-	}
-	// A case that might be confusing, especially with numeric literals
-	if Equal(mockT, 10, uint(10)) {
-		t.Error("Equal should return false")
+
+	for _, c := range cases {
+		res := Equal(mockT, c.expected, c.actual)
+
+		if res != c.result {
+			t.Errorf("Equal(%v, %v) should return %v", c.expected, c.actual, c.result)
+		}
 	}
 }
 
@@ -471,12 +466,6 @@ func TestFalse(t *testing.T) {
 		t.Error("False should return false")
 	}
 
-}
-
-type TestCase struct {
-	expected interface{}
-	actual   interface{}
-	result   bool
 }
 
 func TestExactly(t *testing.T) {

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -100,47 +100,42 @@ func (a *AssertionTesterConformingObject) TestMethod() {
 type AssertionTesterNonConformingObject struct {
 }
 
-func TestObjectsAreEqual(t *testing.T) {
+// TestCase holds the expected/actual values to be passed to most checks and their expected result (true/false)
+type TestCase struct {
+	expected interface{}
+	actual   interface{}
+	result   bool
+}
 
-	if !ObjectsAreEqual("Hello World", "Hello World") {
-		t.Error("objectsAreEqual should return true")
+func TestObjectsAreEqual(t *testing.T) {
+	cases := []TestCase{
+		// cases that are expected to be equal
+		{"Hello World", "Hello World", true},
+		{123, 123, true},
+		{123.5, 123.5, true},
+		{[]byte("Hello World"), []byte("Hello World"), true},
+		{nil, nil, true},
+
+		// cases that are expected not to be equal
+		{map[int]int{5: 10}, map[int]int{10: 20}, false},
+		{'x', "x", false},
+		{"x", 'x', false},
+		{0, 0.1, false},
+		{0.1, 0, false},
+		{time.Now, time.Now, false},
+		{func() {}, func() {}, false},
+		{uint32(10), int32(10), false},
 	}
-	if !ObjectsAreEqual(123, 123) {
-		t.Error("objectsAreEqual should return true")
+
+	for _, c := range cases {
+		res := ObjectsAreEqual(c.expected, c.actual)
+
+		if res != c.result {
+			t.Errorf("Equal(%v, %v) should return %v", c.expected, c.actual, c.result)
+		}
 	}
-	if !ObjectsAreEqual(123.5, 123.5) {
-		t.Error("objectsAreEqual should return true")
-	}
-	if !ObjectsAreEqual([]byte("Hello World"), []byte("Hello World")) {
-		t.Error("objectsAreEqual should return true")
-	}
-	if !ObjectsAreEqual(nil, nil) {
-		t.Error("objectsAreEqual should return true")
-	}
-	if ObjectsAreEqual(map[int]int{5: 10}, map[int]int{10: 20}) {
-		t.Error("objectsAreEqual should return false")
-	}
-	if ObjectsAreEqual('x', "x") {
-		t.Error("objectsAreEqual should return false")
-	}
-	if ObjectsAreEqual("x", 'x') {
-		t.Error("objectsAreEqual should return false")
-	}
-	if ObjectsAreEqual(0, 0.1) {
-		t.Error("objectsAreEqual should return false")
-	}
-	if ObjectsAreEqual(0.1, 0) {
-		t.Error("objectsAreEqual should return false")
-	}
-	if ObjectsAreEqual(time.Now, time.Now) {
-		t.Error("objectsAreEqual should return false")
-	}
-	if ObjectsAreEqual(func() {}, func() {}) {
-		t.Error("objectsAreEqual should return false")
-	}
-	if ObjectsAreEqual(uint32(10), int32(10)) {
-		t.Error("objectsAreEqual should return false")
-	}
+
+	// Cases where type differ but values are equal
 	if !ObjectsAreEqualValues(uint32(10), int32(10)) {
 		t.Error("ObjectsAreEqualValues should return true")
 	}
@@ -180,12 +175,6 @@ func TestIsType(t *testing.T) {
 		t.Error("IsType should return false: AssertionTesterConformingObject is not the same type as AssertionTesterNonConformingObject")
 	}
 
-}
-
-type TestCase struct {
-	expected interface{}
-	actual   interface{}
-	result   bool
 }
 
 func TestEqual(t *testing.T) {

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -502,67 +502,15 @@ func TestExactly(t *testing.T) {
 
 }
 
+type TestCase struct {
+	expected interface{}
+	actual   interface{}
+	result   bool
+}
+
 func TestNotEqual(t *testing.T) {
 
 	mockT := new(testing.T)
-
-	if !NotEqual(mockT, "Hello World", "Hello World!") {
-		t.Error("NotEqual should return true")
-	}
-	if !NotEqual(mockT, 123, 1234) {
-		t.Error("NotEqual should return true")
-	}
-	if !NotEqual(mockT, 123.5, 123.55) {
-		t.Error("NotEqual should return true")
-	}
-	if !NotEqual(mockT, []byte("Hello World"), []byte("Hello World!")) {
-		t.Error("NotEqual should return true")
-	}
-	if !NotEqual(mockT, nil, new(AssertionTesterConformingObject)) {
-		t.Error("NotEqual should return true")
-	}
-	funcA := func() int { return 23 }
-	funcB := func() int { return 42 }
-	if NotEqual(mockT, funcA, funcB) {
-		t.Error("NotEqual should return false")
-	}
-	if NotEqual(mockT, nil, nil) {
-		t.Error("NotEqual should return false")
-	}
-
-	if NotEqual(mockT, "Hello World", "Hello World") {
-		t.Error("NotEqual should return false")
-	}
-	if NotEqual(mockT, 123, 123) {
-		t.Error("NotEqual should return false")
-	}
-	if NotEqual(mockT, 123.5, 123.5) {
-		t.Error("NotEqual should return false")
-	}
-	if NotEqual(mockT, []byte("Hello World"), []byte("Hello World")) {
-		t.Error("NotEqual should return false")
-	}
-	if NotEqual(mockT, new(AssertionTesterConformingObject), new(AssertionTesterConformingObject)) {
-		t.Error("NotEqual should return false")
-	}
-	if NotEqual(mockT, &struct{}{}, &struct{}{}) {
-		t.Error("NotEqual should return false")
-	}
-
-	// A case that might be confusing, especially with numeric literals
-	if !NotEqual(mockT, 10, uint(10)) {
-		t.Error("NotEqual should return false")
-	}
-}
-
-func TestNotEqualValues(t *testing.T) {
-	mockT := new(testing.T)
-
-	type TestCase struct {
-		expected interface{}
-		actual   interface{}
-		result   bool
-	}
 
 	cases := []TestCase{
 		{"Hello World", "Hello World!", true},
@@ -577,9 +525,41 @@ func TestNotEqualValues(t *testing.T) {
 		{[]byte("Hello World"), []byte("Hello World"), false},
 		{new(AssertionTesterConformingObject), new(AssertionTesterConformingObject), false},
 		{&struct{}{}, &struct{}{}, false},
+		{func() int { return 23 }, func() int { return 24 }, false},
+		// A case that might be confusing, especially with numeric literals
+		{int(10), uint(10), true},
+	}
+
+	for _, c := range cases {
+		res := NotEqual(mockT, c.expected, c.actual)
+
+		if res != c.result {
+			t.Errorf("NotEqual(%v, %v) should return %v", c.expected, c.actual, c.result)
+		}
+	}
+}
+
+func TestNotEqualValues(t *testing.T) {
+	mockT := new(testing.T)
+
+	cases := []TestCase{
+		{"Hello World", "Hello World!", true},
+		{123, 1234, true},
+		{123.5, 123.55, true},
+		{[]byte("Hello World"), []byte("Hello World!"), true},
+		{nil, new(AssertionTesterConformingObject), true},
+		{nil, nil, false},
+		{"Hello World", "Hello World", false},
+		{123, 123, false},
+		{123.5, 123.5, false},
+		{[]byte("Hello World"), []byte("Hello World"), false},
+		{new(AssertionTesterConformingObject), new(AssertionTesterConformingObject), false},
+		{&struct{}{}, &struct{}{}, false},
+
+		// Different behaviour from NotEqual()
 		{func() int { return 23 }, func() int { return 24 }, true},
 		{int(10), int(11), true},
-		{int(10), int(10), false},
+		{int(10), uint(10), false},
 
 		{struct{}{}, struct{}{}, false},
 	}
@@ -591,61 +571,6 @@ func TestNotEqualValues(t *testing.T) {
 			t.Errorf("NotEqualValues(%v, %v) should return %v", c.expected, c.actual, c.result)
 		}
 	}
-
-	// Same tests as NotEqual since they behave the same when types are irrelevant
-	if !NotEqualValues(mockT, "Hello World", "Hello World!") {
-		t.Error("NotEqualValues should return true")
-	}
-	if !NotEqualValues(mockT, 123, 1234) {
-		t.Error("NotEqualValues should return true")
-	}
-	if !NotEqualValues(mockT, 123.5, 123.55) {
-		t.Error("NotEqualValues should return true")
-	}
-	if !NotEqualValues(mockT, []byte("Hello World"), []byte("Hello World!")) {
-		t.Error("NotEqualValues should return true")
-	}
-	if !NotEqualValues(mockT, nil, new(AssertionTesterConformingObject)) {
-		t.Error("NotEqualValues should return true")
-	}
-	if NotEqualValues(mockT, nil, nil) {
-		t.Error("NotEqualValues should return false")
-	}
-	if NotEqualValues(mockT, "Hello World", "Hello World") {
-		t.Error("NotEqualValues should return false")
-	}
-	if NotEqualValues(mockT, 123, 123) {
-		t.Error("NotEqualValues should return false")
-	}
-	if NotEqualValues(mockT, 123.5, 123.5) {
-		t.Error("NotEqualValues should return false")
-	}
-	if NotEqualValues(mockT, []byte("Hello World"), []byte("Hello World")) {
-		t.Error("NotEqualValues should return false")
-	}
-	if NotEqualValues(mockT, new(AssertionTesterConformingObject), new(AssertionTesterConformingObject)) {
-		t.Error("NotEqualValues should return false")
-	}
-	if NotEqualValues(mockT, &struct{}{}, &struct{}{}) {
-		t.Error("NotEqualValues should return false")
-	}
-
-	// Special cases where NotEqualValues behaves differently
-	funcA := func() int { return 23 }
-	funcB := func() int { return 42 }
-	if !NotEqualValues(mockT, funcA, funcB) {
-		t.Error("NotEqualValues should return true")
-	}
-	if !NotEqualValues(mockT, int(10), int(11)) {
-		t.Error("NotEqualValues should return true")
-	}
-	if NotEqualValues(mockT, int(10), uint(10)) {
-		t.Error("NotEqualValues should return false")
-	}
-	if NotEqualValues(mockT, struct{}{}, struct{}{}) {
-		t.Error("NotEqualValues should return false")
-	}
-
 }
 
 type A struct {

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -558,13 +558,13 @@ func TestNotEqual(t *testing.T) {
 func TestNotEqualValues(t *testing.T) {
 	mockT := new(testing.T)
 
-	type TestThingy struct {
+	type TestCase struct {
 		expected interface{}
 		actual   interface{}
 		result   bool
 	}
 
-	tests := []TestThingy{
+	cases := []TestCase{
 		{"Hello World", "Hello World!", true},
 		{123, 1234, true},
 		{123.5, 123.55, true},
@@ -584,11 +584,11 @@ func TestNotEqualValues(t *testing.T) {
 		{struct{}{}, struct{}{}, false},
 	}
 
-	for _, ts := range tests {
-		res := NotEqualValues(mockT, ts.expected, ts.actual)
+	for _, c := range cases {
+		res := NotEqualValues(mockT, c.expected, c.actual)
 
-		if res != ts.result {
-			t.Errorf("NotEqualValues(%v, %v) should return %v", ts.expected, ts.actual, ts.result)
+		if res != c.result {
+			t.Errorf("NotEqualValues(%v, %v) should return %v", c.expected, c.actual, c.result)
 		}
 	}
 

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -513,11 +513,14 @@ func TestNotEqual(t *testing.T) {
 	mockT := new(testing.T)
 
 	cases := []TestCase{
+		// cases that are expected not to match
 		{"Hello World", "Hello World!", true},
 		{123, 1234, true},
 		{123.5, 123.55, true},
 		{[]byte("Hello World"), []byte("Hello World!"), true},
 		{nil, new(AssertionTesterConformingObject), true},
+
+		// cases that are expected to match
 		{nil, nil, false},
 		{"Hello World", "Hello World", false},
 		{123, 123, false},
@@ -543,11 +546,14 @@ func TestNotEqualValues(t *testing.T) {
 	mockT := new(testing.T)
 
 	cases := []TestCase{
+		// cases that are expected not to match
 		{"Hello World", "Hello World!", true},
 		{123, 1234, true},
 		{123.5, 123.55, true},
 		{[]byte("Hello World"), []byte("Hello World!"), true},
 		{nil, new(AssertionTesterConformingObject), true},
+
+		// cases that are expected to match
 		{nil, nil, false},
 		{"Hello World", "Hello World", false},
 		{123, 123, false},

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -100,15 +100,12 @@ func (a *AssertionTesterConformingObject) TestMethod() {
 type AssertionTesterNonConformingObject struct {
 }
 
-// TestCase holds the expected/actual values to be passed to most checks and their expected result (true/false)
-type TestCase struct {
-	expected interface{}
-	actual   interface{}
-	result   bool
-}
-
 func TestObjectsAreEqual(t *testing.T) {
-	cases := []TestCase{
+	cases := []struct {
+		expected interface{}
+		actual   interface{}
+		result   bool
+	}{
 		// cases that are expected to be equal
 		{"Hello World", "Hello World", true},
 		{123, 123, true},
@@ -183,7 +180,11 @@ func TestEqual(t *testing.T) {
 	mockT := new(testing.T)
 	var m map[string]interface{}
 
-	cases := []TestCase{
+	cases := []struct {
+		expected interface{}
+		actual   interface{}
+		result   bool
+	}{
 		{"Hello World", "Hello World", true},
 		{123, 123, true},
 		{123.5, 123.5, true},
@@ -465,7 +466,11 @@ func TestExactly(t *testing.T) {
 	b := float64(1)
 	c := float32(1)
 	d := float32(2)
-	cases := []TestCase{
+	cases := []struct {
+		expected interface{}
+		actual   interface{}
+		result   bool
+	}{
 		{a, b, false},
 		{a, d, false},
 		{a, c, true},
@@ -486,7 +491,11 @@ func TestNotEqual(t *testing.T) {
 
 	mockT := new(testing.T)
 
-	cases := []TestCase{
+	cases := []struct {
+		expected interface{}
+		actual   interface{}
+		result   bool
+	}{
 		// cases that are expected not to match
 		{"Hello World", "Hello World!", true},
 		{123, 1234, true},
@@ -519,7 +528,11 @@ func TestNotEqual(t *testing.T) {
 func TestNotEqualValues(t *testing.T) {
 	mockT := new(testing.T)
 
-	cases := []TestCase{
+	cases := []struct {
+		expected interface{}
+		actual   interface{}
+		result   bool
+	}{
 		// cases that are expected not to match
 		{"Hello World", "Hello World!", true},
 		{123, 1234, true},
@@ -568,7 +581,11 @@ func TestContainsNotContains(t *testing.T) {
 	}
 	simpleMap := map[interface{}]interface{}{"Foo": "Bar"}
 
-	cases := []TestCase{
+	cases := []struct {
+		expected interface{}
+		actual   interface{}
+		result   bool
+	}{
 		{"Hello World", "Hello", true},
 		{"Hello World", "Salut", false},
 		{list, "Bar", true},
@@ -626,24 +643,25 @@ func TestContainsFailMessage(t *testing.T) {
 }
 
 func TestSubsetNotSubset(t *testing.T) {
-	type MTestCase struct {
-		TestCase
-		message string
-	}
 
 	// MTestCase adds a custom message to the case
-	cases := []MTestCase{
+	cases := []struct {
+		expected interface{}
+		actual   interface{}
+		result   bool
+		message  string
+	}{
 		// cases that are expected to contain
-		{TestCase{[]int{1, 2, 3}, nil, true}, "given subset is nil"},
-		{TestCase{[]int{1, 2, 3}, []int{}, true}, "any set contains the nil set"},
-		{TestCase{[]int{1, 2, 3}, []int{1, 2}, true}, "[1, 2, 3] contains [1, 2]"},
-		{TestCase{[]int{1, 2, 3}, []int{1, 2, 3}, true}, "[1, 2, 3] contains [1, 2, 3"},
-		{TestCase{[]string{"hello", "world"}, []string{"hello"}, true}, "[\"hello\", \"world\"] contains [\"hello\"]"},
+		{[]int{1, 2, 3}, nil, true, "given subset is nil"},
+		{[]int{1, 2, 3}, []int{}, true, "any set contains the nil set"},
+		{[]int{1, 2, 3}, []int{1, 2}, true, "[1, 2, 3] contains [1, 2]"},
+		{[]int{1, 2, 3}, []int{1, 2, 3}, true, "[1, 2, 3] contains [1, 2, 3"},
+		{[]string{"hello", "world"}, []string{"hello"}, true, "[\"hello\", \"world\"] contains [\"hello\"]"},
 
 		// cases that are expected not to contain
-		{TestCase{[]string{"hello", "world"}, []string{"hello", "testify"}, false}, "[\"hello\", \"world\"] does not contain [\"hello\", \"testify\"]"},
-		{TestCase{[]int{1, 2, 3}, []int{4, 5}, false}, "[1, 2, 3] does not contain [4, 5"},
-		{TestCase{[]int{1, 2, 3}, []int{1, 5}, false}, "[1, 2, 3] does not contain [1, 5]"},
+		{[]string{"hello", "world"}, []string{"hello", "testify"}, false, "[\"hello\", \"world\"] does not contain [\"hello\", \"testify\"]"},
+		{[]int{1, 2, 3}, []int{4, 5}, false, "[1, 2, 3] does not contain [4, 5"},
+		{[]int{1, 2, 3}, []int{1, 5}, false, "[1, 2, 3] does not contain [1, 5]"},
 	}
 
 	t.Run("TestSubset", func(t *testing.T) {
@@ -739,7 +757,11 @@ func Test_includeElement(t *testing.T) {
 func TestElementsMatch(t *testing.T) {
 	mockT := new(testing.T)
 
-	cases := []TestCase{
+	cases := []struct {
+		expected interface{}
+		actual   interface{}
+		result   bool
+	}{
 		// matching
 		{nil, nil, true},
 

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -556,8 +556,41 @@ func TestNotEqual(t *testing.T) {
 }
 
 func TestNotEqualValues(t *testing.T) {
-
 	mockT := new(testing.T)
+
+	type TestThingy struct {
+		expected interface{}
+		actual   interface{}
+		result   bool
+	}
+
+	tests := []TestThingy{
+		{"Hello World", "Hello World!", true},
+		{123, 1234, true},
+		{123.5, 123.55, true},
+		{[]byte("Hello World"), []byte("Hello World!"), true},
+		{nil, new(AssertionTesterConformingObject), true},
+		{nil, nil, false},
+		{"Hello World", "Hello World", false},
+		{123, 123, false},
+		{123.5, 123.5, false},
+		{[]byte("Hello World"), []byte("Hello World"), false},
+		{new(AssertionTesterConformingObject), new(AssertionTesterConformingObject), false},
+		{&struct{}{}, &struct{}{}, false},
+		{func() int { return 23 }, func() int { return 24 }, true},
+		{int(10), int(11), true},
+		{int(10), int(10), false},
+
+		{struct{}{}, struct{}{}, false},
+	}
+
+	for _, ts := range tests {
+		res := NotEqualValues(mockT, ts.expected, ts.actual)
+
+		if res != ts.result {
+			t.Errorf("NotEqualValues(%v, %v) should return %v", ts.expected, ts.actual, ts.result)
+		}
+	}
 
 	// Same tests as NotEqual since they behave the same when types are irrelevant
 	if !NotEqualValues(mockT, "Hello World", "Hello World!") {
@@ -612,6 +645,7 @@ func TestNotEqualValues(t *testing.T) {
 	if NotEqualValues(mockT, struct{}{}, struct{}{}) {
 		t.Error("NotEqualValues should return false")
 	}
+
 }
 
 type A struct {


### PR DESCRIPTION
## Summary

This refactors some of the tests but does not add any new ones.


## Changes


- define test cases in tables where sensible
- combine testcases for `Foo()` and `NotFoo()`, specifically there were testcases were already the same
- make some types local to funcs if not used elsewhere

## Motivation

- table based tests are the way to go.

## Related issues

As discussed in #953 
