### PR TITLE
assert: add NonPositive and NonNegative

### DIFF
--- a/assert/assertion_compare.go
+++ b/assert/assertion_compare.go
@@ -366,6 +366,18 @@ func Positive(t TestingT, e interface{}, msgAndArgs ...interface{}) bool {
 	return compareTwoValues(t, e, zero.Interface(), []CompareType{compareGreater}, "\"%v\" is not positive", msgAndArgs)
 }
 
+// NonPositive asserts that the specified element is positive
+//
+//    assert.Positive(t, 0)
+//    assert.Positive(t, -1.23)
+func NonPositive(t TestingT, e interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	zero := reflect.Zero(reflect.TypeOf(e))
+	return compareTwoValues(t, e, zero.Interface(), []CompareType{compareLess, compareEqual}, "\"%v\" is positive", msgAndArgs)
+}
+
 // Negative asserts that the specified element is negative
 //
 //    assert.Negative(t, -1)
@@ -376,6 +388,18 @@ func Negative(t TestingT, e interface{}, msgAndArgs ...interface{}) bool {
 	}
 	zero := reflect.Zero(reflect.TypeOf(e))
 	return compareTwoValues(t, e, zero.Interface(), []CompareType{compareLess}, "\"%v\" is not negative", msgAndArgs)
