### PR TITLE
assert.ErrorAs: fix error message

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1795,21 +1795,28 @@ func ErrorAs(t TestingT, err error, target interface{}, msgAndArgs ...interface{
 
 	chain := buildErrorChainString(err)
 
+	tt := reflect.TypeOf(target)
+	if tt.Kind() == reflect.Ptr && tt.Elem().Kind() == reflect.Ptr {
+		tv := reflect.New(tt.Elem().Elem())
+		reflect.ValueOf(target).Elem().Set(tv)
+		target = tv.Interface()
+	}
+
 	return Fail(t, fmt.Sprintf("Should be in error chain:\n"+
-		"expected: %q\n"+
+		"expected: %T\n"+
 		"in chain: %s", target, chain,
 	), msgAndArgs...)
 }
 
 func buildErrorChainString(err error) string {
 	if err == nil {
-		return ""
+		return "<nil>"
 	}
 
 	e := errors.Unwrap(err)
-	chain := fmt.Sprintf("%q", err.Error())
+	chain := fmt.Sprintf("%T(%q)", err, err.Error())
 	for e != nil {
-		chain += fmt.Sprintf("\n\t%q", e.Error())
+		chain += fmt.Sprintf("\n\t%T(%q)", e, e.Error())
 		e = errors.Unwrap(e)
 	}
 	return chain

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -100,6 +100,14 @@ func (a *AssertionTesterConformingObject) TestMethod() {
 type AssertionTesterNonConformingObject struct {
 }
 
+type MockT struct {
+	LastMessage string
+}
+
+func (m *MockT) Errorf(format string, a ...interface{}) {
+	m.LastMessage = fmt.Sprintf(format, a...)
+}
+
 func TestObjectsAreEqual(t *testing.T) {
 	cases := []struct {
 		expected interface{}
@@ -2484,22 +2492,45 @@ func TestNotErrorIs(t *testing.T) {
 }
 
 func TestErrorAs(t *testing.T) {
-	mockT := new(testing.T)
 	tests := []struct {
 		err    error
 		result bool
+		msg    string
 	}{
-		{fmt.Errorf("wrap: %w", &customError{}), true},
-		{io.EOF, false},
-		{nil, false},
+		{
+			err:    fmt.Errorf("wrap: %w", &customError{}),
+			result: true,
+		},
+		{
+			err:    io.EOF,
+			result: false,
+			msg: "\n\tError Trace:\t\n\tError:      \tShould be in error chain:\n\t            " +
+				"\texpected: *assert.customError\n\t            " +
+				"\tin chain: *errors.errorString(\"EOF\")\n",
+		},
+		{
+			err:    nil,
+			result: false,
+			msg: "\n\tError Trace:\t\n\tError:      \tShould be in error chain:\n\t            " +
+				"\texpected: *assert.customError\n\t            " +
+				"\tin chain: <nil>\n",
+		},
 	}
 	for _, tt := range tests {
 		tt := tt
 		var target *customError
 		t.Run(fmt.Sprintf("ErrorAs(%#v,%#v)", tt.err, target), func(t *testing.T) {
+			mockT := new(MockT) // not prevent race condition if t.Parallel() will be used in future
 			res := ErrorAs(mockT, tt.err, &target)
 			if res != tt.result {
-				t.Errorf("ErrorAs(%#v,%#v) should return %t)", tt.err, target, tt.result)
+				t.Errorf("ErrorAs(%#v,%#v) should return %t", tt.err, target, tt.result)
+			}
+			if res == false && mockT.LastMessage != tt.msg {
+				t.Errorf("ErrorAs(%#v,%#v)"+
+					"\nShould print\n%s"+
+					"\nbut\n%s"+
+					"\nprinted%s",
+					tt.err, target, tt.msg, mockT.LastMessage, diff(tt.msg, mockT.LastMessage))
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Improve message of `assert.ErrorAs()`

## Changes

* Replace non-informative message like `expected: %!q(**pgconn.PgError=0xc000114050)` to the human readable one.
* Replaced simple output of `"%s", err.Error()` to `"%T(%s)"` for better readability.

## Motivation

* First the `%!q(**pgconn.PgError=0xc000114050)` text is the broken format string
* Second — even fixed, resulting `err.Error()` provides not enough information to see what exactly type of error is expected in `errors.As` and what is provided.

## Related issues

Closes #1115
