### PR TITLE
Clarify what's being linked

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Features include:
 Get started:
 
   * Install testify with [one line of code](#installation), or [update it with another](#staying-up-to-date)
-  * For an introduction to writing test code in Go, see http://golang.org/doc/code.html#Testing
+  * For an introduction to writing test code in Go using its default testing framework, see http://golang.org/doc/code.html#Testing
   * Check out the API Documentation http://godoc.org/github.com/stretchr/testify
   * To make your testing life easier, check out our other project, [gorc](http://github.com/stretchr/gorc)
   * A little about [Test-Driven Development (TDD)](http://en.wikipedia.org/wiki/Test-driven_development)


### PR DESCRIPTION
## Summary
Clarify that the link in question points to the default testing framework, not `testify`.

## Changes
Add clause `using its default testing framework`

## Motivation
It wasn't immediately clear to me that the link in question was bringing me to a *different* testing library's documentation. 