### PR TITLE
Improve mock.MatchedBy failed comparison Diff message

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -728,7 +728,7 @@ func (f argumentMatcher) Matches(argument interface{}) bool {
 }
 
 func (f argumentMatcher) String() string {
-	return fmt.Sprintf("func(%s) bool", f.fn.Type().In(0).Name())
+	return fmt.Sprintf("func(%s) bool", f.fn.Type().In(0).String())
 }
 
 // MatchedBy can be used to match a mock call based on only certain properties

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -1482,6 +1482,10 @@ func (s *timer) GetTime(i int) string {
 	return s.Called(i).Get(0).(string)
 }
 
+func (s *timer) GetTimes(times []int) string {
+	return s.Called(times).Get(0).(string)
+}
+
 type tCustomLogger struct {
 	*testing.T
 	logs []string
@@ -1550,6 +1554,23 @@ func TestArgumentMatcherToPrintMismatch(t *testing.T) {
 	m.On("GetTime", MatchedBy(func(i int) bool { return false })).Return("SomeTime").Once()
 
 	res := m.GetTime(1)
+	require.Equal(t, "SomeTime", res)
+	m.AssertExpectations(t)
+}
+
+func TestArgumentMatcherToPrintMismatchWithReferenceType(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			matchingExp := regexp.MustCompile(
+				`\s+mock: Unexpected Method Call\s+-*\s+GetTimes\(\[\]int\)\s+0: \[\]int\{1\}\s+The closest call I have is:\s+GetTimes\(mock.argumentMatcher\)\s+0: mock.argumentMatcher\{.*?\}\s+Diff:.*\(\[\]int=\[1\]\) not matched by func\(\[\]int\) bool`)
+			assert.Regexp(t, matchingExp, r)
+		}
+	}()
+
+	m := new(timer)
+	m.On("GetTimes", MatchedBy(func(_ []int) bool { return false })).Return("SomeTime").Once()
+
+	res := m.GetTimes([]int{1})
 	require.Equal(t, "SomeTime", res)
 	m.AssertExpectations(t)
 }


### PR DESCRIPTION
## Summary
Improve the Diff message for `mock.MatchedBy` functions taking a reference type.

## Changes
The `argumentMatcher.String` method internally now uses the `reflect.Type.String` method instead of the `reflect.Type.Name` method.

## Motivation
Prior to this change a `mock.MatchedBy` function taking a reference type, such as a slice (`func([]int) bool`), would have the Diff presented as `... func() bool`; now the Diff will accurately be presented as `... func([]int) bool`.

## Related issues
N/A