+}
+
+// NonNegative asserts that the specified element is non negative
+//
+//    assert.Negative(t, 0)
+//    assert.Negative(t, 1.23)
+func NonNegative(t TestingT, e interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	zero := reflect.Zero(reflect.TypeOf(e))
+	return compareTwoValues(t, e, zero.Interface(), []CompareType{compareGreater, compareEqual}, "\"%v\" is negative", msgAndArgs)
 }
 
 func compareTwoValues(t TestingT, e1 interface{}, e2 interface{}, allowedComparesResults []CompareType, failMessage string, msgAndArgs ...interface{}) bool {

--- a/assert/assertion_compare_test.go
+++ b/assert/assertion_compare_test.go
@@ -321,23 +321,23 @@ func TestNonPositive(t *testing.T) {
 	mockT := new(testing.T)
 
 	if !NonPositive(mockT, -1) {
-		t.Error("Positive should return true")
+		t.Error("NonPositive should return true")
 	}
 
 	if !NonPositive(mockT, -1.23) {
-		t.Error("Positive should return true")
+		t.Error("NonPositive should return true")
 	}
 
 	if !NonPositive(mockT, 0) {
-		t.Error("Zero should return true")
+		t.Error("NonPositive should return true")
 	}
 
 	if NonPositive(mockT, 1) {
-		t.Error("Positive should return false")
+		t.Error("NonPositive should return false")
 	}
 
 	if NonPositive(mockT, 1.23) {
-		t.Error("Positive should return false")
+		t.Error("NonPositive should return false")
 	}
 
 	// Check error report
@@ -356,7 +356,7 @@ func TestNonPositive(t *testing.T) {
 		out := &outputT{buf: bytes.NewBuffer(nil)}
 		False(t, NonPositive(out, currCase.e))
 		Contains(t, string(out.buf.Bytes()), currCase.msg)
-		Contains(t, out.helpers, "github.com/stretchr/testify/assert.Positive")
+		Contains(t, out.helpers, "github.com/stretchr/testify/assert.NonPositive")
 	}
 }
 
@@ -402,24 +402,24 @@ func TestNegative(t *testing.T) {
 func TestNonNegative(t *testing.T) {
 	mockT := new(testing.T)
 
-	if !Negative(mockT, -1) {
-		t.Error("Negative should return true")
+	if !NonNegative(mockT, 1) {
+		t.Error("NonNegative should return true")
 	}
 
-	if !Negative(mockT, -1.23) {
-		t.Error("Negative should return true")
+	if !NonNegative(mockT, 1.23) {
+		t.Error("NonNegative should return true")
 	}
 
-	if !Negative(mockT, 0) {
-		t.Error("Zero should return true")
+	if !NonNegative(mockT, 0) {
+		t.Error("NonNegative should return true")
 	}
 
-	if Negative(mockT, 1) {
-		t.Error("Negative should return false")
+	if NonNegative(mockT, -1) {
+		t.Error("NonNegative should return false")
 	}
 
-	if Negative(mockT, 1.23) {
-		t.Error("Negative should return false")
+	if NonNegative(mockT, -1.23) {
+		t.Error("NonNegative should return false")
 	}
 
 	// Check error report
@@ -427,18 +427,18 @@ func TestNonNegative(t *testing.T) {
 		e   interface{}
 		msg string
 	}{
-		{e: int(-1), msg: `"-1" is not negative`},
-		{e: int8(-1), msg: `"-1" is not negative`},
-		{e: int16(-1), msg: `"-1" is not negative`},
-		{e: int32(-1), msg: `"-1" is not negative`},
-		{e: int64(-1), msg: `"-1" is not negative`},
-		{e: float32(-1.23), msg: `"-1.23" is not negative`},
-		{e: float64(-1.23), msg: `"-1.23" is not negative`},
+		{e: int(-1), msg: `"-1" is negative`},
+		{e: int8(-1), msg: `"-1" is negative`},
+		{e: int16(-1), msg: `"-1" is negative`},
+		{e: int32(-1), msg: `"-1" is negative`},
+		{e: int64(-1), msg: `"-1" is negative`},
+		{e: float32(-1.23), msg: `"-1.23" is negative`},
+		{e: float64(-1.23), msg: `"-1.23" is negative`},
 	} {
 		out := &outputT{buf: bytes.NewBuffer(nil)}
 		False(t, NonNegative(out, currCase.e))
 		Contains(t, string(out.buf.Bytes()), currCase.msg)
-		Contains(t, out.helpers, "github.com/stretchr/testify/assert.Negative")
+		Contains(t, out.helpers, "github.com/stretchr/testify/assert.NonNegative")
 	}
 }
 

--- a/assert/assertion_compare_test.go
+++ b/assert/assertion_compare_test.go
@@ -317,6 +317,49 @@ func TestPositive(t *testing.T) {
 	}
 }
 
+func TestNonPositive(t *testing.T) {
+	mockT := new(testing.T)
+
+	if !NonPositive(mockT, -1) {
+		t.Error("Positive should return true")
+	}
+
+	if !NonPositive(mockT, -1.23) {
+		t.Error("Positive should return true")
+	}
+
+	if !NonPositive(mockT, 0) {
+		t.Error("Zero should return true")
+	}
+
+	if NonPositive(mockT, 1) {
+		t.Error("Positive should return false")
+	}
+
+	if NonPositive(mockT, 1.23) {
+		t.Error("Positive should return false")
+	}
+
+	// Check error report
+	for _, currCase := range []struct {
+		e   interface{}
+		msg string
+	}{
+		{e: int(1), msg: `"1" is positive`},
+		{e: int8(1), msg: `"1" is positive`},
+		{e: int16(1), msg: `"1" is positive`},
+		{e: int32(1), msg: `"1" is positive`},
+		{e: int64(1), msg: `"1" is positive`},
+		{e: float32(1.23), msg: `"1.23" is positive`},
+		{e: float64(1.23), msg: `"1.23" is positive`},
+	} {
+		out := &outputT{buf: bytes.NewBuffer(nil)}
+		False(t, NonPositive(out, currCase.e))
+		Contains(t, string(out.buf.Bytes()), currCase.msg)
+		Contains(t, out.helpers, "github.com/stretchr/testify/assert.Positive")
+	}
+}
+
 func TestNegative(t *testing.T) {
 	mockT := new(testing.T)
 
@@ -351,6 +394,49 @@ func TestNegative(t *testing.T) {
 	} {
 		out := &outputT{buf: bytes.NewBuffer(nil)}
 		False(t, Negative(out, currCase.e))
+		Contains(t, string(out.buf.Bytes()), currCase.msg)
+		Contains(t, out.helpers, "github.com/stretchr/testify/assert.Negative")
+	}
+}
+
+func TestNonNegative(t *testing.T) {
+	mockT := new(testing.T)
+
+	if !Negative(mockT, -1) {
+		t.Error("Negative should return true")
+	}
+
+	if !Negative(mockT, -1.23) {
+		t.Error("Negative should return true")
+	}
+
+	if !Negative(mockT, 0) {
+		t.Error("Zero should return true")
+	}
+
+	if Negative(mockT, 1) {
+		t.Error("Negative should return false")
+	}
+
+	if Negative(mockT, 1.23) {
+		t.Error("Negative should return false")
+	}
+
+	// Check error report
+	for _, currCase := range []struct {
+		e   interface{}
+		msg string
+	}{
+		{e: int(-1), msg: `"-1" is not negative`},
+		{e: int8(-1), msg: `"-1" is not negative`},
+		{e: int16(-1), msg: `"-1" is not negative`},
+		{e: int32(-1), msg: `"-1" is not negative`},
+		{e: int64(-1), msg: `"-1" is not negative`},
+		{e: float32(-1.23), msg: `"-1.23" is not negative`},
+		{e: float64(-1.23), msg: `"-1.23" is not negative`},
+	} {
+		out := &outputT{buf: bytes.NewBuffer(nil)}
+		False(t, NonNegative(out, currCase.e))
 		Contains(t, string(out.buf.Bytes()), currCase.msg)
 		Contains(t, out.helpers, "github.com/stretchr/testify/assert.Negative")
 	}

--- a/assert/assertion_format.go
+++ b/assert/assertion_format.go
@@ -464,6 +464,17 @@ func Negativef(t TestingT, e interface{}, msg string, args ...interface{}) bool 
 	return Negative(t, e, append([]interface{}{msg}, args...)...)
 }
 
+// Negativef asserts that the specified element is non negative
+//
+//    assert.Negativef(t, -1, "error message %s", "formatted")
+//    assert.Negativef(t, -1.23, "error message %s", "formatted")
+func NonNegativef(t TestingT, e interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return NonNegative(t, e, append([]interface{}{msg}, args...)...)
+}
+
 // Neverf asserts that the given condition doesn't satisfy in waitFor time,
 // periodically checking the target function each tick.
 //
@@ -679,6 +690,17 @@ func Positivef(t TestingT, e interface{}, msg string, args ...interface{}) bool 
 		h.Helper()
 	}
 	return Positive(t, e, append([]interface{}{msg}, args...)...)
+}
+
+// NonPositivef asserts that the specified element is non positive
+//
+//    assert.NonPositivef(t, 1, "error message %s", "formatted")
+//    assert.NonPositivef(t, 1.23, "error message %s", "formatted")
+func NonPositivef(t TestingT, e interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return NonPositive(t, e, append([]interface{}{msg}, args...)...)
 }
 
 // Regexpf asserts that a specified regexp matches a string.

--- a/assert/assertion_format.go
+++ b/assert/assertion_format.go
@@ -464,17 +464,6 @@ func Negativef(t TestingT, e interface{}, msg string, args ...interface{}) bool 
 	return Negative(t, e, append([]interface{}{msg}, args...)...)
 }
 
-// Negativef asserts that the specified element is non negative
-//
-//    assert.Negativef(t, -1, "error message %s", "formatted")
-//    assert.Negativef(t, -1.23, "error message %s", "formatted")
-func NonNegativef(t TestingT, e interface{}, msg string, args ...interface{}) bool {
-	if h, ok := t.(tHelper); ok {
-		h.Helper()
-	}
-	return NonNegative(t, e, append([]interface{}{msg}, args...)...)
-}
-
 // Neverf asserts that the given condition doesn't satisfy in waitFor time,
 // periodically checking the target function each tick.
 //
@@ -525,6 +514,28 @@ func NoFileExistsf(t TestingT, path string, msg string, args ...interface{}) boo
 		h.Helper()
 	}
 	return NoFileExists(t, path, append([]interface{}{msg}, args...)...)
+}
+
+// NonNegativef asserts that the specified element is non negative
+//
+//    assert.Negative(t, 0)
+//    assert.Negative(t, 1.23)
+func NonNegativef(t TestingT, e interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return NonNegative(t, e, append([]interface{}{msg}, args...)...)
+}
+
+// NonPositivef asserts that the specified element is positive
+//
+//    assert.Positive(t, 0)
+//    assert.Positive(t, -1.23)
+func NonPositivef(t TestingT, e interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return NonPositive(t, e, append([]interface{}{msg}, args...)...)
 }
 
 // NotContainsf asserts that the specified string, list(array, slice...) or map does NOT contain the
@@ -690,17 +701,6 @@ func Positivef(t TestingT, e interface{}, msg string, args ...interface{}) bool 
 		h.Helper()
 	}
 	return Positive(t, e, append([]interface{}{msg}, args...)...)
