### PR TITLE
Add AssertMinNumberOfCalls

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -514,6 +514,22 @@ func (m *Mock) AssertNumberOfCalls(t TestingT, methodName string, expectedCalls 
 	return assert.Equal(t, expectedCalls, actualCalls, fmt.Sprintf("Expected number of calls (%d) does not match the actual number of calls (%d).", expectedCalls, actualCalls))
 }
 
+// AssertMinNumberOfCalls asserts that the method was called at least expectedCalls times.
+func (m *Mock) AssertMinNumberOfCalls(t TestingT, methodName string, expectedCalls int) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	var actualCalls int
+	for _, call := range m.calls() {
+		if call.Method == methodName {
+			actualCalls++
+		}
+	}
+	return assert.GreaterOrEqual(t, actualCalls, expectedCalls, fmt.Sprintf("Acutal number of calls (%d) is below the expected number of calls (%d).", actualCalls, expectedCalls))
+}
+
 // AssertCalled asserts that the method was called.
 // It can produce a false result when an argument is a pointer type and the underlying value changed after calling the mocked method.
 func (m *Mock) AssertCalled(t TestingT, methodName string, arguments ...interface{}) bool {

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -1098,6 +1098,25 @@ func Test_Mock_AssertNumberOfCalls(t *testing.T) {
 
 }
 
+func Test_Mock_AssertMinNumberOfCalls(t *testing.T) {
+
+	var mockedService = new(TestExampleImplementation)
+
+	mockedService.On("Test_Mock_AssertMinNumberOfCalls", 1, 2, 3).Return(5, 6, 7)
+
+	mockedService.Called(1, 2, 3)
+	assert.True(t, mockedService.AssertMinNumberOfCalls(t, "Test_Mock_AssertMinNumberOfCalls", 1))
+
+	mockedService.Called(1, 2, 3)
+	mockedService.Called(1, 2, 3)
+
+	tt := new(testing.T)
+	assert.True(t, mockedService.AssertMinNumberOfCalls(tt, "Test_Mock_AssertMinNumberOfCalls", 2))
+	assert.True(t, mockedService.AssertMinNumberOfCalls(tt, "Test_Mock_AssertMinNumberOfCalls", 3))
+	assert.False(t, mockedService.AssertMinNumberOfCalls(tt, "Test_Mock_AssertMinNumberOfCalls", 4))
+
+}
+
 func Test_Mock_AssertCalled(t *testing.T) {
 
 	var mockedService = new(TestExampleImplementation)


### PR DESCRIPTION
## Summary
<!-- High-level, one sentence summary of what this PR accomplishes -->
Adding a new `AssertMinNumberOfCalls` method for Mock, allowing easier testing of at-least-once guarantees.

## Changes
<!-- * Description of change 1 -->
<!-- * Description of change 2 -->
<!-- ... -->

Add AssertMinNumberOfCalls including test case.

## Motivation
<!-- Why were the changes necessary. -->
In distributed systems, it's often necessary to send messages at least n times. With this new method, it's easy to check that a certain method was called at least n times.

<!-- ## Example usage (if applicable) -->
