### PR TITLE
allow testing for functional options

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -665,15 +665,23 @@ func IsType(t interface{}) *IsTypeArgument {
 	return &IsTypeArgument{t: t}
 }
 
+// FunctionalOptionsArgument is a struct that contains the type and value of an functional option argument
+// for use when type checking.
 type FunctionalOptionsArgument struct {
 	name  string
 	value interface{}
 }
 
+// String returns the string representation of FunctionalOptionsArgument
 func (f *FunctionalOptionsArgument) String() string {
 	return strings.Replace(fmt.Sprintf("%#v", f.value), "[]interface {}", f.name, 1)
 }
 
+// FunctionalOptions returns an FunctionalOptionsArgument object containing the functional option type
+// and the values to check of
+//
+// For example:
+// Assert(t, FunctionalOptions("[]foo.FunctionalOption", foo.Opt1(), foo.Opt2()))
 func FunctionalOptions(name string, value ...interface{}) *FunctionalOptionsArgument {
 	return &FunctionalOptionsArgument{
 		name:  name,

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -1071,13 +1071,30 @@ func Test_Mock_AssertExpectationsFunctionalOptionsType(t *testing.T) {
 
 	var mockedService = new(TestExampleImplementation)
 
-	mockedService.On("TheExampleMethodFunctionalOptions", "test", FunctionalOptions("[]mock.OptionFn", OpNum(1), OpStr("foo"))).Return(nil).Once()
+	mockedService.On("TheExampleMethodFunctionalOptions", "test", FunctionalOptions(OpNum(1), OpStr("foo"))).Return(nil).Once()
 
 	tt := new(testing.T)
 	assert.False(t, mockedService.AssertExpectations(tt))
 
 	// make the call now
 	mockedService.TheExampleMethodFunctionalOptions("test", OpNum(1), OpStr("foo"))
+
+	// now assert expectations
+	assert.True(t, mockedService.AssertExpectations(tt))
+
+}
+
+func Test_Mock_AssertExpectationsFunctionalOptionsType_Empty(t *testing.T) {
+
+	var mockedService = new(TestExampleImplementation)
+
+	mockedService.On("TheExampleMethodFunctionalOptions", "test", FunctionalOptions()).Return(nil).Once()
+
+	tt := new(testing.T)
+	assert.False(t, mockedService.AssertExpectations(tt))
+
+	// make the call now
+	mockedService.TheExampleMethodFunctionalOptions("test")
 
 	// now assert expectations
 	assert.True(t, mockedService.AssertExpectations(tt))

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -32,6 +32,29 @@ func (i *TestExampleImplementation) TheExampleMethod(a, b, c int) (int, error) {
 	return args.Int(0), errors.New("Whoops")
 }
 
+type options struct {
+	num int
+	str string
+}
+
+type OptionFn func(*options)
+
+func OpNum(n int) OptionFn {
+	return func(o *options) {
+		o.num = n
+	}
+}
+
+func OpStr(s string) OptionFn {
+	return func(o *options) {
+		o.str = s
+	}
+}
+func (i *TestExampleImplementation) TheExampleMethodFunctionalOptions(x string, opts ...OptionFn) error {
+	args := i.Called(x, opts)
+	return args.Error(0)
+}
+
 //go:noinline
 func (i *TestExampleImplementation) TheExampleMethod2(yesorno bool) {
 	i.Called(yesorno)
@@ -1038,6 +1061,23 @@ func Test_Mock_AssertExpectationsCustomType(t *testing.T) {
 
 	// make the call now
 	mockedService.TheExampleMethod3(&ExampleType{})
+
+	// now assert expectations
+	assert.True(t, mockedService.AssertExpectations(tt))
+
+}
+
+func Test_Mock_AssertExpectationsFunctionalOptionsType(t *testing.T) {
+
+	var mockedService = new(TestExampleImplementation)
+
+	mockedService.On("TheExampleMethodFunctionalOptions", "test", FunctionalOptions("[]mock.OptionFn", OpNum(1), OpStr("foo"))).Return(nil).Once()
+
+	tt := new(testing.T)
+	assert.False(t, mockedService.AssertExpectations(tt))
+
+	// make the call now
+	mockedService.TheExampleMethodFunctionalOptions("test", OpNum(1), OpStr("foo"))
 
 	// now assert expectations
 	assert.True(t, mockedService.AssertExpectations(tt))


### PR DESCRIPTION
## Summary

This PR fixes #997 

In most go libraries nowadays (etcd, kubernets, aws, etc.) the [functional options pattern](https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis) is being used:

```go
c := client.New(client.WithTimeout(), client.WithLabel("bar"))
```

```go
type opt struct {
  timeout bool
  label string
}

type ClientOption func(*opt)

func WithTimeout() ClientOption {
  return func(o *opt) {
    o.timeout = true
  }
}

func WithLabel(v string) ClientOption {
  return func(o *opt) {
    o.label = v
  }
}

func (c *client) New(opts ...ClientOption) *someClient {
  options := &opt{}
  for _, f := range opts {
    f(options)
  }

  return &someClient{options.timeout, options.label}
}
```

## Changes
Adds a new argument type `FunctionalOptions`

## Motivation
This wasn't possible before.

## Related issues
Closes #997 #1006 
