### PR TITLE
assert.Len: avoid printing the value of very large objects

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -644,6 +644,9 @@ func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) 
 	}
 
 	if l != length {
+		if l > 99 {
+			return Fail(t, fmt.Sprintf("%T should have %d item(s), but has %d", object, length, l), msgAndArgs...)
+		}
 		return Fail(t, fmt.Sprintf("\"%s\" should have %d item(s), but has %d", object, length, l), msgAndArgs...)
 	}
 	return true


### PR DESCRIPTION
## Summary
When testing the `Len` of very large objects, the error message can appear very long or just not appear at all. Having a "printing length limit" helps in keeping the console clean and ensures the message `should have %d item(s), but has %d` appears and can be read.

## Changes
A failed `Len` assertion will print the type of the object instead of its value if the actual length of the object is greater than `100` items. `100` is an arbitrary value and I'm open to changing it.

## Motivation
In my tests some slices have thousands of items and I find myself avoiding

`assert.Len(t, items, expectedItems)`

in favour of

`assert.True(t, len(items) == expectedItems, "expected %d items to be set", expectedItems)`

just because the console gets filled with thousands of values that take all available space and are thus not useful for debugging.

In very large slices no message appears, leaving an empty error behind. 