### PR TITLE
[Fix] Limit the spew recursion

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1622,7 +1622,7 @@ var spewConfig = spew.ConfigState{
 	DisableCapacities:       true,
 	SortKeys:                true,
 	DisableMethods:          true,
-	MaxDepth:                100,
+	MaxDepth:                10,
 }
 
 type tHelper interface {

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1622,6 +1622,7 @@ var spewConfig = spew.ConfigState{
 	DisableCapacities:       true,
 	SortKeys:                true,
 	DisableMethods:          true,
+	MaxDepth:                100,
 }
 
 type tHelper interface {


### PR DESCRIPTION
## Summary

The latest update to golang/protobuf (I am on v1.4.2) break the spew circular data structure detection. This means that when calling `assert.Equal(t, proto1, proto2)`, if it fails it will enter an infinite recursion.

By limiting the recursion with `MaxDepth` set to a large number (10 seems reasonable as a struct that is 10 deep will be pretty large) this means that if there is an issue with recursion (as there is with protobuf) the test will still return a failure in a reasonable time instead of just a timeout.

<!-- High-level, one sentence summary of what this PR accomplishes -->

## Changes
Adding MaxDepth to spew output.

## Motivation
Stop infinite loop if spew fails to detect circular recusion.

## Related issues
<!-- Put `Closes #XXXX` for each issue number this PR fixes/closes -->
