### PR TITLE
mock: fix Maybe().Times(n) and little refactoring

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -650,11 +650,13 @@ func (m *Mock) AssertExpectations(t TestingT) bool {
 }
 
 func (m *Mock) checkExpectation(call *Call) (bool, string) {
-	if !call.optional && !m.methodWasCalled(call.Method, call.Arguments) && call.totalCalls == 0 {
-		return false, fmt.Sprintf("FAIL:\t%s(%s)\n\t\tat: %s", call.Method, call.Arguments.String(), call.callerInfo)
-	}
-	if call.Repeatability > 0 {
-		return false, fmt.Sprintf("FAIL:\t%s(%s)\n\t\tat: %s", call.Method, call.Arguments.String(), call.callerInfo)
+	if !call.optional {
+		if !m.methodWasCalled(call.Method, call.Arguments) && call.totalCalls == 0 {
+			return false, fmt.Sprintf("FAIL:\t%s(%s)\n\t\tat: %s", call.Method, call.Arguments.String(), call.callerInfo)
+		}
+		if call.Repeatability > 0 {
+			return false, fmt.Sprintf("FAIL:\t%s(%s)\n\t\tat: %s", call.Method, call.Arguments.String(), call.callerInfo)
+		}
 	}
 	return true, fmt.Sprintf("PASS:\t%s(%s)", call.Method, call.Arguments.String())
 }

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -1709,6 +1709,24 @@ func Test_Mock_AssertExpectations_Skipped_Test(t *testing.T) {
 	t.Skip("skipping test to ensure AssertExpectations does not fail")
 }
 
+func Test_Mock_AssertExpectations_With_Optional_Repeatability(t *testing.T) {
+	t.Parallel()
+
+	var mockedService = new(TestExampleImplementation)
+
+	mockedService.On("Test_Mock_AssertExpectations_With_Optional_Repeatability", 1, 2, 3).Maybe().Once().Return(5, 6, 7)
+
+	tt := new(testing.T)
+	assert.True(t, mockedService.AssertExpectations(tt))
+
+	mockedService.Called(1, 2, 3)
+
+	assert.True(t, mockedService.AssertExpectations(tt))
+	assert.Panics(t, func() {
+		mockedService.Called(1, 2, 3)
+	})
+}
+
 func Test_Mock_TwoCallsWithDifferentArguments(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
Allow optional calls with fixed repetitions: `m.Maybe().Once() == at most once`

## Changes
Besides little refactoring for readability, the change is simple: only return errors for `m.Repeatibility > 0` if `m.optional` is false

## Motivation
I just tried to create such a mock and was surprised that there is an error. I want to have a mock of which method maybe called, and if it is, it should be called only once.

See the example in the new test.
