### PR TITLE
assert.IsIncreasing et al: support sort.Interface

### DIFF
--- a/assert/assertion_order.go
+++ b/assert/assertion_order.go
@@ -9,7 +9,7 @@ import (
 func isOrdered(t TestingT, object interface{}, allowedComparesResults []CompareType, failMessage string, msgAndArgs ...interface{}) bool {
 	objKind := reflect.TypeOf(object).Kind()
 	if objKind != reflect.Slice && objKind != reflect.Array {
-		return false
+		return Fail(t, fmt.Sprintf("object %T is not a collection", object), msgAndArgs...)
 	}
 
 	objValue := reflect.ValueOf(object)

--- a/assert/assertion_order.go
+++ b/assert/assertion_order.go
@@ -50,6 +50,9 @@ func isOrdered(t TestingT, object interface{}, allowedComparesResults []CompareT
 //    assert.IsIncreasing(t, []float{1, 2})
 //    assert.IsIncreasing(t, []string{"a", "b"})
 func IsIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
 	return isOrdered(t, object, []CompareType{compareLess}, "\"%v\" is not less than \"%v\"", msgAndArgs)
 }
 
@@ -59,6 +62,9 @@ func IsIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) boo
 //    assert.IsNonIncreasing(t, []float{2, 1})
 //    assert.IsNonIncreasing(t, []string{"b", "a"})
 func IsNonIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
 	return isOrdered(t, object, []CompareType{compareEqual, compareGreater}, "\"%v\" is not greater than or equal to \"%v\"", msgAndArgs)
 }
 
@@ -68,6 +74,9 @@ func IsNonIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) 
 //    assert.IsDecreasing(t, []float{2, 1})
 //    assert.IsDecreasing(t, []string{"b", "a"})
 func IsDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
 	return isOrdered(t, object, []CompareType{compareGreater}, "\"%v\" is not greater than \"%v\"", msgAndArgs)
 }
 
@@ -77,5 +86,8 @@ func IsDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) boo
 //    assert.IsNonDecreasing(t, []float{1, 2})
 //    assert.IsNonDecreasing(t, []string{"a", "b"})
 func IsNonDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
 	return isOrdered(t, object, []CompareType{compareLess, compareEqual}, "\"%v\" is not less than or equal to \"%v\"", msgAndArgs)
 }

--- a/assert/assertion_order_test.go
+++ b/assert/assertion_order_test.go
@@ -2,6 +2,7 @@ package assert
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 )
 
@@ -43,10 +44,13 @@ func TestIsIncreasing(t *testing.T) {
 		{collection: []uint64{2, 1}, msg: `"2" is not less than "1"`},
 		{collection: []float32{2.34, 1.23}, msg: `"2.34" is not less than "1.23"`},
 		{collection: []float64{2.34, 1.23}, msg: `"2.34" is not less than "1.23"`},
+		{collection: struct{}{}, msg: `object struct {} is not a collection`},
 	} {
-		out := &outputT{buf: bytes.NewBuffer(nil)}
-		False(t, IsIncreasing(out, currCase.collection))
-		Contains(t, out.buf.String(), currCase.msg)
+		t.Run(fmt.Sprintf("%#v", currCase.collection), func(t *testing.T) {
+			out := &outputT{buf: bytes.NewBuffer(nil)}
+			False(t, IsIncreasing(out, currCase.collection))
+			Contains(t, out.buf.String(), currCase.msg)
+		})
 	}
 }
 
@@ -88,10 +92,13 @@ func TestIsNonIncreasing(t *testing.T) {
 		{collection: []uint64{1, 2}, msg: `"1" is not greater than or equal to "2"`},
 		{collection: []float32{1.23, 2.34}, msg: `"1.23" is not greater than or equal to "2.34"`},
 		{collection: []float64{1.23, 2.34}, msg: `"1.23" is not greater than or equal to "2.34"`},
+		{collection: struct{}{}, msg: `object struct {} is not a collection`},
 	} {
-		out := &outputT{buf: bytes.NewBuffer(nil)}
-		False(t, IsNonIncreasing(out, currCase.collection))
-		Contains(t, out.buf.String(), currCase.msg)
+		t.Run(fmt.Sprintf("%#v", currCase.collection), func(t *testing.T) {
+			out := &outputT{buf: bytes.NewBuffer(nil)}
+			False(t, IsNonIncreasing(out, currCase.collection))
+			Contains(t, out.buf.String(), currCase.msg)
+		})
 	}
 }
 
