### PR TITLE
Nil actual type made AnythingOfType matcher panic

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -909,10 +909,15 @@ func (args Arguments) Diff(objects []interface{}) (string, int) {
 			}
 		} else if reflect.TypeOf(expected) == reflect.TypeOf((*AnythingOfTypeArgument)(nil)).Elem() {
 			// type checking
-			if reflect.TypeOf(actual).Name() != string(expected.(AnythingOfTypeArgument)) && reflect.TypeOf(actual).String() != string(expected.(AnythingOfTypeArgument)) {
+			if reflect.TypeOf(actual) == nil {
+				if expected != AnythingOfTypeArgument("<nil>") {
+					differences++
+					output = fmt.Sprintf("%s\t%d: FAIL:  type %s != type <nil> - %s\n", output, i, expected, actualFmt)
+				}
+			} else if reflect.TypeOf(actual).Name() != string(expected.(AnythingOfTypeArgument)) && reflect.TypeOf(actual).String() != string(expected.(AnythingOfTypeArgument)) {
 				// not match
 				differences++
-				output = fmt.Sprintf("%s\t%d: FAIL:  type %s != type %s - %s\n", output, i, expected, reflect.TypeOf(actual).Name(), actualFmt)
+				output = fmt.Sprintf("%s\t%d: FAIL:  type %s != type %s - %s\n", output, i, expected, reflect.TypeOf(actual).String(), actualFmt)
 			}
 		} else if reflect.TypeOf(expected) == reflect.TypeOf((*IsTypeArgument)(nil)) {
 			t := expected.(*IsTypeArgument).t

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -1613,6 +1613,50 @@ func Test_Arguments_Diff_WithAnythingOfTypeArgument_Failing(t *testing.T) {
 
 }
 
+func Test_Arguments_Diff__WithAnythingOfTypeArgument_NilType(t *testing.T) {
+
+	var args = Arguments([]interface{}{AnythingOfType("<nil>")})
+	var count int
+	_, count = args.Diff([]interface{}{nil})
+
+	assert.Zero(t, count)
+
+}
+
+func Test_Arguments_Diff__WithAnythingOfTypeArgument_NilType_Failing(t *testing.T) {
+
+	var args = Arguments([]interface{}{AnythingOfType("string")})
+	var count int
+	var diff string
+	diff, count = args.Diff([]interface{}{nil})
+
+	assert.Equal(t, 1, count)
+	assert.Contains(t, diff, "type string != type <nil> - (<nil>=<nil>)")
+
+}
+
+func Test_Arguments_Diff__WithAnythingOfTypeArgument_NilValue(t *testing.T) {
+
+	var args = Arguments([]interface{}{AnythingOfType("*string")})
+	var count int
+	_, count = args.Diff([]interface{}{(*string)(nil)})
+
+	assert.Zero(t, count)
+
+}
+
+func Test_Arguments_Diff__WithAnythingOfTypeArgument_NilValue_Failing(t *testing.T) {
+
+	var args = Arguments([]interface{}{AnythingOfType("*int")})
+	var count int
+	var diff string
+	diff, count = args.Diff([]interface{}{(*string)(nil)})
+
+	assert.Equal(t, 1, count)
+	assert.Contains(t, diff, "type *int != type *string - (*string=<nil>)")
+
+}
+
 func Test_Arguments_Diff_WithIsTypeArgument(t *testing.T) {
 	var args = Arguments([]interface{}{"string", IsType(0), true})
 	var count int


### PR DESCRIPTION
## Summary
Passing an actual value of type nil via a Mock into the argument matcher for AnythingOfType in a Mock causes a panic.

## Changes
Handle nil types up front when checking actual types against mock.AnythingOfType before calling any methods on the reflect.Type, which [will be nil](https://pkg.go.dev/reflect#TypeOf) if the value was a nil interface.

## Motivation
Someone may expect their mock to be called with a nil interface, we should not panic in this case.

## Related issues
Closes #1209 
