### PR TITLE
Check condition immediately in *.Eventually

### DIFF
--- a/assert/assertion_format.go
+++ b/assert/assertion_format.go
@@ -145,7 +145,9 @@ func ErrorIsf(t TestingT, err error, target error, msg string, args ...interface
 }
 
 // Eventuallyf asserts that given condition will be met in waitFor time,
-// periodically checking target function each tick.
+// periodically checking target function each tick. The target function
+// is checked once immediately before Eventuallyf starts its periodic
+// checks.
 //
 //    assert.Eventuallyf(t, func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
 func Eventuallyf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) bool {

--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -278,7 +278,9 @@ func (a *Assertions) Errorf(err error, msg string, args ...interface{}) bool {
 }
 
 // Eventually asserts that given condition will be met in waitFor time,
-// periodically checking target function each tick.
+// periodically checking target function each tick. The target function
+// is checked once immediately before Eventually starts its periodic
+// checks.
 //
 //    a.Eventually(func() bool { return true; }, time.Second, 10*time.Millisecond)
 func (a *Assertions) Eventually(condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) bool {
@@ -289,7 +291,9 @@ func (a *Assertions) Eventually(condition func() bool, waitFor time.Duration, ti
 }
 
 // Eventuallyf asserts that given condition will be met in waitFor time,
-// periodically checking target function each tick.
+// periodically checking target function each tick. The target function
+// is checked once immediately before Eventuallyf starts its periodic
+// checks.
 //
 //    a.Eventuallyf(func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
 func (a *Assertions) Eventuallyf(condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) bool {

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1672,7 +1672,9 @@ type tHelper interface {
 }
 
 // Eventually asserts that given condition will be met in waitFor time,
-// periodically checking target function each tick.
+// periodically checking target function each tick. The target function
+// is checked once immediately before Eventually starts its periodic
+// checks.
 //
 //    assert.Eventually(t, func() bool { return true; }, time.Second, 10*time.Millisecond)
 func Eventually(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) bool {

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1680,6 +1680,10 @@ func Eventually(t TestingT, condition func() bool, waitFor time.Duration, tick t
 		h.Helper()
 	}
 
+	if condition() {
+		return true
+	}
+
 	ch := make(chan bool, 1)
 
 	timer := time.NewTimer(waitFor)

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -2416,9 +2416,14 @@ func TestNeverTrue(t *testing.T) {
 
 func TestEventuallyIssue805(t *testing.T) {
 	mockT := new(testing.T)
+	returnVal := false
 
 	NotPanics(t, func() {
-		condition := func() bool { <-time.After(time.Millisecond); return true }
+		condition := func() bool {
+			<-time.After(time.Millisecond)
+			defer func() { returnVal = true }()
+			return returnVal
+		}
 		False(t, Eventually(mockT, condition, time.Millisecond, time.Microsecond))
 	})
 }

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -2374,6 +2374,25 @@ func TestEventuallyTrue(t *testing.T) {
 	True(t, Eventually(t, condition, 100*time.Millisecond, 20*time.Millisecond))
 }
 
+func TestEventuallyTrueImmediately(t *testing.T) {
+	condition := func() bool {
+		return true
+	}
+
+	c := make(chan struct{})
+
+	go func() {
+		Eventually(t, condition, 100*time.Millisecond, 20*time.Millisecond)
+		close(c)
+	}()
+
+	select {
+	case <-c:
+	case <-time.After(20 * time.Millisecond):
+		FailNow(t, `waited too long`)
+	}
+}
+
 func TestNeverFalse(t *testing.T) {
 	condition := func() bool {
 		return false

--- a/require/require.go
+++ b/require/require.go
@@ -351,7 +351,9 @@ func Errorf(t TestingT, err error, msg string, args ...interface{}) {
 }
 
 // Eventually asserts that given condition will be met in waitFor time,
-// periodically checking target function each tick.
+// periodically checking target function each tick. The target function
+// is checked once immediately before Eventually starts its periodic
+// checks.
 //
 //    assert.Eventually(t, func() bool { return true; }, time.Second, 10*time.Millisecond)
 func Eventually(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
@@ -365,7 +367,9 @@ func Eventually(t TestingT, condition func() bool, waitFor time.Duration, tick t
 }
 
 // Eventuallyf asserts that given condition will be met in waitFor time,
-// periodically checking target function each tick.
+// periodically checking target function each tick. The target function
+// is checked once immediately before Eventuallyf starts its periodic
+// checks.
 //
 //    assert.Eventuallyf(t, func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
 func Eventuallyf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {

--- a/require/require_forward.go
+++ b/require/require_forward.go
@@ -279,7 +279,9 @@ func (a *Assertions) Errorf(err error, msg string, args ...interface{}) {
 }
 
 // Eventually asserts that given condition will be met in waitFor time,
-// periodically checking target function each tick.
+// periodically checking target function each tick. The target function
+// is checked once immediately before Eventually starts its periodic
+// checks.
 //
 //    a.Eventually(func() bool { return true; }, time.Second, 10*time.Millisecond)
 func (a *Assertions) Eventually(condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
@@ -290,7 +292,9 @@ func (a *Assertions) Eventually(condition func() bool, waitFor time.Duration, ti
 }
 
 // Eventuallyf asserts that given condition will be met in waitFor time,
-// periodically checking target function each tick.
+// periodically checking target function each tick. The target function
+// is checked once immediately before Eventuallyf starts its periodic
+// checks.
 //
 //    a.Eventuallyf(func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
 func (a *Assertions) Eventuallyf(condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {


### PR DESCRIPTION
## Summary
`assert.Eventually` waits for the tick interval before doing the first check of the condition. In a lot of cases, the condition might be true immediately, so it would be helpful to check it right away..

## Changes
- Return early from `assert.Eventually` if the condition is already met. This will also affect `require.Eventually`.

## Motivation
This change avoids unnecessary waiting and allocations if the condition is true immediately -- it precludes us needing to set up a ticker, timer, and channel. This can save a lot of time when running tests repeatedly.

## Related issues
<!-- Put `Closes #XXXX` for each issue number this PR fixes/closes -->
