### PR TITLE
assert.InDeltaSlice: fix panic

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1497,6 +1497,10 @@ func InDeltaSlice(t TestingT, expected, actual interface{}, delta float64, msgAn
 	actualSlice := reflect.ValueOf(actual)
 	expectedSlice := reflect.ValueOf(expected)
 
+	if expectedSlice.Len() < actualSlice.Len() {
+		return Fail(t, fmt.Sprintf("Too few elements in expected slice"), msgAndArgs...)
+	}
+
 	for i := 0; i < actualSlice.Len(); i++ {
 		result := InDelta(t, actualSlice.Index(i).Interface(), expectedSlice.Index(i).Interface(), delta, msgAndArgs...)
 		if !result {

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1497,14 +1497,14 @@ func InDeltaSlice(t TestingT, expected, actual interface{}, delta float64, msgAn
 	actualSlice := reflect.ValueOf(actual)
 	expectedSlice := reflect.ValueOf(expected)
 
-	if expectedSlice.Len() < actualSlice.Len() {
-		return Fail(t, fmt.Sprintf("Too few elements in expected slice"), msgAndArgs...)
+	expectedLen := expectedSlice.Len()
+	if !Len(t, actual, expectedLen, msgAndArgs...) {
+		return false
 	}
 
-	for i := 0; i < actualSlice.Len(); i++ {
-		result := InDelta(t, actualSlice.Index(i).Interface(), expectedSlice.Index(i).Interface(), delta, msgAndArgs...)
-		if !result {
-			return result
+	for i := 0; i < expectedLen; i++ {
+		if !InDelta(t, actualSlice.Index(i).Interface(), expectedSlice.Index(i).Interface(), delta, msgAndArgs...) {
+			return false
 		}
 	}
 

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -2360,6 +2360,11 @@ func TestInDeltaSlice(t *testing.T) {
 		0.1), "{1, NaN, 2} is not element-wise close to {0, NaN, 3} in delta=0.1")
 
 	False(t, InDeltaSlice(mockT, "", nil, 1), "Expected non numeral slices to fail")
+
+	False(t, InDeltaSlice(mockT,
+		[]float64{1, 2},
+		[]float64{0, 3, 2},
+		1), "Too few elements in expected slice")
 }
 
 func TestInDeltaMapValues(t *testing.T) {

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -2363,8 +2363,13 @@ func TestInDeltaSlice(t *testing.T) {
 
 	False(t, InDeltaSlice(mockT,
 		[]float64{1, 2},
-		[]float64{0, 3, 2},
+		[]float64{1, 2, 3},
 		1), "Too few elements in expected slice")
+
+	False(t, InDeltaSlice(mockT,
+		[]float64{1, 2, 3},
+		[]float64{1, 2},
+		1), "Too much elements in expected slice")
 }
 
 func TestInDeltaMapValues(t *testing.T) {


### PR DESCRIPTION
## Summary

Fix assert.InDeltaSlice to fail instead of to panic when num of elements in expected slice is fewer than actual.

## Changes

When num of elements in expected is fewer than actual, `assert.InDeltaSlice` will fail rather than panic.

The result of test in https://github.com/stretchr/testify/issues/1059#issue-823147438 would be like this.

~~~
--- FAIL: TestInDeltaSlice (0.00s)
    in_delta_slice_test.go:13:
                Error Trace:    in_delta_slice_test.go:13
                Error:          Too few elements in expected slice
                Test:           TestInDeltaSlice
FAIL
FAIL    command-line-arguments  0.224s
FAIL
~~~

## Motivation

Test would stop immediately when one of test panics without recover. At that time the rest of test cases would be skipped.  
Instead, we could continue to run tests by failing.

## Related issues

Closes #1059 
Related to #1263
