### PR TITLE
Update versions supported to include `go 1.16`

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ To update Testify to the latest version, use `go get -u github.com/stretchr/test
 Supported go versions
 ==================
 
-We support the three major Go versions, which are 1.13, 1.14 and 1.15 at the moment.
+We currently support the most recent major Go versions from 1.13 onward.
 
 ------
 


### PR DESCRIPTION
Rather than directly adding `1.16`, I thought better to reword to state the minimum version supported... this way the line doesn't have to get updated with every new release, but instead only when dropping support for old releases.