### PR TITLE
assert.NotErrorAs: new assertion

### DIFF
--- a/assert/assertion_format.go
+++ b/assert/assertion_format.go
@@ -565,6 +565,15 @@ func NotEqualValuesf(t TestingT, expected interface{}, actual interface{}, msg s
 	return NotEqualValues(t, expected, actual, append([]interface{}{msg}, args...)...)
 }
 
+// NotErrorAsf asserts that at none of the errors in err's chain matches target, otherwise, sets target to that error value.
+// This is a wrapper for errors.As.
+func NotErrorAsf(t TestingT, err error, target interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotErrorAs(t, err, target, append([]interface{}{msg}, args...)...)
+}
+
 // NotErrorIsf asserts that at none of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
 func NotErrorIsf(t TestingT, err error, target error, msg string, args ...interface{}) bool {

--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -1119,6 +1119,24 @@ func (a *Assertions) NotEqualf(expected interface{}, actual interface{}, msg str
 	return NotEqualf(a.t, expected, actual, msg, args...)
 }
 
+// NotErrorAs asserts that at none of the errors in err's chain matches target, otherwise, sets target to that error value.
+// This is a wrapper for errors.As.
+func (a *Assertions) NotErrorAs(err error, target interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotErrorAs(a.t, err, target, msgAndArgs...)
+}
+
+// NotErrorAsf asserts that at none of the errors in err's chain matches target, otherwise, sets target to that error value.
+// This is a wrapper for errors.As.
+func (a *Assertions) NotErrorAsf(err error, target interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NotErrorAsf(a.t, err, target, msg, args...)
+}
+
 // NotErrorIs asserts that at none of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
 func (a *Assertions) NotErrorIs(err error, target error, msgAndArgs ...interface{}) bool {

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1801,6 +1801,31 @@ func ErrorAs(t TestingT, err error, target interface{}, msgAndArgs ...interface{
 	), msgAndArgs...)
 }
 
+// NotErrorAs asserts that at none of the errors in err's chain matches target, otherwise, sets target to that error value.
+// This is a wrapper for errors.As.
+func NotErrorAs(t TestingT, err error, target interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if !errors.As(err, target) {
+		return true
+	}
+
+	var expectedText string
+	if target != nil {
+		if tErr, ok := target.(error); ok {
+			expectedText = tErr.Error()
+		}
+	}
+
+	chain := buildErrorChainString(err)
+
+	return Fail(t, fmt.Sprintf("Target error should not be in err chain:\n"+
+		"found: %q\n"+
+		"in chain: %s", expectedText, chain,
+	), msgAndArgs...)
+}
+
 func buildErrorChainString(err error) string {
 	if err == nil {
 		return ""

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -2504,3 +2504,25 @@ func TestErrorAs(t *testing.T) {
 		})
 	}
 }
+
+func TestNotErrorAs(t *testing.T) {
+	mockT := new(testing.T)
+	tests := []struct {
+		err    error
+		result bool
+	}{
+		{fmt.Errorf("wrap: %w", &customError{}), false},
+		{io.EOF, true},
+		{nil, true},
+	}
+	for _, tt := range tests {
+		tt := tt
+		var target *customError
+		t.Run(fmt.Sprintf("NotErrorAs(%#v,%#v)", tt.err, target), func(t *testing.T) {
+			res := NotErrorAs(mockT, tt.err, &target)
+			if res != tt.result {
+				t.Errorf("NotErrorAs(%#v,%#v) should return %t)", tt.err, target, tt.result)
+			}
+		})
+	}
+}

--- a/require/require.go
+++ b/require/require.go
@@ -1426,6 +1426,30 @@ func NotEqualf(t TestingT, expected interface{}, actual interface{}, msg string,
 	t.FailNow()
 }
 
+// NotErrorAs asserts that at none of the errors in err's chain matches target, otherwise, sets target to that error value.
+// This is a wrapper for errors.As.
+func NotErrorAs(t TestingT, err error, target interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotErrorAs(t, err, target, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotErrorAsf asserts that at none of the errors in err's chain matches target, otherwise, sets target to that error value.
+// This is a wrapper for errors.As.
+func NotErrorAsf(t TestingT, err error, target interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotErrorAsf(t, err, target, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
 // NotErrorIs asserts that at none of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
 func NotErrorIs(t TestingT, err error, target error, msgAndArgs ...interface{}) {

--- a/require/require_forward.go
+++ b/require/require_forward.go
@@ -1120,6 +1120,24 @@ func (a *Assertions) NotEqualf(expected interface{}, actual interface{}, msg str
 	NotEqualf(a.t, expected, actual, msg, args...)
 }
 
+// NotErrorAs asserts that at none of the errors in err's chain matches target, otherwise, sets target to that error value.
+// This is a wrapper for errors.As.
+func (a *Assertions) NotErrorAs(err error, target interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotErrorAs(a.t, err, target, msgAndArgs...)
+}
+
+// NotErrorAsf asserts that at none of the errors in err's chain matches target, otherwise, sets target to that error value.
+// This is a wrapper for errors.As.
+func (a *Assertions) NotErrorAsf(err error, target interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotErrorAsf(a.t, err, target, msg, args...)
+}
+
 // NotErrorIs asserts that at none of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
 func (a *Assertions) NotErrorIs(err error, target error, msgAndArgs ...interface{}) {


### PR DESCRIPTION
## Summary
<!-- High-level, one sentence summary of what this PR accomplishes -->

Add `NotErrorAs` methods to check that none of the errors in err's chain matches target.

## Changes
- add `NotErrorAs` and `NotErrorAsf` assertions to `assert` and `require` packages

## Motivation
<!-- Why were the changes necessary. -->

Sometimes, it's essential to check that error does not match an exact type.

<!-- ## Example usage (if applicable) -->

```
func TestExample(t *testing.T) {
	err := errors.New("test error")

	var notFoundErr ErrNotFound
	assert.NotErrorAs(t, err, &notFoundErr)

	err = WrapNotFoundError(err)
	assert.ErrorAs(t, err, &notFoundErr)
}
```

## Related issues
<!-- Put `Closes #XXXX` for each issue number this PR fixes/closes -->
Closes #1066 