### PR TITLE
Make spew config selection configurable to allow for helpful diffs on time.Time objects nested in structs.

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1642,7 +1642,9 @@ func isFunction(arg interface{}) bool {
 	return reflect.TypeOf(arg).Kind() == reflect.Func
 }
 
-var spewConfig = spew.ConfigState{
+const stringerEnabledEnvVarName = "TESTIFY_SPEW_STRINGER_ENABLE"
+
+var spewConfigStringerDisabled = spew.ConfigState{
 	Indent:                  " ",
 	DisablePointerAddresses: true,
 	DisableCapacities:       true,
@@ -1657,6 +1659,20 @@ var spewConfigStringerEnabled = spew.ConfigState{
 	DisableCapacities:       true,
 	SortKeys:                true,
 	MaxDepth:                10,
+}
+
+var spewConfig spew.ConfigState
+
+func setupSpewConfig() {
+	if os.Getenv(stringerEnabledEnvVarName) == "TRUE" {
+		spewConfig = spewConfigStringerEnabled
+		return
+	}
+	spewConfig = spewConfigStringerDisabled
+}
+
+func init() {
+	setupSpewConfig()
 }
 
 type tHelper interface {


### PR DESCRIPTION
## Summary
Make time.Time objects nested inside structs produce reasonable diffs by making spewConfig configurable

## Changes
https://github.com/stretchr/testify/pull/895 had some unintended side-effects on what diffs of `time.Time` see https://github.com/stretchr/testify/issues/1078.

This attempts to solve the problem by allowing the user to select if they want to use the SpewConfig that has Stringer methods enabled. The default behavior remains the same. But if the user runs their tests after setting the environment variable `TESTIFY_SPEW_STRINGER_ENABLE` to `TRUE`, testify will pick the stringer config that does not disable the Stringer methods and thus produces nice diffs for time.Time nested inside struct. 

[This](https://github.com/shawc71/testify-issue-demo/blob/master/example_test.go) contains a minimal repro of this issue, right now those tests produce an almost 1500 line diff on test failure. After this change and  when `TESTIFY_SPEW_STRINGER_ENABLE` env var is set to `TRUE` it will produce a user friendly diff like:

```
--- FAIL: TestDemo (0.00s)
    --- FAIL: TestDemo/same_tzs (0.00s)
        example_test.go:29: 
                Error Trace:    example_test.go:29
                Error:          Not equal: 
                                expected: &testify_issue_demo.structWithTime{someTime:(*time.Time)(0xc00000e460), someString:"some val"}
                                actual  : &testify_issue_demo.structWithTime{someTime:(*time.Time)(0xc00000e4a0), someString:"some val"}
                            
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1,3 +1,3 @@
                                 (*testify_issue_demo.structWithTime)({
                                - someTime: (*time.Time)(2020-05-22 00:00:00 +0000 UTC),
                                + someTime: (*time.Time)(2020-05-21 00:00:00 +0000 UTC),
                                  someString: (string) (len=8) "some val"
                Test:           TestDemo/same_tzs
    --- FAIL: TestDemo/different_tzs (0.00s)
        example_test.go:47: 
                Error Trace:    example_test.go:47
                Error:          Not equal: 
                                expected: &testify_issue_demo.structWithTime{someTime:(*time.Time)(0xc00000e740), someString:"some val"}
                                actual  : &testify_issue_demo.structWithTime{someTime:(*time.Time)(0xc00000e780), someString:"some val"}
                            
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1,3 +1,3 @@
                                 (*testify_issue_demo.structWithTime)({
                                - someTime: (*time.Time)(2020-05-22 00:00:00 +0000 UTC),
                                + someTime: (*time.Time)(2020-05-21 00:00:00 -0400 EDT),
                                  someString: (string) (len=8) "some val"
                Test:           TestDemo/different_tzs
FAIL
FAIL    testify_issue_demo      0.006s

```

## Motivation
Please see https://github.com/stretchr/testify/issues/1078 which describes the issue in detail

<!-- ## Example usage (if applicable) -->

`export TESTIFY_SPEW_STRINGER_ENABLE=TRUE && go test ./...`

## Related issues
https://github.com/stretchr/testify/issues/1078
