### PR TITLE
Give mock.Arguments a method to assign arguments to named return values.

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -731,6 +731,46 @@ func (args Arguments) Get(index int) interface{} {
 	return args[index]
 }
 
+// Returns assigns the arguments to the values pointed to by v. Used to return
+// values in a mocked method.
+//
+// For example:
+//     func (o *MyTestObject) SavePersonDetails(firstname, lastname string, age int) (n int, err error) {
+//       o.Called(firstname, lastname, age).Returns(&n, &err)
+//       return
+//     }
+func (args Arguments) Returns(v ...interface{}) {
+	if len(v) != len(args) {
+		panic(fmt.Sprintf("assert: arguments: Cannot call Returns() with %d value(s) because there are %d argument(s).", len(v), len(args)))
+	}
+
+	for i := range v {
+		val := reflect.ValueOf(v[i])
+		if val.Kind() != reflect.Ptr || !val.Elem().CanSet() {
+			panic(fmt.Sprintf("assert: arguments: Value %d in call of Returns() is non-pointer.", i))
+		}
+
+		arg := reflect.ValueOf(args.Get(i))
+		if !arg.IsValid() {
+			if !canBeNil(val.Elem()) {
+				panic(fmt.Sprintf("assert: arguments: Cannot assign nil argument %d to value in call of Returns().", i))
+			}
+			continue
+		}
+
+		val.Elem().Set(arg)
+	}
+}
+
+func canBeNil(v reflect.Value) bool {
+	k := v.Kind()
+	if k == reflect.Chan || k == reflect.Func || k == reflect.Map || k == reflect.Ptr ||
+		k == reflect.UnsafePointer || k == reflect.Interface || k == reflect.Slice {
+		return true
+	}
+	return false
+}
+
 // Is gets whether the objects match the arguments specified.
 func (args Arguments) Is(objects ...interface{}) bool {
 	for i, obj := range args {

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -1240,6 +1240,77 @@ func Test_Arguments_Get(t *testing.T) {
 
 }
 
+func Test_Arguments_Returns(t *testing.T) {
+
+	var (
+		x    int = 7
+		args     = Arguments([]interface{}{"string", 123, &x, nil, true, nil, errors.New("my hovercraft is full of eels")})
+
+		s         string
+		n         int
+		p, nP     *int
+		b         bool
+		nErr, err error
+	)
+	args.Returns(&s, &n, &p, &nP, &b, &nErr, &err)
+
+	assert.Equal(t, "string", s)
+	assert.Equal(t, 123, n)
+	if assert.NotNil(t, p) {
+		assert.Equal(t, 7, *p)
+	}
+	assert.Nil(t, nP)
+	assert.True(t, b)
+	assert.Error(t, err)
+	assert.NoError(t, nErr)
+
+}
+
+func Test_Arguments_Returns_WithNonPointer(t *testing.T) {
+
+	var args = Arguments([]interface{}{1})
+	var i int
+	assert.PanicsWithValue(t, "assert: arguments: Value 0 in call of Returns() is non-pointer.",
+		func() { args.Returns(i) })
+
+}
+
+func Test_Arguments_Returns_WithPointerAndSinglePointer(t *testing.T) {
+
+	var i int = 1
+	var args = Arguments([]interface{}{&i})
+	var j *int
+	assert.PanicsWithValue(t, "assert: arguments: Value 0 in call of Returns() is non-pointer.",
+		func() { args.Returns(j) })
+
+}
+
+func Test_Arguments_Returns_WithNilArgumentAndNonNilType(t *testing.T) {
+
+	var args = Arguments([]interface{}{nil})
+	var i int
+	assert.PanicsWithValue(t, "assert: arguments: Cannot assign nil argument 0 to value in call of Returns().",
+		func() { args.Returns(&i) })
+
+}
+
+func Test_Arguments_Returns_WithTypeMismatch(t *testing.T) {
+
+	var args = Arguments([]interface{}{1})
+	var i *int
+	assert.Panics(t, func() { args.Returns(&i) })
+
+}
+
+func Test_Arguments_Returns_WithValueLengthMismatch(t *testing.T) {
+
+	var args = Arguments([]interface{}{1})
+	var i, j int
+	assert.PanicsWithValue(t, "assert: arguments: Cannot call Returns() with 2 value(s) because there are 1 argument(s).",
+		func() { args.Returns(&i, &j) })
+
+}
+
 func Test_Arguments_Is(t *testing.T) {
 
 	var args = Arguments([]interface{}{"string", 123, true})


### PR DESCRIPTION
## Summary
Allow users to return values **and** nil pointers in a mock using only one method.

## Changes
* Give `mock.Arguments` a `Returns(v ...interface{})` method to assign arguments into named return values.

## Motivation
To return a nill pointer via mock.Called().Get().(*type) requires a two-value type assertion because nil fails type assertion to pointer types:
```
func (m *MockedType) Method() (*ReturnType, error) {
  args := m.Called()
  var r *ReturnType
  r, _ := args.Get(0).(*ReturnType)
  return r, args.Error(1)
}
```
This also stands a chance of being confusing if the type assertion fails because of a different reason, such as a missing `&` in the call to `Return()`.

Instead, passing named return values to a method by reference means we can avoid using type assertion. This also shrinks the mock method a bit as the user doesn't have to write out a line of type assertions:
```
func (m *MockedType) Method() (r *ReturnType, err error) {
  m.Called().Returns(&r, &err)
  return
}
```

Further; we can give more useful error messages to the user, such as when more arguments are passed to Return() than are unpacked with Get(), which is a silent fault today.

Yet more; users don't have to count the argument indices!

## Related issues
