### PR TITLE
add OnOverwrite function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/sunhao1256/testify
+module github.com/stretchr/testify
 
 go 1.13
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/stretchr/testify
+module github.com/sunhao1256/testify
 
 go 1.13
 

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -289,28 +289,25 @@ func (m *Mock) On(methodName string, arguments ...interface{}) *Call {
 	return c
 }
 
-//If exist same methodName and arguments will overwrite before call
+//Off cancel existed method with arguments call
 
-func (m *Mock) OnOverwrite(methodName string, arguments ...interface{}) *Call {
+func (m *Mock) Off(methodName string, arguments ...interface{}) {
 	for _, arg := range arguments {
 		if v := reflect.ValueOf(arg); v.Kind() == reflect.Func {
 			panic(fmt.Sprintf("cannot use Func in expectations. Use mock.AnythingOfType(\"%T\")", arg))
 		}
 	}
 
-	// Since we start mocks with the .On() function, m.mutex should be reset
 	m.mutex = &sync.Mutex{}
 
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
-	index, c := m.findExpectedCall(methodName, arguments...)
-	c = newCall(m, methodName, assert.CallerInfo(), arguments...)
-	if index >= 0 {
-		m.ExpectedCalls[index] = c
+	index, _ := m.findExpectedCall(methodName, arguments...)
+	if index < 0 {
+		return
 	} else {
-		m.ExpectedCalls = append(m.ExpectedCalls, c)
+		m.ExpectedCalls = append(m.ExpectedCalls[:index], m.ExpectedCalls[index+1:]...)
 	}
-	return c
 }
 
 // /*

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -305,7 +305,7 @@ func (m *Mock) OnOverwrite(methodName string, arguments ...interface{}) *Call {
 	defer m.mutex.Unlock()
 	index, c := m.findExpectedCall(methodName, arguments)
 	c = newCall(m, methodName, assert.CallerInfo(), arguments...)
-	if index < 0 {
+	if index >= 0 {
 		m.ExpectedCalls[index] = c
 	} else {
 		m.ExpectedCalls = append(m.ExpectedCalls, c)

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -303,7 +303,7 @@ func (m *Mock) OnOverwrite(methodName string, arguments ...interface{}) *Call {
 
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
-	index, c := m.findExpectedCall(methodName, arguments)
+	index, c := m.findExpectedCall(methodName, arguments...)
 	c = newCall(m, methodName, assert.CallerInfo(), arguments...)
 	if index >= 0 {
 		m.ExpectedCalls[index] = c


### PR DESCRIPTION
## Summary
when mock repeate regist duplicate method name and arguments ，only return this first arguments , i want supply "OnOverwrite" function to overwrite the old regist  which has been registed

## Changes
mock.go add "Off" function

```go

a := "xx"

d.Mock.On("hello", a).Return("xx1")
d.Mock.On("hello", a).Return("xx2")
get := d.Mock.MethodCalled("hello", a).Get(0) //return xx1
fmt.Println(get)

d.Mock.On("hello", a).Return("xx1")
d.Mock.Off("hello", a)
d.Mock.On("hello", a).Return("xx2")
get := d.Mock.MethodCalled("hello", a).Get(0) //return xx2
fmt.Println(get)
```

## Motivation
we  need off function 

## Related issues
https://github.com/stretchr/testify/issues/558
https://github.com/stretchr/testify/issues/166