### PR TITLE
Added Go 1.18.1 as a build/supported version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go_version: ["1.17.6", "1.16.5", "1.15.13"]
+        go_version: ["1.18.1", "1.17.6", "1.16.5"]
     steps:
       - uses: actions/checkout@v2
       - name: Setup Go

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -245,6 +245,10 @@ func (m *Mock) TestData() objx.Map {
 
 // Test sets the test struct variable of the mock object
 func (m *Mock) Test(t TestingT) {
+	if m.mutex == nil {
+		m.mutex = &sync.Mutex{}
+	}
+
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	m.test = t
@@ -274,6 +278,9 @@ func (m *Mock) On(methodName string, arguments ...interface{}) *Call {
 			panic(fmt.Sprintf("cannot use Func in expectations. Use mock.AnythingOfType(\"%T\")", arg))
 		}
 	}
+
+	// Since we start mocks with the .On() function, m.mutex should be reset
+	m.mutex = &sync.Mutex{}
 
 	m.mutex.Lock()
 	defer m.mutex.Unlock()

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -218,7 +218,7 @@ type Mock struct {
 	// this data completely allowing you to do whatever you like with it.
 	testData objx.Map
 
-	mutex sync.Mutex
+	mutex *sync.Mutex
 }
 
 // String provides a %v format string for Mock.
@@ -232,7 +232,6 @@ func (m *Mock) String() string {
 // TestData holds any data that might be useful for testing.  Testify ignores
 // this data completely allowing you to do whatever you like with it.
 func (m *Mock) TestData() objx.Map {
-
 	if m.testData == nil {
 		m.testData = make(objx.Map)
 	}
@@ -354,7 +353,6 @@ func (m *Mock) findClosestCall(method string, arguments ...interface{}) (*Call, 
 }
 
 func callString(method string, arguments Arguments, includeArgumentValues bool) string {
-
 	var argValsString string
 	if includeArgumentValues {
 		var argVals []string
@@ -378,10 +376,10 @@ func (m *Mock) Called(arguments ...interface{}) Arguments {
 		panic("Couldn't get the caller information")
 	}
 	functionPath := runtime.FuncForPC(pc).Name()
-	//Next four lines are required to use GCCGO function naming conventions.
-	//For Ex:  github_com_docker_libkv_store_mock.WatchTree.pN39_github_com_docker_libkv_store_mock.Mock
-	//uses interface information unlike golang github.com/docker/libkv/store/mock.(*Mock).WatchTree
-	//With GCCGO we need to remove interface information starting from pN<dd>.
+	// Next four lines are required to use GCCGO function naming conventions.
+	// For Ex:  github_com_docker_libkv_store_mock.WatchTree.pN39_github_com_docker_libkv_store_mock.Mock
+	// uses interface information unlike golang github.com/docker/libkv/store/mock.(*Mock).WatchTree
+	// With GCCGO we need to remove interface information starting from pN<dd>.
 	re := regexp.MustCompile("\\.pN\\d+_")
 	if re.MatchString(functionPath) {
 		functionPath = re.Split(functionPath, -1)[0]
@@ -397,7 +395,7 @@ func (m *Mock) Called(arguments ...interface{}) Arguments {
 // If Call.WaitFor is set, blocks until the channel is closed or receives a message.
 func (m *Mock) MethodCalled(methodName string, arguments ...interface{}) Arguments {
 	m.mutex.Lock()
-	//TODO: could combine expected and closes in single loop
+	// TODO: could combine expected and closes in single loop
 	found, call := m.findExpectedCall(methodName, arguments...)
 
 	if found < 0 {
@@ -781,12 +779,12 @@ func (args Arguments) Is(objects ...interface{}) bool {
 //
 // Returns the diff string and number of differences found.
 func (args Arguments) Diff(objects []interface{}) (string, int) {
-	//TODO: could return string as error and nil for No difference
+	// TODO: could return string as error and nil for No difference
 
-	var output = "\n"
+	output := "\n"
 	var differences int
 
-	var maxArgCount = len(args)
+	maxArgCount := len(args)
 	if len(objects) > maxArgCount {
 		maxArgCount = len(objects)
 	}
@@ -819,14 +817,12 @@ func (args Arguments) Diff(objects []interface{}) (string, int) {
 				output = fmt.Sprintf("%s\t%d: FAIL:  %s not matched by %s\n", output, i, actualFmt, matcher)
 			}
 		} else if reflect.TypeOf(expected) == reflect.TypeOf((*AnythingOfTypeArgument)(nil)).Elem() {
-
 			// type checking
 			if reflect.TypeOf(actual).Name() != string(expected.(AnythingOfTypeArgument)) && reflect.TypeOf(actual).String() != string(expected.(AnythingOfTypeArgument)) {
 				// not match
 				differences++
 				output = fmt.Sprintf("%s\t%d: FAIL:  type %s != type %s - %s\n", output, i, expected, reflect.TypeOf(actual).Name(), actualFmt)
 			}
-
 		} else if reflect.TypeOf(expected) == reflect.TypeOf((*IsTypeArgument)(nil)) {
 			t := expected.(*IsTypeArgument).t
 			if reflect.TypeOf(t) != reflect.TypeOf(actual) {
@@ -834,7 +830,6 @@ func (args Arguments) Diff(objects []interface{}) (string, int) {
 				output = fmt.Sprintf("%s\t%d: FAIL:  type %s != type %s - %s\n", output, i, reflect.TypeOf(t).Name(), reflect.TypeOf(actual).Name(), actualFmt)
 			}
 		} else {
-
 			// normal checking
 
 			if assert.ObjectsAreEqual(expected, Anything) || assert.ObjectsAreEqual(actual, Anything) || assert.ObjectsAreEqual(actual, expected) {
@@ -854,7 +849,6 @@ func (args Arguments) Diff(objects []interface{}) (string, int) {
 	}
 
 	return output, differences
-
 }
 
 // Assert compares the arguments with the specified objects and fails if
@@ -876,7 +870,6 @@ func (args Arguments) Assert(t TestingT, objects ...interface{}) bool {
 	t.Errorf("%sArguments do not match.", assert.CallerInfo())
 
 	return false
-
 }
 
 // String gets the argument at the specified index. Panics if there is no argument, or
@@ -885,7 +878,6 @@ func (args Arguments) Assert(t TestingT, objects ...interface{}) bool {
 // If no index is provided, String() returns a complete string representation
 // of the arguments.
 func (args Arguments) String(indexOrNil ...int) string {
-
 	if len(indexOrNil) == 0 {
 		// normal String() method - return a string representation of the args
 		var argsStr []string
@@ -895,7 +887,7 @@ func (args Arguments) String(indexOrNil ...int) string {
 		return strings.Join(argsStr, ",")
 	} else if len(indexOrNil) == 1 {
 		// Index has been specified - get the argument at that index
-		var index = indexOrNil[0]
+		index := indexOrNil[0]
 		var s string
 		var ok bool
 		if s, ok = args.Get(index).(string); !ok {
@@ -905,7 +897,6 @@ func (args Arguments) String(indexOrNil ...int) string {
 	}
 
 	panic(fmt.Sprintf("assert: arguments: Wrong number of arguments passed to String.  Must be 0 or 1, not %d", len(indexOrNil)))
-
 }
 
 // Int gets the argument at the specified index. Panics if there is no argument, or


### PR DESCRIPTION
## Summary
Added Go 1.18.1, removed Go 1.15.13 from the build versions. This brings us up-to-date with the latest supported Go versions.

## Changes
Add Go 1.18.1
Removed Go 1.15.13 as a build version as it's no longer supported