### PR TITLE
Make sure time.Time comparison produces a helpful diff. closes #989

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1609,12 +1609,17 @@ func diff(expected interface{}, actual interface{}) string {
 	}
 
 	var e, a string
-	if et != reflect.TypeOf("") {
-		e = spewConfig.Sdump(expected)
-		a = spewConfig.Sdump(actual)
-	} else {
+
+	switch et {
+	case reflect.TypeOf(""):
 		e = reflect.ValueOf(expected).String()
 		a = reflect.ValueOf(actual).String()
+	case reflect.TypeOf(time.Time{}):
+		e = spewConfigStringerEnabled.Sdump(expected)
+		a = spewConfigStringerEnabled.Sdump(actual)
+	default:
+		e = spewConfig.Sdump(expected)
+		a = spewConfig.Sdump(actual)
 	}
 
 	diff, _ := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
@@ -1643,6 +1648,14 @@ var spewConfig = spew.ConfigState{
 	DisableCapacities:       true,
 	SortKeys:                true,
 	DisableMethods:          true,
+	MaxDepth:                10,
+}
+
+var spewConfigStringerEnabled = spew.ConfigState{
+	Indent:                  " ",
+	DisablePointerAddresses: true,
+	DisableCapacities:       true,
+	SortKeys:                true,
 	MaxDepth:                10,
 }
 

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -1991,6 +1991,23 @@ Diff:
 		diffTestingStruct{A: "some string", B: 15},
 	)
 	Equal(t, expected, actual)
+
+	expected = `
+
+Diff:
+--- Expected
++++ Actual
+@@ -1,2 +1,2 @@
+-(time.Time) 2020-09-24 00:00:00 +0000 UTC
++(time.Time) 2020-09-25 00:00:00 +0000 UTC
+ 
+`
+
+	actual = diff(
+		time.Date(2020, 9, 24, 0, 0, 0, 0, time.UTC),
+		time.Date(2020, 9, 25, 0, 0, 0, 0, time.UTC),
+	)
+	Equal(t, expected, actual)
 }
 
 func TestTimeEqualityErrorFormatting(t *testing.T) {


### PR DESCRIPTION
Make sure time.Time comparison produces a helpful diff. closes #989


## Summary
Make sure time.Time comparison produces a helpful diff
again. This partially reverses the changes in #895 for
time.Time and allows it to be easily expanded for more
types in the future if needed.

## Changes
Analyzes the type when diffing, and uses a different
Spew config for time.Time

Introduce a test for diffing time.Time

## Motivation
See bug #989

## Related issues
Closes #989 