### PR TITLE
Add ErrorsMatch assertion

### DIFF
--- a/assert/assertion_format.go
+++ b/assert/assertion_format.go
@@ -134,7 +134,7 @@ func ErrorIsf(t TestingT, err error, target error, msg string, args ...interface
 
 // ErrorsMatchf asserts that two errors are equal, unless the expected error
 // is AnError, in which case the actual error can be any non-nil error.
-// Errors are compared directly, without errors.Is
+// Errors are compared directly, without errors.Is().
 //
 //    assert.ErrorsMatchf(t, io.ErrUnexpectedEOF, err, "error message %s", "formatted")
 //    assert.ErrorsMatchf(t, nil, error(nil), "error message %s", "formatted")

--- a/assert/assertion_format.go
+++ b/assert/assertion_format.go
@@ -132,6 +132,20 @@ func ErrorIsf(t TestingT, err error, target error, msg string, args ...interface
 	return ErrorIs(t, err, target, append([]interface{}{msg}, args...)...)
 }
 
+// ErrorsMatchf asserts that two errors are equal, unless the expected error
+// is AnError, in which case the actual error can be any non-nil error.
+// Errors are compared directly, without errors.Is
+//
+//    assert.ErrorsMatchf(t, io.ErrUnexpectedEOF, err, "error message %s", "formatted")
+//    assert.ErrorsMatchf(t, nil, error(nil), "error message %s", "formatted")
+//    assert.ErrorsMatchf(t, assert.AnError, errors.New("any error"), "error message %s", "formatted")
+func ErrorsMatchf(t TestingT, expected error, actual error, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return ErrorsMatch(t, expected, actual, append([]interface{}{msg}, args...)...)
+}
+
 // Eventuallyf asserts that given condition will be met in waitFor time,
 // periodically checking target function each tick.
 //

--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -253,6 +253,34 @@ func (a *Assertions) Errorf(err error, msg string, args ...interface{}) bool {
 	return Errorf(a.t, err, msg, args...)
 }
 
+// ErrorsMatch asserts that two errors are equal, unless the expected error
+// is AnError, in which case the actual error can be any non-nil error.
+// Errors are compared directly, without errors.Is
+//
+//    a.ErrorsMatch(io.ErrUnexpectedEOF, err)
+//    a.ErrorsMatch(nil, error(nil))
+//    a.ErrorsMatch(assert.AnError, errors.New("any error"))
+func (a *Assertions) ErrorsMatch(expected error, actual error, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return ErrorsMatch(a.t, expected, actual, msgAndArgs...)
+}
+
+// ErrorsMatchf asserts that two errors are equal, unless the expected error
+// is AnError, in which case the actual error can be any non-nil error.
+// Errors are compared directly, without errors.Is
+//
+//    a.ErrorsMatchf(io.ErrUnexpectedEOF, err, "error message %s", "formatted")
+//    a.ErrorsMatchf(nil, error(nil), "error message %s", "formatted")
+//    a.ErrorsMatchf(assert.AnError, errors.New("any error"), "error message %s", "formatted")
+func (a *Assertions) ErrorsMatchf(expected error, actual error, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return ErrorsMatchf(a.t, expected, actual, msg, args...)
+}
+
 // Eventually asserts that given condition will be met in waitFor time,
 // periodically checking target function each tick.
 //

--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -255,7 +255,7 @@ func (a *Assertions) Errorf(err error, msg string, args ...interface{}) bool {
 
 // ErrorsMatch asserts that two errors are equal, unless the expected error
 // is AnError, in which case the actual error can be any non-nil error.
-// Errors are compared directly, without errors.Is
+// Errors are compared directly, without errors.Is().
 //
 //    a.ErrorsMatch(io.ErrUnexpectedEOF, err)
 //    a.ErrorsMatch(nil, error(nil))
@@ -269,7 +269,7 @@ func (a *Assertions) ErrorsMatch(expected error, actual error, msgAndArgs ...int
 
 // ErrorsMatchf asserts that two errors are equal, unless the expected error
 // is AnError, in which case the actual error can be any non-nil error.
-// Errors are compared directly, without errors.Is
+// Errors are compared directly, without errors.Is().
 //
 //    a.ErrorsMatchf(io.ErrUnexpectedEOF, err, "error message %s", "formatted")
 //    a.ErrorsMatchf(nil, error(nil), "error message %s", "formatted")

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1771,3 +1771,26 @@ func buildErrorChainString(err error) string {
 	}
 	return chain
 }
+
+// ErrorsMatch asserts that two errors are equal, unless the expected error
+// is AnError, in which case the actual error can be any non-nil error.
+// Errors are compared directly, errors.Is is not used.
+//
+//    assert.ErrorsMatch(t, io.ErrUnexpectedEOF, err)
+//    assert.ErrorsMatch(t, nil, error(nil))
+//    assert.ErrorsMatch(t, assert.AnError, errors.New("any error"))
+func ErrorsMatch(t TestingT, expected, actual error, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	if expected == nil {
+		return NoError(t, actual, msgAndArgs...)
+	}
+
+	if expected == AnError {
+		return Error(t, actual, msgAndArgs...)
+	}
+
+	return Equal(t, expected, actual, msgAndArgs...)
+}

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1774,7 +1774,7 @@ func buildErrorChainString(err error) string {
 
 // ErrorsMatch asserts that two errors are equal, unless the expected error
 // is AnError, in which case the actual error can be any non-nil error.
-// Errors are compared directly, without errors.Is
+// Errors are compared directly, without errors.Is().
 //
 //    assert.ErrorsMatch(t, io.ErrUnexpectedEOF, err)
 //    assert.ErrorsMatch(t, nil, error(nil))

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1774,7 +1774,7 @@ func buildErrorChainString(err error) string {
 
 // ErrorsMatch asserts that two errors are equal, unless the expected error
 // is AnError, in which case the actual error can be any non-nil error.
-// Errors are compared directly, errors.Is is not used.
+// Errors are compared directly, without errors.Is
 //
 //    assert.ErrorsMatch(t, io.ErrUnexpectedEOF, err)
 //    assert.ErrorsMatch(t, nil, error(nil))

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -2448,3 +2448,31 @@ func TestErrorAs(t *testing.T) {
 		})
 	}
 }
+
+func TestErrorsMatch(t *testing.T) {
+	mockT := new(testing.T)
+	tests := []struct {
+		expected error
+		actual   error
+		result   bool
+	}{
+		{AnError, errors.New("error"), true},
+		{AnError, nil, false},
+		{errors.New("error"), errors.New("error"), true},
+		{errors.New("error1"), errors.New("error2"), false},
+		{nil, errors.New("error"), false},
+		{errors.New("error"), nil, false},
+		{nil, nil, true},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(fmt.Sprintf("ErrorsMatch(%#v,%#v)", tt.expected, tt.actual), func(t *testing.T) {
+			res := ErrorsMatch(mockT, tt.expected, tt.actual)
+			if res != tt.result {
+				t.Errorf("ErrorsMatch(%#v,%#v) should return %t)", tt.expected, tt.actual, tt.result)
+			}
+		})
+	}
+}

--- a/require/require.go
+++ b/require/require.go
@@ -322,7 +322,7 @@ func Errorf(t TestingT, err error, msg string, args ...interface{}) {
 
 // ErrorsMatch asserts that two errors are equal, unless the expected error
 // is AnError, in which case the actual error can be any non-nil error.
-// Errors are compared directly, without errors.Is
+// Errors are compared directly, without errors.Is().
 //
 //    assert.ErrorsMatch(t, io.ErrUnexpectedEOF, err)
 //    assert.ErrorsMatch(t, nil, error(nil))
@@ -339,7 +339,7 @@ func ErrorsMatch(t TestingT, expected error, actual error, msgAndArgs ...interfa
 
 // ErrorsMatchf asserts that two errors are equal, unless the expected error
 // is AnError, in which case the actual error can be any non-nil error.
-// Errors are compared directly, without errors.Is
+// Errors are compared directly, without errors.Is().
 //
 //    assert.ErrorsMatchf(t, io.ErrUnexpectedEOF, err, "error message %s", "formatted")
 //    assert.ErrorsMatchf(t, nil, error(nil), "error message %s", "formatted")

--- a/require/require.go
+++ b/require/require.go
@@ -320,6 +320,40 @@ func Errorf(t TestingT, err error, msg string, args ...interface{}) {
 	t.FailNow()
 }
 
+// ErrorsMatch asserts that two errors are equal, unless the expected error
+// is AnError, in which case the actual error can be any non-nil error.
+// Errors are compared directly, without errors.Is
+//
+//    assert.ErrorsMatch(t, io.ErrUnexpectedEOF, err)
+//    assert.ErrorsMatch(t, nil, error(nil))
+//    assert.ErrorsMatch(t, assert.AnError, errors.New("any error"))
+func ErrorsMatch(t TestingT, expected error, actual error, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ErrorsMatch(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// ErrorsMatchf asserts that two errors are equal, unless the expected error
+// is AnError, in which case the actual error can be any non-nil error.
+// Errors are compared directly, without errors.Is
+//
+//    assert.ErrorsMatchf(t, io.ErrUnexpectedEOF, err, "error message %s", "formatted")
+//    assert.ErrorsMatchf(t, nil, error(nil), "error message %s", "formatted")
+//    assert.ErrorsMatchf(t, assert.AnError, errors.New("any error"), "error message %s", "formatted")
+func ErrorsMatchf(t TestingT, expected error, actual error, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ErrorsMatchf(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
 // Eventually asserts that given condition will be met in waitFor time,
 // periodically checking target function each tick.
 //

--- a/require/require_forward.go
+++ b/require/require_forward.go
@@ -256,7 +256,7 @@ func (a *Assertions) Errorf(err error, msg string, args ...interface{}) {
 
 // ErrorsMatch asserts that two errors are equal, unless the expected error
 // is AnError, in which case the actual error can be any non-nil error.
-// Errors are compared directly, without errors.Is
+// Errors are compared directly, without errors.Is().
 //
 //    a.ErrorsMatch(io.ErrUnexpectedEOF, err)
 //    a.ErrorsMatch(nil, error(nil))
@@ -270,7 +270,7 @@ func (a *Assertions) ErrorsMatch(expected error, actual error, msgAndArgs ...int
 
 // ErrorsMatchf asserts that two errors are equal, unless the expected error
 // is AnError, in which case the actual error can be any non-nil error.
-// Errors are compared directly, without errors.Is
+// Errors are compared directly, without errors.Is().
 //
 //    a.ErrorsMatchf(io.ErrUnexpectedEOF, err, "error message %s", "formatted")
 //    a.ErrorsMatchf(nil, error(nil), "error message %s", "formatted")

--- a/require/require_forward.go
+++ b/require/require_forward.go
@@ -254,6 +254,34 @@ func (a *Assertions) Errorf(err error, msg string, args ...interface{}) {
 	Errorf(a.t, err, msg, args...)
 }
 
+// ErrorsMatch asserts that two errors are equal, unless the expected error
+// is AnError, in which case the actual error can be any non-nil error.
+// Errors are compared directly, without errors.Is
+//
+//    a.ErrorsMatch(io.ErrUnexpectedEOF, err)
+//    a.ErrorsMatch(nil, error(nil))
+//    a.ErrorsMatch(assert.AnError, errors.New("any error"))
+func (a *Assertions) ErrorsMatch(expected error, actual error, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ErrorsMatch(a.t, expected, actual, msgAndArgs...)
+}
+
+// ErrorsMatchf asserts that two errors are equal, unless the expected error
+// is AnError, in which case the actual error can be any non-nil error.
+// Errors are compared directly, without errors.Is
+//
+//    a.ErrorsMatchf(io.ErrUnexpectedEOF, err, "error message %s", "formatted")
+//    a.ErrorsMatchf(nil, error(nil), "error message %s", "formatted")
+//    a.ErrorsMatchf(assert.AnError, errors.New("any error"), "error message %s", "formatted")
+func (a *Assertions) ErrorsMatchf(expected error, actual error, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ErrorsMatchf(a.t, expected, actual, msg, args...)
+}
+
 // Eventually asserts that given condition will be met in waitFor time,
 // periodically checking target function each tick.
 //


### PR DESCRIPTION
## Summary
This PR adds `assert.ErrorsMatch` for comparing errors of different kinds.

## Changes
- Add ErrorsMatch assertion

## Motivation
There are times when I have to write table-driven tests and check errors of different kinds. `assert.Equal` works well, though not all errors are comparable like that, mostly because they are not sentinels. Of course, I can use `assert.Error` for this and check whether the actual error is non-nil, but then I need to mark my test cases somehow, so that they wouldn't use `assert.Equal` like others do. `assert.AnError` seems like a good 'marker' for such cases, but there is no function in `assert` package that would use it as a 'marker' to check whether the actual error is non-nil (and use `assert.Error` internally). The new `assert.ErrorsMatch` would be able to accept `assert.AnError` to check whether the actual error is non-nil, and compare errors directly when the expected error is not `assert.AnError`. Example:

```go
func TestCalc(t *testing.T) {
    cases := []struct{
        Name string
        Input int
        Err error
    }{
        {
            Name: "Unknown error",
            Input: -10,
            Err: assert.AnError,
        },
        {
            Name: "io.ErrUnexpectedEOF error",
            Input: 200,
            Err: io.ErrUnexpectedEOF,
        },
        {
            Name: "No error",
            Input: 3000,
            Err: nil,
        },
    }

    for _, case := range cases {
        t.Run(case.Name, func(t *testing.T) {
              err := calc(case.Input)
              assert.ErrorsMatch(t, c.Err, err)
        })
    }
}

func calc(input int) error {
    if input == -10 {
        return otherCalc()
    }

    if input == 200 {
        return io.ErrUnexpectedEOF
    }

    return nil
}
```
