### PR TITLE
time equal added

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -60,6 +60,12 @@ func ObjectsAreEqual(expected, actual interface{}) bool {
 		return expected == actual
 	}
 
+	if e, ok := objectToTime(expected); ok {
+		if a, ok := objectToTime(actual); ok {
+			return e.Equal(a)
+		}
+	}
+
 	exp, ok := expected.([]byte)
 	if !ok {
 		return reflect.DeepEqual(expected, actual)
@@ -1792,4 +1798,17 @@ func buildErrorChainString(err error) string {
 		e = errors.Unwrap(e)
 	}
 	return chain
+}
+
+// objectToTime is used to convert an object to time.Time
+func objectToTime(o interface{}) (time.Time, bool) {
+	if s, ok := o.(time.Time); ok {
+		return s, true
+	}
+	if p, ok := o.(*time.Time); ok {
+		if p != nil {
+			return *p, true
+		}
+	}
+	return time.Time{}, false
 }

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -198,10 +198,14 @@ func TestEqual(t *testing.T) {
 		{uint64(123), uint64(123), true, ""},
 		{myType("1"), myType("1"), true, ""},
 		{&struct{}{}, &struct{}{}, true, "pointer equality is based on equality of underlying value"},
+		{time.Date(2020, 3, 1, 12, 23, 14, 0, time.UTC), time.Date(2020, 3, 1, 12, 23, 14, 0, time.UTC), true, ""},
+		{time.Date(2020, 6, 3, 12, 23, 14, 0, time.UTC), time.Date(2020, 6, 3, 12, 23, 14, 0, time.UTC), true, ""},
 
 		// Not expected to be equal
 		{m["bar"], "something", false, ""},
 		{myType("1"), myType("2"), false, ""},
+		{time.Date(2020, 3, 1, 12, 23, 14, 0, time.UTC), time.Date(2020, 5, 1, 12, 23, 14, 0, time.UTC), false, ""},
+		{time.Date(2020, 6, 3, 12, 23, 14, 0, time.UTC), time.Date(2020, 8, 3, 12, 23, 14, 0, time.UTC), false, ""},
 
 		// A case that might be confusing, especially with numeric literals
 		{10, uint(10), false, ""},


### PR DESCRIPTION
assert.Equal is now able to compare time.Time objects (issue #1010)