### PR TITLE
Modify testify to allow for testing proto equality

### DIFF
--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -100,7 +100,25 @@ func (a *AssertionTesterConformingObject) TestMethod() {
 type AssertionTesterNonConformingObject struct {
 }
 
+type TestProto struct {
+	Field1        string
+	state         string
+	sizeCache     string
+	unknownFields string
+}
+
+type TestProto2 struct {
+	Test *TestProto
+}
+
 func TestObjectsAreEqual(t *testing.T) {
+	testProtoA := &TestProto{Field1: "A", state: "A", sizeCache: "A", unknownFields: "A"}
+	testProtoB := &TestProto{Field1: "A", state: "B", sizeCache: "B", unknownFields: "B"}
+	testProtoC := &TestProto{Field1: "B", state: "B", sizeCache: "B", unknownFields: "B"}
+	testProto2A := &TestProto2{testProtoA}
+	testProto2B := &TestProto2{testProtoB}
+	testProto2C := &TestProto2{testProtoC}
+
 	cases := []struct {
 		expected interface{}
 		actual   interface{}
@@ -112,6 +130,9 @@ func TestObjectsAreEqual(t *testing.T) {
 		{123.5, 123.5, true},
 		{[]byte("Hello World"), []byte("Hello World"), true},
 		{nil, nil, true},
+		{testProtoA, testProtoB, true},
+		{[]*TestProto{testProtoA}, []*TestProto{testProtoB}, true},
+		{testProto2A, testProto2B, true},
 
 		// cases that are expected not to be equal
 		{map[int]int{5: 10}, map[int]int{10: 20}, false},
@@ -122,6 +143,9 @@ func TestObjectsAreEqual(t *testing.T) {
 		{time.Now, time.Now, false},
 		{func() {}, func() {}, false},
 		{uint32(10), int32(10), false},
+		{testProtoA, testProtoC, false},
+		{[]*TestProto{testProtoA}, []*TestProto{testProtoC}, false},
+		{testProto2A, testProto2C, false},
 	}
 
 	for _, c := range cases {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/davecgh/go-spew v1.1.0
+	github.com/google/go-cmp v0.5.4
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/stretchr/objx v0.1.0
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,12 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
+github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=


### PR DESCRIPTION
The default testify library breaks on assert.Equal for new protobuf messages.

This modifies testify to bring in go-cmp; it then ignores the protobuf-generated fields.
