### PR TITLE
Unpack variadic msgAndArgs in comparison functions

### DIFF
--- a/assert/assertion_compare.go
+++ b/assert/assertion_compare.go
@@ -313,7 +313,7 @@ func Greater(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	return compareTwoValues(t, e1, e2, []CompareType{compareGreater}, "\"%v\" is not greater than \"%v\"", msgAndArgs)
+	return compareTwoValues(t, e1, e2, []CompareType{compareGreater}, "\"%v\" is not greater than \"%v\"", msgAndArgs...)
 }
 
 // GreaterOrEqual asserts that the first element is greater than or equal to the second
@@ -326,7 +326,7 @@ func GreaterOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...in
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	return compareTwoValues(t, e1, e2, []CompareType{compareGreater, compareEqual}, "\"%v\" is not greater than or equal to \"%v\"", msgAndArgs)
+	return compareTwoValues(t, e1, e2, []CompareType{compareGreater, compareEqual}, "\"%v\" is not greater than or equal to \"%v\"", msgAndArgs...)
 }
 
 // Less asserts that the first element is less than the second
@@ -338,7 +338,7 @@ func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{})
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	return compareTwoValues(t, e1, e2, []CompareType{compareLess}, "\"%v\" is not less than \"%v\"", msgAndArgs)
+	return compareTwoValues(t, e1, e2, []CompareType{compareLess}, "\"%v\" is not less than \"%v\"", msgAndArgs...)
 }
 
 // LessOrEqual asserts that the first element is less than or equal to the second
@@ -351,7 +351,7 @@ func LessOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...inter
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	return compareTwoValues(t, e1, e2, []CompareType{compareLess, compareEqual}, "\"%v\" is not less than or equal to \"%v\"", msgAndArgs)
+	return compareTwoValues(t, e1, e2, []CompareType{compareLess, compareEqual}, "\"%v\" is not less than or equal to \"%v\"", msgAndArgs...)
 }
 
 // Positive asserts that the specified element is positive
@@ -363,7 +363,7 @@ func Positive(t TestingT, e interface{}, msgAndArgs ...interface{}) bool {
 		h.Helper()
 	}
 	zero := reflect.Zero(reflect.TypeOf(e))
-	return compareTwoValues(t, e, zero.Interface(), []CompareType{compareGreater}, "\"%v\" is not positive", msgAndArgs)
+	return compareTwoValues(t, e, zero.Interface(), []CompareType{compareGreater}, "\"%v\" is not positive", msgAndArgs...)
 }
 
 // Negative asserts that the specified element is negative
@@ -375,7 +375,7 @@ func Negative(t TestingT, e interface{}, msgAndArgs ...interface{}) bool {
 		h.Helper()
 	}
 	zero := reflect.Zero(reflect.TypeOf(e))