@@ -133,10 +140,13 @@ func TestIsDecreasing(t *testing.T) {
 		{collection: []uint64{1, 2}, msg: `"1" is not greater than "2"`},
 		{collection: []float32{1.23, 2.34}, msg: `"1.23" is not greater than "2.34"`},
 		{collection: []float64{1.23, 2.34}, msg: `"1.23" is not greater than "2.34"`},
+		{collection: struct{}{}, msg: `object struct {} is not a collection`},
 	} {
-		out := &outputT{buf: bytes.NewBuffer(nil)}
-		False(t, IsDecreasing(out, currCase.collection))
-		Contains(t, out.buf.String(), currCase.msg)
+		t.Run(fmt.Sprintf("%#v", currCase.collection), func(t *testing.T) {
+			out := &outputT{buf: bytes.NewBuffer(nil)}
+			False(t, IsDecreasing(out, currCase.collection))
+			Contains(t, out.buf.String(), currCase.msg)
+		})
 	}
 }
 
@@ -178,9 +188,12 @@ func TestIsNonDecreasing(t *testing.T) {
 		{collection: []uint64{2, 1}, msg: `"2" is not less than or equal to "1"`},
 		{collection: []float32{2.34, 1.23}, msg: `"2.34" is not less than or equal to "1.23"`},
 		{collection: []float64{2.34, 1.23}, msg: `"2.34" is not less than or equal to "1.23"`},
+		{collection: struct{}{}, msg: `object struct {} is not a collection`},
 	} {
-		out := &outputT{buf: bytes.NewBuffer(nil)}
-		False(t, IsNonDecreasing(out, currCase.collection))
-		Contains(t, out.buf.String(), currCase.msg)
+		t.Run(fmt.Sprintf("%#v", currCase.collection), func(t *testing.T) {
+			out := &outputT{buf: bytes.NewBuffer(nil)}
+			False(t, IsNonDecreasing(out, currCase.collection))
+			Contains(t, out.buf.String(), currCase.msg)
+		})
 	}
 }

--- a/assert/assertion_order_test.go
+++ b/assert/assertion_order_test.go
@@ -6,6 +6,14 @@ import (
 	"testing"
 )
 
