### PR TITLE
assert: add partial equal assertion for JSON

### DIFF
--- a/assert/assertion_format.go
+++ b/assert/assertion_format.go
@@ -417,6 +417,20 @@ func JSONEqf(t TestingT, expected string, actual string, msg string, args ...int
 	return JSONEq(t, expected, actual, append([]interface{}{msg}, args...)...)
 }
 
+// JSONPartialEqf asserts that the expected JSON construct exists within
+// the actual. Note that while the order of the properties does not
+// matter, the order of elements within an array does matter. This can
+// be circumvented by using an empty map to properly offset the expected.
+//
+//    assert.JSONPartialEqf(t, `{"foo": {"foo": "bar"}}`, `{"hello": "world", "foo": {"foo": "bar", "hello": "world"}}`, "error message %s", "formatted")
+//    assert.JSONPartialEqf(t, `{"foo": [{}, {"hello": "world"}]}`, `{"hello": "world", "foo": [{"foo": "bar"}, {"hello": "world"}]}`, "error message %s", "formatted")
+func JSONPartialEqf(t TestingT, expected string, actual string, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return JSONPartialEq(t, expected, actual, append([]interface{}{msg}, args...)...)
+}
+
 // Lenf asserts that the specified object has specific length.
 // Lenf also fails if the object has a type that len() not accept.
 //

--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -823,6 +823,34 @@ func (a *Assertions) JSONEqf(expected string, actual string, msg string, args ..
 	return JSONEqf(a.t, expected, actual, msg, args...)
 }
 
