### PR TITLE
Use %v when formatting objects in assert.Len

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -637,11 +637,11 @@ func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) 
 	}
 	ok, l := getLen(object)
 	if !ok {
-		return Fail(t, fmt.Sprintf("\"%s\" could not be applied builtin len()", object), msgAndArgs...)
+		return Fail(t, fmt.Sprintf("\"%v\" could not be applied builtin len()", object), msgAndArgs...)
 	}
 
 	if l != length {
-		return Fail(t, fmt.Sprintf("\"%s\" should have %d item(s), but has %d", object, length, l), msgAndArgs...)
+		return Fail(t, fmt.Sprintf("\"%v\" should have %d item(s), but has %d", object, length, l), msgAndArgs...)
 	}
 	return true
 }


### PR DESCRIPTION
## Summary

Fix `assert.Len`'s error message for non-`%s`able values.

## Details

It was using %s, which doesn't work if the thing being len'ed is not a
`[]string` or similar.  For example, `assert.Len(t, []int{1}, 0)` says
that `[%!s(int=1)] should have 1 item(s), but has 0`.  Now it uses `%v`
which will work for almost anything.