### PR TITLE
fix typos in comments and tests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,10 +14,10 @@ assignees: ''
 <!-- A detailed description of the bug -->
 
 ## Step To Reproduce
-<!-- Steps or code snippet to reproduce the behaviour -->
+<!-- Steps or code snippet to reproduce the behavior -->
 
-## Expected behaviour
+## Expected behavior
 <!-- A clear and concise description of what you expected to happen -->
 
-## Actual behaviour
+## Actual behavior
 <!-- What testify does -->

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -880,7 +880,7 @@ func TestNotEqualValues(t *testing.T) {
 		{new(AssertionTesterConformingObject), new(AssertionTesterConformingObject), false},
 		{&struct{}{}, &struct{}{}, false},
 
-		// Different behaviour from NotEqual()
+		// Different behavior from NotEqual()
 		{func() int { return 23 }, func() int { return 24 }, true},
 		{int(10), int(11), true},
 		{int(10), uint(10), false},

--- a/suite/suite_test.go
+++ b/suite/suite_test.go
@@ -21,7 +21,7 @@ import (
 type SuiteRequireTwice struct{ Suite }
 
 // TestSuiteRequireTwice checks for regressions of issue #149 where
-// suite.requirements was not initialised in suite.SetT()
+// suite.requirements was not initialized in suite.SetT()
 // A regression would result on these tests panicking rather than failing.
 func TestSuiteRequireTwice(t *testing.T) {
 	ok := testing.RunTests(
@@ -693,15 +693,15 @@ func TestSubtestPanic(t *testing.T) {
 	assert.True(t, suite.inTearDownSuite)
 }
 
-type unInitialisedSuite struct {
+type unInitializedSuite struct {
 	Suite
 }
 
-// TestUnInitialisedSuites asserts the behaviour of the suite methods when the
-// suite is not initialised
-func TestUnInitialisedSuites(t *testing.T) {
+// TestUnInitializedSuites asserts the behavior of the suite methods when the
+// suite is not initialized
+func TestUnInitializedSuites(t *testing.T) {
 	t.Run("should panic on Require", func(t *testing.T) {
-		suite := new(unInitialisedSuite)
+		suite := new(unInitializedSuite)
 
 		assert.Panics(t, func() {
 			suite.Require().True(true)
@@ -709,7 +709,7 @@ func TestUnInitialisedSuites(t *testing.T) {
 	})
 
 	t.Run("should panic on Assert", func(t *testing.T) {
-		suite := new(unInitialisedSuite)
+		suite := new(unInitializedSuite)
 
 		assert.Panics(t, func() {
 			suite.Assert().True(true)


### PR DESCRIPTION
## Summary
fix typos in documentation, comments and tests

## Motivation

I looked at the documentation, then found one typo in Panic: "functon" instead of "function"

So decided to check a bit further.

## Changes

I used the following tools to validate the typos:
* https://github.com/crate-ci/typos
* https://github.com/streetsidesoftware/cspell-cli
* https://github.com/codespell-project/codespell

I applied automatic fixes, then reviewed them manually one by one, before committing and opening this PR

## Related issues

None
