### PR TITLE
Allow suite methods to take *testing.T parameter

### DIFF
--- a/suite/suite.go
+++ b/suite/suite.go
@@ -172,7 +172,18 @@ func Run(t *testing.T, suite TestingSuite) {
 					stats.start(method.Name)
 				}
 
-				method.Func.Call([]reflect.Value{reflect.ValueOf(suite)})
+				switch method.Type.NumIn() {
+				case 1:
+					method.Func.Call([]reflect.Value{reflect.ValueOf(suite)})
+				case 2:
+					if method.Type.In(1) == reflect.TypeOf(&testing.T{}) {
+						method.Func.Call([]reflect.Value{reflect.ValueOf(suite), reflect.ValueOf(t)})
+						break
+					}
+					fallthrough
+				default:
+					t.Error("invalid test method signature: expecting no parameters, or single *testing.T")
+				}
 			},
 		}
 		tests = append(tests, test)

--- a/suite/suite_test.go
+++ b/suite/suite_test.go
@@ -216,10 +216,10 @@ func (suite *SuiteTester) TestOne() {
 }
 
 // TestTwo is another example of a test.
-func (suite *SuiteTester) TestTwo() {
+func (suite *SuiteTester) TestTwo(t *testing.T) {
 	beforeCount := suite.TestTwoRunCount
 	suite.TestTwoRunCount++
-	assert.NotEqual(suite.T(), suite.TestTwoRunCount, beforeCount)
+	assert.NotEqual(t, suite.TestTwoRunCount, beforeCount)
 	suite.NotEqual(suite.TestTwoRunCount, beforeCount)
 }
 


### PR DESCRIPTION
## Summary
Allow suite methods to take `*testing.T` parameter (as normal tests do). This is BC, and we are already messing with reflection there, so no penalties either.

## Changes
Extend allowed suite method signature to include optional `*testing.T`.
Fail with a friendly error when the signature doesn't match (before it panicked).

## Motivation
There are many places where you need `t`, like for example for mocks and other testing libraries. And typing `s.T()` get's tedious after a while, and is completely avoidable at no cost :)

```
type MyTestSuite struct {
	suite.Suite
}

func (s *MyTestSuite) TestLorem(t *testing.T) {
	s.Same(t, s.T())

	mockA := mocks.NewMockA(t)
	mockB := mocks.NewMockB(t)
	mockIHaveTooManyMocks := mocks.NewMockMyLife()

	testStuff(mockA, mockB, mockIHaveTooManyMocks)
}

func (s *MyTestSuite) TestSimple() {
	s.NotEqual("this is", "backwards compatible")
}
```
