### PR TITLE
Closes #1040

### DIFF
--- a/assert/assertion_format.go
+++ b/assert/assertion_format.go
@@ -421,11 +421,11 @@ func JSONEqf(t TestingT, expected string, actual string, msg string, args ...int
 // Lenf also fails if the object has a type that len() not accept.
 //
 //    assert.Lenf(t, mySlice, 3, "error message %s", "formatted")
-func Lenf(t TestingT, object interface{}, length int, msg string, args ...interface{}) bool {
+func Lenf(t TestingT, expected int, actual interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	return Len(t, object, length, append([]interface{}{msg}, args...)...)
+	return Len(t, expected, actual, append([]interface{}{msg}, args...)...)
 }
 
 // Lessf asserts that the first element is less than the second

--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -827,22 +827,22 @@ func (a *Assertions) JSONEqf(expected string, actual string, msg string, args ..
 // Len also fails if the object has a type that len() not accept.
 //
 //    a.Len(mySlice, 3)
-func (a *Assertions) Len(object interface{}, length int, msgAndArgs ...interface{}) bool {
+func (a *Assertions) Len(expected int, object interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
-	return Len(a.t, object, length, msgAndArgs...)
+	return Len(a.t, expected, object, msgAndArgs...)
 }
 
 // Lenf asserts that the specified object has specific length.
 // Lenf also fails if the object has a type that len() not accept.
 //
 //    a.Lenf(mySlice, 3, "error message %s", "formatted")
-func (a *Assertions) Lenf(object interface{}, length int, msg string, args ...interface{}) bool {
+func (a *Assertions) Lenf(length int, object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
-	return Lenf(a.t, object, length, msg, args...)
+	return Lenf(a.t, length, object, msg, args...)
 }
 
 // Less asserts that the first element is less than the second

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -631,17 +631,17 @@ func getLen(x interface{}) (ok bool, length int) {
 // Len also fails if the object has a type that len() not accept.
 //
 //    assert.Len(t, mySlice, 3)
-func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) bool {
+func Len(t TestingT, expected int, actual interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	ok, l := getLen(object)
+	ok, l := getLen(actual)
 	if !ok {
-		return Fail(t, fmt.Sprintf("\"%s\" could not be applied builtin len()", object), msgAndArgs...)
+		return Fail(t, fmt.Sprintf("\"%s\" could not be applied builtin len()", actual), msgAndArgs...)
 	}
 
-	if l != length {
-		return Fail(t, fmt.Sprintf("\"%s\" should have %d item(s), but has %d", object, length, l), msgAndArgs...)
+	if l != expected {
+		return Fail(t, fmt.Sprintf("\"%s\" should have %d item(s), but has %d", actual, expected, l), msgAndArgs...)
 	}
 	return true
 }

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -1235,12 +1235,12 @@ func Test_getLen(t *testing.T) {
 func TestLen(t *testing.T) {
 	mockT := new(testing.T)
 
-	False(t, Len(mockT, nil, 0), "nil does not have length")
+	False(t, Len(mockT, 0, nil), "nil does not have length")
 	False(t, Len(mockT, 0, 0), "int does not have length")
-	False(t, Len(mockT, true, 0), "true does not have length")
-	False(t, Len(mockT, false, 0), "false does not have length")
+	False(t, Len(mockT, 0, true), "true does not have length")
+	False(t, Len(mockT, 0, false), "false does not have length")
 	False(t, Len(mockT, 'A', 0), "Rune does not have length")
-	False(t, Len(mockT, struct{}{}, 0), "Struct does not have length")
+	False(t, Len(mockT, 0, struct{}{}), "Struct does not have length")
 
 	ch := make(chan int, 5)
 	ch <- 1
@@ -1267,7 +1267,7 @@ func TestLen(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		True(t, Len(mockT, c.v, c.l), "%#v have %d items", c.v, c.l)
+		True(t, Len(mockT, c.l, c.v), "%#v have %d items", c.v, c.l)
 	}
 
 	cases = []struct {
@@ -1290,7 +1290,7 @@ func TestLen(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		False(t, Len(mockT, c.v, c.l), "%#v have %d items", c.v, c.l)
+		False(t, Len(mockT, c.l, c.v), "%#v have %d items", c.v, c.l)
 	}
 }
 

--- a/assert/forward_assertions_test.go
+++ b/assert/forward_assertions_test.go
@@ -391,12 +391,12 @@ func TestLenWrapper(t *testing.T) {
 	assert := New(t)
 	mockAssert := New(new(testing.T))
 
-	assert.False(mockAssert.Len(nil, 0), "nil does not have length")
+	assert.False(mockAssert.Len(0, nil), "nil does not have length")
 	assert.False(mockAssert.Len(0, 0), "int does not have length")
-	assert.False(mockAssert.Len(true, 0), "true does not have length")
-	assert.False(mockAssert.Len(false, 0), "false does not have length")
+	assert.False(mockAssert.Len(0, true), "true does not have length")
+	assert.False(mockAssert.Len(0, false), "false does not have length")
 	assert.False(mockAssert.Len('A', 0), "Rune does not have length")
-	assert.False(mockAssert.Len(struct{}{}, 0), "Struct does not have length")
+	assert.False(mockAssert.Len(0, struct{}{}), "Struct does not have length")
 
 	ch := make(chan int, 5)
 	ch <- 1
@@ -423,7 +423,7 @@ func TestLenWrapper(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		assert.True(mockAssert.Len(c.v, c.l), "%#v have %d items", c.v, c.l)
+		assert.True(mockAssert.Len(c.l, c.v), "%#v have %d items", c.v, c.l)
 	}
 }
 

--- a/require/require.go
+++ b/require/require.go
@@ -6,10 +6,11 @@
 package require
 
 import (
-	assert "github.com/stretchr/testify/assert"
 	http "net/http"
 	url "net/url"
 	time "time"
+
+	assert "github.com/stretchr/testify/assert"
 )
 
 // Condition uses a Comparison to assert a complex condition.
@@ -1056,25 +1057,25 @@ func JSONEqf(t TestingT, expected string, actual string, msg string, args ...int
 // Len also fails if the object has a type that len() not accept.
 //
 //    assert.Len(t, mySlice, 3)
-func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) {
+func Len(t TestingT, expected int, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	if assert.Len(t, object, length, msgAndArgs...) {
+	if assert.Len(t, expected, actual, msgAndArgs...) {
 		return
 	}
 	t.FailNow()
 }
 
 // Lenf asserts that the specified object has specific length.
-// Lenf also fails if the object has a type that len() not accept.
+// Lenf also fails if the object has a type that len() doesn't accept.
 //
 //    assert.Lenf(t, mySlice, 3, "error message %s", "formatted")
-func Lenf(t TestingT, object interface{}, length int, msg string, args ...interface{}) {
+func Lenf(t TestingT, expected int, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	if assert.Lenf(t, object, length, msg, args...) {
+	if assert.Lenf(t, expected, actual, msg, args...) {
 		return
 	}
 	t.FailNow()

--- a/require/require_forward.go
+++ b/require/require_forward.go
@@ -6,10 +6,11 @@
 package require
 
 import (
-	assert "github.com/stretchr/testify/assert"
 	http "net/http"
 	url "net/url"
 	time "time"
+
+	assert "github.com/stretchr/testify/assert"
 )
 
 // Condition uses a Comparison to assert a complex condition.
@@ -828,22 +829,22 @@ func (a *Assertions) JSONEqf(expected string, actual string, msg string, args ..
 // Len also fails if the object has a type that len() not accept.
 //
 //    a.Len(mySlice, 3)
-func (a *Assertions) Len(object interface{}, length int, msgAndArgs ...interface{}) {
+func (a *Assertions) Len(length int, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
-	Len(a.t, object, length, msgAndArgs...)
+	Len(a.t, length, object, msgAndArgs...)
 }
 
 // Lenf asserts that the specified object has specific length.
 // Lenf also fails if the object has a type that len() not accept.
 //
 //    a.Lenf(mySlice, 3, "error message %s", "formatted")
-func (a *Assertions) Lenf(object interface{}, length int, msg string, args ...interface{}) {
+func (a *Assertions) Lenf(length int, object interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
-	Lenf(a.t, object, length, msg, args...)
+	Lenf(a.t, length, object, msg, args...)
 }
 
 // Less asserts that the first element is less than the second


### PR DESCRIPTION
fixed argument order

## Summary
Fixes the order of Len and Lenf functions (like Equals)

## Related issues
Closes #1040 