-	return compareTwoValues(t, e, zero.Interface(), []CompareType{compareLess}, "\"%v\" is not negative", msgAndArgs)
+	return compareTwoValues(t, e, zero.Interface(), []CompareType{compareLess}, "\"%v\" is not negative", msgAndArgs...)
 }
 
 func compareTwoValues(t TestingT, e1 interface{}, e2 interface{}, allowedComparesResults []CompareType, failMessage string, msgAndArgs ...interface{}) bool {

--- a/assert/assertion_compare_test.go
+++ b/assert/assertion_compare_test.go
@@ -116,6 +116,8 @@ func callerName(skip int) string {
 
 func TestGreater(t *testing.T) {
 	mockT := new(testing.T)
+	msgAndArgs := []interface{}{"error message %s", "formatted"}
+	expMsg := "error message formatted"
 
 	if !Greater(mockT, 2, 1) {
 		t.Error("Greater should return true")
@@ -149,14 +151,17 @@ func TestGreater(t *testing.T) {
 		{less: float64(1.23), greater: float64(2.34), msg: `"1.23" is not greater than "2.34"`},
 	} {
 		out := &outputT{buf: bytes.NewBuffer(nil)}
-		False(t, Greater(out, currCase.less, currCase.greater))
+		False(t, Greater(out, currCase.less, currCase.greater, msgAndArgs...))
 		Contains(t, string(out.buf.Bytes()), currCase.msg)
+		Contains(t, string(out.buf.Bytes()), expMsg)
 		Contains(t, out.helpers, "github.com/stretchr/testify/assert.Greater")
 	}
 }
 
 func TestGreaterOrEqual(t *testing.T) {
 	mockT := new(testing.T)
+	msgAndArgs := []interface{}{"error message %s", "formatted"}
+	expMsg := "error message formatted"
 
 	if !GreaterOrEqual(mockT, 2, 1) {
 		t.Error("GreaterOrEqual should return true")
@@ -190,14 +195,17 @@ func TestGreaterOrEqual(t *testing.T) {
 		{less: float64(1.23), greater: float64(2.34), msg: `"1.23" is not greater than or equal to "2.34"`},
 	} {
 		out := &outputT{buf: bytes.NewBuffer(nil)}
-		False(t, GreaterOrEqual(out, currCase.less, currCase.greater))
+		False(t, GreaterOrEqual(out, currCase.less, currCase.greater, msgAndArgs...))
 		Contains(t, string(out.buf.Bytes()), currCase.msg)
+		Contains(t, string(out.buf.Bytes()), expMsg)
 		Contains(t, out.helpers, "github.com/stretchr/testify/assert.GreaterOrEqual")
 	}
 }
 
 func TestLess(t *testing.T) {
 	mockT := new(testing.T)
+	msgAndArgs := []interface{}{"error message %s", "formatted"}
+	expMsg := "error message formatted"
 
 	if !Less(mockT, 1, 2) {
 		t.Error("Less should return true")
@@ -231,14 +239,17 @@ func TestLess(t *testing.T) {
 		{less: float64(1.23), greater: float64(2.34), msg: `"2.34" is not less than "1.23"`},
 	} {
 		out := &outputT{buf: bytes.NewBuffer(nil)}
-		False(t, Less(out, currCase.greater, currCase.less))
+		False(t, Less(out, currCase.greater, currCase.less, msgAndArgs...))
 		Contains(t, string(out.buf.Bytes()), currCase.msg)
+		Contains(t, string(out.buf.Bytes()), expMsg)
 		Contains(t, out.helpers, "github.com/stretchr/testify/assert.Less")
 	}
 }
 
 func TestLessOrEqual(t *testing.T) {
 	mockT := new(testing.T)
+	msgAndArgs := []interface{}{"error message %s", "formatted"}
+	expMsg := "error message formatted"
 
 	if !LessOrEqual(mockT, 1, 2) {
 		t.Error("LessOrEqual should return true")
@@ -272,14 +283,17 @@ func TestLessOrEqual(t *testing.T) {
 		{less: float64(1.23), greater: float64(2.34), msg: `"2.34" is not less than or equal to "1.23"`},
 	} {
 		out := &outputT{buf: bytes.NewBuffer(nil)}
-		False(t, LessOrEqual(out, currCase.greater, currCase.less))
+		False(t, LessOrEqual(out, currCase.greater, currCase.less, msgAndArgs...))
 		Contains(t, string(out.buf.Bytes()), currCase.msg)
+		Contains(t, string(out.buf.Bytes()), expMsg)
 		Contains(t, out.helpers, "github.com/stretchr/testify/assert.LessOrEqual")
 	}
 }
 
 func TestPositive(t *testing.T) {
 	mockT := new(testing.T)
+	msgAndArgs := []interface{}{"error message %s", "formatted"}
+	expMsg := "error message formatted"
 
 	if !Positive(mockT, 1) {
 		t.Error("Positive should return true")
@@ -311,14 +325,17 @@ func TestPositive(t *testing.T) {
 		{e: float64(-1.23), msg: `"-1.23" is not positive`},
 	} {
 		out := &outputT{buf: bytes.NewBuffer(nil)}
-		False(t, Positive(out, currCase.e))
+		False(t, Positive(out, currCase.e, msgAndArgs...))
 		Contains(t, string(out.buf.Bytes()), currCase.msg)
+		Contains(t, string(out.buf.Bytes()), expMsg)
 		Contains(t, out.helpers, "github.com/stretchr/testify/assert.Positive")
 	}
 }
 
 func TestNegative(t *testing.T) {
 	mockT := new(testing.T)
+	msgAndArgs := []interface{}{"error message %s", "formatted"}
+	expMsg := "error message formatted"
 
 	if !Negative(mockT, -1) {
 		t.Error("Negative should return true")
@@ -350,8 +367,9 @@ func TestNegative(t *testing.T) {
 		{e: float64(1.23), msg: `"1.23" is not negative`},
 	} {
 		out := &outputT{buf: bytes.NewBuffer(nil)}
-		False(t, Negative(out, currCase.e))
+		False(t, Negative(out, currCase.e, msgAndArgs...))
 		Contains(t, string(out.buf.Bytes()), currCase.msg)
+		Contains(t, string(out.buf.Bytes()), expMsg)
 		Contains(t, out.helpers, "github.com/stretchr/testify/assert.Negative")
 	}
 }


### PR DESCRIPTION
## Summary
Comparison functions now unpack trailing arguments in when sending off to helper function so final message is properly formatted.

## Changes
Unpacked `msgAndArgs` when sending off to `compareTwoValues` in `Greater`, `GreaterOrEqual`, `Less`, `LessOrEqual`, `Positive`, and `Negative`. Also added to tests to prevent regression.

## Motivation
Example: 
When calling `Greater(t, 1, 2, "error message %s", "formatted")`
Before: "[error message %s formatted]"
After: "error message formatted"
