### PR TITLE
Workaround race condition in printing of diff values.

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -886,7 +886,7 @@ func (args Arguments) Diff(objects []interface{}) (string, int) {
 			actualFmt = "(Missing)"
 		} else {
 			actual = objects[i]
-			actualFmt = fmt.Sprintf("(%[1]T=%[1]v)", actual)
+			actualFmt = fmt.Sprintf("(%[1]T=%[1]p)", actual)
 		}
 
 		if len(args) <= i {
@@ -894,7 +894,7 @@ func (args Arguments) Diff(objects []interface{}) (string, int) {
 			expectedFmt = "(Missing)"
 		} else {
 			expected = args[i]
-			expectedFmt = fmt.Sprintf("(%[1]T=%[1]v)", expected)
+			expectedFmt = fmt.Sprintf("(%[1]T=%[1]p)", expected)
 		}
 
 		if matcher, ok := expected.(argumentMatcher); ok {


### PR DESCRIPTION
## Summary
When a pointer argument is used in `Run()` and this object is modified in an asynchronous fashion, the evaluation of `%v` in `Arguments.Diff` causes a race condition.

### Example output
```
==================
WARNING: DATA RACE
Write at 0x00c000161a80 by goroutine 9:
  github.com/ipfs-search/ipfs-search/components/crawler.(*CrawlerTestSuite).TestCrawlAddReference.func1()
      /Users/drbob/Development/ipfs-search/components/crawler/crawler_test.go:1040 +0x108
  github.com/stretchr/testify/mock.(*Mock).MethodCalled()
      /Users/drbob/Development/testify/mock/mock.go:538 +0x118e
  github.com/stretchr/testify/mock.(*Mock).MethodCalled()
      /Users/drbob/Development/testify/mock/mock.go:460 +0xb9
  github.com/stretchr/testify/mock.(*Mock).Called()
      /Users/drbob/Development/testify/mock/mock.go:450 +0x1a4
  github.com/ipfs-search/ipfs-search/components/index.(*Mock).Get()
      /Users/drbob/Development/ipfs-search/components/index/mock.go:27 +0x1f3
  github.com/ipfs-search/ipfs-search/components/index.MultiGet.func1()
      /Users/drbob/Development/ipfs-search/components/index/multiget.go:25 +0x121
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /Users/drbob/go/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:57 +0x91

Previous read at 0x00c000161a80 by goroutine 11:
  reflect.packEface()
      /usr/local/Cellar/go/1.18.2/libexec/src/reflect/value.go:130 +0xfd
  reflect.valueInterface()
      /usr/local/Cellar/go/1.18.2/libexec/src/reflect/value.go:1460 +0x188
  reflect.Value.Interface()
      /usr/local/Cellar/go/1.18.2/libexec/src/reflect/value.go:1430 +0xc9
  fmt.(*pp).printValue()
      /usr/local/Cellar/go/1.18.2/libexec/src/fmt/print.go:722 +0xca
  fmt.(*pp).printValue()
      /usr/local/Cellar/go/1.18.2/libexec/src/fmt/print.go:806 +0x1c92
  fmt.(*pp).printValue()
      /usr/local/Cellar/go/1.18.2/libexec/src/fmt/print.go:876 +0x12be
  fmt.(*pp).printArg()
      /usr/local/Cellar/go/1.18.2/libexec/src/fmt/print.go:712 +0xdf4
  fmt.(*pp).doPrintf()
      /usr/local/Cellar/go/1.18.2/libexec/src/fmt/print.go:1026 +0x48f
  fmt.Sprintf()
      /usr/local/Cellar/go/1.18.2/libexec/src/fmt/print.go:219 +0x67
  github.com/stretchr/testify/mock.Arguments.Diff()
      /Users/drbob/Development/testify/mock/mock.go:883 +0x18e
  github.com/stretchr/testify/mock.(*Mock).findExpectedCall()
      /Users/drbob/Development/testify/mock/mock.go:355 +0x144
  github.com/stretchr/testify/mock.(*Mock).MethodCalled()
      /Users/drbob/Development/testify/mock/mock.go:460 +0xb9
  github.com/stretchr/testify/mock.(*Mock).Called()
      /Users/drbob/Development/testify/mock/mock.go:450 +0x1a4
  github.com/ipfs-search/ipfs-search/components/index.(*Mock).Get()
      /Users/drbob/Development/ipfs-search/components/index/mock.go:27 +0x1f3
  github.com/ipfs-search/ipfs-search/components/index.MultiGet.func1()
      /Users/drbob/Development/ipfs-search/components/index/multiget.go:25 +0x121
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /Users/drbob/go/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:57 +0x91

Goroutine 9 (running) created at:
  golang.org/x/sync/errgroup.(*Group).Go()
      /Users/drbob/go/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:54 +0xee
  github.com/ipfs-search/ipfs-search/components/index.MultiGet()
      /Users/drbob/Development/ipfs-search/components/index/multiget.go:22 +0x5a4
  github.com/ipfs-search/ipfs-search/components/crawler.(*Crawler).getExistingItem()
      /Users/drbob/Development/ipfs-search/components/crawler/existingitem.go:22 +0x2e4
  github.com/ipfs-search/ipfs-search/components/crawler.(*Crawler).updateMaybeExisting()
      /Users/drbob/Development/ipfs-search/components/crawler/update.go:142 +0x16c
  github.com/ipfs-search/ipfs-search/components/crawler.(*Crawler).Crawl()
      /Users/drbob/Development/ipfs-search/components/crawler/crawler.go:60 +0x3e5
  github.com/ipfs-search/ipfs-search/components/crawler.(*CrawlerTestSuite).TestCrawlAddReference()
      /Users/drbob/Development/ipfs-search/components/crawler/crawler_test.go:1083 +0x1187
  runtime.call16()
      /usr/local/Cellar/go/1.18.2/libexec/src/runtime/asm_amd64.s:701 +0x48
  reflect.Value.Call()
      /usr/local/Cellar/go/1.18.2/libexec/src/reflect/value.go:339 +0xd7
  github.com/stretchr/testify/suite.Run.func1()
      /Users/drbob/Development/testify/suite/suite.go:175 +0x6dc
  testing.tRunner()
      /usr/local/Cellar/go/1.18.2/libexec/src/testing/testing.go:1439 +0x213
  testing.(*T).Run.func1()
      /usr/local/Cellar/go/1.18.2/libexec/src/testing/testing.go:1486 +0x47

Goroutine 11 (finished) created at:
  golang.org/x/sync/errgroup.(*Group).Go()
      /Users/drbob/go/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:54 +0xee
  github.com/ipfs-search/ipfs-search/components/index.MultiGet()
      /Users/drbob/Development/ipfs-search/components/index/multiget.go:22 +0x5a4
  github.com/ipfs-search/ipfs-search/components/crawler.(*Crawler).getExistingItem()
      /Users/drbob/Development/ipfs-search/components/crawler/existingitem.go:22 +0x2e4
  github.com/ipfs-search/ipfs-search/components/crawler.(*Crawler).updateMaybeExisting()
      /Users/drbob/Development/ipfs-search/components/crawler/update.go:142 +0x16c
  github.com/ipfs-search/ipfs-search/components/crawler.(*Crawler).Crawl()
      /Users/drbob/Development/ipfs-search/components/crawler/crawler.go:60 +0x3e5
  github.com/ipfs-search/ipfs-search/components/crawler.(*CrawlerTestSuite).TestCrawlAddReference()
      /Users/drbob/Development/ipfs-search/components/crawler/crawler_test.go:1083 +0x1187
  runtime.call16()
      /usr/local/Cellar/go/1.18.2/libexec/src/runtime/asm_amd64.s:701 +0x48
  reflect.Value.Call()
      /usr/local/Cellar/go/1.18.2/libexec/src/reflect/value.go:339 +0xd7
  github.com/stretchr/testify/suite.Run.func1()
      /Users/drbob/Development/testify/suite/suite.go:175 +0x6dc
  testing.tRunner()
      /usr/local/Cellar/go/1.18.2/libexec/src/testing/testing.go:1439 +0x213
  testing.(*T).Run.func1()
      /usr/local/Cellar/go/1.18.2/libexec/src/testing/testing.go:1486 +0x47
==================
```

### Relevant code
```golang
	s.fileIdx.
		On("Get", mock.Anything, r.Resource.ID, mock.Anything, []string{"references", "last-seen"}).
		Run(func(args mock.Arguments) {
			u := args.Get(2).(*indexTypes.Update)
			lastSeen := time.Now()
			u.LastSeen = &lastSeen
			u.References = indexTypes.References{
				indexTypes.Reference{
					ParentHash: "Qmc8mmzycvXnzgwBHokZQd97iWAmtdFMqX4FZUAQ5AQdQi",
					Name:       "ExistingReference.pdf",
				},
			}
		}).
		Return(true, nil).
		Once()
```
https://github.com/ipfs-search/ipfs-search/blob/fix_race_condition/components/crawler/crawler_test.go#L1040

## Changes
Replaced `%v` by `%p`, inspired by https://github.com/stretchr/testify/commit/6241f9ab994219cafb009b160a20acf4a62063aa.

## Motivation
We need to test for race conditions in our code, not the testing library. ;)

This is a workaround and should not be seen as a full fix. It is also lacking regression tests and causes existing tests to fail. Regrettably, I currently lack bandwith to provide them.

## Related issues
#125

