### PR TITLE
fixing panic in calls to assertion with nil m.mutex

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -521,7 +521,7 @@ func AssertExpectationsForObjects(t TestingT, testObjects ...interface{}) bool {
 	for _, obj := range testObjects {
 		if m, ok := obj.(*Mock); ok {
 			t.Logf("Deprecated mock.AssertExpectationsForObjects(myMock.Mock) use mock.AssertExpectationsForObjects(myMock)")
-			obj = &m
+			obj = m
 		}
 		m := obj.(assertExpectationser)
 		if !m.AssertExpectations(t) {

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -255,7 +255,7 @@ type Mock struct {
 	// this data completely allowing you to do whatever you like with it.
 	testData objx.Map
 
-	mutex *sync.Mutex
+	mutex sync.Mutex
 }
 
 // String provides a %v format string for Mock.
@@ -282,10 +282,6 @@ func (m *Mock) TestData() objx.Map {
 
 // Test sets the test struct variable of the mock object
 func (m *Mock) Test(t TestingT) {
-	if m.mutex == nil {
-		m.mutex = &sync.Mutex{}
-	}
-
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	m.test = t
@@ -317,7 +313,7 @@ func (m *Mock) On(methodName string, arguments ...interface{}) *Call {
 	}
 
 	// Since we start mocks with the .On() function, m.mutex should be reset
-	m.mutex = &sync.Mutex{}
+	m.mutex = sync.Mutex{}
 
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
@@ -544,9 +540,6 @@ func AssertExpectationsForObjects(t TestingT, testObjects ...interface{}) bool {
 func (m *Mock) AssertExpectations(t TestingT) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
-	}
-	if m.mutex == nil {
-		m.mutex = &sync.Mutex{}
 	}
 
 	m.mutex.Lock()

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -312,9 +312,6 @@ func (m *Mock) On(methodName string, arguments ...interface{}) *Call {
 		}
 	}
 
-	// Since we start mocks with the .On() function, m.mutex should be reset
-	m.mutex = sync.Mutex{}
-
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	c := newCall(m, methodName, assert.CallerInfo(), arguments...)

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -519,7 +519,7 @@ func AssertExpectationsForObjects(t TestingT, testObjects ...interface{}) bool {
 		h.Helper()
 	}
 	for _, obj := range testObjects {
-		if m, ok := obj.(Mock); ok {
+		if m, ok := obj.(*Mock); ok {
 			t.Logf("Deprecated mock.AssertExpectationsForObjects(myMock.Mock) use mock.AssertExpectationsForObjects(myMock)")
 			obj = &m
 		}


### PR DESCRIPTION
## Summary
<!-- High-level, one sentence summary of what this PR accomplishes -->
@Cleancut and I found these changes that should be reverted as they are causing panics after library updates.

This reverts a change that was made in https://github.com/stretchr/testify/pull/1182
That PR makes m.mutex a pointer which now needs to be checked but it's not checked for nil everywhere.
It also reset the mutex in the `.On` function when it could actually have locks from other callers.

## Changes
- revert `m.mutex` back to a non pointer value
- don't throw away the lock that might be used concurrently in the `.On` function

## Motivation
Fixing panics and crashes in the library after a minor update.

## Related issues
This should also help with these issues:
- https://github.com/stretchr/testify/issues/1208
- https://github.com/stretchr/testify/issues/1210
- https://github.com/stretchr/testify/issues/1206 (introduces a workaround while keeping the new pointer)