### PR TITLE
Use (time.Time).Equal for time objects

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -60,6 +60,12 @@ func ObjectsAreEqual(expected, actual interface{}) bool {
 		return expected == actual
 	}
 
+	if e, ok := objectToTime(expected); ok {
+		if a, ok := objectToTime(actual); ok {
+			return e.Equal(a)
+		}
+	}
+
 	exp, ok := expected.([]byte)
 	if !ok {
 		return reflect.DeepEqual(expected, actual)
@@ -73,6 +79,20 @@ func ObjectsAreEqual(expected, actual interface{}) bool {
 		return exp == nil && act == nil
 	}
 	return bytes.Equal(exp, act)
+}
+
+func objectToTime(o interface{}) (time.Time, bool) {
+	s, ok := o.(time.Time)
+	if ok {
+		return s, ok
+	}
+
+	p, ok := o.(*time.Time)
+	if ok {
+		return *p, true
+	}
+
+	return time.Time{}, false
 }
 
 // ObjectsAreEqualValues gets whether two objects are equal, or if their

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -1990,7 +1990,7 @@ func TestTimeEqualUsesBuiltinFunction(t *testing.T) {
 
 // sinkT is a helper TestingT to discard generated errors
 // Is intended to be used when assertion message is not relevant, but result it is
-type sinkT struct {}
+type sinkT struct{}
 
 func (s sinkT) Errorf(string, ...interface{}) {}
 

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -1975,6 +1975,25 @@ Diff:
 	Equal(t, expected, actual)
 }
 
+func TestTimeEqualUsesBuiltinFunction(t *testing.T) {
+	t0, err := time.ParseInLocation("2006-01-02T15:04:05", "2020-03-01T12:23:14", &time.Location{})
+	NoError(t, err)
+
+	t1 := time.Date(2020, 3, 1, 12, 23, 14, 0, time.UTC)
+
+	sinkT := sinkT{}
+	testifyAssertion := Equal(sinkT, t0, t1)
+	builtinAssertion := t0.Equal(t1)
+
+	Equal(t, builtinAssertion, testifyAssertion)
+}
+
+// sinkT is a helper TestingT to discard generated errors
+// Is intended to be used when assertion message is not relevant, but result it is
+type sinkT struct {}
+
+func (s sinkT) Errorf(string, ...interface{}) {}
+
 func TestTimeEqualityErrorFormatting(t *testing.T) {
 	mockT := new(mockTestingT)
 


### PR DESCRIPTION
## Summary
Use built-in Equal method when compare `time.Time` objects

## Changes
When use Equal, try to cast given objects into `time.Time` and uses (time.Time).Equal in case of true

## Motivation
See #1010 

## Related issues
Closes #1010 

Breaking change
