### PR TITLE
Add ErrorContains

### DIFF
--- a/assert/assertion_format.go
+++ b/assert/assertion_format.go
@@ -123,6 +123,18 @@ func ErrorAsf(t TestingT, err error, target interface{}, msg string, args ...int
 	return ErrorAs(t, err, target, append([]interface{}{msg}, args...)...)
 }
 
+// ErrorContainsf asserts that a function returned an error (i.e. not `nil`)
+// and that the error contains the specified substring.
+//
+//   actualObj, err := SomeFunction()
+//   assert.ErrorContainsf(t, err,  expectedErrorSubString, "error message %s", "formatted")
+func ErrorContainsf(t TestingT, theError error, contains string, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return ErrorContains(t, theError, contains, append([]interface{}{msg}, args...)...)
+}
+
 // ErrorIsf asserts that at least one of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
 func ErrorIsf(t TestingT, err error, target error, msg string, args ...interface{}) bool {

--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -222,6 +222,30 @@ func (a *Assertions) ErrorAsf(err error, target interface{}, msg string, args ..
 	return ErrorAsf(a.t, err, target, msg, args...)
 }
 
+// ErrorContains asserts that a function returned an error (i.e. not `nil`)
+// and that the error contains the specified substring.
+//
+//   actualObj, err := SomeFunction()
+//   a.ErrorContains(err,  expectedErrorSubString)
+func (a *Assertions) ErrorContains(theError error, contains string, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return ErrorContains(a.t, theError, contains, msgAndArgs...)
+}
+
+// ErrorContainsf asserts that a function returned an error (i.e. not `nil`)
+// and that the error contains the specified substring.
+//
+//   actualObj, err := SomeFunction()
+//   a.ErrorContainsf(err,  expectedErrorSubString, "error message %s", "formatted")
+func (a *Assertions) ErrorContainsf(theError error, contains string, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return ErrorContainsf(a.t, theError, contains, msg, args...)
+}
+
 // ErrorIs asserts that at least one of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
 func (a *Assertions) ErrorIs(err error, target error, msgAndArgs ...interface{}) bool {

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1375,6 +1375,27 @@ func EqualError(t TestingT, theError error, errString string, msgAndArgs ...inte
 	return true
 }
 
+// ErrorContains asserts that a function returned an error (i.e. not `nil`)
+// and that the error contains the specified substring.
+//
+//   actualObj, err := SomeFunction()
+//   assert.ErrorContains(t, err,  expectedErrorSubString)
+func ErrorContains(t TestingT, theError error, contains string, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if !Error(t, theError, msgAndArgs...) {
+		return false
+	}
+
+	actual := theError.Error()
+	if !strings.Contains(actual, contains) {
+		return Fail(t, fmt.Sprintf("Error %#v does not contain %#v", actual, contains), msgAndArgs...)
+	}
+
+	return true
+}
+
 // matchRegexp return true if a specified regexp matches a string.
 func matchRegexp(rx interface{}, str interface{}) bool {
 

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -1079,6 +1079,24 @@ func TestEqualError(t *testing.T) {
 		"EqualError should return true")
 }
 
+func TestErrorContains(t *testing.T) {
+	mockT := new(testing.T)
+
+	// start with a nil error
+	var err error
+	False(t, ErrorContains(mockT, err, ""),
+		"ErrorContains should return false for nil arg")
+
+	// now set an error
+	err = errors.New("some error: another error")
+	False(t, ErrorContains(mockT, err, "bad error"),
+		"ErrorContains should return false for different error string")
+	True(t, ErrorContains(mockT, err, "some error"),
+		"ErrorContains should return true")
+	True(t, ErrorContains(mockT, err, "another error"),
+		"ErrorContains should return true")
+}
+
 func Test_isEmpty(t *testing.T) {
 
 	chWithValue := make(chan struct{}, 1)

--- a/assert/forward_assertions_test.go
+++ b/assert/forward_assertions_test.go
@@ -315,6 +315,25 @@ func TestErrorWrapper(t *testing.T) {
 
 }
 
+func TestErrorContainsWrapper(t *testing.T) {
+	assert := New(t)
+	mockAssert := New(new(testing.T))
+
+	// start with a nil error
+	var err error
+	assert.False(mockAssert.ErrorContains(err, ""),
+		"ErrorContains should return false for nil arg")
+
+	// now set an error
+	err = errors.New("some error: another error")
+	assert.False(mockAssert.ErrorContains(err, "different error"),
+		"ErrorContains should return false for different error string")
+	assert.True(mockAssert.ErrorContains(err, "some error"),
+		"ErrorContains should return true")
+	assert.True(mockAssert.ErrorContains(err, "another error"),
+		"ErrorContains should return true")
+}
+
 func TestEqualErrorWrapper(t *testing.T) {
 	assert := New(t)
 	mockAssert := New(new(testing.T))

--- a/require/forward_requirements_test.go
+++ b/require/forward_requirements_test.go
@@ -196,6 +196,18 @@ func TestErrorWrapper(t *testing.T) {
 	}
 }
 
+func TestErrorContainsWrapper(t *testing.T) {
+	require := New(t)
+	require.ErrorContains(errors.New("some error: another error"), "some error")
+
+	mockT := new(MockT)
+	mockRequire := New(mockT)
+	mockRequire.ErrorContains(errors.New("some error: another error"), "different error")
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
 func TestEqualErrorWrapper(t *testing.T) {
 	require := New(t)
 	require.EqualError(errors.New("some error"), "some error")

--- a/require/require.go
+++ b/require/require.go
@@ -280,6 +280,36 @@ func ErrorAsf(t TestingT, err error, target interface{}, msg string, args ...int
 	t.FailNow()
 }
 
+// ErrorContains asserts that a function returned an error (i.e. not `nil`)
+// and that the error contains the specified substring.
+//
+//   actualObj, err := SomeFunction()
+//   assert.ErrorContains(t, err,  expectedErrorSubString)
+func ErrorContains(t TestingT, theError error, contains string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ErrorContains(t, theError, contains, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// ErrorContainsf asserts that a function returned an error (i.e. not `nil`)
+// and that the error contains the specified substring.
+//
+//   actualObj, err := SomeFunction()
+//   assert.ErrorContainsf(t, err,  expectedErrorSubString, "error message %s", "formatted")
+func ErrorContainsf(t TestingT, theError error, contains string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ErrorContainsf(t, theError, contains, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
 // ErrorIs asserts that at least one of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
 func ErrorIs(t TestingT, err error, target error, msgAndArgs ...interface{}) {

--- a/require/require_forward.go
+++ b/require/require_forward.go
@@ -223,6 +223,30 @@ func (a *Assertions) ErrorAsf(err error, target interface{}, msg string, args ..
 	ErrorAsf(a.t, err, target, msg, args...)
 }
 
+// ErrorContains asserts that a function returned an error (i.e. not `nil`)
+// and that the error contains the specified substring.
+//
+//   actualObj, err := SomeFunction()
+//   a.ErrorContains(err,  expectedErrorSubString)
+func (a *Assertions) ErrorContains(theError error, contains string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ErrorContains(a.t, theError, contains, msgAndArgs...)
+}
+
+// ErrorContainsf asserts that a function returned an error (i.e. not `nil`)
+// and that the error contains the specified substring.
+//
+//   actualObj, err := SomeFunction()
+//   a.ErrorContainsf(err,  expectedErrorSubString, "error message %s", "formatted")
+func (a *Assertions) ErrorContainsf(theError error, contains string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ErrorContainsf(a.t, theError, contains, msg, args...)
+}
+
 // ErrorIs asserts that at least one of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
 func (a *Assertions) ErrorIs(err error, target error, msgAndArgs ...interface{}) {

--- a/require/requirements_test.go
+++ b/require/requirements_test.go
@@ -208,6 +208,17 @@ func TestError(t *testing.T) {
 	}
 }
 
+func TestErrorContains(t *testing.T) {
+
+	ErrorContains(t, errors.New("some error: another error"), "some error")
+
+	mockT := new(MockT)
+	ErrorContains(mockT, errors.New("some error"), "different error")
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
 func TestEqualError(t *testing.T) {
 
 	EqualError(t, errors.New("some error"), "some error")


### PR DESCRIPTION
## Summary
It's common practice to wrap errors, so that you do not have a transitive dependency on the error format of a third party library, but also so that you are able to exactly match you are testing a specific error case correctly.

This change adds an `ErrorContains()` method to check that both an error is reurned, and it contains a provided string.

## Changes
Added `ErrorContains()` and `ErrorContainsf()`.

## Motivation

When I wrap errors returned from third party modules:

```go
func method(f foo, b bar) error {
        if err := f(); err != nil {
                return fmt.Errorf("foo failed: %w", err)
        }
        if err := b(); err != nil {
                return fmt.Errorf("bar failed: %w", err)
        }
        return nil
}
```

This then forces me to write:

```go
f := func() error { return assert.AnError }
b := func() error { return nil }
err := method(f, b)
require.Error(t, err)
assert.Contains(t, err.Error(), "foo failed")

f = func() error { return nil }
b = func() error { return assert.AnError }
err = method(f, b)
require.Error(t, err)
assert.Contains(t, err.Error(), "bar failed")
```
This change removes the `require` and `Error()` unpacking:

```go
f := func() error { return assert.AnError }
b := func() error { return nil }
err := method(f, b)
assert.ErrorContains(t, err, "foo failed")

f = func() error { return nil }
b = func() error { return assert.AnError }
err = method(f, b)
assert.ErrorContains(t, err, "bar failed")
```

## Related issues

