### PR TITLE
Update Go versions in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,13 @@ os: linux
 jobs:
   include:
     - go: "1.10.x"
-    - go: "1.11.x"
-      env: GO111MODULE=off
-    - go: "1.11.x"
-      env: GO111MODULE=on
-    - go: "1.12.x"
-      env: GO111MODULE=off
-    - go: "1.12.x"
-      env: GO111MODULE=on
     - go: "1.13.x"
       env: GO111MODULE=off
     - go: "1.13.x"
+      env: GO111MODULE=on
+    - go: "1.14.x"
+      env: GO111MODULE=off
+    - go: "1.14.x"
       env: GO111MODULE=on
     - go: master
       env: GO111MODULE=on


### PR DESCRIPTION
## Summary
Updated the versions of Go we run on to reflect our support protocol. This is as discussed in the #testify-maintainers Slack channel

## Changes
* Removed Go 1.11, 1.12 and 1.13 from the Travis build. Have kept Go 1.10 as a sentinel build in-case we break something with Go modules.

## Motivation
Supports the latest Go (1.14) and reduces workload by removing runs for unsupported versions.
