### PR TITLE
Fix custom messages in comparison-assertions

### DIFF
--- a/assert/assertion_compare.go
+++ b/assert/assertion_compare.go
@@ -310,7 +310,7 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (CompareType, bool) {
 //    assert.Greater(t, float64(2), float64(1))
 //    assert.Greater(t, "b", "a")
 func Greater(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
-	return compareTwoValues(t, e1, e2, []CompareType{compareGreater}, "\"%v\" is not greater than \"%v\"", msgAndArgs)
+	return compareTwoValues(t, e1, e2, []CompareType{compareGreater}, "\"%v\" is not greater than \"%v\"", msgAndArgs...)
 }
 
 // GreaterOrEqual asserts that the first element is greater than or equal to the second
@@ -320,7 +320,7 @@ func Greater(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface
 //    assert.GreaterOrEqual(t, "b", "a")
 //    assert.GreaterOrEqual(t, "b", "b")
 func GreaterOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
-	return compareTwoValues(t, e1, e2, []CompareType{compareGreater, compareEqual}, "\"%v\" is not greater than or equal to \"%v\"", msgAndArgs)
+	return compareTwoValues(t, e1, e2, []CompareType{compareGreater, compareEqual}, "\"%v\" is not greater than or equal to \"%v\"", msgAndArgs...)
 }
 
 // Less asserts that the first element is less than the second
@@ -329,7 +329,7 @@ func GreaterOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...in
 //    assert.Less(t, float64(1), float64(2))
 //    assert.Less(t, "a", "b")
 func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
-	return compareTwoValues(t, e1, e2, []CompareType{compareLess}, "\"%v\" is not less than \"%v\"", msgAndArgs)
+	return compareTwoValues(t, e1, e2, []CompareType{compareLess}, "\"%v\" is not less than \"%v\"", msgAndArgs...)
 }
 
 // LessOrEqual asserts that the first element is less than or equal to the second
@@ -339,7 +339,7 @@ func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{})
 //    assert.LessOrEqual(t, "a", "b")
 //    assert.LessOrEqual(t, "b", "b")
 func LessOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
-	return compareTwoValues(t, e1, e2, []CompareType{compareLess, compareEqual}, "\"%v\" is not less than or equal to \"%v\"", msgAndArgs)
+	return compareTwoValues(t, e1, e2, []CompareType{compareLess, compareEqual}, "\"%v\" is not less than or equal to \"%v\"", msgAndArgs...)
 }
 
 // Positive asserts that the specified element is positive
@@ -348,7 +348,7 @@ func LessOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...inter
 //    assert.Positive(t, 1.23)
 func Positive(t TestingT, e interface{}, msgAndArgs ...interface{}) bool {
 	zero := reflect.Zero(reflect.TypeOf(e))
-	return compareTwoValues(t, e, zero.Interface(), []CompareType{compareGreater}, "\"%v\" is not positive", msgAndArgs)
+	return compareTwoValues(t, e, zero.Interface(), []CompareType{compareGreater}, "\"%v\" is not positive", msgAndArgs...)
 }
 
 // Negative asserts that the specified element is negative
@@ -357,7 +357,7 @@ func Positive(t TestingT, e interface{}, msgAndArgs ...interface{}) bool {
 //    assert.Negative(t, -1.23)
 func Negative(t TestingT, e interface{}, msgAndArgs ...interface{}) bool {
 	zero := reflect.Zero(reflect.TypeOf(e))
-	return compareTwoValues(t, e, zero.Interface(), []CompareType{compareLess}, "\"%v\" is not negative", msgAndArgs)
+	return compareTwoValues(t, e, zero.Interface(), []CompareType{compareLess}, "\"%v\" is not negative", msgAndArgs...)
 }
 
 func compareTwoValues(t TestingT, e1 interface{}, e2 interface{}, allowedComparesResults []CompareType, failMessage string, msgAndArgs ...interface{}) bool {

--- a/assert/assertion_compare_test.go
+++ b/assert/assertion_compare_test.go
@@ -251,6 +251,22 @@ func TestLessOrEqual(t *testing.T) {
 	}
 }
 
+func TestComparisonCustomMessages(t *testing.T) {
+	for _, currCase := range []struct {
+		assert func(t TestingT) bool
+		msg    string
+	}{
+		{func(t TestingT) bool { return Greater(t, 1, 2, "%v wasn't greater", 1) }, "1 wasn't greater"},
+		{func(t TestingT) bool { return GreaterOrEqual(t, 1, 2, "%v wasn't greater/equal", 1) }, "1 wasn't greater/equal"},
+		{func(t TestingT) bool { return Less(t, 1, 0, "%v wasn't less", 1) }, "1 wasn't less"},
+		{func(t TestingT) bool { return LessOrEqual(t, 1, 0, "%v wasn't less/equal", 1) }, "1 wasn't less/equal"},
+	} {
+		out := &outputT{buf: bytes.NewBuffer(nil)}
+		False(t, currCase.assert(out))
+		Contains(t, string(out.buf.Bytes()), currCase.msg)
+	}
+}
+
 func TestPositive(t *testing.T) {
 	mockT := new(testing.T)
 


### PR DESCRIPTION
## Summary
This PR fixes custom messages in comparison-assertions.

## Changes
The assesrtions now pass varargs rather than a single slice arg.

## Motivation
The comparison-assertions were passing msgAndArgs as a slice rather than
varargs, which meant that the entire message-and-arguments got printed
as a single slice.  Now it gets printf-ed correctly.  See test cases for examples.

Edit: Fixes the rest of #1034 (the other part was fixed by #1026).