### PR TITLE
assert: s/rune/r/ to avoid "rune" predeclared ident shadowing #642

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -172,8 +172,8 @@ func isTest(name, prefix string) bool {
 	if len(name) == len(prefix) { // "Test" is ok
 		return true
 	}
-	rune, _ := utf8.DecodeRuneInString(name[len(prefix):])
-	return !unicode.IsLower(rune)
+	r, _ := utf8.DecodeRuneInString(name[len(prefix):])
+	return !unicode.IsLower(r)
 }
 
 func messageFromMsgAndArgs(msgAndArgs ...interface{}) string {


### PR DESCRIPTION
## Summary

Since its a simple fix, let's just do the rebase ourselves as it were. Thanks for the original PR @quasllyte (#642)
