### PR TITLE
add assertion order

### DIFF
--- a/assert/assertion_format.go
+++ b/assert/assertion_format.go
@@ -321,6 +321,54 @@ func InEpsilonSlicef(t TestingT, expected interface{}, actual interface{}, epsil
 	return InEpsilonSlice(t, expected, actual, epsilon, append([]interface{}{msg}, args...)...)
 }
 
+// IsDecreasingf asserts that the collection is decreasing
+//
+//    assert.IsDecreasingf(t, []int{2, 1, 0}, "error message %s", "formatted")
+//    assert.IsDecreasingf(t, []float{2, 1}, "error message %s", "formatted")
+//    assert.IsDecreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
+func IsDecreasingf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return IsDecreasing(t, object, append([]interface{}{msg}, args...)...)
+}
+
+// IsIncreasingf asserts that the collection is increasing
+//
+//    assert.IsIncreasingf(t, []int{1, 2, 3}, "error message %s", "formatted")
+//    assert.IsIncreasingf(t, []float{1, 2}, "error message %s", "formatted")
+//    assert.IsIncreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
+func IsIncreasingf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return IsIncreasing(t, object, append([]interface{}{msg}, args...)...)
+}
+
+// IsNonDecreasingf asserts that the collection is not decreasing
+//
+//    assert.IsNonDecreasingf(t, []int{1, 1, 2}, "error message %s", "formatted")
+//    assert.IsNonDecreasingf(t, []float{1, 2}, "error message %s", "formatted")
+//    assert.IsNonDecreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
+func IsNonDecreasingf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return IsNonDecreasing(t, object, append([]interface{}{msg}, args...)...)
+}
+
+// IsNonIncreasingf asserts that the collection is not increasing
+//
+//    assert.IsNonIncreasingf(t, []int{2, 1, 1}, "error message %s", "formatted")
+//    assert.IsNonIncreasingf(t, []float{2, 1}, "error message %s", "formatted")
+//    assert.IsNonIncreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
+func IsNonIncreasingf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return IsNonIncreasing(t, object, append([]interface{}{msg}, args...)...)
+}
+
 // IsTypef asserts that the specified objects are of the same type.
 func IsTypef(t TestingT, expectedType interface{}, object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {

--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -631,6 +631,102 @@ func (a *Assertions) InEpsilonf(expected interface{}, actual interface{}, epsilo
 	return InEpsilonf(a.t, expected, actual, epsilon, msg, args...)
 }
 
+// IsDecreasing asserts that the collection is decreasing
+//
+//    a.IsDecreasing([]int{2, 1, 0})
+//    a.IsDecreasing([]float{2, 1})
+//    a.IsDecreasing([]string{"b", "a"})
+func (a *Assertions) IsDecreasing(object interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return IsDecreasing(a.t, object, msgAndArgs...)
+}
+
+// IsDecreasingf asserts that the collection is decreasing
+//
+//    a.IsDecreasingf([]int{2, 1, 0}, "error message %s", "formatted")
+//    a.IsDecreasingf([]float{2, 1}, "error message %s", "formatted")
+//    a.IsDecreasingf([]string{"b", "a"}, "error message %s", "formatted")
+func (a *Assertions) IsDecreasingf(object interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return IsDecreasingf(a.t, object, msg, args...)
+}
+
+// IsIncreasing asserts that the collection is increasing
+//
+//    a.IsIncreasing([]int{1, 2, 3})
+//    a.IsIncreasing([]float{1, 2})
+//    a.IsIncreasing([]string{"a", "b"})
+func (a *Assertions) IsIncreasing(object interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return IsIncreasing(a.t, object, msgAndArgs...)
+}
+
+// IsIncreasingf asserts that the collection is increasing
+//
+//    a.IsIncreasingf([]int{1, 2, 3}, "error message %s", "formatted")
+//    a.IsIncreasingf([]float{1, 2}, "error message %s", "formatted")
+//    a.IsIncreasingf([]string{"a", "b"}, "error message %s", "formatted")
+func (a *Assertions) IsIncreasingf(object interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return IsIncreasingf(a.t, object, msg, args...)
+}
+
+// IsNonDecreasing asserts that the collection is not decreasing
+//
+//    a.IsNonDecreasing([]int{1, 1, 2})
+//    a.IsNonDecreasing([]float{1, 2})
+//    a.IsNonDecreasing([]string{"a", "b"})
+func (a *Assertions) IsNonDecreasing(object interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return IsNonDecreasing(a.t, object, msgAndArgs...)
+}
+
+// IsNonDecreasingf asserts that the collection is not decreasing
+//
+//    a.IsNonDecreasingf([]int{1, 1, 2}, "error message %s", "formatted")
+//    a.IsNonDecreasingf([]float{1, 2}, "error message %s", "formatted")
+//    a.IsNonDecreasingf([]string{"a", "b"}, "error message %s", "formatted")
+func (a *Assertions) IsNonDecreasingf(object interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return IsNonDecreasingf(a.t, object, msg, args...)
+}
+
+// IsNonIncreasing asserts that the collection is not increasing
+//
+//    a.IsNonIncreasing([]int{2, 1, 1})
+//    a.IsNonIncreasing([]float{2, 1})
+//    a.IsNonIncreasing([]string{"b", "a"})
+func (a *Assertions) IsNonIncreasing(object interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return IsNonIncreasing(a.t, object, msgAndArgs...)
+}
+
+// IsNonIncreasingf asserts that the collection is not increasing
+//
+//    a.IsNonIncreasingf([]int{2, 1, 1}, "error message %s", "formatted")
+//    a.IsNonIncreasingf([]float{2, 1}, "error message %s", "formatted")
+//    a.IsNonIncreasingf([]string{"b", "a"}, "error message %s", "formatted")
+func (a *Assertions) IsNonIncreasingf(object interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return IsNonIncreasingf(a.t, object, msg, args...)
+}
+
 // IsType asserts that the specified objects are of the same type.
 func (a *Assertions) IsType(expectedType interface{}, object interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {

--- a/assert/assertion_order.go
+++ b/assert/assertion_order.go
@@ -1,0 +1,81 @@
+package assert
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// isOrdered checks that collection contains orderable elements.
+func isOrdered(t TestingT, object interface{}, allowedComparesResults []CompareType, failMessage string, msgAndArgs ...interface{}) bool {
+	objKind := reflect.TypeOf(object).Kind()
+	if objKind != reflect.Slice && objKind != reflect.Array {
+		return false
+	}
+
+	objValue := reflect.ValueOf(object)
+	objLen := objValue.Len()
+
+	if objLen <= 1 {
+		return true
+	}
+
+	value := objValue.Index(0)
+	valueInterface := value.Interface()
+	firstValueKind := value.Kind()
+
+	for i := 1; i < objLen; i++ {
+		prevValue := value
+		prevValueInterface := valueInterface
+
+		value = objValue.Index(i)
+		valueInterface = value.Interface()
+
+		compareResult, isComparable := compare(prevValueInterface, valueInterface, firstValueKind)
+
+		if !isComparable {
+			return Fail(t, fmt.Sprintf("Can not compare type \"%s\"", reflect.TypeOf(value)), msgAndArgs...)
+		}
+
+		if !containsValue(allowedComparesResults, compareResult) {
+			return Fail(t, fmt.Sprintf(failMessage, prevValue, value), msgAndArgs...)
+		}
+	}
+
+	return true
+}
+
+// IsIncreasing asserts that the collection is increasing
+//
+//    assert.IsIncreasing(t, []int{1, 2, 3})
+//    assert.IsIncreasing(t, []float{1, 2})
+//    assert.IsIncreasing(t, []string{"a", "b"})
+func IsIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
+	return isOrdered(t, object, []CompareType{compareLess}, "\"%v\" is not less than \"%v\"", msgAndArgs)
+}
+
+// IsNonIncreasing asserts that the collection is not increasing
+//
+//    assert.IsNonIncreasing(t, []int{2, 1, 1})
+//    assert.IsNonIncreasing(t, []float{2, 1})
+//    assert.IsNonIncreasing(t, []string{"b", "a"})
+func IsNonIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
+	return isOrdered(t, object, []CompareType{compareEqual, compareGreater}, "\"%v\" is not greater than or equal to \"%v\"", msgAndArgs)
+}
+
+// IsDecreasing asserts that the collection is decreasing
+//
+//    assert.IsDecreasing(t, []int{2, 1, 0})
+//    assert.IsDecreasing(t, []float{2, 1})
+//    assert.IsDecreasing(t, []string{"b", "a"})
+func IsDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
+	return isOrdered(t, object, []CompareType{compareGreater}, "\"%v\" is not greater than \"%v\"", msgAndArgs)
+}
+
+// IsNonDecreasing asserts that the collection is not decreasing
+//
+//    assert.IsNonDecreasing(t, []int{1, 1, 2})
+//    assert.IsNonDecreasing(t, []float{1, 2})
+//    assert.IsNonDecreasing(t, []string{"a", "b"})
+func IsNonDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
+	return isOrdered(t, object, []CompareType{compareLess, compareEqual}, "\"%v\" is not less than or equal to \"%v\"", msgAndArgs)
+}

