### PR TITLE
assert.formatUnequalValues(): fix misleading output #400

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -429,8 +429,7 @@ func samePointers(first, second interface{}) bool {
 // to a type conversion in the Go grammar.
 func formatUnequalValues(expected, actual interface{}) (e string, a string) {
 	if reflect.TypeOf(expected) != reflect.TypeOf(actual) {
-		return fmt.Sprintf("%T(%s)", expected, truncatingFormat(expected)),
-			fmt.Sprintf("%T(%s)", actual, truncatingFormat(actual))
+		return truncatingFormat(expected), truncatingFormat(actual)
 	}
 	switch expected.(type) {
 	case time.Duration:
@@ -444,7 +443,7 @@ func formatUnequalValues(expected, actual interface{}) (e string, a string) {
 // This helps keep formatted error messages lines from exceeding the
 // bufio.MaxScanTokenSize max line length that the go testing framework imposes.
 func truncatingFormat(data interface{}) string {
-	value := fmt.Sprintf("%#v", data)
+	value := fmt.Sprintf("%T(%v)", data, data)
 	max := bufio.MaxScanTokenSize - 100 // Give us some space the type info too if needed.
 	if len(value) > max {
 		value = value[0:max] + "<... truncated>"


### PR DESCRIPTION
fix: formatUnequalValues() output is misleading
    use "%T(%v)" instead of using the "%#v" fmt format, avoid formatting output errors

# Related
#400
#1116