### PR TITLE
mock: get call count in thread safe way

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -578,6 +578,20 @@ func (m *Mock) IsMethodCallable(t TestingT, methodName string, arguments ...inte
 	return false
 }
 
+
+// NumberOfCalls returns the number of times a method was called
+func (m *Mock) NumberOfCalls(methodName string) int {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	var actualCalls int
+	for _, call := range m.calls() {
+		if call.Method == methodName {
+			actualCalls++
+		}
+	}
+	return actualCalls
+}
+
 // isArgsEqual compares arguments
 func isArgsEqual(expected Arguments, args []interface{}) bool {
 	if len(expected) != len(args) {

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -578,7 +578,6 @@ func (m *Mock) IsMethodCallable(t TestingT, methodName string, arguments ...inte
 	return false
 }
 
-
 // NumberOfCalls returns the number of times a method was called
 func (m *Mock) NumberOfCalls(methodName string) int {
 	m.mutex.Lock()

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -1476,6 +1476,17 @@ func Test_MockReturnAndCalledConcurrent(t *testing.T) {
 	wg.Wait()
 }
 
+func Test_Mock_NumberOfCalls(t *testing.T) {
+	var mockedService = new(TestExampleImplementation)
+	mockedService.On("Test_Mock_NumberOfCalls", 1, 2, 3).Return(5, 6, 7)
+
+	mockedService.Called(1, 2, 3)
+	assert.Equal(t, mockedService.NumberOfCalls("Test_Mock_NumberOfCalls"), 1)
+	mockedService.Called(1, 2, 3)
+
+	assert.Equal(t, mockedService.NumberOfCalls("Test_Mock_NumberOfCalls"), 2)
+}
+
 type timer struct{ Mock }
 
 func (s *timer) GetTime(i int) string {

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -1124,37 +1124,6 @@ func Test_Mock_AssertCalled_WithAnythingOfTypeArgument(t *testing.T) {
 
 }
 
-func Test_Mock_AssertNumberOfCallsIsThreadSafe(t *testing.T) {
-
-	var mockedService = new(TestExampleImplementation)
-
-	mockedService.On("TheExampleMethod", 1, 2, 3).Return(5, 6, 7)
-
-	done := make(chan struct{})
-	shutdown := func() {
-		time.Sleep(10 * time.Millisecond)
-		close(done)
-		time.Sleep(10 * time.Millisecond)
-	}
-
-	go func() {
-		for {
-			select {
-			case <-done:
-				return
-			default:
-				_, _ = mockedService.TheExampleMethod(1, 2, 3)
-			}
-		}
-	}()
-
-	shutdown()
-	finalCallCount := mockedService.NumberOfCalls("TheExampleMethod")
-
-	assert.True(t, mockedService.AssertNumberOfCalls(t, "TheExampleMethod", finalCallCount))
-
-}
-
 func Test_Mock_AssertCalled_WithArguments(t *testing.T) {
 
 	var mockedService = new(TestExampleImplementation)
@@ -1517,6 +1486,38 @@ func Test_Mock_NumberOfCalls(t *testing.T) {
 
 	assert.Equal(t, mockedService.NumberOfCalls("Test_Mock_NumberOfCalls"), 2)
 }
+
+func Test_Mock_NumberOfCallsIsThreadSafe(t *testing.T) {
+
+	var mockedService = new(TestExampleImplementation)
+
+	mockedService.On("TheExampleMethod", 1, 2, 3).Return(5, 6, 7)
+
+	done := make(chan struct{})
+	shutdown := func() {
+		time.Sleep(10 * time.Millisecond)
+		close(done)
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	go func() {
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				_, _ = mockedService.TheExampleMethod(1, 2, 3)
+			}
+		}
+	}()
+
+	shutdown()
+	finalCallCount := mockedService.NumberOfCalls("TheExampleMethod")
+
+	assert.Greater(t, finalCallCount, 0)
+
+}
+
 
 type timer struct{ Mock }
 

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -1518,7 +1518,6 @@ func Test_Mock_NumberOfCallsIsThreadSafe(t *testing.T) {
 
 }
 
-
 type timer struct{ Mock }
 
 func (s *timer) GetTime(i int) string {


### PR DESCRIPTION
## Summary
Allows returning number of calls to a specific method in a thread safe way.

## Changes
Adds a new method on the `Mock` object that returns the call count.

## Motivation
There was a need to get the call count information on a given mock. Accessing the `Calls` member leads to a race condition as the lock is neglected. 

## Example usage (if applicable)
```go
type client interface {
	Do(x int)
}

type owner struct {
	c client
}

func (o owner) Start() chan struct{} {
	done := make(chan struct{})
	go func() {
		for {
			select {
			case <-done:
				return
			case <-time.After(2 * time.Millisecond):
				o.c.Do(1)
			}
		}
	}()

	return done
}

type clientMock struct {
	mock.Mock
}

func (m *clientMock) Do(x int) {
	m.Called(x)
}

func TestOwnerCloses(t *testing.T) {
	m := &clientMock{}
	m.On("Do", mock.AnythingOfType("int"))
	defer m.AssertExpectations(t)

	o := owner{c: m}
	done := o.Start()
	time.Sleep(5*time.Millisecond)	// wait for some time, the client gets called finite amount of times
	close(done)
	time.Sleep(2*time.Millisecond)	// allow closing

	expected := m.NumberOfCalls("Do")
	time.Sleep(10*time.Millisecond)	// test if the client was called during the time
	actual := m.NumberOfCalls("Do")

	assert.Equal(t, expected, actual)
}
```

## Related issues
Closes #964