### PR TITLE
mock: fix matching []byte vs []uint8 #387

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -785,8 +785,11 @@ func (args Arguments) Diff(objects []interface{}) (string, int) {
 			}
 		} else if reflect.TypeOf(expected) == reflect.TypeOf((*AnythingOfTypeArgument)(nil)).Elem() {
 
+			// check for []byte and []uint8
+			var matchedBtye = string(expected.(AnythingOfTypeArgument)) == "[]byte" && reflect.TypeOf(actual).String() == "[]uint8"
+
 			// type checking
-			if reflect.TypeOf(actual).Name() != string(expected.(AnythingOfTypeArgument)) && reflect.TypeOf(actual).String() != string(expected.(AnythingOfTypeArgument)) {
+			if reflect.TypeOf(actual).Name() != string(expected.(AnythingOfTypeArgument)) && reflect.TypeOf(actual).String() != string(expected.(AnythingOfTypeArgument)) && !matchedBtye {
 				// not match
 				differences++
 				output = fmt.Sprintf("%s\t%d: FAIL:  type %s != type %s - %s\n", output, i, expected, reflect.TypeOf(actual).Name(), actualFmt)

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -462,6 +462,19 @@ func Test_Mock_On_WithFuncTypeArg(t *testing.T) {
 	})
 }
 
+func Test_Mock_On_WithAnythingOfType_Byte(t *testing.T) {
+
+	mockedService := new(TestExampleImplementation)
+
+	mockedService.
+		On("Test_Mock_On_WithAnythingOfType_Byte", Anything).
+		Return()
+
+	mockedService.Called([]byte("byte"))
+
+	assert.True(t, mockedService.AssertCalled(t, "Test_Mock_On_WithAnythingOfType_Byte", AnythingOfType("[]byte")))
+}
+
 func Test_Mock_Return(t *testing.T) {
 
 	// make a test impl object


### PR DESCRIPTION
## Summary
This is a bug reported in #387 . The reason is that according to [this](https://golang.org/pkg/builtin/#byte), that says byte is an alias of uint8, that's why the issue can work around by calling `AnythingOfType("[]uint8")` works

because of the implementation of `Diff` uses `reflect`
This is not a really good fix but it is a quick fix and less likely to break the code.

I do not implement the case where you use call with `[]byte("byte")` as an argument and try to match it with `AnythingOfType("[]uint8")` . Because this create more complex in the code and might require rewriting the whole matching logics.

## Changes
Add a bool of checking if `AnythingOfType("[]byte")` is used and if the actual reflection is `[]uint8`, it matches.
Add a test


## Motivation
because it is on current milestone and no one picks it.

## Related issues
#387 
