### PR TITLE
Update go versions in build matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go_version: ["1.17.6", "1.16.5", "1.15.13"]
+        go_version: ["1.17.8", "1.16.15", "1.15.15"]
     steps:
       - uses: actions/checkout@v2
       - name: Setup Go


### PR DESCRIPTION
These are the latest versions listed on https://go.dev/dl/

I didn't add `1.18` as it seemed like a somewhat generic release, so beyond the scope of this PR.