-}
-
-// NonPositivef asserts that the specified element is non positive
-//
-//    assert.NonPositivef(t, 1, "error message %s", "formatted")
-//    assert.NonPositivef(t, 1.23, "error message %s", "formatted")
-func NonPositivef(t TestingT, e interface{}, msg string, args ...interface{}) bool {
-	if h, ok := t.(tHelper); ok {
-		h.Helper()
-	}
-	return NonPositive(t, e, append([]interface{}{msg}, args...)...)
 }
 
 // Regexpf asserts that a specified regexp matches a string.

--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -1021,6 +1021,50 @@ func (a *Assertions) NoFileExistsf(path string, msg string, args ...interface{})
 	return NoFileExistsf(a.t, path, msg, args...)
 }
 
+// NonNegative asserts that the specified element is non negative
+//
+//    assert.Negative(t, 0)
+//    assert.Negative(t, 1.23)
+func (a *Assertions) NonNegative(e interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NonNegative(a.t, e, msgAndArgs...)
+}
+
+// NonNegativef asserts that the specified element is non negative
+//
+//    assert.Negative(t, 0)
+//    assert.Negative(t, 1.23)
+func (a *Assertions) NonNegativef(e interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NonNegativef(a.t, e, msg, args...)
+}
+
+// NonPositive asserts that the specified element is positive
+//
+//    assert.Positive(t, 0)
+//    assert.Positive(t, -1.23)
+func (a *Assertions) NonPositive(e interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NonPositive(a.t, e, msgAndArgs...)
+}
+
+// NonPositivef asserts that the specified element is positive
+//
+//    assert.Positive(t, 0)
+//    assert.Positive(t, -1.23)
+func (a *Assertions) NonPositivef(e interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NonPositivef(a.t, e, msg, args...)
+}
+
 // NotContains asserts that the specified string, list(array, slice...) or map does NOT contain the
 // specified substring or element.
 //

