### PR TITLE
Mock can be deadlocked by a panic

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -812,7 +812,16 @@ func (args Arguments) Diff(objects []interface{}) (string, int) {
 		}
 
 		if matcher, ok := expected.(argumentMatcher); ok {
-			if matcher.Matches(actual) {
+			var matches bool
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						actualFmt = fmt.Sprintf("panic in argument matcher: %v", r)
+					}
+				}()
+				matches = matcher.Matches(actual)
+			}()
+			if matches {
 				output = fmt.Sprintf("%s\t%d: PASS:  %s matched by %s\n", output, i, actualFmt, matcher)
 			} else {
 				differences++


### PR DESCRIPTION
## Summary
If an argumentMatcher function panics and AssertExpectations is deferred then the test would deadlock.

## Changes
* Capture panics from argumentMatcher functions and show them to the user as a difference

## Motivation
It was reported that when AssertExpectations() is deferred and an argumentMatcher function panics, that the test will deadlock.

Example from linked issue:
```go
import (
	"testing"

	"github.com/stretchr/testify/mock"
)

type Mock struct {
	mock.Mock
}

func (_m *Mock) F() {
	_m.Called()
}

func TestMatcherPanic(t *testing.T) {
  m := &Mock{}
  defer m.AssertExpectations(t)

  matcher := mock.MatchedBy(func(_ interface{}) bool {
    panic("my hovercraft is full of eels")
  })
  m.On("F", matcher)

  m.F()
}
```

After this change the output will now look like:
```
--- FAIL: TestMatcherPanic (0.00s)
    /Users/alandaws/src/github.com/brackendawson/kata/mock.go:264: 
        
        mock: Unexpected Method Call
        -----------------------------
        
        F()
        		
        
        The closest call I have is: 
        
        F(mock.argumentMatcher)
        		0: mock.argumentMatcher{fn:reflect.Value{typ:(*reflect.rtype)(0x126a520), ptr:(unsafe.Pointer)(0x12b5f88), flag:0x13}}
        
        Provided 1 arguments, mocked for 0 arguments
        Diff: 0: FAIL:  panic in argument matcher: my hovercraft is full of eels not matched by func(interface {}) bool
    /Users/alandaws/src/github.com/brackendawson/kata/panic.go:661: FAIL:	F(mock.argumentMatcher)
        		at: [kata_test.go:25]
    /Users/alandaws/src/github.com/brackendawson/kata/panic.go:661: FAIL: 0 out of 1 expectation(s) were met.
        	The code you are testing needs to make 1 more call(s).
        	at: [panic.go:661 testing.go:756 kata_test.go:14 kata_test.go:27]
```

I wonder if that is obvious enough?

## Related issues
fixes #1155 
