### PR TITLE
fix data race in the suit

### DIFF
--- a/suite/suite.go
+++ b/suite/suite.go
@@ -22,15 +22,15 @@ var matchMethod = flag.String("testify.m", "", "regular expression to select tes
 // retrieving the current *testing.T context.
 type Suite struct {
 	*assert.Assertions
-	mu      sync.Mutex
+	mu      sync.RWMutex
 	require *require.Assertions
 	t       *testing.T
 }
 
 // T retrieves the current *testing.T context.
 func (suite *Suite) T() *testing.T {
-	suite.mu.Lock()
-	defer suite.mu.Unlock()
+	suite.mu.RLock()
+	defer suite.mu.RUnlock()
 	return suite.t
 }
 

--- a/suite/suite.go
+++ b/suite/suite.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"regexp"
 	"runtime/debug"
+	"sync"
 	"testing"
 	"time"
 
@@ -21,17 +22,22 @@ var matchMethod = flag.String("testify.m", "", "regular expression to select tes
 // retrieving the current *testing.T context.
 type Suite struct {
 	*assert.Assertions
+	mu      sync.Mutex
 	require *require.Assertions
 	t       *testing.T
 }
 
 // T retrieves the current *testing.T context.
 func (suite *Suite) T() *testing.T {
+	suite.mu.Lock()
+	defer suite.mu.Unlock()
 	return suite.t
 }
 
 // SetT sets the current *testing.T context.
 func (suite *Suite) SetT(t *testing.T) {
+	suite.mu.Lock()
+	defer suite.mu.Unlock()
 	suite.t = t
 	suite.Assertions = assert.New(t)
 	suite.require = require.New(t)
@@ -39,6 +45,8 @@ func (suite *Suite) SetT(t *testing.T) {
 
 // Require returns a require context for suite.
 func (suite *Suite) Require() *require.Assertions {
+	suite.mu.Lock()
+	defer suite.mu.Unlock()
 	if suite.require == nil {
 		suite.require = require.New(suite.T())
 	}
@@ -51,6 +59,8 @@ func (suite *Suite) Require() *require.Assertions {
 // assert.Assertions with require.Assertions), this method is provided so you
 // can call `suite.Assert().NoError()`.
 func (suite *Suite) Assert() *assert.Assertions {
+	suite.mu.Lock()
+	defer suite.mu.Unlock()
 	if suite.Assertions == nil {
 		suite.Assertions = assert.New(suite.T())
 	}


### PR DESCRIPTION
Signed-off-by: Weizhen Wang <wangweizhen@pingcap.com>

## Summary
<!-- High-level, one sentence summary of what this PR accomplishes -->

we find a data race in the suit. so we think Mutex is added to the suit for solving it.

ref https://github.com/pingcap/tidb/issues/32747

```
==================
WARNING: DATA RACE
Write at 0x00c026a29588 by goroutine 117:
  github.com/stretchr/testify/suite.(*Suite).SetT()
      /home/prow/go/pkg/mod/github.com/stretchr/testify@v1.7.0/suite/suite.go:37 +0x148
  github.com/pingcap/tidb/executor_test.(*infosSchemaClusterTableSuite).SetT()
      <autogenerated>:1 +0x44
  github.com/stretchr/testify/suite.Run.func1()
      /home/prow/go/pkg/mod/github.com/stretchr/testify@v1.7.0/suite/suite.go:128 +0xcc
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1259 +0x22f
  testing.(*T).Run·dwrap·21()
      /usr/local/go/src/testing/testing.go:1306 +0x47
Previous read at 0x00c026a29588 by goroutine 209:
  github.com/stretchr/testify/suite.(*Suite).Require()
      /home/prow/go/pkg/mod/github.com/stretchr/testify@v1.7.0/suite/suite.go:42 +0x5a
  github.com/pingcap/tidb/executor_test.(*infosSchemaClusterTableSuite).setUpRPCService.func1()
      /go/tidb/executor/infoschema_cluster_table_test.go:86 +0x46
Goroutine 117 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1306 +0x726
  github.com/stretchr/testify/suite.runTests()
      /home/prow/go/pkg/mod/github.com/stretchr/testify@v1.7.0/suite/suite.go:203 +0x18f
  github.com/stretchr/testify/suite.Run()
      /home/prow/go/pkg/mod/github.com/stretchr/testify@v1.7.0/suite/suite.go:176 +0x994
  github.com/pingcap/tidb/executor_test.TestInfoSchemaClusterTable()
      /go/tidb/executor/infoschema_cluster_table_test.go:57 +0x44
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1259 +0x22f
  testing.(*T).Run·dwrap·21()
      /usr/local/go/src/testing/testing.go:1306 +0x47
Goroutine 209 (running) created at:
  github.com/pingcap/tidb/executor_test.(*infosSchemaClusterTableSuite).setUpRPCService()
      /go/tidb/executor/infoschema_cluster_table_test.go:85 +0x5d2
  github.com/pingcap/tidb/executor_test.(*infosSchemaClusterTableSuite).SetupSuite()
      /go/tidb/executor/infoschema_cluster_table_test.go:62 +0x184
  github.com/stretchr/testify/suite.Run()
      /home/prow/go/pkg/mod/github.com/stretchr/testify@v1.7.0/suite/suite.go:118 +0x5b7
  github.com/pingcap/tidb/executor_test.TestInfoSchemaClusterTable()
      /go/tidb/executor/infoschema_cluster_table_test.go:57 +0x44
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1259 +0x22f
  testing.(*T).Run·dwrap·21()
      /usr/local/go/src/testing/testing.go:1306 +0x47
================== 
```
## Changes

add Mutex to the suit.
<!-- * Description of change 1 -->
<!-- * Description of change 2 -->
<!-- ... -->

## Motivation
<!-- Why were the changes necessary. -->

fix data race.

<!-- ## Example usage (if applicable) -->

## Related issues
<!-- Put `Closes #XXXX` for each issue number this PR fixes/closes -->


