### PR TITLE
#750: added NoErrors to assert and require

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1335,6 +1335,17 @@ func NoError(t TestingT, err error, msgAndArgs ...interface{}) bool {
 	return true
 }
 
+// NoErrors asserts that multiple functions return no errors
+func NoErrors(t TestingT, msg string, errors ...error) bool {
+	for index, err := range errors {
+		message := fmt.Sprintf("error found in index %d -> %s", index, msg)
+		if !NoError(t, err, message) {
+			return false
+		}
+	}
+	return true
+}
+
 // Error asserts that a function returned an error (i.e. not `nil`).
 //
 //   actualObj, err := SomeFunction()

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -1029,6 +1029,14 @@ func TestNoError(t *testing.T) {
 	False(t, NoError(mockT, err), "NoError should fail with empty error interface")
 }
 
+func TestNoErrors(t *testing.T) {
+	mockT := new(testing.T)
+
+	True(t, NoErrors(mockT, "nils should cause absolutely no problem", nil, nil, nil))
+
+	False(t, NoErrors(mockT, "errors should cause a bunch of problems", errors.New("error1"), errors.New("error2"), errors.New("error3")))
+}
+
 type customError struct{}
 
 func (*customError) Error() string { return "fail" }

--- a/require/require.go
+++ b/require/require.go
@@ -6,10 +6,12 @@
 package require
 
 import (
-	assert "github.com/stretchr/testify/assert"
+	"fmt"
 	http "net/http"
 	url "net/url"
 	time "time"
+
+	assert "github.com/stretchr/testify/assert"
 )
 
 // Condition uses a Comparison to assert a complex condition.
@@ -1278,6 +1280,17 @@ func NoErrorf(t TestingT, err error, msg string, args ...interface{}) {
 		return
 	}
 	t.FailNow()
+}
+
+// NoErrors requires multiple functions not to return any errors
+func NoErrors(t TestingT, msg string, errors ...error) {
+	for index, err := range errors {
+		message := fmt.Sprintf("error found in index %d -> %s", index, msg)
+		if !assert.NoError(t, err, message) {
+			t.FailNow()
+		}
+
+	}
 }
 
 // NoFileExists checks whether a file does not exist in a given path. It fails

--- a/require/requirements_test.go
+++ b/require/requirements_test.go
@@ -197,6 +197,15 @@ func TestNoError(t *testing.T) {
 	}
 }
 
+func TestNoErrors(t *testing.T) {
+	NoErrors(t, "nils should not cause any trouble", nil, nil, nil)
+	mockT := new(MockT)
+	NoErrors(mockT, "multiple errors", errors.New("some error"), errors.New("some error 2"), errors.New("some error 3"))
+	if !mockT.Failed {
+		t.Error("Check should fail")
+	}
+}
+
 func TestError(t *testing.T) {
 
 	Error(t, errors.New("some error"))


### PR DESCRIPTION
## Summary
added NoErrors to assert and require

## Changes
NoErrors function in assertions.go and require.go

## Example usage 
assert.NoErrors(t, "message", possibleError1, possibleError2, possibleError3)

## Related issues
Closes #750 
