### PR TITLE
Colorize 'expected' and 'actual'

### DIFF
--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -13,16 +13,30 @@ import (
 
 // Condition uses a Comparison to assert a complex condition.
 func (a *Assertions) Condition(comp Comparison, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return Condition(a.t, comp, msgAndArgs...)
 }
 
 // Conditionf uses a Comparison to assert a complex condition.
 func (a *Assertions) Conditionf(comp Comparison, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return Conditionf(a.t, comp, msg, args...)
 }
@@ -34,8 +48,15 @@ func (a *Assertions) Conditionf(comp Comparison, msg string, args ...interface{}
 //    a.Contains(["Hello", "World"], "World")
 //    a.Contains({"Hello": "World"}, "Hello")
 func (a *Assertions) Contains(s interface{}, contains interface{}, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return Contains(a.t, s, contains, msgAndArgs...)
 }
@@ -47,8 +68,15 @@ func (a *Assertions) Contains(s interface{}, contains interface{}, msgAndArgs ..
 //    a.Containsf(["Hello", "World"], "World", "error message %s", "formatted")
 //    a.Containsf({"Hello": "World"}, "Hello", "error message %s", "formatted")
 func (a *Assertions) Containsf(s interface{}, contains interface{}, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return Containsf(a.t, s, contains, msg, args...)
 }
@@ -56,8 +84,15 @@ func (a *Assertions) Containsf(s interface{}, contains interface{}, msg string, 
 // DirExists checks whether a directory exists in the given path. It also fails
 // if the path is a file rather a directory or there is an error checking whether it exists.
 func (a *Assertions) DirExists(path string, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return DirExists(a.t, path, msgAndArgs...)
 }
@@ -65,8 +100,15 @@ func (a *Assertions) DirExists(path string, msgAndArgs ...interface{}) bool {
 // DirExistsf checks whether a directory exists in the given path. It also fails
 // if the path is a file rather a directory or there is an error checking whether it exists.
 func (a *Assertions) DirExistsf(path string, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return DirExistsf(a.t, path, msg, args...)
 }
@@ -77,8 +119,15 @@ func (a *Assertions) DirExistsf(path string, msg string, args ...interface{}) bo
 //
 // a.ElementsMatch([1, 3, 2, 3], [1, 3, 3, 2])
 func (a *Assertions) ElementsMatch(listA interface{}, listB interface{}, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return ElementsMatch(a.t, listA, listB, msgAndArgs...)
 }
@@ -89,8 +138,15 @@ func (a *Assertions) ElementsMatch(listA interface{}, listB interface{}, msgAndA
 //
 // a.ElementsMatchf([1, 3, 2, 3], [1, 3, 3, 2], "error message %s", "formatted")
 func (a *Assertions) ElementsMatchf(listA interface{}, listB interface{}, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return ElementsMatchf(a.t, listA, listB, msg, args...)
 }
@@ -100,8 +156,15 @@ func (a *Assertions) ElementsMatchf(listA interface{}, listB interface{}, msg st
 //
 //  a.Empty(obj)
 func (a *Assertions) Empty(object interface{}, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return Empty(a.t, object, msgAndArgs...)
 }
@@ -111,8 +174,15 @@ func (a *Assertions) Empty(object interface{}, msgAndArgs ...interface{}) bool {
 //
 //  a.Emptyf(obj, "error message %s", "formatted")
 func (a *Assertions) Emptyf(object interface{}, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return Emptyf(a.t, object, msg, args...)
 }
@@ -126,19 +196,15 @@ func (a *Assertions) Emptyf(object interface{}, msg string, args ...interface{})
 // cannot be determined and will always fail.
 func (a *Assertions) Equal(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
 	t, c := Retrieve(a.t)
-
 	if t != nil {
 		a.t = t
 	}
-
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
-
 	if c != nil {
 		a.t = WrapColorize(t)
 	}
-
 	return Equal(a.t, expected, actual, msgAndArgs...)
 }
 
@@ -149,19 +215,15 @@ func (a *Assertions) Equal(expected interface{}, actual interface{}, msgAndArgs 
 //   a.EqualError(err,  expectedErrorString)
 func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...interface{}) bool {
 	t, c := Retrieve(a.t)
-
 	if t != nil {
 		a.t = t
 	}
-
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
-
 	if c != nil {
 		a.t = WrapColorize(t)
 	}
-
 	return EqualError(a.t, theError, errString, msgAndArgs...)
 }
 
@@ -171,8 +233,15 @@ func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...
 //   actualObj, err := SomeFunction()
 //   a.EqualErrorf(err,  expectedErrorString, "error message %s", "formatted")
 func (a *Assertions) EqualErrorf(theError error, errString string, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return EqualErrorf(a.t, theError, errString, msg, args...)
 }
@@ -183,19 +252,15 @@ func (a *Assertions) EqualErrorf(theError error, errString string, msg string, a
 //    a.EqualValues(uint32(123), int32(123))
 func (a *Assertions) EqualValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
 	t, c := Retrieve(a.t)
-
 	if t != nil {
 		a.t = t
 	}
-
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
-
 	if c != nil {
 		a.t = WrapColorize(t)
 	}
-
 	return EqualValues(a.t, expected, actual, msgAndArgs...)
 }
 
@@ -204,8 +269,15 @@ func (a *Assertions) EqualValues(expected interface{}, actual interface{}, msgAn
 //
 //    a.EqualValuesf(uint32(123), int32(123), "error message %s", "formatted")
 func (a *Assertions) EqualValuesf(expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return EqualValuesf(a.t, expected, actual, msg, args...)
 }
@@ -218,8 +290,15 @@ func (a *Assertions) EqualValuesf(expected interface{}, actual interface{}, msg 
 // referenced values (as opposed to the memory addresses). Function equality
 // cannot be determined and will always fail.
 func (a *Assertions) Equalf(expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return Equalf(a.t, expected, actual, msg, args...)
 }
@@ -231,8 +310,15 @@ func (a *Assertions) Equalf(expected interface{}, actual interface{}, msg string
 // 	   assert.Equal(t, expectedError, err)
 //   }
 func (a *Assertions) Error(err error, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return Error(a.t, err, msgAndArgs...)
 }
@@ -240,8 +326,15 @@ func (a *Assertions) Error(err error, msgAndArgs ...interface{}) bool {
 // ErrorAs asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
 // This is a wrapper for errors.As.
 func (a *Assertions) ErrorAs(err error, target interface{}, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return ErrorAs(a.t, err, target, msgAndArgs...)
 }
@@ -249,8 +342,15 @@ func (a *Assertions) ErrorAs(err error, target interface{}, msgAndArgs ...interf
 // ErrorAsf asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
 // This is a wrapper for errors.As.
 func (a *Assertions) ErrorAsf(err error, target interface{}, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return ErrorAsf(a.t, err, target, msg, args...)
 }
@@ -258,8 +358,15 @@ func (a *Assertions) ErrorAsf(err error, target interface{}, msg string, args ..
 // ErrorIs asserts that at least one of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
 func (a *Assertions) ErrorIs(err error, target error, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return ErrorIs(a.t, err, target, msgAndArgs...)
 }
@@ -267,8 +374,15 @@ func (a *Assertions) ErrorIs(err error, target error, msgAndArgs ...interface{})
 // ErrorIsf asserts that at least one of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
 func (a *Assertions) ErrorIsf(err error, target error, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return ErrorIsf(a.t, err, target, msg, args...)
 }
@@ -280,8 +394,15 @@ func (a *Assertions) ErrorIsf(err error, target error, msg string, args ...inter
 // 	   assert.Equal(t, expectedErrorf, err)
 //   }
 func (a *Assertions) Errorf(err error, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return Errorf(a.t, err, msg, args...)
 }
@@ -291,8 +412,15 @@ func (a *Assertions) Errorf(err error, msg string, args ...interface{}) bool {
 //
 //    a.Eventually(func() bool { return true; }, time.Second, 10*time.Millisecond)
 func (a *Assertions) Eventually(condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return Eventually(a.t, condition, waitFor, tick, msgAndArgs...)
 }
@@ -302,8 +430,15 @@ func (a *Assertions) Eventually(condition func() bool, waitFor time.Duration, ti
 //
 //    a.Eventuallyf(func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
 func (a *Assertions) Eventuallyf(condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return Eventuallyf(a.t, condition, waitFor, tick, msg, args...)
 }
@@ -312,8 +447,15 @@ func (a *Assertions) Eventuallyf(condition func() bool, waitFor time.Duration, t
 //
 //    a.Exactly(int32(123), int64(123))
 func (a *Assertions) Exactly(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return Exactly(a.t, expected, actual, msgAndArgs...)
 }
@@ -322,40 +464,75 @@ func (a *Assertions) Exactly(expected interface{}, actual interface{}, msgAndArg
 //
 //    a.Exactlyf(int32(123), int64(123), "error message %s", "formatted")
 func (a *Assertions) Exactlyf(expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return Exactlyf(a.t, expected, actual, msg, args...)
 }
 
 // Fail reports a failure through
 func (a *Assertions) Fail(failureMessage string, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return Fail(a.t, failureMessage, msgAndArgs...)
 }
 
 // FailNow fails test
 func (a *Assertions) FailNow(failureMessage string, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return FailNow(a.t, failureMessage, msgAndArgs...)
 }
 
 // FailNowf fails test
 func (a *Assertions) FailNowf(failureMessage string, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return FailNowf(a.t, failureMessage, msg, args...)
 }
 
 // Failf reports a failure through
 func (a *Assertions) Failf(failureMessage string, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return Failf(a.t, failureMessage, msg, args...)
 }
@@ -364,8 +541,15 @@ func (a *Assertions) Failf(failureMessage string, msg string, args ...interface{
 //
 //    a.False(myBool)
 func (a *Assertions) False(value bool, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return False(a.t, value, msgAndArgs...)
 }
@@ -374,8 +558,15 @@ func (a *Assertions) False(value bool, msgAndArgs ...interface{}) bool {
 //
 //    a.Falsef(myBool, "error message %s", "formatted")
 func (a *Assertions) Falsef(value bool, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return Falsef(a.t, value, msg, args...)
 }
@@ -383,8 +574,15 @@ func (a *Assertions) Falsef(value bool, msg string, args ...interface{}) bool {
 // FileExists checks whether a file exists in the given path. It also fails if
 // the path points to a directory or there is an error when trying to check the file.
 func (a *Assertions) FileExists(path string, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return FileExists(a.t, path, msgAndArgs...)
 }
@@ -392,8 +590,15 @@ func (a *Assertions) FileExists(path string, msgAndArgs ...interface{}) bool {
 // FileExistsf checks whether a file exists in the given path. It also fails if
 // the path points to a directory or there is an error when trying to check the file.
 func (a *Assertions) FileExistsf(path string, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return FileExistsf(a.t, path, msg, args...)
 }
@@ -404,8 +609,15 @@ func (a *Assertions) FileExistsf(path string, msg string, args ...interface{}) b
 //    a.Greater(float64(2), float64(1))
 //    a.Greater("b", "a")
 func (a *Assertions) Greater(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return Greater(a.t, e1, e2, msgAndArgs...)
 }
@@ -417,8 +629,15 @@ func (a *Assertions) Greater(e1 interface{}, e2 interface{}, msgAndArgs ...inter
 //    a.GreaterOrEqual("b", "a")
 //    a.GreaterOrEqual("b", "b")
 func (a *Assertions) GreaterOrEqual(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return GreaterOrEqual(a.t, e1, e2, msgAndArgs...)
 }
@@ -430,8 +649,15 @@ func (a *Assertions) GreaterOrEqual(e1 interface{}, e2 interface{}, msgAndArgs .
 //    a.GreaterOrEqualf("b", "a", "error message %s", "formatted")
 //    a.GreaterOrEqualf("b", "b", "error message %s", "formatted")
 func (a *Assertions) GreaterOrEqualf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return GreaterOrEqualf(a.t, e1, e2, msg, args...)
 }
@@ -442,8 +668,15 @@ func (a *Assertions) GreaterOrEqualf(e1 interface{}, e2 interface{}, msg string,
 //    a.Greaterf(float64(2), float64(1), "error message %s", "formatted")
 //    a.Greaterf("b", "a", "error message %s", "formatted")
 func (a *Assertions) Greaterf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return Greaterf(a.t, e1, e2, msg, args...)
 }
@@ -455,8 +688,15 @@ func (a *Assertions) Greaterf(e1 interface{}, e2 interface{}, msg string, args .
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPBodyContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return HTTPBodyContains(a.t, handler, method, url, values, str, msgAndArgs...)
 }
@@ -468,8 +708,15 @@ func (a *Assertions) HTTPBodyContains(handler http.HandlerFunc, method string, u
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPBodyContainsf(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return HTTPBodyContainsf(a.t, handler, method, url, values, str, msg, args...)
 }
@@ -481,8 +728,15 @@ func (a *Assertions) HTTPBodyContainsf(handler http.HandlerFunc, method string, 
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPBodyNotContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return HTTPBodyNotContains(a.t, handler, method, url, values, str, msgAndArgs...)
 }
@@ -494,8 +748,15 @@ func (a *Assertions) HTTPBodyNotContains(handler http.HandlerFunc, method string
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPBodyNotContainsf(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return HTTPBodyNotContainsf(a.t, handler, method, url, values, str, msg, args...)
 }
@@ -506,8 +767,15 @@ func (a *Assertions) HTTPBodyNotContainsf(handler http.HandlerFunc, method strin
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPError(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return HTTPError(a.t, handler, method, url, values, msgAndArgs...)
 }
@@ -518,8 +786,15 @@ func (a *Assertions) HTTPError(handler http.HandlerFunc, method string, url stri
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPErrorf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return HTTPErrorf(a.t, handler, method, url, values, msg, args...)
 }
@@ -530,8 +805,15 @@ func (a *Assertions) HTTPErrorf(handler http.HandlerFunc, method string, url str
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPRedirect(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return HTTPRedirect(a.t, handler, method, url, values, msgAndArgs...)
 }
@@ -542,8 +824,15 @@ func (a *Assertions) HTTPRedirect(handler http.HandlerFunc, method string, url s
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPRedirectf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return HTTPRedirectf(a.t, handler, method, url, values, msg, args...)
 }
@@ -554,8 +843,15 @@ func (a *Assertions) HTTPRedirectf(handler http.HandlerFunc, method string, url 
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPStatusCode(handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return HTTPStatusCode(a.t, handler, method, url, values, statuscode, msgAndArgs...)
 }
@@ -566,8 +862,15 @@ func (a *Assertions) HTTPStatusCode(handler http.HandlerFunc, method string, url
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPStatusCodef(handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return HTTPStatusCodef(a.t, handler, method, url, values, statuscode, msg, args...)
 }
@@ -578,8 +881,15 @@ func (a *Assertions) HTTPStatusCodef(handler http.HandlerFunc, method string, ur
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPSuccess(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return HTTPSuccess(a.t, handler, method, url, values, msgAndArgs...)
 }
@@ -590,8 +900,15 @@ func (a *Assertions) HTTPSuccess(handler http.HandlerFunc, method string, url st
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPSuccessf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return HTTPSuccessf(a.t, handler, method, url, values, msg, args...)
 }
@@ -600,8 +917,15 @@ func (a *Assertions) HTTPSuccessf(handler http.HandlerFunc, method string, url s
 //
 //    a.Implements((*MyInterface)(nil), new(MyObject))
 func (a *Assertions) Implements(interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return Implements(a.t, interfaceObject, object, msgAndArgs...)
 }
@@ -610,8 +934,15 @@ func (a *Assertions) Implements(interfaceObject interface{}, object interface{},
 //
 //    a.Implementsf((*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
 func (a *Assertions) Implementsf(interfaceObject interface{}, object interface{}, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return Implementsf(a.t, interfaceObject, object, msg, args...)
 }
@@ -620,40 +951,75 @@ func (a *Assertions) Implementsf(interfaceObject interface{}, object interface{}
 //
 // 	 a.InDelta(math.Pi, 22/7.0, 0.01)
 func (a *Assertions) InDelta(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return InDelta(a.t, expected, actual, delta, msgAndArgs...)
 }
 
 // InDeltaMapValues is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
 func (a *Assertions) InDeltaMapValues(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return InDeltaMapValues(a.t, expected, actual, delta, msgAndArgs...)
 }
 
 // InDeltaMapValuesf is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
 func (a *Assertions) InDeltaMapValuesf(expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return InDeltaMapValuesf(a.t, expected, actual, delta, msg, args...)
 }
 
 // InDeltaSlice is the same as InDelta, except it compares two slices.
 func (a *Assertions) InDeltaSlice(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return InDeltaSlice(a.t, expected, actual, delta, msgAndArgs...)
 }
 
 // InDeltaSlicef is the same as InDelta, except it compares two slices.
 func (a *Assertions) InDeltaSlicef(expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return InDeltaSlicef(a.t, expected, actual, delta, msg, args...)
 }
@@ -662,40 +1028,75 @@ func (a *Assertions) InDeltaSlicef(expected interface{}, actual interface{}, del
 //
 // 	 a.InDeltaf(math.Pi, 22/7.0, 0.01, "error message %s", "formatted")
 func (a *Assertions) InDeltaf(expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return InDeltaf(a.t, expected, actual, delta, msg, args...)
 }
 
 // InEpsilon asserts that expected and actual have a relative error less than epsilon
 func (a *Assertions) InEpsilon(expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return InEpsilon(a.t, expected, actual, epsilon, msgAndArgs...)
 }
 
 // InEpsilonSlice is the same as InEpsilon, except it compares each value from two slices.
 func (a *Assertions) InEpsilonSlice(expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return InEpsilonSlice(a.t, expected, actual, epsilon, msgAndArgs...)
 }
 
 // InEpsilonSlicef is the same as InEpsilon, except it compares each value from two slices.
 func (a *Assertions) InEpsilonSlicef(expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return InEpsilonSlicef(a.t, expected, actual, epsilon, msg, args...)
 }
 
 // InEpsilonf asserts that expected and actual have a relative error less than epsilon
 func (a *Assertions) InEpsilonf(expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return InEpsilonf(a.t, expected, actual, epsilon, msg, args...)
 }
@@ -706,8 +1107,15 @@ func (a *Assertions) InEpsilonf(expected interface{}, actual interface{}, epsilo
 //    a.IsDecreasing([]float{2, 1})
 //    a.IsDecreasing([]string{"b", "a"})
 func (a *Assertions) IsDecreasing(object interface{}, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return IsDecreasing(a.t, object, msgAndArgs...)
 }
@@ -718,8 +1126,15 @@ func (a *Assertions) IsDecreasing(object interface{}, msgAndArgs ...interface{})
 //    a.IsDecreasingf([]float{2, 1}, "error message %s", "formatted")
 //    a.IsDecreasingf([]string{"b", "a"}, "error message %s", "formatted")
 func (a *Assertions) IsDecreasingf(object interface{}, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return IsDecreasingf(a.t, object, msg, args...)
 }
@@ -730,8 +1145,15 @@ func (a *Assertions) IsDecreasingf(object interface{}, msg string, args ...inter
 //    a.IsIncreasing([]float{1, 2})
 //    a.IsIncreasing([]string{"a", "b"})
 func (a *Assertions) IsIncreasing(object interface{}, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return IsIncreasing(a.t, object, msgAndArgs...)
 }
@@ -742,8 +1164,15 @@ func (a *Assertions) IsIncreasing(object interface{}, msgAndArgs ...interface{})
 //    a.IsIncreasingf([]float{1, 2}, "error message %s", "formatted")
 //    a.IsIncreasingf([]string{"a", "b"}, "error message %s", "formatted")
 func (a *Assertions) IsIncreasingf(object interface{}, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return IsIncreasingf(a.t, object, msg, args...)
 }
@@ -754,8 +1183,15 @@ func (a *Assertions) IsIncreasingf(object interface{}, msg string, args ...inter
 //    a.IsNonDecreasing([]float{1, 2})
 //    a.IsNonDecreasing([]string{"a", "b"})
 func (a *Assertions) IsNonDecreasing(object interface{}, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return IsNonDecreasing(a.t, object, msgAndArgs...)
 }
@@ -766,8 +1202,15 @@ func (a *Assertions) IsNonDecreasing(object interface{}, msgAndArgs ...interface
 //    a.IsNonDecreasingf([]float{1, 2}, "error message %s", "formatted")
 //    a.IsNonDecreasingf([]string{"a", "b"}, "error message %s", "formatted")
 func (a *Assertions) IsNonDecreasingf(object interface{}, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return IsNonDecreasingf(a.t, object, msg, args...)
 }
@@ -778,8 +1221,15 @@ func (a *Assertions) IsNonDecreasingf(object interface{}, msg string, args ...in
 //    a.IsNonIncreasing([]float{2, 1})
 //    a.IsNonIncreasing([]string{"b", "a"})
 func (a *Assertions) IsNonIncreasing(object interface{}, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return IsNonIncreasing(a.t, object, msgAndArgs...)
 }
@@ -790,24 +1240,45 @@ func (a *Assertions) IsNonIncreasing(object interface{}, msgAndArgs ...interface
 //    a.IsNonIncreasingf([]float{2, 1}, "error message %s", "formatted")
 //    a.IsNonIncreasingf([]string{"b", "a"}, "error message %s", "formatted")
 func (a *Assertions) IsNonIncreasingf(object interface{}, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return IsNonIncreasingf(a.t, object, msg, args...)
 }
 
 // IsType asserts that the specified objects are of the same type.
 func (a *Assertions) IsType(expectedType interface{}, object interface{}, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return IsType(a.t, expectedType, object, msgAndArgs...)
 }
 
 // IsTypef asserts that the specified objects are of the same type.
 func (a *Assertions) IsTypef(expectedType interface{}, object interface{}, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return IsTypef(a.t, expectedType, object, msg, args...)
 }
@@ -816,8 +1287,15 @@ func (a *Assertions) IsTypef(expectedType interface{}, object interface{}, msg s
 //
 //  a.JSONEq(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
 func (a *Assertions) JSONEq(expected string, actual string, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return JSONEq(a.t, expected, actual, msgAndArgs...)
 }
@@ -826,8 +1304,15 @@ func (a *Assertions) JSONEq(expected string, actual string, msgAndArgs ...interf
 //
 //  a.JSONEqf(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
 func (a *Assertions) JSONEqf(expected string, actual string, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return JSONEqf(a.t, expected, actual, msg, args...)
 }
@@ -837,8 +1322,15 @@ func (a *Assertions) JSONEqf(expected string, actual string, msg string, args ..
 //
 //    a.Len(mySlice, 3)
 func (a *Assertions) Len(object interface{}, length int, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return Len(a.t, object, length, msgAndArgs...)
 }
@@ -848,8 +1340,15 @@ func (a *Assertions) Len(object interface{}, length int, msgAndArgs ...interface
 //
 //    a.Lenf(mySlice, 3, "error message %s", "formatted")
 func (a *Assertions) Lenf(object interface{}, length int, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return Lenf(a.t, object, length, msg, args...)
 }
@@ -860,8 +1359,15 @@ func (a *Assertions) Lenf(object interface{}, length int, msg string, args ...in
 //    a.Less(float64(1), float64(2))
 //    a.Less("a", "b")
 func (a *Assertions) Less(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return Less(a.t, e1, e2, msgAndArgs...)
 }
@@ -873,8 +1379,15 @@ func (a *Assertions) Less(e1 interface{}, e2 interface{}, msgAndArgs ...interfac
 //    a.LessOrEqual("a", "b")
 //    a.LessOrEqual("b", "b")
 func (a *Assertions) LessOrEqual(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return LessOrEqual(a.t, e1, e2, msgAndArgs...)
 }
@@ -886,8 +1399,15 @@ func (a *Assertions) LessOrEqual(e1 interface{}, e2 interface{}, msgAndArgs ...i
 //    a.LessOrEqualf("a", "b", "error message %s", "formatted")
 //    a.LessOrEqualf("b", "b", "error message %s", "formatted")
 func (a *Assertions) LessOrEqualf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return LessOrEqualf(a.t, e1, e2, msg, args...)
 }
@@ -898,8 +1418,15 @@ func (a *Assertions) LessOrEqualf(e1 interface{}, e2 interface{}, msg string, ar
 //    a.Lessf(float64(1), float64(2), "error message %s", "formatted")
 //    a.Lessf("a", "b", "error message %s", "formatted")
 func (a *Assertions) Lessf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return Lessf(a.t, e1, e2, msg, args...)
 }
@@ -909,8 +1436,15 @@ func (a *Assertions) Lessf(e1 interface{}, e2 interface{}, msg string, args ...i
 //
 //    a.Never(func() bool { return false; }, time.Second, 10*time.Millisecond)
 func (a *Assertions) Never(condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return Never(a.t, condition, waitFor, tick, msgAndArgs...)
 }
@@ -920,8 +1454,15 @@ func (a *Assertions) Never(condition func() bool, waitFor time.Duration, tick ti
 //
 //    a.Neverf(func() bool { return false; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
 func (a *Assertions) Neverf(condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return Neverf(a.t, condition, waitFor, tick, msg, args...)
 }
@@ -930,8 +1471,15 @@ func (a *Assertions) Neverf(condition func() bool, waitFor time.Duration, tick t
 //
 //    a.Nil(err)
 func (a *Assertions) Nil(object interface{}, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return Nil(a.t, object, msgAndArgs...)
 }
@@ -940,8 +1488,15 @@ func (a *Assertions) Nil(object interface{}, msgAndArgs ...interface{}) bool {
 //
 //    a.Nilf(err, "error message %s", "formatted")
 func (a *Assertions) Nilf(object interface{}, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return Nilf(a.t, object, msg, args...)
 }
@@ -949,8 +1504,15 @@ func (a *Assertions) Nilf(object interface{}, msg string, args ...interface{}) b
 // NoDirExists checks whether a directory does not exist in the given path.
 // It fails if the path points to an existing _directory_ only.
 func (a *Assertions) NoDirExists(path string, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return NoDirExists(a.t, path, msgAndArgs...)
 }
@@ -958,8 +1520,15 @@ func (a *Assertions) NoDirExists(path string, msgAndArgs ...interface{}) bool {
 // NoDirExistsf checks whether a directory does not exist in the given path.
 // It fails if the path points to an existing _directory_ only.
 func (a *Assertions) NoDirExistsf(path string, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return NoDirExistsf(a.t, path, msg, args...)
 }
@@ -971,8 +1540,15 @@ func (a *Assertions) NoDirExistsf(path string, msg string, args ...interface{}) 
 // 	   assert.Equal(t, expectedObj, actualObj)
 //   }
 func (a *Assertions) NoError(err error, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return NoError(a.t, err, msgAndArgs...)
 }
@@ -984,8 +1560,15 @@ func (a *Assertions) NoError(err error, msgAndArgs ...interface{}) bool {
 // 	   assert.Equal(t, expectedObj, actualObj)
 //   }
 func (a *Assertions) NoErrorf(err error, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return NoErrorf(a.t, err, msg, args...)
 }
@@ -993,8 +1576,15 @@ func (a *Assertions) NoErrorf(err error, msg string, args ...interface{}) bool {
 // NoFileExists checks whether a file does not exist in a given path. It fails
 // if the path points to an existing _file_ only.
 func (a *Assertions) NoFileExists(path string, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return NoFileExists(a.t, path, msgAndArgs...)
 }
@@ -1002,8 +1592,15 @@ func (a *Assertions) NoFileExists(path string, msgAndArgs ...interface{}) bool {
 // NoFileExistsf checks whether a file does not exist in a given path. It fails
 // if the path points to an existing _file_ only.
 func (a *Assertions) NoFileExistsf(path string, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return NoFileExistsf(a.t, path, msg, args...)
 }
@@ -1015,8 +1612,15 @@ func (a *Assertions) NoFileExistsf(path string, msg string, args ...interface{})
 //    a.NotContains(["Hello", "World"], "Earth")
 //    a.NotContains({"Hello": "World"}, "Earth")
 func (a *Assertions) NotContains(s interface{}, contains interface{}, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return NotContains(a.t, s, contains, msgAndArgs...)
 }
@@ -1028,8 +1632,15 @@ func (a *Assertions) NotContains(s interface{}, contains interface{}, msgAndArgs
 //    a.NotContainsf(["Hello", "World"], "Earth", "error message %s", "formatted")
 //    a.NotContainsf({"Hello": "World"}, "Earth", "error message %s", "formatted")
 func (a *Assertions) NotContainsf(s interface{}, contains interface{}, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return NotContainsf(a.t, s, contains, msg, args...)
 }
@@ -1041,8 +1652,15 @@ func (a *Assertions) NotContainsf(s interface{}, contains interface{}, msg strin
 //    assert.Equal(t, "two", obj[1])
 //  }
 func (a *Assertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return NotEmpty(a.t, object, msgAndArgs...)
 }
@@ -1054,8 +1672,15 @@ func (a *Assertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) boo
 //    assert.Equal(t, "two", obj[1])
 //  }
 func (a *Assertions) NotEmptyf(object interface{}, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return NotEmptyf(a.t, object, msg, args...)
 }
@@ -1067,8 +1692,15 @@ func (a *Assertions) NotEmptyf(object interface{}, msg string, args ...interface
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
 func (a *Assertions) NotEqual(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return NotEqual(a.t, expected, actual, msgAndArgs...)
 }
@@ -1077,8 +1709,15 @@ func (a *Assertions) NotEqual(expected interface{}, actual interface{}, msgAndAr
 //
 //    a.NotEqualValues(obj1, obj2)
 func (a *Assertions) NotEqualValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return NotEqualValues(a.t, expected, actual, msgAndArgs...)
 }
@@ -1087,8 +1726,15 @@ func (a *Assertions) NotEqualValues(expected interface{}, actual interface{}, ms
 //
 //    a.NotEqualValuesf(obj1, obj2, "error message %s", "formatted")
 func (a *Assertions) NotEqualValuesf(expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return NotEqualValuesf(a.t, expected, actual, msg, args...)
 }
@@ -1100,8 +1746,15 @@ func (a *Assertions) NotEqualValuesf(expected interface{}, actual interface{}, m
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
 func (a *Assertions) NotEqualf(expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return NotEqualf(a.t, expected, actual, msg, args...)
 }
@@ -1109,8 +1762,15 @@ func (a *Assertions) NotEqualf(expected interface{}, actual interface{}, msg str
 // NotErrorIs asserts that at none of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
 func (a *Assertions) NotErrorIs(err error, target error, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return NotErrorIs(a.t, err, target, msgAndArgs...)
 }
@@ -1118,8 +1778,15 @@ func (a *Assertions) NotErrorIs(err error, target error, msgAndArgs ...interface
 // NotErrorIsf asserts that at none of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
 func (a *Assertions) NotErrorIsf(err error, target error, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return NotErrorIsf(a.t, err, target, msg, args...)
 }
@@ -1128,8 +1795,15 @@ func (a *Assertions) NotErrorIsf(err error, target error, msg string, args ...in
 //
 //    a.NotNil(err)
 func (a *Assertions) NotNil(object interface{}, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return NotNil(a.t, object, msgAndArgs...)
 }
@@ -1138,8 +1812,15 @@ func (a *Assertions) NotNil(object interface{}, msgAndArgs ...interface{}) bool 
 //
 //    a.NotNilf(err, "error message %s", "formatted")
 func (a *Assertions) NotNilf(object interface{}, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return NotNilf(a.t, object, msg, args...)
 }
@@ -1148,8 +1829,15 @@ func (a *Assertions) NotNilf(object interface{}, msg string, args ...interface{}
 //
 //   a.NotPanics(func(){ RemainCalm() })
 func (a *Assertions) NotPanics(f PanicTestFunc, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return NotPanics(a.t, f, msgAndArgs...)
 }
@@ -1158,8 +1846,15 @@ func (a *Assertions) NotPanics(f PanicTestFunc, msgAndArgs ...interface{}) bool 
 //
 //   a.NotPanicsf(func(){ RemainCalm() }, "error message %s", "formatted")
 func (a *Assertions) NotPanicsf(f PanicTestFunc, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return NotPanicsf(a.t, f, msg, args...)
 }
@@ -1169,8 +1864,15 @@ func (a *Assertions) NotPanicsf(f PanicTestFunc, msg string, args ...interface{}
 //  a.NotRegexp(regexp.MustCompile("starts"), "it's starting")
 //  a.NotRegexp("^start", "it's not starting")
 func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return NotRegexp(a.t, rx, str, msgAndArgs...)
 }
@@ -1180,8 +1882,15 @@ func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...in
 //  a.NotRegexpf(regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
 //  a.NotRegexpf("^start", "it's not starting", "error message %s", "formatted")
 func (a *Assertions) NotRegexpf(rx interface{}, str interface{}, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return NotRegexpf(a.t, rx, str, msg, args...)
 }
@@ -1193,8 +1902,15 @@ func (a *Assertions) NotRegexpf(rx interface{}, str interface{}, msg string, arg
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
 func (a *Assertions) NotSame(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return NotSame(a.t, expected, actual, msgAndArgs...)
 }
@@ -1206,8 +1922,15 @@ func (a *Assertions) NotSame(expected interface{}, actual interface{}, msgAndArg
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
 func (a *Assertions) NotSamef(expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return NotSamef(a.t, expected, actual, msg, args...)
 }
@@ -1217,8 +1940,15 @@ func (a *Assertions) NotSamef(expected interface{}, actual interface{}, msg stri
 //
 //    a.NotSubset([1, 3, 4], [1, 2], "But [1, 3, 4] does not contain [1, 2]")
 func (a *Assertions) NotSubset(list interface{}, subset interface{}, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return NotSubset(a.t, list, subset, msgAndArgs...)
 }
@@ -1228,24 +1958,45 @@ func (a *Assertions) NotSubset(list interface{}, subset interface{}, msgAndArgs 
 //
 //    a.NotSubsetf([1, 3, 4], [1, 2], "But [1, 3, 4] does not contain [1, 2]", "error message %s", "formatted")
 func (a *Assertions) NotSubsetf(list interface{}, subset interface{}, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return NotSubsetf(a.t, list, subset, msg, args...)
 }
 
 // NotZero asserts that i is not the zero value for its type.
 func (a *Assertions) NotZero(i interface{}, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return NotZero(a.t, i, msgAndArgs...)
 }
 
 // NotZerof asserts that i is not the zero value for its type.
 func (a *Assertions) NotZerof(i interface{}, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return NotZerof(a.t, i, msg, args...)
 }
@@ -1254,8 +2005,15 @@ func (a *Assertions) NotZerof(i interface{}, msg string, args ...interface{}) bo
 //
 //   a.Panics(func(){ GoCrazy() })
 func (a *Assertions) Panics(f PanicTestFunc, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return Panics(a.t, f, msgAndArgs...)
 }
@@ -1266,8 +2024,15 @@ func (a *Assertions) Panics(f PanicTestFunc, msgAndArgs ...interface{}) bool {
 //
 //   a.PanicsWithError("crazy error", func(){ GoCrazy() })
 func (a *Assertions) PanicsWithError(errString string, f PanicTestFunc, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return PanicsWithError(a.t, errString, f, msgAndArgs...)
 }
@@ -1278,8 +2043,15 @@ func (a *Assertions) PanicsWithError(errString string, f PanicTestFunc, msgAndAr
 //
 //   a.PanicsWithErrorf("crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
 func (a *Assertions) PanicsWithErrorf(errString string, f PanicTestFunc, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return PanicsWithErrorf(a.t, errString, f, msg, args...)
 }
@@ -1289,8 +2061,15 @@ func (a *Assertions) PanicsWithErrorf(errString string, f PanicTestFunc, msg str
 //
 //   a.PanicsWithValue("crazy error", func(){ GoCrazy() })
 func (a *Assertions) PanicsWithValue(expected interface{}, f PanicTestFunc, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return PanicsWithValue(a.t, expected, f, msgAndArgs...)
 }
@@ -1300,8 +2079,15 @@ func (a *Assertions) PanicsWithValue(expected interface{}, f PanicTestFunc, msgA
 //
 //   a.PanicsWithValuef("crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
 func (a *Assertions) PanicsWithValuef(expected interface{}, f PanicTestFunc, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return PanicsWithValuef(a.t, expected, f, msg, args...)
 }
@@ -1310,8 +2096,15 @@ func (a *Assertions) PanicsWithValuef(expected interface{}, f PanicTestFunc, msg
 //
 //   a.Panicsf(func(){ GoCrazy() }, "error message %s", "formatted")
 func (a *Assertions) Panicsf(f PanicTestFunc, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return Panicsf(a.t, f, msg, args...)
 }
@@ -1321,8 +2114,15 @@ func (a *Assertions) Panicsf(f PanicTestFunc, msg string, args ...interface{}) b
 //  a.Regexp(regexp.MustCompile("start"), "it's starting")
 //  a.Regexp("start...$", "it's not starting")
 func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return Regexp(a.t, rx, str, msgAndArgs...)
 }
@@ -1332,8 +2132,15 @@ func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...inter
 //  a.Regexpf(regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
 //  a.Regexpf("start...$", "it's not starting", "error message %s", "formatted")
 func (a *Assertions) Regexpf(rx interface{}, str interface{}, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return Regexpf(a.t, rx, str, msg, args...)
 }
@@ -1346,19 +2153,15 @@ func (a *Assertions) Regexpf(rx interface{}, str interface{}, msg string, args .
 // determined based on the equality of both type and value.
 func (a *Assertions) Same(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
 	t, c := Retrieve(a.t)
-
 	if t != nil {
 		a.t = t
 	}
-
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
-
 	if c != nil {
 		a.t = WrapColorize(t)
 	}
-
 	return Same(a.t, expected, actual, msgAndArgs...)
 }
 
@@ -1369,8 +2172,15 @@ func (a *Assertions) Same(expected interface{}, actual interface{}, msgAndArgs .
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
 func (a *Assertions) Samef(expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return Samef(a.t, expected, actual, msg, args...)
 }
@@ -1380,8 +2190,15 @@ func (a *Assertions) Samef(expected interface{}, actual interface{}, msg string,
 //
 //    a.Subset([1, 2, 3], [1, 2], "But [1, 2, 3] does contain [1, 2]")
 func (a *Assertions) Subset(list interface{}, subset interface{}, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return Subset(a.t, list, subset, msgAndArgs...)
 }
@@ -1391,8 +2208,15 @@ func (a *Assertions) Subset(list interface{}, subset interface{}, msgAndArgs ...
 //
 //    a.Subsetf([1, 2, 3], [1, 2], "But [1, 2, 3] does contain [1, 2]", "error message %s", "formatted")
 func (a *Assertions) Subsetf(list interface{}, subset interface{}, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return Subsetf(a.t, list, subset, msg, args...)
 }
@@ -1401,8 +2225,15 @@ func (a *Assertions) Subsetf(list interface{}, subset interface{}, msg string, a
 //
 //    a.True(myBool)
 func (a *Assertions) True(value bool, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return True(a.t, value, msgAndArgs...)
 }
@@ -1411,8 +2242,15 @@ func (a *Assertions) True(value bool, msgAndArgs ...interface{}) bool {
 //
 //    a.Truef(myBool, "error message %s", "formatted")
 func (a *Assertions) Truef(value bool, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return Truef(a.t, value, msg, args...)
 }
@@ -1421,8 +2259,15 @@ func (a *Assertions) Truef(value bool, msg string, args ...interface{}) bool {
 //
 //   a.WithinDuration(time.Now(), time.Now(), 10*time.Second)
 func (a *Assertions) WithinDuration(expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return WithinDuration(a.t, expected, actual, delta, msgAndArgs...)
 }
@@ -1431,40 +2276,75 @@ func (a *Assertions) WithinDuration(expected time.Time, actual time.Time, delta 
 //
 //   a.WithinDurationf(time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
 func (a *Assertions) WithinDurationf(expected time.Time, actual time.Time, delta time.Duration, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return WithinDurationf(a.t, expected, actual, delta, msg, args...)
 }
 
 // YAMLEq asserts that two YAML strings are equivalent.
 func (a *Assertions) YAMLEq(expected string, actual string, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return YAMLEq(a.t, expected, actual, msgAndArgs...)
 }
 
 // YAMLEqf asserts that two YAML strings are equivalent.
 func (a *Assertions) YAMLEqf(expected string, actual string, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return YAMLEqf(a.t, expected, actual, msg, args...)
 }
 
 // Zero asserts that i is the zero value for its type.
 func (a *Assertions) Zero(i interface{}, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return Zero(a.t, i, msgAndArgs...)
 }
 
 // Zerof asserts that i is the zero value for its type.
 func (a *Assertions) Zerof(i interface{}, msg string, args ...interface{}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil {
+		a.t = t
+	}
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
+	}
+	if c != nil {
+		a.t = WrapColorize(t)
 	}
 	return Zerof(a.t, i, msg, args...)
 }

--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -125,9 +125,20 @@ func (a *Assertions) Emptyf(object interface{}, msg string, args ...interface{})
 // referenced values (as opposed to the memory addresses). Function equality
 // cannot be determined and will always fail.
 func (a *Assertions) Equal(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+
+	if t != nil {
+		a.t = t
+	}
+
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
+
+	if c != nil {
+		a.t = WrapColorize(t)
+	}
+
 	return Equal(a.t, expected, actual, msgAndArgs...)
 }
 
@@ -137,9 +148,20 @@ func (a *Assertions) Equal(expected interface{}, actual interface{}, msgAndArgs 
 //   actualObj, err := SomeFunction()
 //   a.EqualError(err,  expectedErrorString)
 func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+
+	if t != nil {
+		a.t = t
+	}
+
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
+
+	if c != nil {
+		a.t = WrapColorize(t)
+	}
+
 	return EqualError(a.t, theError, errString, msgAndArgs...)
 }
 
@@ -160,9 +182,20 @@ func (a *Assertions) EqualErrorf(theError error, errString string, msg string, a
 //
 //    a.EqualValues(uint32(123), int32(123))
 func (a *Assertions) EqualValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+
+	if t != nil {
+		a.t = t
+	}
+
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
+
+	if c != nil {
+		a.t = WrapColorize(t)
+	}
+
 	return EqualValues(a.t, expected, actual, msgAndArgs...)
 }
 
@@ -1312,9 +1345,20 @@ func (a *Assertions) Regexpf(rx interface{}, str interface{}, msg string, args .
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
 func (a *Assertions) Same(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(a.t)
+
+	if t != nil {
+		a.t = t
+	}
+
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
+
+	if c != nil {
+		a.t = WrapColorize(t)
+	}
+
 	return Same(a.t, expected, actual, msgAndArgs...)
 }
 

--- a/assert/assertion_forward.go.tmpl
+++ b/assert/assertion_forward.go.tmpl
@@ -1,5 +1,8 @@
 {{.CommentWithoutT "a"}}
 func (a *Assertions) {{.DocInfo.Name}}({{.Params}}) bool {
+	t, c := Retrieve(a.t)
+	if t != nil { a.t = t }
 	if h, ok := a.t.(tHelper); ok { h.Helper() }
+	if c != nil { a.t = WrapColorize(t) }
 	return {{.DocInfo.Name}}(a.t, {{.ForwardedParams}})
 }

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -242,6 +242,7 @@ func Fail(t TestingT, failureMessage string, msgAndArgs ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
+
 	content := []labeledContent{
 		{"Error Trace", strings.Join(CallerInfo(), "\n\t\t\t")},
 		{"Error", failureMessage},
@@ -332,6 +333,8 @@ func IsType(t TestingT, expectedType interface{}, object interface{}, msgAndArgs
 // referenced values (as opposed to the memory addresses). Function equality
 // cannot be determined and will always fail.
 func Equal(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(t)
+
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -343,9 +346,15 @@ func Equal(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) 
 	if !ObjectsAreEqual(expected, actual) {
 		diff := diff(expected, actual)
 		expected, actual = formatUnequalValues(expected, actual)
-		return Fail(t, fmt.Sprintf("Not equal: \n"+
+		failureMessage := fmt.Sprintf("Not equal: \n"+
 			"expected: %s\n"+
-			"actual  : %s%s", expected, actual, diff), msgAndArgs...)
+			"actual  : %s%s", expected, actual, diff)
+
+		if c != nil {
+			failureMessage = c.Message(failureMessage)
+		}
+
+		return Fail(t, failureMessage, msgAndArgs...)
 	}
 
 	return true
@@ -372,14 +381,22 @@ func validateEqualArgs(expected, actual interface{}) error {
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
 func Same(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(t)
+
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
 
 	if !samePointers(expected, actual) {
-		return Fail(t, fmt.Sprintf("Not same: \n"+
-			"expected: %p %#v\n"+
-			"actual  : %p %#v", expected, expected, actual, actual), msgAndArgs...)
+		failureMessage := "Not same: \n" +
+			"expected: %p %#v\n" +
+			"actual  : %p %#v"
+
+		if c != nil {
+			failureMessage = c.Message(failureMessage)
+		}
+
+		return Fail(t, fmt.Sprintf(failureMessage, expected, expected, actual, actual), msgAndArgs...)
 	}
 
 	return true
@@ -457,6 +474,8 @@ func truncatingFormat(data interface{}) string {
 //
 //    assert.EqualValues(t, uint32(123), int32(123))
 func EqualValues(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(t)
+
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -464,9 +483,15 @@ func EqualValues(t TestingT, expected, actual interface{}, msgAndArgs ...interfa
 	if !ObjectsAreEqualValues(expected, actual) {
 		diff := diff(expected, actual)
 		expected, actual = formatUnequalValues(expected, actual)
-		return Fail(t, fmt.Sprintf("Not equal: \n"+
-			"expected: %s\n"+
-			"actual  : %s%s", expected, actual, diff), msgAndArgs...)
+		failureMessage := "Not equal: \n" +
+			"expected: %s\n" +
+			"actual  : %s%s"
+
+		if c != nil {
+			failureMessage = c.Message(failureMessage)
+		}
+
+		return Fail(t, fmt.Sprintf(failureMessage, expected, actual, diff), msgAndArgs...)
 	}
 
 	return true
@@ -1358,6 +1383,8 @@ func Error(t TestingT, err error, msgAndArgs ...interface{}) bool {
 //   actualObj, err := SomeFunction()
 //   assert.EqualError(t, err,  expectedErrorString)
 func EqualError(t TestingT, theError error, errString string, msgAndArgs ...interface{}) bool {
+	t, c := Retrieve(t)
+
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1368,9 +1395,15 @@ func EqualError(t TestingT, theError error, errString string, msgAndArgs ...inte
 	actual := theError.Error()
 	// don't need to use deep equals here, we know they are both strings
 	if expected != actual {
-		return Fail(t, fmt.Sprintf("Error message not equal:\n"+
-			"expected: %q\n"+
-			"actual  : %q", expected, actual), msgAndArgs...)
+		failureMessage := "Error message not equal:\n" +
+			"expected: %q\n" +
+			"actual  : %q"
+
+		if c != nil {
+			failureMessage = c.Message(failureMessage)
+		}
+
+		return Fail(t, fmt.Sprintf(failureMessage, expected, actual), msgAndArgs...)
 	}
 	return true
 }

--- a/assert/colorize.go
+++ b/assert/colorize.go
@@ -1,0 +1,43 @@
+package assert
+
+import (
+	"regexp"
+)
+
+// Colorize struct to colorize failure message
+type Colorize struct {
+	t TestingT
+}
+
+// Errorf implements for TestingT interface
+func (c Colorize) Errorf(format string, args ...interface{}) {
+	c.t.Errorf(format, args...)
+}
+
+// Message implements colourize actual and expected at the very least
+func (Colorize) Message(failureMessage string) string {
+	re := regexp.MustCompile(`(.*)\n(expected.*)\n(actual.*)`)
+
+	return string(
+		re.ReplaceAll(
+			[]byte(failureMessage),
+			[]byte("\033[33m${1}\033[0m\n\033[32m${2}\033[0m\n\033[31m${3}\033[0m"),
+		),
+	)
+}
+
+// WrapColorize wrappers around TestingT to Colorize
+func WrapColorize(t TestingT) Colorize {
+	return Colorize{
+		t: t,
+	}
+}
+
+// Retrieve is a helper function to retrieve field of TestingT and Colorize or return self and nil
+func Retrieve(t TestingT) (TestingT, *Colorize) {
+	if c, ok := t.(Colorize); ok {
+		return c.t, &c
+	}
+
+	return t, nil
+}

--- a/assert/colorize_test.go
+++ b/assert/colorize_test.go
@@ -1,0 +1,36 @@
+package assert
+
+import (
+	// "errors"
+	"fmt"
+	"testing"
+)
+
+// func TestColorize(t *testing.T) {
+// 	wrapT := WrapColorize(t)
+// 	assert := New(wrapT)
+
+// 	Equal(wrapT, 1, 2)
+// 	Equal(wrapT, "A", "b")
+// 	Equal(t, 1, 2)
+// 	assert.Equal(3, 4)
+
+// 	Same(wrapT, new(Colorize), new(Colorize))
+// 	Same(t, new(Colorize), new(Colorize))
+// 	assert.Same(new(Colorize), new(Colorize))
+
+// 	EqualValues(wrapT, uint32(123), int32(124))
+// 	EqualValues(t, uint32(123), int32(124))
+// 	assert.EqualValues(uint32(123), int32(124))
+
+// 	EqualError(wrapT, errors.New("foo"), "bar")
+// 	EqualError(t, errors.New("foo"), "bar")
+// 	assert.EqualError(errors.New("foo"), "bar")
+// }
+
+func TestColorize_Message(t *testing.T) {
+	failureMessage := fmt.Sprintf("Not equal: \n"+
+		"expected: %s\n"+
+		"actual  : %s%s", "expected", "actual", "diff")
+	fmt.Println(WrapColorize(t).Message(failureMessage))
+}


### PR DESCRIPTION
## Summary
<!-- High-level, one sentence summary of what this PR accomplishes -->
Colorize "expected" and "actual"

## Changes
<!-- * Description of change 1 -->
<!-- * Description of change 2 -->
<!-- ... -->
Resolves #946 

## Motivation
<!-- Why were the changes necessary. -->

1. @boyan-soubachov says "It's an interesting idea."

1. @mvdkleijn says "I like this idea."

<!-- ## Example usage (if applicable) -->
```go
package testify

import (
	"errors"
	"testing"

	"github.com/stretchr/testify/assert"
)

func TestExamples(t *testing.T) {
	wrapT := assert.WrapColorize(t)
	newAssert := assert.New(wrapT)

	assert.Equal(wrapT, 1, 2)
	assert.Equal(wrapT, "A", "b")
	newAssert.Equal(3, 4)

	assert.Same(wrapT, new(assert.Colorize), new(assert.Colorize))
	newAssert.Same(new(assert.Colorize), new(assert.Colorize))

	assert.EqualValues(wrapT, uint32(123), int32(124))
	newAssert.EqualValues(uint32(123), int32(124))

	assert.EqualError(wrapT, errors.New("foo"), "bar")
	newAssert.EqualError(errors.New("foo"), "bar")
}
```

## Related issues
<!-- Put `Closes #XXXX` for each issue number this PR fixes/closes -->
N/A

## Screenshot

### TestColorize
<img width="430" alt="TestColorize" src="https://user-images.githubusercontent.com/16009255/90783929-45aca100-e333-11ea-9093-bf268aa8754d.png">

### Equal
<img width="370" alt="Equal" src="https://user-images.githubusercontent.com/16009255/90784004-59f09e00-e333-11ea-9bab-cfcf0ae79d77.png">

### Same
<img width="772" alt="Same" src="https://user-images.githubusercontent.com/16009255/90784050-670d8d00-e333-11ea-9a71-65f26b1a8355.png">

### EqualValues
<img width="459" alt="EqualValues" src="https://user-images.githubusercontent.com/16009255/90784102-78ef3000-e333-11ea-830e-b9f5c74a2ddf.png">

### EqualError
<img width="468" alt="EqualError" src="https://user-images.githubusercontent.com/16009255/90784089-74c31280-e333-11ea-998a-64bde13a6ff5.png">