### PR TITLE
mock.Anything: a specific type so it can't be mistaken for a string

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -651,12 +651,12 @@ func (m *Mock) calls() []Call {
 type Arguments []interface{}
 
 // Intentionally make mock.Anything a different type from string
-type anything string
+type anything struct{}
 
-const (
+var (
 	// Anything is used in Diff and Assert when the argument being tested
 	// shouldn't be taken into consideration.
-	Anything = anything("mock.Anything")
+	Anything = anything{}
 )
 
 // AnythingOfTypeArgument is a string that contains the type of an argument

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -650,10 +650,13 @@ func (m *Mock) calls() []Call {
 // Arguments holds an array of method arguments or return values.
 type Arguments []interface{}
 
+// Intentionally make mock.Anything a different type from string
+type anything string
+
 const (
 	// Anything is used in Diff and Assert when the argument being tested
 	// shouldn't be taken into consideration.
-	Anything = "mock.Anything"
+	Anything = anything("mock.Anything")
 )
 
 // AnythingOfTypeArgument is a string that contains the type of an argument


### PR DESCRIPTION
## Summary

This change makes `mock.Anything` its own type

## Changes
* Introduce a custom internal type for `mock.Anything`

## Motivation
While refactoring tests to use strongly typed `On_` calls generated by mockery with this PR  https://github.com/vektra/mockery/pull/375 I started getting unexpected test failures because some tests were using `mock.Anything` where a string was expected and the functions were receiving `"mock.Anything"` as the parameter. `mock.Anything` should have its own type to make situations like this a compile-time error. I don't believe this change should affect existing tests that use `mock.Anything`.
