### PR TITLE
feat: IsError ErrorAssertionFunc

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1337,6 +1337,21 @@ func NoError(t TestingT, err error, msgAndArgs ...interface{}) bool {
 	return true
 }
 
+// IsError asserts that a function returned a specific error.
+//
+//   actualObj, err := SomeFunction()
+//   if assert.IsError(expectedErr)(t, err) {
+//	   assert.Equal(t, expectedObj, actualObj)
+//   }
+func IsError(theError error) func(t TestingT, err error, msgAndArgs ...interface{}) bool {
+	return func(t TestingT, err error, msgAndArgs ...interface{}) bool {
+		if theError == nil {
+			return Fail(t, "An expected error is required but got nil.")
+		}
+		return EqualError(t, err, theError.Error(), msgAndArgs...)
+	}
+}
+
 // Error asserts that a function returned an error (i.e. not `nil`).
 //
 //   actualObj, err := SomeFunction()

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -1061,6 +1061,44 @@ func TestNoError(t *testing.T) {
 	False(t, NoError(mockT, err), "NoError should fail with empty error interface")
 }
 
+func TestIsError(t *testing.T) {
+
+	mockT := new(testing.T)
+
+	// start with a nil error
+	var expetedErr error
+	var err error
+
+	False(t, IsError(expetedErr)(mockT, err), "IsError should return True for nil expected error")
+
+	// now set an expected error
+	expetedErr = errors.New("expected error")
+
+	False(t, IsError(expetedErr)(mockT, err), "IsError should return True for nil arg")
+
+	// now set error to same as expected error
+	err = errors.New("expected error")
+
+	True(t, IsError(expetedErr)(mockT, err), "IsError with error should return True for same error")
+
+	// now set error to another error
+	err = errors.New("another error")
+
+	False(t, IsError(expetedErr)(mockT, err), "IsError with error should return False for different error")
+
+	// returning an empty error interface
+	err = func() error {
+		var err *customError
+		return err
+	}()
+
+	if err == nil { // err is not nil here!
+		t.Errorf("Error should be nil due to empty interface: %s", err)
+	}
+
+	False(t, IsError(expetedErr)(mockT, err), "IsError should fail with empty error interface")
+}
+
 type customError struct{}
 
 func (*customError) Error() string { return "fail" }


### PR DESCRIPTION
## Summary
[gotest -template=testify](https://github.com/cweill/gotests/tree/develop/templates/testify) has an `assert.ErrorAssertionFunc` as one of the parameters. Testify has `assert.NoError` and `assert.Error` which asserts the functions returns an error or not. Usually this is enough but sometimes checking for a specific error is more appropriate. 

## Changes
Add `IsError` that takes an `expectedErr` as a parameter and returns an `assert.ErrorAssertionFunc` 

## Motivation
While `assert.EqualError` checks for specific errors, it is not an `assert.ErrorAssertionFunc` so can not be used in the template table tests. A new function that takes an `expectedErr` and returns an `assert.ErrorAssertionFunc` makes testing for specific errors easier and clearer.

<!-- ## Example usage (if applicable) -->

```
func Example(input int) (bool, error) {
	switch input {
	case 1:
		return false, errors.New("1 not allowed")
	case 2:
		return false, errors.New("2 not allowed")
	default:
		return true, nil
	}
}
```
Example test
```
func TestExample(t *testing.T) {
	type args struct {
		input int
	}
	tests := []struct {
		name      string
		args      args
		want      bool
		assertion assert.ErrorAssertionFunc
	}{
		{
			"condition-1",
			args{1},
			true,
			assert.IsError(errors.New("2 not allowed")),
		},
		{
			"condition-2",
			args{2},
			true,
			assert.IsError(errors.New("2 not allowed")),
		},
		{
			"condition-other",
			args{99},
			true,
			assert.NoError,
		},
	}
	for _, tt := range tests {
		t.Run(tt.name, func(t *testing.T) {
			got, err := Example(tt.args.input)
			tt.assertion(t, err)
			assert.Equal(t, tt.want, got)
		})
	}
}
```