### PR TITLE
Fix Call.Unset() panic (issue #1236)

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -218,16 +218,22 @@ func (c *Call) Unset() *Call {
 
 	foundMatchingCall := false
 
-	for i, call := range c.Parent.ExpectedCalls {
+	// in-place filter slice for calls to be removed - iterate from 0'th to last skipping unnecessary ones
+	var index int // write index
+	for _, call := range c.Parent.ExpectedCalls {
 		if call.Method == c.Method {
 			_, diffCount := call.Arguments.Diff(c.Arguments)
 			if diffCount == 0 {
 				foundMatchingCall = true
-				// Remove from ExpectedCalls
-				c.Parent.ExpectedCalls = append(c.Parent.ExpectedCalls[:i], c.Parent.ExpectedCalls[i+1:]...)
+				// Remove from ExpectedCalls - just skip it
+				continue
 			}
 		}
+		c.Parent.ExpectedCalls[index] = call
+		index++
 	}
+	// trim slice up to last copied index
+	c.Parent.ExpectedCalls = c.Parent.ExpectedCalls[:index]
 
 	if !foundMatchingCall {
 		unlockOnce.Do(c.unlock)


### PR DESCRIPTION
## Summary
`Unset()` doesn't work as expected in documentation. Instead of unsetting call specification it causes panic.

Reason: During call specification filtering `Unset()` changes len of a `ExpectedCalls` slice while using index from original slice. Under some circumstances it tries to reslice elements beyond of the slice boundaries. That causes panic.

## Changes
The proposed solution uses independent write index to count elements kept in result slice.
Tests (the simplest and  a more complicated cases) and comments are included.


<!-- ... -->

## Motivation
Because core functionality required by users to write tests doesn't work as expected.

<!-- ## Example usage (if applicable) -->

```golang
// Unset removes a mock handler from being called.
test.On("func", mock.Anything).Return(nil)  // OK
test.On("func", mock.Anything).Unset()      // panic
```

## Related issues
Closes #1236 
