### PR TITLE
Add WithinTimeRange method

### DIFF
--- a/assert/assertion_format.go
+++ b/assert/assertion_format.go
@@ -736,6 +736,16 @@ func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta tim
 	return WithinDuration(t, expected, actual, delta, append([]interface{}{msg}, args...)...)
 }
 
+// WithinTimeRangef asserts that a time is within a certain range (inclusive).
+//
+//   assert.WithinTimeRangef(t, time.Now(), time.Now(), time.Now(), "error message %s", "formatted")
+func WithinTimeRangef(t TestingT, expected time.Time, start time.Time, end time.Time, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return WithinTimeRange(t, expected, start, end, append([]interface{}{msg}, args...)...)
+}
+
 // YAMLEqf asserts that two YAML strings are equivalent.
 func YAMLEqf(t TestingT, expected string, actual string, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {

--- a/assert/assertion_format.go
+++ b/assert/assertion_format.go
@@ -736,7 +736,7 @@ func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta tim
 	return WithinDuration(t, expected, actual, delta, append([]interface{}{msg}, args...)...)
 }
 
-// WithinTimeRangef asserts that a time is within a certain range (inclusive).
+// WithinTimeRangef asserts that a time is within a time range (inclusive).
 //
 //   assert.WithinTimeRangef(t, time.Now(), time.Now(), time.Now(), "error message %s", "formatted")
 func WithinTimeRangef(t TestingT, expected time.Time, start time.Time, end time.Time, msg string, args ...interface{}) bool {

--- a/assert/assertion_format.go
+++ b/assert/assertion_format.go
@@ -738,7 +738,7 @@ func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta tim
 
 // WithinRangef asserts that a time is within a time range (inclusive).
 //
-//   assert.WithinRangef(t, time.Now(), time.Now(), time.Now(), "error message %s", "formatted")
+//   assert.WithinRangef(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second), "error message %s", "formatted")
 func WithinRangef(t TestingT, actual time.Time, start time.Time, end time.Time, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()

--- a/assert/assertion_format.go
+++ b/assert/assertion_format.go
@@ -739,11 +739,11 @@ func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta tim
 // WithinRangef asserts that a time is within a time range (inclusive).
 //
 //   assert.WithinRangef(t, time.Now(), time.Now(), time.Now(), "error message %s", "formatted")
-func WithinRangef(t TestingT, expected time.Time, start time.Time, end time.Time, msg string, args ...interface{}) bool {
+func WithinRangef(t TestingT, actual time.Time, start time.Time, end time.Time, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	return WithinRange(t, expected, start, end, append([]interface{}{msg}, args...)...)
+	return WithinRange(t, actual, start, end, append([]interface{}{msg}, args...)...)
 }
 
 // YAMLEqf asserts that two YAML strings are equivalent.

--- a/assert/assertion_format.go
+++ b/assert/assertion_format.go
@@ -736,14 +736,14 @@ func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta tim
 	return WithinDuration(t, expected, actual, delta, append([]interface{}{msg}, args...)...)
 }
 
-// WithinTimeRangef asserts that a time is within a time range (inclusive).
+// WithinRangef asserts that a time is within a time range (inclusive).
 //
-//   assert.WithinTimeRangef(t, time.Now(), time.Now(), time.Now(), "error message %s", "formatted")
-func WithinTimeRangef(t TestingT, expected time.Time, start time.Time, end time.Time, msg string, args ...interface{}) bool {
+//   assert.WithinRangef(t, time.Now(), time.Now(), time.Now(), "error message %s", "formatted")
+func WithinRangef(t TestingT, expected time.Time, start time.Time, end time.Time, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	return WithinTimeRange(t, expected, start, end, append([]interface{}{msg}, args...)...)
+	return WithinRange(t, expected, start, end, append([]interface{}{msg}, args...)...)
 }
 
 // YAMLEqf asserts that two YAML strings are equivalent.

--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -1463,7 +1463,7 @@ func (a *Assertions) WithinDurationf(expected time.Time, actual time.Time, delta
 
 // WithinRange asserts that a time is within a time range (inclusive).
 //
-//   a.WithinRange(time.Now(), time.Now(), time.Now())
+//   a.WithinRange(time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second))
 func (a *Assertions) WithinRange(actual time.Time, start time.Time, end time.Time, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1473,7 +1473,7 @@ func (a *Assertions) WithinRange(actual time.Time, start time.Time, end time.Tim
 
 // WithinRangef asserts that a time is within a time range (inclusive).
 //
-//   a.WithinRangef(time.Now(), time.Now(), time.Now(), "error message %s", "formatted")
+//   a.WithinRangef(time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second), "error message %s", "formatted")
 func (a *Assertions) WithinRangef(actual time.Time, start time.Time, end time.Time, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()

--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -1464,21 +1464,21 @@ func (a *Assertions) WithinDurationf(expected time.Time, actual time.Time, delta
 // WithinRange asserts that a time is within a time range (inclusive).
 //
 //   a.WithinRange(time.Now(), time.Now(), time.Now())
-func (a *Assertions) WithinRange(expected time.Time, start time.Time, end time.Time, msgAndArgs ...interface{}) bool {
+func (a *Assertions) WithinRange(actual time.Time, start time.Time, end time.Time, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
-	return WithinRange(a.t, expected, start, end, msgAndArgs...)
+	return WithinRange(a.t, actual, start, end, msgAndArgs...)
 }
 
 // WithinRangef asserts that a time is within a time range (inclusive).
 //
 //   a.WithinRangef(time.Now(), time.Now(), time.Now(), "error message %s", "formatted")
-func (a *Assertions) WithinRangef(expected time.Time, start time.Time, end time.Time, msg string, args ...interface{}) bool {
+func (a *Assertions) WithinRangef(actual time.Time, start time.Time, end time.Time, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
-	return WithinRangef(a.t, expected, start, end, msg, args...)
+	return WithinRangef(a.t, actual, start, end, msg, args...)
 }
 
 // YAMLEq asserts that two YAML strings are equivalent.

--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -1461,6 +1461,26 @@ func (a *Assertions) WithinDurationf(expected time.Time, actual time.Time, delta
 	return WithinDurationf(a.t, expected, actual, delta, msg, args...)
 }
 
+// WithinTimeRange asserts that a time is within a certain range (inclusive).
+//
+//   a.WithinTimeRange(time.Now(), time.Now(), time.Now())
+func (a *Assertions) WithinTimeRange(expected time.Time, start time.Time, end time.Time, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return WithinTimeRange(a.t, expected, start, end, msgAndArgs...)
+}
+
+// WithinTimeRangef asserts that a time is within a certain range (inclusive).
+//
+//   a.WithinTimeRangef(time.Now(), time.Now(), time.Now())
+func (a *Assertions) WithinTimeRangef(expected time.Time, start time.Time, end time.Time, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return WithinTimeRangef(a.t, expected, start, end, msg, args...)
+}
+
 // YAMLEq asserts that two YAML strings are equivalent.
 func (a *Assertions) YAMLEq(expected string, actual string, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {

--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -1461,7 +1461,7 @@ func (a *Assertions) WithinDurationf(expected time.Time, actual time.Time, delta
 	return WithinDurationf(a.t, expected, actual, delta, msg, args...)
 }
 
-// WithinTimeRange asserts that a time is within a certain range (inclusive).
+// WithinTimeRange asserts that a time is within a time range (inclusive).
 //
 //   a.WithinTimeRange(time.Now(), time.Now(), time.Now())
 func (a *Assertions) WithinTimeRange(expected time.Time, start time.Time, end time.Time, msgAndArgs ...interface{}) bool {
@@ -1471,9 +1471,9 @@ func (a *Assertions) WithinTimeRange(expected time.Time, start time.Time, end ti
 	return WithinTimeRange(a.t, expected, start, end, msgAndArgs...)
 }
 
-// WithinTimeRangef asserts that a time is within a certain range (inclusive).
+// WithinTimeRangef asserts that a time is within a time range (inclusive).
 //
-//   a.WithinTimeRangef(time.Now(), time.Now(), time.Now())
+//   a.WithinTimeRangef(time.Now(), time.Now(), time.Now(), "error message %s", "formatted")
 func (a *Assertions) WithinTimeRangef(expected time.Time, start time.Time, end time.Time, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()

--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -1461,24 +1461,24 @@ func (a *Assertions) WithinDurationf(expected time.Time, actual time.Time, delta
 	return WithinDurationf(a.t, expected, actual, delta, msg, args...)
 }
 
-// WithinTimeRange asserts that a time is within a time range (inclusive).
+// WithinRange asserts that a time is within a time range (inclusive).
 //
-//   a.WithinTimeRange(time.Now(), time.Now(), time.Now())
-func (a *Assertions) WithinTimeRange(expected time.Time, start time.Time, end time.Time, msgAndArgs ...interface{}) bool {
+//   a.WithinRange(time.Now(), time.Now(), time.Now())
+func (a *Assertions) WithinRange(expected time.Time, start time.Time, end time.Time, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
-	return WithinTimeRange(a.t, expected, start, end, msgAndArgs...)
+	return WithinRange(a.t, expected, start, end, msgAndArgs...)
 }
 
-// WithinTimeRangef asserts that a time is within a time range (inclusive).
+// WithinRangef asserts that a time is within a time range (inclusive).
 //
-//   a.WithinTimeRangef(time.Now(), time.Now(), time.Now(), "error message %s", "formatted")
-func (a *Assertions) WithinTimeRangef(expected time.Time, start time.Time, end time.Time, msg string, args ...interface{}) bool {
+//   a.WithinRangef(time.Now(), time.Now(), time.Now(), "error message %s", "formatted")
+func (a *Assertions) WithinRangef(expected time.Time, start time.Time, end time.Time, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
-	return WithinTimeRangef(a.t, expected, start, end, msg, args...)
+	return WithinRangef(a.t, expected, start, end, msg, args...)
 }
 
 // YAMLEq asserts that two YAML strings are equivalent.

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1118,7 +1118,7 @@ func WithinRange(t TestingT, actual, start, end time.Time, msgAndArgs ...interfa
 	}
 
 	if end.Before(start) {
-		return Fail(t, "start should be before end", msgAndArgs...)
+		return Fail(t, "Start should be before end", msgAndArgs...)
 	}
 
 	if actual.Before(start) {

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1112,7 +1112,7 @@ func WithinDuration(t TestingT, expected, actual time.Time, delta time.Duration,
 // WithinRange asserts that a time is within a time range (inclusive).
 //
 //   assert.WithinRange(t, time.Now(), time.Now(), time.Now())
-func WithinRange(t TestingT, expected, start, end time.Time, msgAndArgs ...interface{}) bool {
+func WithinRange(t TestingT, actual, start, end time.Time, msgAndArgs ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1121,10 +1121,10 @@ func WithinRange(t TestingT, expected, start, end time.Time, msgAndArgs ...inter
 		return Fail(t, "start should be before end", msgAndArgs...)
 	}
 
-	if expected.Before(start) {
-		return Fail(t, fmt.Sprintf("Time %v expected to be in time range %v to %v, but is before the range", expected, start, end), msgAndArgs...)
-	} else if expected.After(end) {
-		return Fail(t, fmt.Sprintf("Time %v expected to be in time range %v to %v, but is after the range", expected, start, end), msgAndArgs...)
+	if actual.Before(start) {
+		return Fail(t, fmt.Sprintf("Time %v expected to be in time range %v to %v, but is before the range", actual, start, end), msgAndArgs...)
+	} else if actual.After(end) {
+		return Fail(t, fmt.Sprintf("Time %v expected to be in time range %v to %v, but is after the range", actual, start, end), msgAndArgs...)
 	}
 
 	return true

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1111,7 +1111,7 @@ func WithinDuration(t TestingT, expected, actual time.Time, delta time.Duration,
 
 // WithinRange asserts that a time is within a time range (inclusive).
 //
-//   assert.WithinRange(t, time.Now(), time.Now(), time.Now())
+//   assert.WithinRange(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second))
 func WithinRange(t TestingT, actual, start, end time.Time, msgAndArgs ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1109,10 +1109,10 @@ func WithinDuration(t TestingT, expected, actual time.Time, delta time.Duration,
 	return true
 }
 
-// WithinTimeRange asserts that a time is within a time range (inclusive).
+// WithinRange asserts that a time is within a time range (inclusive).
 //
-//   assert.WithinTimeRange(t, time.Now(), time.Now(), time.Now())
-func WithinTimeRange(t TestingT, expected, start, end time.Time, msgAndArgs ...interface{}) bool {
+//   assert.WithinRange(t, time.Now(), time.Now(), time.Now())
+func WithinRange(t TestingT, expected, start, end time.Time, msgAndArgs ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1109,6 +1109,27 @@ func WithinDuration(t TestingT, expected, actual time.Time, delta time.Duration,
 	return true
 }
 
+// WithinTimeRange asserts that a time is within a time range (inclusive).
+//
+//   assert.WithinTimeRange(t, time.Now(), time.Now(), time.Now())
+func WithinTimeRange(t TestingT, expected, start, end time.Time, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	if end.Before(start) {
+		return Fail(t, "start should be before end", msgAndArgs...)
+	}
+
+	if expected.Before(start) {
+		return Fail(t, fmt.Sprintf("Time %v expected to be in time range %v to %v, but is before the range", expected, start, end), msgAndArgs...)
+	} else if expected.After(end) {
+		return Fail(t, fmt.Sprintf("Time %v expected to be in time range %v to %v, but is after the range", expected, start, end), msgAndArgs...)
+	}
+
+	return true
+}
+
 func toFloat(x interface{}) (float64, bool) {
 	var xf float64
 	xok := true

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -1352,7 +1352,7 @@ func TestWithinRange(t *testing.T) {
 	s := n.Add(-time.Second)
 	e := n.Add(time.Second)
 
-	True(t, WithinRange(mockT, n, n, n), "Exact same expected, start, and end values return true")
+	True(t, WithinRange(mockT, n, n, n), "Exact same actual, start, and end values return true")
 
 	True(t, WithinRange(mockT, n, s, e), "Time in range is within the time range")
 	True(t, WithinRange(mockT, s, s, e), "The start time is within the time range")

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -1345,6 +1345,25 @@ func TestWithinDuration(t *testing.T) {
 	False(t, WithinDuration(mockT, b, a, -11*time.Second), "A 10s difference is not within a 9s time difference")
 }
 
+func TestWithinTimeRange(t *testing.T) {
+
+	mockT := new(testing.T)
+	n := time.Now()
+	s := n.Add(-time.Second)
+	e := n.Add(time.Second)
+
+	True(t, WithinTimeRange(mockT, n, n, n), "Exact same expected, start, and end values return true")
+
+	True(t, WithinTimeRange(mockT, n, s, e), "Time in range is within the time range")
+	True(t, WithinTimeRange(mockT, s, s, e), "The start time is within the time range")
+	True(t, WithinTimeRange(mockT, e, s, e), "The end time is within the time range")
+
+	False(t, WithinTimeRange(mockT, s.Add(-time.Nanosecond), s, e, "Just before the start time is not within the time range"))
+	False(t, WithinTimeRange(mockT, e.Add(time.Nanosecond), s, e, "Just after the end time is not within the time range"))
+
+	False(t, WithinTimeRange(mockT, n, e, s, "Just after the end time is not within the time range"))
+}
+
 func TestInDelta(t *testing.T) {
 	mockT := new(testing.T)
 

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -1345,23 +1345,23 @@ func TestWithinDuration(t *testing.T) {
 	False(t, WithinDuration(mockT, b, a, -11*time.Second), "A 10s difference is not within a 9s time difference")
 }
 
-func TestWithinTimeRange(t *testing.T) {
+func TestWithinRange(t *testing.T) {
 
 	mockT := new(testing.T)
 	n := time.Now()
 	s := n.Add(-time.Second)
 	e := n.Add(time.Second)
 
-	True(t, WithinTimeRange(mockT, n, n, n), "Exact same expected, start, and end values return true")
+	True(t, WithinRange(mockT, n, n, n), "Exact same expected, start, and end values return true")
 
-	True(t, WithinTimeRange(mockT, n, s, e), "Time in range is within the time range")
-	True(t, WithinTimeRange(mockT, s, s, e), "The start time is within the time range")
-	True(t, WithinTimeRange(mockT, e, s, e), "The end time is within the time range")
+	True(t, WithinRange(mockT, n, s, e), "Time in range is within the time range")
+	True(t, WithinRange(mockT, s, s, e), "The start time is within the time range")
+	True(t, WithinRange(mockT, e, s, e), "The end time is within the time range")
 
-	False(t, WithinTimeRange(mockT, s.Add(-time.Nanosecond), s, e, "Just before the start time is not within the time range"))
-	False(t, WithinTimeRange(mockT, e.Add(time.Nanosecond), s, e, "Just after the end time is not within the time range"))
+	False(t, WithinRange(mockT, s.Add(-time.Nanosecond), s, e, "Just before the start time is not within the time range"))
+	False(t, WithinRange(mockT, e.Add(time.Nanosecond), s, e, "Just after the end time is not within the time range"))
 
-	False(t, WithinTimeRange(mockT, n, e, s, "Just after the end time is not within the time range"))
+	False(t, WithinRange(mockT, n, e, s, "Just after the end time is not within the time range"))
 }
 
 func TestInDelta(t *testing.T) {

--- a/require/require.go
+++ b/require/require.go
@@ -1864,6 +1864,32 @@ func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta tim
 	t.FailNow()
 }
 
+// WithinTimeRange asserts that a time is within a time range (inclusive).
+//
+//   assert.WithinTimeRange(t, time.Now(), time.Now(), time.Now())
+func WithinTimeRange(t TestingT, expected time.Time, start time.Time, end time.Time, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.WithinTimeRange(t, expected, start, end, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// WithinTimeRangef asserts that a time is within a time range (inclusive).
+//
+//   assert.WithinTimeRangef(t, time.Now(), time.Now(), time.Now(), "error message %s", "formatted")
+func WithinTimeRangef(t TestingT, expected time.Time, start time.Time, end time.Time, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.WithinTimeRangef(t, expected, start, end, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
 // YAMLEq asserts that two YAML strings are equivalent.
 func YAMLEq(t TestingT, expected string, actual string, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {

--- a/require/require.go
+++ b/require/require.go
@@ -1866,7 +1866,7 @@ func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta tim
 
 // WithinRange asserts that a time is within a time range (inclusive).
 //
-//   assert.WithinRange(t, time.Now(), time.Now(), time.Now())
+//   assert.WithinRange(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second))
 func WithinRange(t TestingT, actual time.Time, start time.Time, end time.Time, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1879,7 +1879,7 @@ func WithinRange(t TestingT, actual time.Time, start time.Time, end time.Time, m
 
 // WithinRangef asserts that a time is within a time range (inclusive).
 //
-//   assert.WithinRangef(t, time.Now(), time.Now(), time.Now(), "error message %s", "formatted")
+//   assert.WithinRangef(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second), "error message %s", "formatted")
 func WithinRangef(t TestingT, actual time.Time, start time.Time, end time.Time, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()

--- a/require/require.go
+++ b/require/require.go
@@ -1867,11 +1867,11 @@ func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta tim
 // WithinRange asserts that a time is within a time range (inclusive).
 //
 //   assert.WithinRange(t, time.Now(), time.Now(), time.Now())
-func WithinRange(t TestingT, expected time.Time, start time.Time, end time.Time, msgAndArgs ...interface{}) {
+func WithinRange(t TestingT, actual time.Time, start time.Time, end time.Time, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	if assert.WithinRange(t, expected, start, end, msgAndArgs...) {
+	if assert.WithinRange(t, actual, start, end, msgAndArgs...) {
 		return
 	}
 	t.FailNow()
@@ -1880,11 +1880,11 @@ func WithinRange(t TestingT, expected time.Time, start time.Time, end time.Time,
 // WithinRangef asserts that a time is within a time range (inclusive).
 //
 //   assert.WithinRangef(t, time.Now(), time.Now(), time.Now(), "error message %s", "formatted")
-func WithinRangef(t TestingT, expected time.Time, start time.Time, end time.Time, msg string, args ...interface{}) {
+func WithinRangef(t TestingT, actual time.Time, start time.Time, end time.Time, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	if assert.WithinRangef(t, expected, start, end, msg, args...) {
+	if assert.WithinRangef(t, actual, start, end, msg, args...) {
 		return
 	}
 	t.FailNow()

--- a/require/require.go
+++ b/require/require.go
@@ -1864,27 +1864,27 @@ func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta tim
 	t.FailNow()
 }
 
-// WithinTimeRange asserts that a time is within a time range (inclusive).
+// WithinRange asserts that a time is within a time range (inclusive).
 //
-//   assert.WithinTimeRange(t, time.Now(), time.Now(), time.Now())
-func WithinTimeRange(t TestingT, expected time.Time, start time.Time, end time.Time, msgAndArgs ...interface{}) {
+//   assert.WithinRange(t, time.Now(), time.Now(), time.Now())
+func WithinRange(t TestingT, expected time.Time, start time.Time, end time.Time, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	if assert.WithinTimeRange(t, expected, start, end, msgAndArgs...) {
+	if assert.WithinRange(t, expected, start, end, msgAndArgs...) {
 		return
 	}
 	t.FailNow()
 }
 
-// WithinTimeRangef asserts that a time is within a time range (inclusive).
+// WithinRangef asserts that a time is within a time range (inclusive).
 //
-//   assert.WithinTimeRangef(t, time.Now(), time.Now(), time.Now(), "error message %s", "formatted")
-func WithinTimeRangef(t TestingT, expected time.Time, start time.Time, end time.Time, msg string, args ...interface{}) {
+//   assert.WithinRangef(t, time.Now(), time.Now(), time.Now(), "error message %s", "formatted")
+func WithinRangef(t TestingT, expected time.Time, start time.Time, end time.Time, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	if assert.WithinTimeRangef(t, expected, start, end, msg, args...) {
+	if assert.WithinRangef(t, expected, start, end, msg, args...) {
 		return
 	}
 	t.FailNow()

--- a/require/require_forward.go
+++ b/require/require_forward.go
@@ -1462,24 +1462,24 @@ func (a *Assertions) WithinDurationf(expected time.Time, actual time.Time, delta
 	WithinDurationf(a.t, expected, actual, delta, msg, args...)
 }
 
-// WithinTimeRange asserts that a time is within a time range (inclusive).
+// WithinRange asserts that a time is within a time range (inclusive).
 //
-//   a.WithinTimeRange(time.Now(), time.Now(), time.Now())
-func (a *Assertions) WithinTimeRange(expected time.Time, start time.Time, end time.Time, msgAndArgs ...interface{}) {
+//   a.WithinRange(time.Now(), time.Now(), time.Now())
+func (a *Assertions) WithinRange(expected time.Time, start time.Time, end time.Time, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
-	WithinTimeRange(a.t, expected, start, end, msgAndArgs...)
+	WithinRange(a.t, expected, start, end, msgAndArgs...)
 }
 
-// WithinTimeRangef asserts that a time is within a time range (inclusive).
+// WithinRangef asserts that a time is within a time range (inclusive).
 //
-//   a.WithinTimeRangef(time.Now(), time.Now(), time.Now(), "error message %s", "formatted")
-func (a *Assertions) WithinTimeRangef(expected time.Time, start time.Time, end time.Time, msg string, args ...interface{}) {
+//   a.WithinRangef(time.Now(), time.Now(), time.Now(), "error message %s", "formatted")
+func (a *Assertions) WithinRangef(expected time.Time, start time.Time, end time.Time, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
-	WithinTimeRangef(a.t, expected, start, end, msg, args...)
+	WithinRangef(a.t, expected, start, end, msg, args...)
 }
 
 // YAMLEq asserts that two YAML strings are equivalent.

--- a/require/require_forward.go
+++ b/require/require_forward.go
@@ -1465,21 +1465,21 @@ func (a *Assertions) WithinDurationf(expected time.Time, actual time.Time, delta
 // WithinRange asserts that a time is within a time range (inclusive).
 //
 //   a.WithinRange(time.Now(), time.Now(), time.Now())
-func (a *Assertions) WithinRange(expected time.Time, start time.Time, end time.Time, msgAndArgs ...interface{}) {
+func (a *Assertions) WithinRange(actual time.Time, start time.Time, end time.Time, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
-	WithinRange(a.t, expected, start, end, msgAndArgs...)
+	WithinRange(a.t, actual, start, end, msgAndArgs...)
 }
 
 // WithinRangef asserts that a time is within a time range (inclusive).
 //
 //   a.WithinRangef(time.Now(), time.Now(), time.Now(), "error message %s", "formatted")
-func (a *Assertions) WithinRangef(expected time.Time, start time.Time, end time.Time, msg string, args ...interface{}) {
+func (a *Assertions) WithinRangef(actual time.Time, start time.Time, end time.Time, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
-	WithinRangef(a.t, expected, start, end, msg, args...)
+	WithinRangef(a.t, actual, start, end, msg, args...)
 }
 
 // YAMLEq asserts that two YAML strings are equivalent.

--- a/require/require_forward.go
+++ b/require/require_forward.go
@@ -1462,6 +1462,26 @@ func (a *Assertions) WithinDurationf(expected time.Time, actual time.Time, delta
 	WithinDurationf(a.t, expected, actual, delta, msg, args...)
 }
 
+// WithinTimeRange asserts that a time is within a time range (inclusive).
+//
+//   a.WithinTimeRange(time.Now(), time.Now(), time.Now())
+func (a *Assertions) WithinTimeRange(expected time.Time, start time.Time, end time.Time, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	WithinTimeRange(a.t, expected, start, end, msgAndArgs...)
+}
+
+// WithinTimeRangef asserts that a time is within a time range (inclusive).
+//
+//   a.WithinTimeRangef(time.Now(), time.Now(), time.Now(), "error message %s", "formatted")
+func (a *Assertions) WithinTimeRangef(expected time.Time, start time.Time, end time.Time, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	WithinTimeRangef(a.t, expected, start, end, msg, args...)
+}
+
 // YAMLEq asserts that two YAML strings are equivalent.
 func (a *Assertions) YAMLEq(expected string, actual string, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {

--- a/require/require_forward.go
+++ b/require/require_forward.go
@@ -1464,7 +1464,7 @@ func (a *Assertions) WithinDurationf(expected time.Time, actual time.Time, delta
 
 // WithinRange asserts that a time is within a time range (inclusive).
 //
-//   a.WithinRange(time.Now(), time.Now(), time.Now())
+//   a.WithinRange(time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second))
 func (a *Assertions) WithinRange(actual time.Time, start time.Time, end time.Time, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1474,7 +1474,7 @@ func (a *Assertions) WithinRange(actual time.Time, start time.Time, end time.Tim
 
 // WithinRangef asserts that a time is within a time range (inclusive).
 //
-//   a.WithinRangef(time.Now(), time.Now(), time.Now(), "error message %s", "formatted")
+//   a.WithinRangef(time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second), "error message %s", "formatted")
 func (a *Assertions) WithinRangef(actual time.Time, start time.Time, end time.Time, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()


### PR DESCRIPTION
## Summary
Add `WithinTimeRange` and `WithinTimeRangef` assertion methods.

## Changes
Adds the `WithinTimeRange` assertion function that checks whether the _expected_ time is on or after the _start_ time and on or before the _end_ time. If _end_ is before _start_ the function also fails.

Adds `WithinTimeRange` and `WithTimeRangef` methods on `*Assertions` that calls the `WithinTimeRange` function internally. 

## Motivation
There are cases where one would like to test that a time value is within a certain range, for example when the code being tested updates a timestamp:
```
before := time.Now()
actual := Foo()
after := time.Now()

assert.WithinTimeRange(t, actual.timeStamp, before, after)
```

Currently, the only time-related assertion method is `WithinDuration`, but in the above mentioned situation it leads to one of the following solutions:
- Using two `assert.True` checks against the `before` and `after` times.
 ```
before := time.Now()
actual := Foo()
after := time.Now()

assert.True(t, actual.timeStamp.After(before))
assert.True(t, actual.timeStamp.Before(after))
```
- Deriving a _duration_ from the `before` and `after` times to use in the `WithDuration` assertion.
```
before := time.Now()
actual := Foo()
after := time.Now()
halfDur := after.Sub(before) / 2

assert.WithinDuration(t, actual.timeStamp, before.Add(halfDur), halfDur)
```
- Using `WithDuration` to assert against `time.Now()` with an arbitrary duration, leading to flaky tests.
```
before := time.Now()
actual := Foo()
after := time.Now()

assert.WithinDuration(t, actual.timeStamp, time.Now(), time.Second)
```

## Related issues
https://github.com/stretchr/testify/pull/689
