### PR TITLE
Add argument matcher for JSON content in mocks

### DIFF
--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -1690,3 +1690,34 @@ type user interface {
 type mockUser struct{ Mock }
 
 func (m *mockUser) Use(c caller) { m.Called(c) }
+
+type jsonHandler struct{ Mock }
+
+func (m *jsonHandler) FunctionThatHandlesJSON(json interface{}) bool {
+	return m.Called(json).Bool(0)
+}
+
+func Test_MatchesJSON(t *testing.T) {
+	mock := new(jsonHandler)
+	mock.On("FunctionThatHandlesJSON", JSONEq(`{"name": "Esdras", "age": 36}`)).Return(true)
+
+	resultString := mock.FunctionThatHandlesJSON(`{"age": 36, "name": "Esdras"}`)
+	assert.True(t, resultString)
+
+	resultByte := mock.FunctionThatHandlesJSON([]byte(`{"age": 36, "name": "Esdras"}`))
+	assert.True(t, resultByte)
+
+	resultMap := mock.FunctionThatHandlesJSON(map[string]interface{}{"name": "Esdras", "age": 36})
+	assert.True(t, resultMap)
+
+	var input struct {
+		Name string `json:"name"`
+		Age  int    `json:"age"`
+	}
+	input.Name = "Esdras"
+	input.Age = 36
+	resultStruct := mock.FunctionThatHandlesJSON(input)
+	assert.True(t, resultStruct)
+
+	mock.AssertExpectations(t)
+}


### PR DESCRIPTION
## Summary
A matcher to use when we need to check if a parameter passed to a mocked function is a JSON we expect the function to receive.

## Changes
- A function `JSONEq(expectedJSON string) argumentMatcher` in the mock package
- Add a `description` field to `argumentMatcher`, so we can use a friendly description for this new JSON matcher

## Motivation
I needed to implement some mocks for functions where a JSON string was received. The JSON fields could come in different orders, so matching wasn't very trivial and was becoming repetitive. I needed to implement custom matchers for this purpose, so I decided to open a PR with this feature. :)
