### PR TITLE
don't copy mutex

### DIFF
--- a/suite/suite.go
+++ b/suite/suite.go
@@ -22,7 +22,7 @@ var matchMethod = flag.String("testify.m", "", "regular expression to select tes
 // retrieving the current *testing.T context.
 type Suite struct {
 	*assert.Assertions
-	mu      sync.RWMutex
+	mu      *sync.RWMutex
 	require *require.Assertions
 	t       *testing.T
 }


### PR DESCRIPTION
## Summary
prevent govet: copylocks when referencing suite.Suite by using a pointer to the mutex

## Changes
- switch mu to a pointer

## Motivation
fix govet complaints

## Related issues
Closes #1199
