### PR TITLE
mock: Call.Unset(): fix panic #1236

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -217,7 +217,7 @@ func (c *Call) Unset() *Call {
 	defer unlockOnce.Do(c.unlock)
 
 	foundMatchingCall := false
-	
+
 	tmp := make([]*Call, 0)
 	for _, call := range c.Parent.ExpectedCalls {
 		if call.Method == c.Method {

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -220,14 +220,17 @@ func (c *Call) Unset() *Call {
 
 	tmp := make([]*Call, 0)
 	for _, call := range c.Parent.ExpectedCalls {
-		if call.Method == c.Method {
-			_, diffCount := call.Arguments.Diff(c.Arguments)
-			if diffCount == 0 {
-				foundMatchingCall = true
-			} else {
-				tmp = append(tmp, call)
-			}
+		if call.Method != c.Method {
+			tmp = append(tmp, call)
+			continue
 		}
+
+		_, diffCount := call.Arguments.Diff(c.Arguments)
+		if diffCount > 0 {
+			tmp = append(tmp, call)
+			continue
+		}
+		foundMatchingCall = true
 	}
 	c.Parent.ExpectedCalls = tmp
 

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -217,17 +217,19 @@ func (c *Call) Unset() *Call {
 	defer unlockOnce.Do(c.unlock)
 
 	foundMatchingCall := false
-
-	for i, call := range c.Parent.ExpectedCalls {
+	
+	tmp := make([]*Call, 0)
+	for _, call := range c.Parent.ExpectedCalls {
 		if call.Method == c.Method {
 			_, diffCount := call.Arguments.Diff(c.Arguments)
 			if diffCount == 0 {
 				foundMatchingCall = true
-				// Remove from ExpectedCalls
-				c.Parent.ExpectedCalls = append(c.Parent.ExpectedCalls[:i], c.Parent.ExpectedCalls[i+1:]...)
+			} else {
+				tmp = append(tmp, call)
 			}
 		}
 	}
+	c.Parent.ExpectedCalls = tmp
 
 	if !foundMatchingCall {
 		unlockOnce.Do(c.unlock)


### PR DESCRIPTION
## Summary
This PR aims to fix #1236. While it's not the pretties fix, it avoids panic

## Changes
Within `Unset` function instead of iterating over an slice and removing items from it at same time, a temporary slice is created, during iteration orginal logic is used to decide if the item should be removed, and if not, item is added to temporary slice.
After iteration temporary slice overrides orginal slice, preventing panic.

## Motivation
As library user, I want this function to work.

## Related issues
<!-- Put `Closes #XXXX` for each issue number this PR fixes/closes -->
Closes #1236
