### PR TITLE
Revise test case name on README.md of mock section

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ func (m *MyMockedObject) DoSomething(number int) (bool, error) {
 
 // TestSomething is an example of how to use our test object to
 // make assertions about some target code we are testing.
-func TestDoSomething(t *testing.T) {
+func TestSomething(t *testing.T) {
 
   // create an instance of our test object
   testObj := new(MyMockedObject)
@@ -169,12 +169,12 @@ func TestDoSomething(t *testing.T) {
 
 }
 
-// TestSomethingElse is a second example of how to use our test object to
+// TestSomethingWithPlaceholder is a second example of how to use our test object to
 // make assertions about some target code we are testing.
 // This time using a placeholder. Placeholders might be used when the
 // data being passed in is normally dynamically generated and cannot be
 // predicted beforehand (eg. containing hashes that are time sensitive)
-func TestDoSomethingWithPlaceholder(t *testing.T) {
+func TestSomethingWithPlaceholder(t *testing.T) {
 
   // create an instance of our test object
   testObj := new(MyMockedObject)

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ func (m *MyMockedObject) DoSomething(number int) (bool, error) {
 
 // TestSomething is an example of how to use our test object to
 // make assertions about some target code we are testing.
-func TestSomething(t *testing.T) {
+func TestDoSomething(t *testing.T) {
 
   // create an instance of our test object
   testObj := new(MyMockedObject)
@@ -174,7 +174,7 @@ func TestSomething(t *testing.T) {
 // This time using a placeholder. Placeholders might be used when the
 // data being passed in is normally dynamically generated and cannot be
 // predicted beforehand (eg. containing hashes that are time sensitive)
-func TestSomethingElse(t *testing.T) {
+func TestDoSomethingWithPlaceholder(t *testing.T) {
 
   // create an instance of our test object
   testObj := new(MyMockedObject)


### PR DESCRIPTION
## Summary
On README.md, there are many examples as useful.
But I was a little worried about a test case name on Mock section.
I think test case name should contain a target method name accurately and indicate what would you want to test.
So I change two test case name on readme.

## Changes
I change two test case name as below.

1. Match method name to sample method.
`func TestSomething(t *testing.T)` → `func TestDoSomething(t *testing.T)`

2. Match method name to sample method and indicate what is the different with above.
`func TestSomethingElse(t *testing.T)` → `func TestDoSomethingWithPlaceholder(t *testing.T)`

## Motivation
Test case name should indicate which method is targeted and what you want to test.
It's important not only production code but also sample code.

