### PR TITLE
arrays value types in a zero-initialized state are considered empty

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -565,10 +565,6 @@ func isEmpty(object interface{}) bool {
 	// collection types are empty when they have no element
 	case reflect.Chan, reflect.Map, reflect.Slice:
 		return objValue.Len() == 0
-	// array types are empty when they match their zero-initialized state
-	case reflect.Array:
-		zero := reflect.Zero(objValue.Type()).Interface()
-		return ObjectsAreEqual(zero, object)
 	// pointers are empty if nil or if the value they point to is empty
 	case reflect.Ptr:
 		if objValue.IsNil() {
@@ -576,7 +572,8 @@ func isEmpty(object interface{}) bool {
 		}
 		deref := objValue.Elem().Interface()
 		return isEmpty(deref)
-		// for all other types, compare against the zero value
+	// for all other types, compare against the zero value
+	// array types are empty when they match their zero-initialized state
 	default:
 		zero := reflect.Zero(objValue.Type())
 		return reflect.DeepEqual(object, zero.Interface())

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -563,9 +563,13 @@ func isEmpty(object interface{}) bool {
 
 	switch objValue.Kind() {
 	// collection types are empty when they have no element
-	case reflect.Array, reflect.Chan, reflect.Map, reflect.Slice:
+	case reflect.Chan, reflect.Map, reflect.Slice:
 		return objValue.Len() == 0
-		// pointers are empty if nil or if the value they point to is empty
+	// array types are empty when they match their zero-initialized state
+	case reflect.Array:
+		zero := reflect.Zero(objValue.Type()).Interface()
+		return ObjectsAreEqual(zero, object)
+	// pointers are empty if nil or if the value they point to is empty
 	case reflect.Ptr:
 		if objValue.IsNil() {
 			return true

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -1131,6 +1131,7 @@ func Test_isEmpty(t *testing.T) {
 	True(t, isEmpty(new(time.Time)))
 	True(t, isEmpty(time.Time{}))
 	True(t, isEmpty(make(chan struct{})))
+	True(t, isEmpty([1]int{}))
 	False(t, isEmpty("something"))
 	False(t, isEmpty(errors.New("something")))
 	False(t, isEmpty([]string{"something"}))
@@ -1138,7 +1139,7 @@ func Test_isEmpty(t *testing.T) {
 	False(t, isEmpty(true))
 	False(t, isEmpty(map[string]string{"Hello": "World"}))
 	False(t, isEmpty(chWithValue))
-
+	False(t, isEmpty([1]int{42}))
 }
 
 func TestEmpty(t *testing.T) {
@@ -1172,6 +1173,7 @@ func TestEmpty(t *testing.T) {
 	True(t, Empty(mockT, TStruct{}), "struct with zero values is empty")
 	True(t, Empty(mockT, TString("")), "empty aliased string is empty")
 	True(t, Empty(mockT, sP), "ptr to nil value is empty")
+	True(t, Empty(mockT, [1]int{}), "array is state")
 
 	False(t, Empty(mockT, "something"), "Non Empty string is not empty")
 	False(t, Empty(mockT, errors.New("something")), "Non nil object is not empty")
@@ -1182,6 +1184,7 @@ func TestEmpty(t *testing.T) {
 	False(t, Empty(mockT, TStruct{x: 1}), "struct with initialized values is empty")
 	False(t, Empty(mockT, TString("abc")), "non-empty aliased string is empty")
 	False(t, Empty(mockT, xP), "ptr to non-nil value is not empty")
+	False(t, Empty(mockT, [1]int{42}), "array is not state")
 }
 
 func TestNotEmpty(t *testing.T) {
@@ -1196,6 +1199,7 @@ func TestNotEmpty(t *testing.T) {
 	False(t, NotEmpty(mockT, 0), "Zero int value is empty")
 	False(t, NotEmpty(mockT, false), "False value is empty")
 	False(t, NotEmpty(mockT, make(chan struct{})), "Channel without values is empty")
+	False(t, NotEmpty(mockT, [1]int{}), "array is state")
 
 	True(t, NotEmpty(mockT, "something"), "Non Empty string is not empty")
 	True(t, NotEmpty(mockT, errors.New("something")), "Non nil object is not empty")
@@ -1203,6 +1207,7 @@ func TestNotEmpty(t *testing.T) {
 	True(t, NotEmpty(mockT, 1), "Non-zero int value is not empty")
 	True(t, NotEmpty(mockT, true), "True value is not empty")
 	True(t, NotEmpty(mockT, chWithValue), "Channel with values is not empty")
+	True(t, NotEmpty(mockT, [1]int{42}), "array is not state")
 }
 
 func Test_getLen(t *testing.T) {


### PR DESCRIPTION
## Summary

With this pull request, arrays value types in a zero-initialized state are considered empty.
Before that, only the zero-length arrays were considered empty.
The new behavior is backward compatible with the existing currently test coverage.

## Changes

- added test cases for `assert.Empty` with array value types.
- added test cases for `assert.NotEmpty` with array value types.
- Adjust implementation according to the new test cases
- minor refactoring

## Motivation

When I was reading the code source for learning purposes.
I discovered by chance that the `assert.isEmpty / case reflect.Array` code part doesn't have coverage.

```go
assert.Empty(t, [1]int{})
assert.NotEmpty(t, [1]int{42})
```

## Related issues

I'm not aware of any, but I didn't deeply check through the issues.
