### PR TITLE
assert: allow comparing time.Time

### DIFF
--- a/assert/assertion_compare.go
+++ b/assert/assertion_compare.go
@@ -306,7 +306,7 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (CompareType, bool) {
 	case reflect.Struct:
 		{
 			// All structs enter here. We're not interested in most types.
-			if !obj1Value.CanConvert(timeType) {
+			if !canConvert(obj1Value, timeType) {
 				break
 			}
 

--- a/assert/assertion_compare.go
+++ b/assert/assertion_compare.go
@@ -3,6 +3,7 @@ package assert
 import (
 	"fmt"
 	"reflect"
+	"time"
 )
 
 type CompareType int
@@ -30,6 +31,8 @@ var (
 	float64Type = reflect.TypeOf(float64(1))
 
 	stringType = reflect.TypeOf("")
+
+	timeType = reflect.TypeOf(time.Time{})
 )
 
 func compare(obj1, obj2 interface{}, kind reflect.Kind) (CompareType, bool) {
@@ -298,6 +301,27 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (CompareType, bool) {
 			if stringobj1 < stringobj2 {
 				return compareLess, true
 			}
+		}
+	// Check for known struct types we can check for compare results.
+	case reflect.Struct:
+		{
+			// All structs enter here. We're not interested in most types.
+			if !obj1Value.CanConvert(timeType) {
+				break
+			}
+
+			// time.Time can compared!
+			timeObj1, ok := obj1.(time.Time)
+			if !ok {
+				timeObj1 = obj1Value.Convert(timeType).Interface().(time.Time)
+			}
+
+			timeObj2, ok := obj2.(time.Time)
+			if !ok {
+				timeObj2 = obj2Value.Convert(timeType).Interface().(time.Time)
+			}
+
+			return compare(timeObj1.UnixNano(), timeObj2.UnixNano(), reflect.Int64)
 		}
 	}
 

--- a/assert/assertion_compare_can_convert.go
+++ b/assert/assertion_compare_can_convert.go
@@ -1,3 +1,4 @@
+//go:build go1.17
 // +build go1.17
 
 // TODO: once support for Go 1.16 is dropped, this file can be

--- a/assert/assertion_compare_can_convert.go
+++ b/assert/assertion_compare_can_convert.go
@@ -1,0 +1,11 @@
+// +build go1.17
+
+package assert
+
+import "reflect"
+
+// Wrapper around reflect.Value.CanConvert, for compatability
+// reasons.
+func canConvert(value reflect.Value, to reflect.Type) bool {
+	return value.CanConvert(to)
+}

--- a/assert/assertion_compare_can_convert.go
+++ b/assert/assertion_compare_can_convert.go
@@ -1,5 +1,9 @@
 // +build go1.17
 
+// TODO: once support for Go 1.16 is dropped, this file can be
+//       merged/removed with assertion_compare_go1.17_test.go and
+//       assertion_compare_legacy.go
+
 package assert
 
 import "reflect"

--- a/assert/assertion_compare_go1.17_test.go
+++ b/assert/assertion_compare_go1.17_test.go
@@ -1,3 +1,4 @@
+//go:build go1.17
 // +build go1.17
 
 // TODO: once support for Go 1.16 is dropped, this file can be

--- a/assert/assertion_compare_go1.17_test.go
+++ b/assert/assertion_compare_go1.17_test.go
@@ -1,0 +1,49 @@
+// +build go1.17
+
+package assert
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestCompare17(t *testing.T) {
+	type customTime time.Time
+	for _, currCase := range []struct {
+		less    interface{}
+		greater interface{}
+		cType   string
+	}{
+		{less: time.Now(), greater: time.Now().Add(time.Hour), cType: "time.Time"},
+		{less: customTime(time.Now()), greater: customTime(time.Now().Add(time.Hour)), cType: "time.Time"},
+	} {
+		resLess, isComparable := compare(currCase.less, currCase.greater, reflect.ValueOf(currCase.less).Kind())
+		if !isComparable {
+			t.Error("object should be comparable for type " + currCase.cType)
+		}
+
+		if resLess != compareLess {
+			t.Errorf("object less (%v) should be less than greater (%v) for type "+currCase.cType,
+				currCase.less, currCase.greater)
+		}
+
+		resGreater, isComparable := compare(currCase.greater, currCase.less, reflect.ValueOf(currCase.less).Kind())
+		if !isComparable {
+			t.Error("object are comparable for type " + currCase.cType)
+		}
+
+		if resGreater != compareGreater {
+			t.Errorf("object greater should be greater than less for type " + currCase.cType)
+		}
+
+		resEqual, isComparable := compare(currCase.less, currCase.less, reflect.ValueOf(currCase.less).Kind())
+		if !isComparable {
+			t.Error("object are comparable for type " + currCase.cType)
+		}
+
+		if resEqual != 0 {
+			t.Errorf("objects should be equal for type " + currCase.cType)
+		}
+	}
+}

--- a/assert/assertion_compare_go1.17_test.go
+++ b/assert/assertion_compare_go1.17_test.go
@@ -1,5 +1,9 @@
 // +build go1.17
 
+// TODO: once support for Go 1.16 is dropped, this file can be
+//       merged/removed with assertion_compare_can_convert.go and
+//       assertion_compare_legacy.go
+
 package assert
 
 import (

--- a/assert/assertion_compare_legacy.go
+++ b/assert/assertion_compare_legacy.go
@@ -1,3 +1,4 @@
+//go:build !go1.17
 // +build !go1.17
 
 // TODO: once support for Go 1.16 is dropped, this file can be

--- a/assert/assertion_compare_legacy.go
+++ b/assert/assertion_compare_legacy.go
@@ -1,5 +1,9 @@
 // +build !go1.17
 
+// TODO: once support for Go 1.16 is dropped, this file can be
+//       merged/removed with assertion_compare_go1.17_test.go and
+//       assertion_compare_can_convert.go
+
 package assert
 
 import "reflect"

--- a/assert/assertion_compare_legacy.go
+++ b/assert/assertion_compare_legacy.go
@@ -1,0 +1,11 @@
+// +build !go1.17
+
+package assert
+
+import "reflect"
+
+// Older versions of Go does not have the reflect.Value.CanConvert
+// method.
+func canConvert(value reflect.Value, to reflect.Type) bool {
+	return false
+}

--- a/assert/assertion_compare_test.go
+++ b/assert/assertion_compare_test.go
@@ -6,7 +6,6 @@ import (
 	"reflect"
 	"runtime"
 	"testing"
-	"time"
 )
 
 func TestCompare(t *testing.T) {
@@ -23,7 +22,6 @@ func TestCompare(t *testing.T) {
 	type customFloat32 float32
 	type customFloat64 float64
 	type customString string
-	type customTime time.Time
 	for _, currCase := range []struct {
 		less    interface{}
 		greater interface{}
@@ -54,8 +52,6 @@ func TestCompare(t *testing.T) {
 		{less: customFloat32(1.23), greater: customFloat32(2.23), cType: "float32"},
 		{less: float64(1.23), greater: float64(2.34), cType: "float64"},
 		{less: customFloat64(1.23), greater: customFloat64(2.34), cType: "float64"},
-		{less: time.Now(), greater: time.Now().Add(time.Hour), cType: "time.Time"},
-		{less: customTime(time.Now()), greater: customTime(time.Now().Add(time.Hour)), cType: "time.Time"},
 	} {
 		resLess, isComparable := compare(currCase.less, currCase.greater, reflect.ValueOf(currCase.less).Kind())
 		if !isComparable {

--- a/assert/assertion_compare_test.go
+++ b/assert/assertion_compare_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"runtime"
 	"testing"
+	"time"
 )
 
 func TestCompare(t *testing.T) {
@@ -22,6 +23,7 @@ func TestCompare(t *testing.T) {
 	type customFloat32 float32
 	type customFloat64 float64
 	type customString string
+	type customTime time.Time
 	for _, currCase := range []struct {
 		less    interface{}
 		greater interface{}
@@ -52,6 +54,8 @@ func TestCompare(t *testing.T) {
 		{less: customFloat32(1.23), greater: customFloat32(2.23), cType: "float32"},
 		{less: float64(1.23), greater: float64(2.34), cType: "float64"},
 		{less: customFloat64(1.23), greater: customFloat64(2.34), cType: "float64"},
+		{less: time.Now(), greater: time.Now().Add(time.Hour), cType: "time.Time"},
+		{less: customTime(time.Now()), greater: customTime(time.Now().Add(time.Hour)), cType: "time.Time"},
 	} {
 		resLess, isComparable := compare(currCase.less, currCase.greater, reflect.ValueOf(currCase.less).Kind())
 		if !isComparable {
@@ -59,7 +63,8 @@ func TestCompare(t *testing.T) {
 		}
 
 		if resLess != compareLess {
-			t.Errorf("object less should be less than greater for type " + currCase.cType)
+			t.Errorf("object less (%v) should be less than greater (%v) for type "+currCase.cType,
+				currCase.less, currCase.greater)
 		}
 
 		resGreater, isComparable := compare(currCase.greater, currCase.less, reflect.ValueOf(currCase.less).Kind())


### PR DESCRIPTION
## Summary
Add support for comparing `time>Time` and custom types derived from it.  

## Changes
When comparing types, see if we're comparing `time.Time`, or a custom type based on `time.Time`. If that's the case, compare their Unix timestamps, with the smallest possible resolution. 

## Motivation
This now allows sticking a `time.Time` into `assert.Greater` and `assert.Less`, which is nice. Time stamps have a natural ordering, so I'd expect this to work. 