### PR TITLE
Update TravisCI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: go
+os: linux
 
-sudo: false
-
-matrix:
+jobs:
   include:
     - go: "1.10.x"
     - go: "1.11.x"


### PR DESCRIPTION
## Summary
Updates our TravisCI config to address warnings/errors as listed here: https://travis-ci.org/github/stretchr/testify/builds/692581492/config

## Changes
* Remove unused `sudo` flag
* Change deprecated `matrix` field to `jobs`
* Explicitly use Linux as the build environment

## Motivation
Without these changes, it seems to be causing Travis builds to pause and not complete.

https://travis-ci.org/github/stretchr/testify/builds/692581492/config