### PR TITLE
Fixed FailfastSuite failing when test.count > 1

### DIFF
--- a/suite/suite_test.go
+++ b/suite/suite_test.go
@@ -537,7 +537,8 @@ func TestSuiteWithStats(t *testing.T) {
 // It logs calls in the callOrder slice which we then use to assert the correct calls were made
 type FailfastSuite struct {
 	Suite
-	callOrder []string
+	callOrder       []string
+	callOrderPerRun []string
 }
 
 func (s *FailfastSuite) call(method string) {
@@ -560,11 +561,15 @@ func TestFailfastSuite(t *testing.T) {
 	)
 	assert.Equal(t, false, ok)
 	if failFast {
-		// Test A Fails and because we are running with failfast Test B never runs and we proceed straight to TearDownSuite
-		assert.Equal(t, "SetupSuite;SetupTest;Test A Fails;TearDownTest;TearDownSuite", strings.Join(s.callOrder, ";"))
+		for _, callOrder := range s.callOrderPerRun {
+			// Test A Fails and because we are running with failfast Test B never runs and we proceed straight to TearDownSuite
+			assert.Equal(t, "SetupSuite;SetupTest;Test A Fails;TearDownTest;TearDownSuite", callOrder)
+		}
 	} else {
-		// Test A Fails and because we are running without failfast we continue and run Test B and then proceed to TearDownSuite
-		assert.Equal(t, "SetupSuite;SetupTest;Test A Fails;TearDownTest;SetupTest;Test B Passes;TearDownTest;TearDownSuite", strings.Join(s.callOrder, ";"))
+		for _, callOrder := range s.callOrderPerRun {
+			// Test A Fails and because we are running without failfast we continue and run Test B and then proceed to TearDownSuite
+			assert.Equal(t, "SetupSuite;SetupTest;Test A Fails;TearDownTest;SetupTest;Test B Passes;TearDownTest;TearDownSuite", callOrder)
+		}
 	}
 }
 func TestFailfastSuiteFailFastOn(t *testing.T) {
@@ -586,6 +591,8 @@ func (s *FailfastSuite) SetupSuite() {
 
 func (s *FailfastSuite) TearDownSuite() {
 	s.call("TearDownSuite")
+	s.callOrderPerRun = append(s.callOrderPerRun, strings.Join(s.callOrder, ";"))
+	s.callOrder = []string{}
 }
 func (s *FailfastSuite) SetupTest() {
 	s.call("SetupTest")


### PR DESCRIPTION
FailfastSuite used a callOrder slice that gets populated by the suite methods and compared it to a string literal. When test.count is > 1 callOrder is overpopulated and does not match the expected string. Fixed this by having TearDownSuite dump the callOrder into a new slice callOrderPerRun and have tests assert each run separately.

## Summary
Fixes TestFailfastSuite failing when test.count is set > 1

## Changes
FailfastSuite now dumps callOrder into callOrderPerRun when TearDownSuite is called.
TestFailfastSuite now compares the string literal to each entry of callOrderPerRun

## Motivation
Previously running go test ./... test.count=2 resulted in failure

## Related issues