+// JSONPartialEq asserts that the expected JSON construct exists within
+// the actual. Note that while the order of the properties does not
+// matter, the order of elements within an array does matter. This can
+// be circumvented by using an empty map to properly offset the expected.
+//
+//    a.JSONPartialEq(`{"foo": {"foo": "bar"}}`, `{"hello": "world", "foo": {"foo": "bar", "hello": "world"}}`)
+//    a.JSONPartialEq(`{"foo": [{}, {"hello": "world"}]}`, `{"hello": "world", "foo": [{"foo": "bar"}, {"hello": "world"}]}`)
+func (a *Assertions) JSONPartialEq(expected string, actual string, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return JSONPartialEq(a.t, expected, actual, msgAndArgs...)
+}
+
+// JSONPartialEqf asserts that the expected JSON construct exists within
+// the actual. Note that while the order of the properties does not
+// matter, the order of elements within an array does matter. This can
+// be circumvented by using an empty map to properly offset the expected.
+//
+//    a.JSONPartialEqf(`{"foo": {"foo": "bar"}}`, `{"hello": "world", "foo": {"foo": "bar", "hello": "world"}}`, "error message %s", "formatted")
+//    a.JSONPartialEqf(`{"foo": [{}, {"hello": "world"}]}`, `{"hello": "world", "foo": [{"foo": "bar"}, {"hello": "world"}]}`, "error message %s", "formatted")
+func (a *Assertions) JSONPartialEqf(expected string, actual string, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return JSONPartialEqf(a.t, expected, actual, msg, args...)
+}
+
 // Len asserts that the specified object has specific length.
 // Len also fails if the object has a type that len() not accept.
 //

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1611,8 +1611,8 @@ func prune(a, b *interface{}) {
 	case []interface{}:
 		temp := []interface{}{}
 
-		for i, aValue := range aTyped {
-			if bArray, ok := (*b).([]interface{}); ok {
+		if bArray, ok := (*b).([]interface{}); ok {
+			for i, aValue := range aTyped {
 				if len(bArray) > i {
 					prune(&aValue, &bArray[i])
 					temp = append(temp, aValue)

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1598,8 +1598,8 @@ func JSONPartialEq(t TestingT, expected string, actual string, msgAndArgs ...int
 func prune(a, b *interface{}) {
 	switch aTyped := (*a).(type) {
 	case map[string]interface{}:
-		for k, aValue := range aTyped {
-			if bMap, ok := (*b).(map[string]interface{}); ok {
+		if bMap, ok := (*b).(map[string]interface{}); ok {
+			for k, aValue := range aTyped {
 				if bValue, ok := bMap[k]; ok {
 					prune(&aValue, &bValue)
 					aTyped[k] = aValue

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -1873,8 +1873,7 @@ func TestJSONPartialEq_EquivalentButNotEqual(t *testing.T) {
 
 func TestJSONPartialEq_HashOfArraysAndHashes(t *testing.T) {
 	mockT := new(testing.T)
-	True(t, JSONPartialEq(mockT, "{\r\n\t\"numeric\": 1.5,\r\n\t\"array\": [{\"foo\": \"bar\"}, 1, \"string\", [\"nested\", \"array\", 5.5]],\r\n\t\"hash\": {\"nested\": \"hash\", \"nested_slice\": [\"this\", \"is\", \"nested\"]},\r\n\t\"string\": \"foo\"\r\n}",
-		"{\r\n\t\"numeric\": 1.5,\r\n\t\"hash\": {\"nested\": \"hash\", \"nested_slice\": [\"this\", \"is\", \"nested\"]},\r\n\t\"string\": \"foo\",\r\n\t\"array\": [{\"foo\": \"bar\"}, 1, \"string\", [\"nested\", \"array\", 5.5]]\r\n}"))
+	True(t, JSONPartialEq(mockT, `{"numeric": 1.5, "array": [{"foo": "bar"}, 1, "string", ["nested", "array", 5.5]], "hash": {"nested": "hash", "nested_slice": ["this", "is", "nested"]}, "string": "foo"}`, `{"numeric": 1.5, "hash": {"nested": "hash", "nested_slice": ["this", "is", "nested"]}, "string": "foo", "array": [{"foo": "bar"}, 1, "string", ["nested", "array", 5.5]]}`))
 }
 
 func TestJSONPartialEq_Array(t *testing.T) {

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -1796,6 +1796,122 @@ func TestJSONEq_ArraysOfDifferentOrder(t *testing.T) {
 	False(t, JSONEq(mockT, `["foo", {"hello": "world", "nested": "hash"}]`, `[{ "hello": "world", "nested": "hash"}, "foo"]`))
 }
 
+func TestJSONPartialEq_EqualSubset(t *testing.T) {
+	mockT := new(testing.T)
+	True(t, JSONPartialEq(mockT, `{"foo": {"foo": "bar"}}`, `{"hello": "world", "foo": {"foo": "bar", "hello": "world"}}`))
+}
+
+func TestJSONPartialEq_EquivalentButNotEqualSubset(t *testing.T) {
+	mockT := new(testing.T)
+	True(t, JSONPartialEq(mockT, `{"foo": {"foo": "bar"}}`, `{"hello": "world", "foo": {"hello": "world", "foo": "bar"}}`))
+}
+
+func TestJSONPartialEq_NotEqualPropertyKeySubset(t *testing.T) {
+	mockT := new(testing.T)
+	False(t, JSONPartialEq(mockT, `{"foo": {"hello": "bar"}}`, `{"hello": "world", "foo": {"foo": "bar", "hello": "world"}}`))
+}
+
+func TestJSONPartialEq_NotEqualPropertyValueSubset(t *testing.T) {
+	mockT := new(testing.T)
+	False(t, JSONPartialEq(mockT, `{"foo": {"foo": "world"}}`, `{"hello": "world", "foo": {"foo": "bar", "hello": "world"}}`))
+}
+
+func TestJSONPartialEq_EqualArray(t *testing.T) {
+	mockT := new(testing.T)
+	True(t, JSONPartialEq(mockT, `{"foo": ["bar", "hello", "world"]}`, `{"hello": "world", "foo": ["bar", "hello", "world"]}`))
+}
+
+func TestJSONPartialEq_NotEqualArray(t *testing.T) {
+	mockT := new(testing.T)
+	False(t, JSONPartialEq(mockT, `{"foo": ["hello", "world", "bar"]}`, `{"hello": "world", "foo": ["bar", "hello", "world"]}`))
+}
+
+func TestJSONPartialEq_EqualArraySubset(t *testing.T) {
+	mockT := new(testing.T)
+	True(t, JSONPartialEq(mockT, `{"foo": ["bar"]}`, `{"hello": "world", "foo": ["bar", "hello", "world"]}`))
+}
+
+func TestJSONPartialEq_NotEqualArraySubset(t *testing.T) {
+	mockT := new(testing.T)
+	False(t, JSONPartialEq(mockT, `{"foo": ["world"]}`, `{"hello": "world", "foo": ["bar", "hello", "world"]}`))
+}
+
+func TestJSONPartialEq_EqualArrayOfMaps(t *testing.T) {
+	mockT := new(testing.T)
+	True(t, JSONPartialEq(mockT, `{"foo": [{"foo": "bar"}, {"hello": "world"}]}`, `{"hello": "world", "foo": [{"foo": "bar"}, {"hello": "world"}]}`))
+}
+
+func TestJSONPartialEq_NotEqualArrayOfMaps(t *testing.T) {
+	mockT := new(testing.T)
+	False(t, JSONPartialEq(mockT, `{"foo": [{"hello": "world"}, {"foo": "bar"}]}`, `{"hello": "world", "foo": [{"foo": "bar"}, {"hello": "world"}]}`))
+}
+
+func TestJSONPartialEq_EqualArrayOfMapsSubset(t *testing.T) {
+	mockT := new(testing.T)
+	True(t, JSONPartialEq(mockT, `{"foo": [{"foo": "bar"}]}`, `{"hello": "world", "foo": [{"foo": "bar"}, {"hello": "world"}]}`))
+}
+
+func TestJSONPartialEq_NotEqualArrayOfMapsSubset(t *testing.T) {
+	mockT := new(testing.T)
+	False(t, JSONPartialEq(mockT, `{"foo": [{"hello": "world"}]}`, `{"hello": "world", "foo": [{"foo": "bar"}, {"hello": "world"}]}`))
+}
+
+func TestJSONPartialEq_EqualArrayOfMapsWithSpacerSubset(t *testing.T) {
+	mockT := new(testing.T)
+	True(t, JSONPartialEq(mockT, `{"foo": [{}, {"hello": "world"}]}`, `{"hello": "world", "foo": [{"foo": "bar"}, {"hello": "world"}]}`))
+}
+
+func TestJSONPartialEq_EqualSONString(t *testing.T) {
+	mockT := new(testing.T)
+	True(t, JSONPartialEq(mockT, `{"hello": "world", "foo": "bar"}`, `{"hello": "world", "foo": "bar"}`))
+}
+
+func TestJSONPartialEq_EquivalentButNotEqual(t *testing.T) {
+	mockT := new(testing.T)
+	True(t, JSONPartialEq(mockT, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`))
+}
+
+func TestJSONPartialEq_HashOfArraysAndHashes(t *testing.T) {
+	mockT := new(testing.T)
+	True(t, JSONPartialEq(mockT, "{\r\n\t\"numeric\": 1.5,\r\n\t\"array\": [{\"foo\": \"bar\"}, 1, \"string\", [\"nested\", \"array\", 5.5]],\r\n\t\"hash\": {\"nested\": \"hash\", \"nested_slice\": [\"this\", \"is\", \"nested\"]},\r\n\t\"string\": \"foo\"\r\n}",
+		"{\r\n\t\"numeric\": 1.5,\r\n\t\"hash\": {\"nested\": \"hash\", \"nested_slice\": [\"this\", \"is\", \"nested\"]},\r\n\t\"string\": \"foo\",\r\n\t\"array\": [{\"foo\": \"bar\"}, 1, \"string\", [\"nested\", \"array\", 5.5]]\r\n}"))
+}
+
+func TestJSONPartialEq_Array(t *testing.T) {
+	mockT := new(testing.T)
+	True(t, JSONPartialEq(mockT, `["foo", {"hello": "world", "nested": "hash"}]`, `["foo", {"nested": "hash", "hello": "world"}]`))
+}
+
+func TestJSONPartialEq_HashAndArrayNotEquivalent(t *testing.T) {
+	mockT := new(testing.T)
+	False(t, JSONPartialEq(mockT, `["foo", {"hello": "world", "nested": "hash"}]`, `{"foo": "bar", {"nested": "hash", "hello": "world"}}`))
+}
+
+func TestJSONPartialEq_HashesNotEquivalent(t *testing.T) {
+	mockT := new(testing.T)
+	False(t, JSONPartialEq(mockT, `{"foo": "bar", "hello": "world"}`, `{"foo": "bar"}`))
+}
+
+func TestJSONPartialEq_ActualIsNotJSON(t *testing.T) {
+	mockT := new(testing.T)
+	False(t, JSONPartialEq(mockT, `{"foo": "bar"}`, "Not JSON"))
+}
+
+func TestJSONPartialEq_ExpectedIsNotJSON(t *testing.T) {
+	mockT := new(testing.T)
+	False(t, JSONPartialEq(mockT, "Not JSON", `{"foo": "bar", "hello": "world"}`))
+}
+
+func TestJSONPartialEq_ExpectedAndActualNotJSON(t *testing.T) {
+	mockT := new(testing.T)
+	False(t, JSONPartialEq(mockT, "Not JSON", "Not JSON"))
+}
+
+func TestJSONPartialEq_ArraysOfDifferentOrder(t *testing.T) {
+	mockT := new(testing.T)
+	False(t, JSONPartialEq(mockT, `["foo", {"hello": "world", "nested": "hash"}]`, `[{ "hello": "world", "nested": "hash"}, "foo"]`))
+}
+
 func TestYAMLEq_EqualYAMLString(t *testing.T) {
 	mockT := new(testing.T)
 	True(t, YAMLEq(mockT, `{"hello": "world", "foo": "bar"}`, `{"hello": "world", "foo": "bar"}`))

--- a/require/require.go
+++ b/require/require.go
@@ -1052,6 +1052,40 @@ func JSONEqf(t TestingT, expected string, actual string, msg string, args ...int
 	t.FailNow()
 }
 
+// JSONPartialEq asserts that the expected JSON construct exists within
+// the actual. Note that while the order of the properties does not
+// matter, the order of elements within an array does matter. This can
+// be circumvented by using an empty map to properly offset the expected.
+//
+//    assert.JSONPartialEq(t, `{"foo": {"foo": "bar"}}`, `{"hello": "world", "foo": {"foo": "bar", "hello": "world"}}`)
+//    assert.JSONPartialEq(t, `{"foo": [{}, {"hello": "world"}]}`, `{"hello": "world", "foo": [{"foo": "bar"}, {"hello": "world"}]}`)
+func JSONPartialEq(t TestingT, expected string, actual string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.JSONPartialEq(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// JSONPartialEqf asserts that the expected JSON construct exists within
+// the actual. Note that while the order of the properties does not
+// matter, the order of elements within an array does matter. This can
+// be circumvented by using an empty map to properly offset the expected.
+//
+//    assert.JSONPartialEqf(t, `{"foo": {"foo": "bar"}}`, `{"hello": "world", "foo": {"foo": "bar", "hello": "world"}}`, "error message %s", "formatted")
+//    assert.JSONPartialEqf(t, `{"foo": [{}, {"hello": "world"}]}`, `{"hello": "world", "foo": [{"foo": "bar"}, {"hello": "world"}]}`, "error message %s", "formatted")
+func JSONPartialEqf(t TestingT, expected string, actual string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.JSONPartialEqf(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
 // Len asserts that the specified object has specific length.
 // Len also fails if the object has a type that len() not accept.
 //

--- a/require/require_forward.go
+++ b/require/require_forward.go
@@ -824,6 +824,34 @@ func (a *Assertions) JSONEqf(expected string, actual string, msg string, args ..
 	JSONEqf(a.t, expected, actual, msg, args...)
 }
 
+// JSONPartialEq asserts that the expected JSON construct exists within
+// the actual. Note that while the order of the properties does not
+// matter, the order of elements within an array does matter. This can
+// be circumvented by using an empty map to properly offset the expected.
+//
+//    a.JSONPartialEq(`{"foo": {"foo": "bar"}}`, `{"hello": "world", "foo": {"foo": "bar", "hello": "world"}}`)
+//    a.JSONPartialEq(`{"foo": [{}, {"hello": "world"}]}`, `{"hello": "world", "foo": [{"foo": "bar"}, {"hello": "world"}]}`)
+func (a *Assertions) JSONPartialEq(expected string, actual string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	JSONPartialEq(a.t, expected, actual, msgAndArgs...)
+}
+
+// JSONPartialEqf asserts that the expected JSON construct exists within
+// the actual. Note that while the order of the properties does not
+// matter, the order of elements within an array does matter. This can
+// be circumvented by using an empty map to properly offset the expected.
+//
+//    a.JSONPartialEqf(`{"foo": {"foo": "bar"}}`, `{"hello": "world", "foo": {"foo": "bar", "hello": "world"}}`, "error message %s", "formatted")
+//    a.JSONPartialEqf(`{"foo": [{}, {"hello": "world"}]}`, `{"hello": "world", "foo": [{"foo": "bar"}, {"hello": "world"}]}`, "error message %s", "formatted")
+func (a *Assertions) JSONPartialEqf(expected string, actual string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	JSONPartialEqf(a.t, expected, actual, msg, args...)
+}
+
 // Len asserts that the specified object has specific length.
 // Len also fails if the object has a type that len() not accept.
 //


### PR DESCRIPTION
## Summary
Allows for the assertion of partial expected JSON against the actual.

## Changes
- Added function `JSONPartialEqf` to assert that the expected JSON construct exists within the actual JSON construct. This is done through the usage of the `prune` function that first removes all branches of the actual JSON that do not exist in the expected. The remaining branches are then compared with `DeepEqual`.

## Motivation
When using Terratest to test against either the returned plan JSON or the returned state JSON, it is impossible in all cases to provide a 100% complete expected JSON to compare against the actual due to the amount of data returned. This new assert function will allow for partial equivalence to allow for validating only a key portion of the plan/state against what is expected without needing to further refine the returned actual.

This simple example shows that a partial tree can be checked for existence with the actual return:

```
a.JSONPartialEq(`{"foo": {"foo": "bar"}}`, `{"hello": "world", "foo": {"foo": "bar", "hello": "world"}}`)
```

## Related issues
This may partially resolve #833.