--- a/require/require.go
+++ b/require/require.go
@@ -1304,6 +1304,62 @@ func NoFileExistsf(t TestingT, path string, msg string, args ...interface{}) {
 	t.FailNow()
 }
 
+// NonNegative asserts that the specified element is non negative
+//
+//    assert.Negative(t, 0)
+//    assert.Negative(t, 1.23)
+func NonNegative(t TestingT, e interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NonNegative(t, e, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NonNegativef asserts that the specified element is non negative
+//
+//    assert.Negative(t, 0)
+//    assert.Negative(t, 1.23)
+func NonNegativef(t TestingT, e interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NonNegativef(t, e, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NonPositive asserts that the specified element is positive
+//
+//    assert.Positive(t, 0)
+//    assert.Positive(t, -1.23)
+func NonPositive(t TestingT, e interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NonPositive(t, e, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NonPositivef asserts that the specified element is positive
+//
+//    assert.Positive(t, 0)
+//    assert.Positive(t, -1.23)
+func NonPositivef(t TestingT, e interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NonPositivef(t, e, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
 // NotContains asserts that the specified string, list(array, slice...) or map does NOT contain the
 // specified substring or element.
 //

--- a/require/require_forward.go
+++ b/require/require_forward.go
@@ -1022,6 +1022,50 @@ func (a *Assertions) NoFileExistsf(path string, msg string, args ...interface{})
 	NoFileExistsf(a.t, path, msg, args...)
 }
 
+// NonNegative asserts that the specified element is non negative
+//
+//    assert.Negative(t, 0)
+//    assert.Negative(t, 1.23)
+func (a *Assertions) NonNegative(e interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NonNegative(a.t, e, msgAndArgs...)
+}
+
+// NonNegativef asserts that the specified element is non negative
+//
+//    assert.Negative(t, 0)
+//    assert.Negative(t, 1.23)
+func (a *Assertions) NonNegativef(e interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NonNegativef(a.t, e, msg, args...)
+}
+
+// NonPositive asserts that the specified element is positive
+//
+//    assert.Positive(t, 0)
+//    assert.Positive(t, -1.23)
+func (a *Assertions) NonPositive(e interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NonPositive(a.t, e, msgAndArgs...)
+}
+
+// NonPositivef asserts that the specified element is positive
+//
+//    assert.Positive(t, 0)
+//    assert.Positive(t, -1.23)
+func (a *Assertions) NonPositivef(e interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NonPositivef(a.t, e, msg, args...)
+}
+
 // NotContains asserts that the specified string, list(array, slice...) or map does NOT contain the
 // specified substring or element.
 //


### PR DESCRIPTION
## Summary
Add NonPositive and NonNegative functions.


## Motivation
I suppose it could be the extension of checking for positive and negative functionality

<!-- ## Example usage (if applicable) -->

## Related issues
<!-- Put `Closes #XXXX` for each issue number this PR fixes/closes -->