--- a/assert/assertion_order.go
+++ b/assert/assertion_order.go
@@ -33,7 +33,7 @@ func isOrdered(t TestingT, object interface{}, allowedComparesResults []CompareT
 		compareResult, isComparable := compare(prevValueInterface, valueInterface, firstValueKind)
 
 		if !isComparable {
-			return Fail(t, fmt.Sprintf("Can not compare type \"%s\"", reflect.TypeOf(value)), msgAndArgs...)
+			return Fail(t, fmt.Sprintf("Can not compare type \"%s\" and \"%s\"", reflect.TypeOf(value), reflect.TypeOf(prevValue)), msgAndArgs...)
 		}
 
 		if !containsValue(allowedComparesResults, compareResult) {

--- a/assert/assertion_order_test.go
+++ b/assert/assertion_order_test.go
@@ -31,6 +31,8 @@ func TestIsIncreasing(t *testing.T) {
 	}{
 		{collection: []string{"b", "a"}, msg: `"b" is not less than "a"`},
 		{collection: []int{2, 1}, msg: `"2" is not less than "1"`},
+		{collection: []int{2, 1, 3, 4, 5, 6, 7}, msg: `"2" is not less than "1"`},
+		{collection: []int{-1, 0, 2, 1}, msg: `"2" is not less than "1"`},
 		{collection: []int8{2, 1}, msg: `"2" is not less than "1"`},
 		{collection: []int16{2, 1}, msg: `"2" is not less than "1"`},
 		{collection: []int32{2, 1}, msg: `"2" is not less than "1"`},
@@ -74,6 +76,8 @@ func TestIsNonIncreasing(t *testing.T) {
 	}{
 		{collection: []string{"a", "b"}, msg: `"a" is not greater than or equal to "b"`},
 		{collection: []int{1, 2}, msg: `"1" is not greater than or equal to "2"`},
+		{collection: []int{1, 2, 7, 6, 5, 4, 3}, msg: `"1" is not greater than or equal to "2"`},
+		{collection: []int{5, 4, 3, 1, 2}, msg: `"1" is not greater than or equal to "2"`},
 		{collection: []int8{1, 2}, msg: `"1" is not greater than or equal to "2"`},
 		{collection: []int16{1, 2}, msg: `"1" is not greater than or equal to "2"`},
 		{collection: []int32{1, 2}, msg: `"1" is not greater than or equal to "2"`},
@@ -117,6 +121,8 @@ func TestIsDecreasing(t *testing.T) {
 	}{
 		{collection: []string{"a", "b"}, msg: `"a" is not greater than "b"`},
 		{collection: []int{1, 2}, msg: `"1" is not greater than "2"`},
+		{collection: []int{1, 2, 7, 6, 5, 4, 3}, msg: `"1" is not greater than "2"`},
+		{collection: []int{5, 4, 3, 1, 2}, msg: `"1" is not greater than "2"`},
 		{collection: []int8{1, 2}, msg: `"1" is not greater than "2"`},
 		{collection: []int16{1, 2}, msg: `"1" is not greater than "2"`},
 		{collection: []int32{1, 2}, msg: `"1" is not greater than "2"`},
@@ -160,6 +166,8 @@ func TestIsNonDecreasing(t *testing.T) {
 	}{
 		{collection: []string{"b", "a"}, msg: `"b" is not less than or equal to "a"`},
 		{collection: []int{2, 1}, msg: `"2" is not less than or equal to "1"`},
+		{collection: []int{2, 1, 3, 4, 5, 6, 7}, msg: `"2" is not less than or equal to "1"`},
+		{collection: []int{-1, 0, 2, 1}, msg: `"2" is not less than or equal to "1"`},
 		{collection: []int8{2, 1}, msg: `"2" is not less than or equal to "1"`},
 		{collection: []int16{2, 1}, msg: `"2" is not less than or equal to "1"`},
 		{collection: []int32{2, 1}, msg: `"2" is not less than or equal to "1"`},

--- a/assert/assertion_order_test.go
+++ b/assert/assertion_order_test.go
@@ -1,0 +1,178 @@
+package assert
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestIsIncreasing(t *testing.T) {
+	mockT := new(testing.T)
+
+	if !IsIncreasing(mockT, []int{1, 2}) {
+		t.Error("IsIncreasing should return true")
+	}
+
+	if !IsIncreasing(mockT, []int{1, 2, 3, 4, 5}) {
+		t.Error("IsIncreasing should return true")
+	}
+
+	if IsIncreasing(mockT, []int{1, 1}) {
+		t.Error("IsIncreasing should return false")
+	}
+
+	if IsIncreasing(mockT, []int{2, 1}) {
+		t.Error("IsIncreasing should return false")
+	}
+
+	// Check error report
+	for _, currCase := range []struct {
+		collection interface{}
+		msg        string
+	}{
+		{collection: []string{"b", "a"}, msg: `"b" is not less than "a"`},
+		{collection: []int{2, 1}, msg: `"2" is not less than "1"`},
+		{collection: []int8{2, 1}, msg: `"2" is not less than "1"`},
+		{collection: []int16{2, 1}, msg: `"2" is not less than "1"`},
+		{collection: []int32{2, 1}, msg: `"2" is not less than "1"`},
+		{collection: []int64{2, 1}, msg: `"2" is not less than "1"`},
+		{collection: []uint8{2, 1}, msg: `"2" is not less than "1"`},
+		{collection: []uint16{2, 1}, msg: `"2" is not less than "1"`},
+		{collection: []uint32{2, 1}, msg: `"2" is not less than "1"`},
+		{collection: []uint64{2, 1}, msg: `"2" is not less than "1"`},
+		{collection: []float32{2.34, 1.23}, msg: `"2.34" is not less than "1.23"`},
+		{collection: []float64{2.34, 1.23}, msg: `"2.34" is not less than "1.23"`},
+	} {
+		out := &outputT{buf: bytes.NewBuffer(nil)}
+		False(t, IsIncreasing(out, currCase.collection))
+		Contains(t, string(out.buf.Bytes()), currCase.msg)
+	}
+}
+
+func TestIsNonIncreasing(t *testing.T) {
+	mockT := new(testing.T)
+
+	if !IsNonIncreasing(mockT, []int{2, 1}) {
+		t.Error("IsNonIncreasing should return true")
+	}
+
+	if !IsNonIncreasing(mockT, []int{5, 4, 4, 3, 2, 1}) {
+		t.Error("IsNonIncreasing should return true")
+	}
+
+	if !IsNonIncreasing(mockT, []int{1, 1}) {
+		t.Error("IsNonIncreasing should return true")
+	}
+
+	if IsNonIncreasing(mockT, []int{1, 2}) {
+		t.Error("IsNonIncreasing should return false")
+	}
+
+	// Check error report
+	for _, currCase := range []struct {
+		collection interface{}
+		msg        string
+	}{
+		{collection: []string{"a", "b"}, msg: `"a" is not greater than or equal to "b"`},
+		{collection: []int{1, 2}, msg: `"1" is not greater than or equal to "2"`},
+		{collection: []int8{1, 2}, msg: `"1" is not greater than or equal to "2"`},
+		{collection: []int16{1, 2}, msg: `"1" is not greater than or equal to "2"`},
+		{collection: []int32{1, 2}, msg: `"1" is not greater than or equal to "2"`},
+		{collection: []int64{1, 2}, msg: `"1" is not greater than or equal to "2"`},
+		{collection: []uint8{1, 2}, msg: `"1" is not greater than or equal to "2"`},
+		{collection: []uint16{1, 2}, msg: `"1" is not greater than or equal to "2"`},
+		{collection: []uint32{1, 2}, msg: `"1" is not greater than or equal to "2"`},
+		{collection: []uint64{1, 2}, msg: `"1" is not greater than or equal to "2"`},
+		{collection: []float32{1.23, 2.34}, msg: `"1.23" is not greater than or equal to "2.34"`},
+		{collection: []float64{1.23, 2.34}, msg: `"1.23" is not greater than or equal to "2.34"`},
+	} {
+		out := &outputT{buf: bytes.NewBuffer(nil)}
+		False(t, IsNonIncreasing(out, currCase.collection))
+		Contains(t, string(out.buf.Bytes()), currCase.msg)
+	}
+}
+
+func TestIsDecreasing(t *testing.T) {
+	mockT := new(testing.T)
+
+	if !IsDecreasing(mockT, []int{2, 1}) {
+		t.Error("IsDecreasing should return true")
+	}
+
+	if !IsDecreasing(mockT, []int{5, 4, 3, 2, 1}) {
+		t.Error("IsDecreasing should return true")
+	}
+
+	if IsDecreasing(mockT, []int{1, 1}) {
+		t.Error("IsDecreasing should return false")
+	}
+
+	if IsDecreasing(mockT, []int{1, 2}) {
+		t.Error("IsDecreasing should return false")
+	}
+
+	// Check error report
+	for _, currCase := range []struct {
+		collection interface{}
+		msg        string
+	}{
+		{collection: []string{"a", "b"}, msg: `"a" is not greater than "b"`},
+		{collection: []int{1, 2}, msg: `"1" is not greater than "2"`},
+		{collection: []int8{1, 2}, msg: `"1" is not greater than "2"`},
+		{collection: []int16{1, 2}, msg: `"1" is not greater than "2"`},
+		{collection: []int32{1, 2}, msg: `"1" is not greater than "2"`},
+		{collection: []int64{1, 2}, msg: `"1" is not greater than "2"`},
+		{collection: []uint8{1, 2}, msg: `"1" is not greater than "2"`},
+		{collection: []uint16{1, 2}, msg: `"1" is not greater than "2"`},
+		{collection: []uint32{1, 2}, msg: `"1" is not greater than "2"`},
+		{collection: []uint64{1, 2}, msg: `"1" is not greater than "2"`},
+		{collection: []float32{1.23, 2.34}, msg: `"1.23" is not greater than "2.34"`},
+		{collection: []float64{1.23, 2.34}, msg: `"1.23" is not greater than "2.34"`},
+	} {
+		out := &outputT{buf: bytes.NewBuffer(nil)}
+		False(t, IsDecreasing(out, currCase.collection))
+		Contains(t, string(out.buf.Bytes()), currCase.msg)
+	}
+}
+
+func TestIsNonDecreasing(t *testing.T) {
+	mockT := new(testing.T)
+
+	if !IsNonDecreasing(mockT, []int{1, 2}) {
+		t.Error("IsNonDecreasing should return true")
+	}
+
+	if !IsNonDecreasing(mockT, []int{1, 1, 2, 3, 4, 5}) {
+		t.Error("IsNonDecreasing should return true")
+	}
+
+	if !IsNonDecreasing(mockT, []int{1, 1}) {
+		t.Error("IsNonDecreasing should return false")
+	}
+
+	if IsNonDecreasing(mockT, []int{2, 1}) {
+		t.Error("IsNonDecreasing should return false")
+	}
+
+	// Check error report
+	for _, currCase := range []struct {
+		collection interface{}
+		msg        string
+	}{
+		{collection: []string{"b", "a"}, msg: `"b" is not less than or equal to "a"`},
+		{collection: []int{2, 1}, msg: `"2" is not less than or equal to "1"`},
+		{collection: []int8{2, 1}, msg: `"2" is not less than or equal to "1"`},
+		{collection: []int16{2, 1}, msg: `"2" is not less than or equal to "1"`},
+		{collection: []int32{2, 1}, msg: `"2" is not less than or equal to "1"`},
+		{collection: []int64{2, 1}, msg: `"2" is not less than or equal to "1"`},
+		{collection: []uint8{2, 1}, msg: `"2" is not less than or equal to "1"`},
+		{collection: []uint16{2, 1}, msg: `"2" is not less than or equal to "1"`},
+		{collection: []uint32{2, 1}, msg: `"2" is not less than or equal to "1"`},
+		{collection: []uint64{2, 1}, msg: `"2" is not less than or equal to "1"`},
+		{collection: []float32{2.34, 1.23}, msg: `"2.34" is not less than or equal to "1.23"`},
+		{collection: []float64{2.34, 1.23}, msg: `"2.34" is not less than or equal to "1.23"`},
+	} {
+		out := &outputT{buf: bytes.NewBuffer(nil)}
+		False(t, IsNonDecreasing(out, currCase.collection))
+		Contains(t, string(out.buf.Bytes()), currCase.msg)
+	}
+}

--- a/require/require.go
+++ b/require/require.go
@@ -806,6 +806,126 @@ func InEpsilonf(t TestingT, expected interface{}, actual interface{}, epsilon fl
 	t.FailNow()
 }
 
+// IsDecreasing asserts that the collection is decreasing
+//
+//    assert.IsDecreasing(t, []int{2, 1, 0})
+//    assert.IsDecreasing(t, []float{2, 1})
+//    assert.IsDecreasing(t, []string{"b", "a"})
+func IsDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsDecreasing(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsDecreasingf asserts that the collection is decreasing
+//
+//    assert.IsDecreasingf(t, []int{2, 1, 0}, "error message %s", "formatted")
+//    assert.IsDecreasingf(t, []float{2, 1}, "error message %s", "formatted")
+//    assert.IsDecreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
+func IsDecreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsDecreasingf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsIncreasing asserts that the collection is increasing
+//
+//    assert.IsIncreasing(t, []int{1, 2, 3})
+//    assert.IsIncreasing(t, []float{1, 2})
+//    assert.IsIncreasing(t, []string{"a", "b"})
+func IsIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsIncreasing(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsIncreasingf asserts that the collection is increasing
+//
+//    assert.IsIncreasingf(t, []int{1, 2, 3}, "error message %s", "formatted")
+//    assert.IsIncreasingf(t, []float{1, 2}, "error message %s", "formatted")
+//    assert.IsIncreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
+func IsIncreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsIncreasingf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsNonDecreasing asserts that the collection is not decreasing
+//
+//    assert.IsNonDecreasing(t, []int{1, 1, 2})
+//    assert.IsNonDecreasing(t, []float{1, 2})
+//    assert.IsNonDecreasing(t, []string{"a", "b"})
+func IsNonDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsNonDecreasing(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsNonDecreasingf asserts that the collection is not decreasing
+//
+//    assert.IsNonDecreasingf(t, []int{1, 1, 2}, "error message %s", "formatted")
+//    assert.IsNonDecreasingf(t, []float{1, 2}, "error message %s", "formatted")
+//    assert.IsNonDecreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
+func IsNonDecreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsNonDecreasingf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsNonIncreasing asserts that the collection is not increasing
+//
+//    assert.IsNonIncreasing(t, []int{2, 1, 1})
+//    assert.IsNonIncreasing(t, []float{2, 1})
+//    assert.IsNonIncreasing(t, []string{"b", "a"})
+func IsNonIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsNonIncreasing(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsNonIncreasingf asserts that the collection is not increasing
+//
+//    assert.IsNonIncreasingf(t, []int{2, 1, 1}, "error message %s", "formatted")
+//    assert.IsNonIncreasingf(t, []float{2, 1}, "error message %s", "formatted")
+//    assert.IsNonIncreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
+func IsNonIncreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsNonIncreasingf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
 // IsType asserts that the specified objects are of the same type.
 func IsType(t TestingT, expectedType interface{}, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {

--- a/require/require_forward.go
+++ b/require/require_forward.go
@@ -632,6 +632,102 @@ func (a *Assertions) InEpsilonf(expected interface{}, actual interface{}, epsilo
 	InEpsilonf(a.t, expected, actual, epsilon, msg, args...)
 }
 
+// IsDecreasing asserts that the collection is decreasing
+//
+//    a.IsDecreasing([]int{2, 1, 0})
+//    a.IsDecreasing([]float{2, 1})
+//    a.IsDecreasing([]string{"b", "a"})
+func (a *Assertions) IsDecreasing(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsDecreasing(a.t, object, msgAndArgs...)
+}
+
+// IsDecreasingf asserts that the collection is decreasing
+//
+//    a.IsDecreasingf([]int{2, 1, 0}, "error message %s", "formatted")
+//    a.IsDecreasingf([]float{2, 1}, "error message %s", "formatted")
+//    a.IsDecreasingf([]string{"b", "a"}, "error message %s", "formatted")
+func (a *Assertions) IsDecreasingf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsDecreasingf(a.t, object, msg, args...)
+}
+
+// IsIncreasing asserts that the collection is increasing
+//
+//    a.IsIncreasing([]int{1, 2, 3})
+//    a.IsIncreasing([]float{1, 2})
+//    a.IsIncreasing([]string{"a", "b"})
+func (a *Assertions) IsIncreasing(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsIncreasing(a.t, object, msgAndArgs...)
+}
+
+// IsIncreasingf asserts that the collection is increasing
+//
+//    a.IsIncreasingf([]int{1, 2, 3}, "error message %s", "formatted")
+//    a.IsIncreasingf([]float{1, 2}, "error message %s", "formatted")
+//    a.IsIncreasingf([]string{"a", "b"}, "error message %s", "formatted")
+func (a *Assertions) IsIncreasingf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsIncreasingf(a.t, object, msg, args...)
+}
+
+// IsNonDecreasing asserts that the collection is not decreasing
+//
+//    a.IsNonDecreasing([]int{1, 1, 2})
+//    a.IsNonDecreasing([]float{1, 2})
+//    a.IsNonDecreasing([]string{"a", "b"})
+func (a *Assertions) IsNonDecreasing(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsNonDecreasing(a.t, object, msgAndArgs...)
+}
+
+// IsNonDecreasingf asserts that the collection is not decreasing
+//
+//    a.IsNonDecreasingf([]int{1, 1, 2}, "error message %s", "formatted")
+//    a.IsNonDecreasingf([]float{1, 2}, "error message %s", "formatted")
+//    a.IsNonDecreasingf([]string{"a", "b"}, "error message %s", "formatted")
+func (a *Assertions) IsNonDecreasingf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsNonDecreasingf(a.t, object, msg, args...)
+}
+
+// IsNonIncreasing asserts that the collection is not increasing
+//
+//    a.IsNonIncreasing([]int{2, 1, 1})
+//    a.IsNonIncreasing([]float{2, 1})
+//    a.IsNonIncreasing([]string{"b", "a"})
+func (a *Assertions) IsNonIncreasing(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsNonIncreasing(a.t, object, msgAndArgs...)
+}
+
+// IsNonIncreasingf asserts that the collection is not increasing
+//
+//    a.IsNonIncreasingf([]int{2, 1, 1}, "error message %s", "formatted")
+//    a.IsNonIncreasingf([]float{2, 1}, "error message %s", "formatted")
+//    a.IsNonIncreasingf([]string{"b", "a"}, "error message %s", "formatted")
+func (a *Assertions) IsNonIncreasingf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsNonIncreasingf(a.t, object, msg, args...)
+}
+
 // IsType asserts that the specified objects are of the same type.
 func (a *Assertions) IsType(expectedType interface{}, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {


### PR DESCRIPTION
## Summary
Add assertion of collections ordering.

## Changes

## Motivation
It could help to check collection on specific order.

```go
 assert.IsIncreasing(t, []int{1, 2, 3})
```

## Related issues
Closes #710 
