### PR TITLE
Remove Go 1.10 from Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os: linux
 
 jobs:
   include:
-    - go: "1.10.x"
     - go: "1.13.x"
       env: GO111MODULE=off
     - go: "1.13.x"


### PR DESCRIPTION
## Summary
Remove Go 1.10 from TravisCI builds due to it being deprecated

## Motivation
Go 1.10 is unsupported by the Go team. It is also preventing us from adding code and fixes for features available in newer versions of Go.
