### PR TITLE
This vet fix regressed Mock

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -562,9 +562,9 @@ func AssertExpectationsForObjects(t TestingT, testObjects ...interface{}) bool {
 		h.Helper()
 	}
 	for _, obj := range testObjects {
-		if m, ok := obj.(*Mock); ok {
+		if m, ok := obj.(Mock); ok {
 			t.Logf("Deprecated mock.AssertExpectationsForObjects(myMock.Mock) use mock.AssertExpectationsForObjects(myMock)")
-			obj = m
+			obj = &m
 		}
 		m := obj.(assertExpectationser)
 		if !m.AssertExpectations(t) {

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -1223,6 +1223,10 @@ func Test_AssertExpectationsForObjects_Helper(t *testing.T) {
 
 	assert.True(t, AssertExpectationsForObjects(t, &mockedService1.Mock, &mockedService2.Mock, &mockedService3.Mock, &mockedService4.Mock))
 	assert.True(t, AssertExpectationsForObjects(t, mockedService1, mockedService2, mockedService3, mockedService4))
+	// The following is a third way of calling AssertExpectationsForObjects
+	// which at least one user did and which historically works:
+	// https://github.com/stretchr/testify/issues/1227
+	assert.True(t, AssertExpectationsForObjects(t, mockedService1.Mock, mockedService2.Mock, mockedService3.Mock, mockedService4.Mock))
 
 }
 


### PR DESCRIPTION
## Summary
The attempt to fix a legitimate go vet finding (https://github.com/stretchr/testify/commit/b5ce16571001d6e96e1693ac891fed5c2510c651) breaks the referenced deprecated use case in v1.8.0. This vet finding can't be fixed until v2. The mutex is only copied when people use the deprecated case.

## Changes
Revert invalid change from https://github.com/stretchr/testify/commit/b5ce16571001d6e96e1693ac891fed5c2510c651

## Motivation
This caused a regression in v1.8.0 for people using a deprecated call to AssertExpectationsForObjects

## Related issues
fixes #1227