+type sortInterface struct {
+	content []int
+}
+
+func (s *sortInterface) Len() int           { return len(s.content) }
+func (s *sortInterface) Swap(i, j int)      { s.content[i], s.content[j] = s.content[j], s.content[i] }
+func (s *sortInterface) Less(i, j int) bool { return s.content[i] < s.content[j] }
+
 func TestIsIncreasing(t *testing.T) {
 	mockT := new(testing.T)
 
@@ -23,6 +31,10 @@ func TestIsIncreasing(t *testing.T) {
 
 	if IsIncreasing(mockT, []int{2, 1}) {
 		t.Error("IsIncreasing should return false")
+	}
+
+	if !IsIncreasing(mockT, &sortInterface{[]int{1, 2, 4}}) {
+		t.Error("IsIncreasing should return true")
 	}
 
 	// Check error report
@@ -44,6 +56,8 @@ func TestIsIncreasing(t *testing.T) {
 		{collection: []uint64{2, 1}, msg: `"2" is not less than "1"`},
 		{collection: []float32{2.34, 1.23}, msg: `"2.34" is not less than "1.23"`},
 		{collection: []float64{2.34, 1.23}, msg: `"2.34" is not less than "1.23"`},
+		{collection: &sortInterface{[]int{2, 1}}, msg: `element 0 is not less than element 1`},
+		{collection: &sortInterface{[]int{1, 1}}, msg: `element 0 is not less than element 1`},
 		{collection: struct{}{}, msg: `object struct {} is not a collection`},
 	} {
 		t.Run(fmt.Sprintf("%#v", currCase.collection), func(t *testing.T) {
@@ -73,6 +87,10 @@ func TestIsNonIncreasing(t *testing.T) {
 		t.Error("IsNonIncreasing should return false")
 	}
 
+	if !IsNonIncreasing(mockT, &sortInterface{[]int{10, 9, 9, 2}}) {
+		t.Error("IsNonIncreasing should return true")
+	}
+
 	// Check error report
 	for _, currCase := range []struct {
 		collection interface{}
@@ -92,6 +110,7 @@ func TestIsNonIncreasing(t *testing.T) {
 		{collection: []uint64{1, 2}, msg: `"1" is not greater than or equal to "2"`},
 		{collection: []float32{1.23, 2.34}, msg: `"1.23" is not greater than or equal to "2.34"`},
 		{collection: []float64{1.23, 2.34}, msg: `"1.23" is not greater than or equal to "2.34"`},
+		{collection: &sortInterface{[]int{1, 2}}, msg: `element 0 is not greater than or equal to element 1`},
 		{collection: struct{}{}, msg: `object struct {} is not a collection`},
 	} {
 		t.Run(fmt.Sprintf("%#v", currCase.collection), func(t *testing.T) {
@@ -121,6 +140,10 @@ func TestIsDecreasing(t *testing.T) {
 		t.Error("IsDecreasing should return false")
 	}
 
+	if !IsDecreasing(mockT, &sortInterface{[]int{4, 2, 1}}) {
+		t.Error("IsDecreasing should return true")
+	}
+
 	// Check error report
 	for _, currCase := range []struct {
 		collection interface{}
@@ -140,6 +163,8 @@ func TestIsDecreasing(t *testing.T) {
 		{collection: []uint64{1, 2}, msg: `"1" is not greater than "2"`},
 		{collection: []float32{1.23, 2.34}, msg: `"1.23" is not greater than "2.34"`},
 		{collection: []float64{1.23, 2.34}, msg: `"1.23" is not greater than "2.34"`},
+		{collection: &sortInterface{[]int{1, 2}}, msg: `element 0 is not greater than element 1`},
+		{collection: &sortInterface{[]int{1, 1}}, msg: `element 0 is not greater than element 1`},
 		{collection: struct{}{}, msg: `object struct {} is not a collection`},
 	} {
 		t.Run(fmt.Sprintf("%#v", currCase.collection), func(t *testing.T) {
@@ -169,6 +194,18 @@ func TestIsNonDecreasing(t *testing.T) {
 		t.Error("IsNonDecreasing should return false")
 	}
 
+	if !IsNonDecreasing(mockT, &sortInterface{[]int{1, 2, 2, 10}}) {
+		t.Error("IsNonDecreasing should return true")
+	}
+
+	if !IsNonDecreasing(mockT, &sortInterface{[]int{1}}) {
+		t.Error("IsNonDecreasing should return true")
+	}
+
+	if !IsNonDecreasing(mockT, &sortInterface{[]int{}}) {
+		t.Error("IsNonDecreasing should return true")
+	}
+
 	// Check error report
 	for _, currCase := range []struct {
 		collection interface{}
@@ -188,6 +225,7 @@ func TestIsNonDecreasing(t *testing.T) {
 		{collection: []uint64{2, 1}, msg: `"2" is not less than or equal to "1"`},
 		{collection: []float32{2.34, 1.23}, msg: `"2.34" is not less than or equal to "1.23"`},
 		{collection: []float64{2.34, 1.23}, msg: `"2.34" is not less than or equal to "1.23"`},
+		{collection: &sortInterface{[]int{2, 1}}, msg: `element 0 is not less than or equal to element 1`},
 		{collection: struct{}{}, msg: `object struct {} is not a collection`},
 	} {
 		t.Run(fmt.Sprintf("%#v", currCase.collection), func(t *testing.T) {

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -817,12 +817,15 @@ func Test_Mock_Called_blocks(t *testing.T) {
 
 	ch := make(chan Arguments)
 
+	timer := time.NewTimer(1 * time.Millisecond)
+	defer timer.Stop()
+
 	go asyncCall(&mockedService.Mock, ch)
 
 	select {
 	case <-ch:
 		t.Fatal("should have waited")
-	case <-time.After(1 * time.Millisecond):
+	case <-timer.C:
 	}
 
 	returnArguments := <-ch


### PR DESCRIPTION
## Summary
Support collections which implement `sort.Interface` as objects to `IsIncreasing`, `IsNonDecreasing`, `IsDecreasing` & `IsNonIncreasing`.

## Changes
* Fixed unrelated bug in `IsIncreasing`, `IsNonDecreasing`, `IsDecreasing` & `IsNonIncreasing`, if a non-collection is passed as object then the assertion returns false without failing the test. 😱
* Make `IsIncreasing`, `IsNonDecreasing`, `IsDecreasing` & `IsNonIncreasing` into helper functions, they already should be and their generated siblings already are.
* If object passed to `IsIncreasing`, `IsNonDecreasing`, `IsDecreasing` or `IsNonIncreasing` implements `sort.Interface`, check its ordering using that interface. This is done first as a performance concern because the algorithm does not use reflection.

## Motivation
If you have a collection which implements `sort.Interface`, you can now assert the four ordering primitives against it. For `IsIncreasing` this could have been expressed as `assert.True(t, sort.IsSorted(object))`, but for `IsNonDecreasing`, `IsDecreasing` or `IsNonIncreasing` you would have to write the algorithm in the test.

## Related issues
closes #1122 
