### PR TITLE
Add error contains all

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1456,6 +1456,57 @@ func ErrorContains(t TestingT, theError error, contains string, msgAndArgs ...in
 	return true
 }
 
+// ErrorContainsAll provides an ErrorAssertionFunc that asserts that a function returned an error (i.e. not `nil`)
+// and that the error contains all of the specified substrings in the order they are provided.
+// This is particularly useful for table driven tests where this provides an error assertion compatible with NoError.
+// If further combined with a mock, it allows to check that respective errors are wrapped in the correct order.
+//
+//   assertion := assert.ErrorContainsAll(expectedWrappingErrorSubString, expectedWrappedErrorSubString)
+//   assertion(t, err)
+//  
+//   tests := []struct {
+//     input      int
+//     assertion  assert.ErrorAssertionFunc
+//   }{
+//     {
+//       name:       "OK",
+//       input:      1,
+//     	 assertion:  assert.NoError,
+//     },
+//     {
+//       name:       "FAIL",
+//       input:      -1,
+//       assertion:  assert.ErrorContainsAll(expectedWrappingErrorSubString, expectedWrappedErrorSubString),
+//     },
+//   }
+//   for _, tt := range tests {
+//     t.Run(tt.name, func(t *testing.T) {
+//       tt.assertion(t, SomeFunction(tt.input))
+//     }
+//   }
+func ErrorContainsAll(contains ...string) ErrorAssertionFunc {
+	return func(t TestingT, theError error, msgAndArgs ...interface{}) bool {
+		if !Error(t, theError, msgAndArgs...) {
+			return false
+		}
+
+		actual := theError.Error()
+		actualFragment := actual
+		for i, errText := range contains {
+			errTextAt := strings.Index(actualFragment, errText)
+			if errTextAt < 0 {
+				if i == 0 {
+					return Fail(t, fmt.Sprintf("Error %#v does not contain %#v", actual, errText), msgAndArgs...)
+				}
+				return Fail(t, fmt.Sprintf("Error %#v does not contain %#v after %#v", actual, errText, contains[i-1]), msgAndArgs...)
+			}
+			actualFragment = actualFragment[errTextAt+len(errText):]
+		}
+
+		return true
+	}
+}
+
 // matchRegexp return true if a specified regexp matches a string.
 func matchRegexp(rx interface{}, str interface{}) bool {
 

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1461,9 +1461,14 @@ func ErrorContains(t TestingT, theError error, contains string, msgAndArgs ...in
 // This is particularly useful for table driven tests where this provides an error assertion compatible with NoError.
 // If further combined with a mock, it allows to check that respective errors are wrapped in the correct order.
 //
+//   err := SomeFunction()
 //   assertion := assert.ErrorContainsAll(expectedWrappingErrorSubString, expectedWrappedErrorSubString)
 //   assertion(t, err)
-//  
+//
+//   err := SomeFunction()
+//   assertion := assert.ErrorContainsAll(expectedErrorSubString)
+//   assertion(t, err)
+//
 //   tests := []struct {
 //     input      int
 //     assertion  assert.ErrorAssertionFunc

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1456,40 +1456,40 @@ func ErrorContains(t TestingT, theError error, contains string, msgAndArgs ...in
 	return true
 }
 
-// ErrorContainsAll provides an ErrorAssertionFunc that asserts that a function returned an error (i.e. not `nil`)
+// ErrorContainsAllAssertion provides an ErrorAssertionFunc that asserts that a function returned an error (i.e. not `nil`)
 // and that the error contains all of the specified substrings in the order they are provided.
 // This is particularly useful for table driven tests where this provides an error assertion compatible with NoError.
 // If further combined with a mock, it allows to check that respective errors are wrapped in the correct order.
 //
-//   err := SomeFunction()
-//   assertion := assert.ErrorContainsAll(expectedWrappingErrorSubString, expectedWrappedErrorSubString)
-//   assertion(t, err)
+//  err := SomeFunction()
+//  assertion := assert.ErrorContainsAllAssertion(expectedWrappingErrorSubString, expectedWrappedErrorSubString)
+//  assertion(t, err)
 //
-//   err := SomeFunction()
-//   assertion := assert.ErrorContainsAll(expectedErrorSubString)
-//   assertion(t, err)
+//  err := SomeFunction()
+//  assertion := assert.ErrorContainsAllAssertion(expectedErrorSubString)
+//  assertion(t, err)
 //
-//   tests := []struct {
-//     input      int
-//     assertion  assert.ErrorAssertionFunc
-//   }{
-//     {
-//       name:       "OK",
-//       input:      1,
-//     	 assertion:  assert.NoError,
-//     },
-//     {
-//       name:       "FAIL",
-//       input:      -1,
-//       assertion:  assert.ErrorContainsAll(expectedWrappingErrorSubString, expectedWrappedErrorSubString),
-//     },
-//   }
-//   for _, tt := range tests {
-//     t.Run(tt.name, func(t *testing.T) {
-//       tt.assertion(t, SomeFunction(tt.input))
-//     }
-//   }
-func ErrorContainsAll(contains ...string) ErrorAssertionFunc {
+//  tests := []struct {
+//    input      int
+//    assertion  assert.ErrorAssertionFunc
+//  }{
+//    {
+//      name:       "OK",
+//      input:      1,
+//    	 assertion:  assert.NoError,
+//    },
+//    {
+//      name:       "FAIL",
+//      input:      -1,
+//      assertion:  assert.ErrorContainsAllAssertion(expectedWrappingErrorSubString, expectedWrappedErrorSubString),
+//    },
+//  }
+//  for _, tt := range tests {
+//    t.Run(tt.name, func(t *testing.T) {
+//      tt.assertion(t, SomeFunction(tt.input))
+//    }
+//  }
+func ErrorContainsAllAssertion(contains ...string) ErrorAssertionFunc {
 	return func(t TestingT, theError error, msgAndArgs ...interface{}) bool {
 		if !Error(t, theError, msgAndArgs...) {
 			return false

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -1145,6 +1145,36 @@ func TestErrorContains(t *testing.T) {
 		"ErrorContains should return true")
 }
 
+func TestErrorContainsAll(t *testing.T) {
+	mockT := new(testing.T)
+
+	var err error
+	False(t, ErrorContainsAll("some error")(mockT, err),
+		"result of ErrorContainsAll should return false for nil argument")
+
+	err = errors.New("some error: another error: yet another failure")
+	True(t, ErrorContainsAll("some error", "another error", "yet another failure")(mockT, err),
+		"result of ErrorContainsAll should return true")
+	True(t, ErrorContainsAll("some error", "yet another failure")(mockT, err),
+		"result of ErrorContainsAll should return true")
+	True(t, ErrorContainsAll("yet another failure")(mockT, err),
+		"result of ErrorContainsAll should return true")
+	True(t, ErrorContainsAll("")(mockT, err),
+		"result of ErrorContainsAll should return true on empty substring")
+	True(t, ErrorContainsAll()(mockT, err),
+		"result of ErrorContainsAll should return true when no substrings were provided")
+	False(t, ErrorContainsAll("another error", "some error", "yet another failure")(mockT, err),
+		"result of ErrorContainsAll should return false if sequence of errors is reversed")
+	False(t, ErrorContainsAll("some error", "error that does not exist")(mockT, err),
+		"result of ErrorContainsAll should return false if error does not contain one of the substrings")
+	False(t, ErrorContainsAll("error that does not exist")(mockT, err),
+		"result of ErrorContainsAll should return false if error does not contain the only provided substring")
+
+	err = errors.New("SomeErrorAnotherErrorYetAnotherFailure")
+	True(t, ErrorContainsAll("SomeError", "AnotherError", "YetAnotherFailure")(mockT, err),
+		"result of ErrorContainsAll should return true even if texts are glued together")
+}
+
 func Test_isEmpty(t *testing.T) {
 
 	chWithValue := make(chan struct{}, 1)

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -1145,34 +1145,34 @@ func TestErrorContains(t *testing.T) {
 		"ErrorContains should return true")
 }
 
-func TestErrorContainsAll(t *testing.T) {
+func TestErrorContainsAllAssertion(t *testing.T) {
 	mockT := new(testing.T)
 
 	var err error
-	False(t, ErrorContainsAll("some error")(mockT, err),
-		"result of ErrorContainsAll should return false for nil argument")
+	False(t, ErrorContainsAllAssertion("some error")(mockT, err),
+		"result of ErrorContainsAllAssertion should return false for nil argument")
 
 	err = errors.New("some error: another error: yet another failure")
-	True(t, ErrorContainsAll("some error", "another error", "yet another failure")(mockT, err),
-		"result of ErrorContainsAll should return true")
-	True(t, ErrorContainsAll("some error", "yet another failure")(mockT, err),
-		"result of ErrorContainsAll should return true")
-	True(t, ErrorContainsAll("yet another failure")(mockT, err),
-		"result of ErrorContainsAll should return true")
-	True(t, ErrorContainsAll("")(mockT, err),
-		"result of ErrorContainsAll should return true on empty substring")
-	True(t, ErrorContainsAll()(mockT, err),
-		"result of ErrorContainsAll should return true when no substrings were provided")
-	False(t, ErrorContainsAll("another error", "some error", "yet another failure")(mockT, err),
-		"result of ErrorContainsAll should return false if sequence of errors is reversed")
-	False(t, ErrorContainsAll("some error", "error that does not exist")(mockT, err),
-		"result of ErrorContainsAll should return false if error does not contain one of the substrings")
-	False(t, ErrorContainsAll("error that does not exist")(mockT, err),
-		"result of ErrorContainsAll should return false if error does not contain the only provided substring")
+	True(t, ErrorContainsAllAssertion("some error", "another error", "yet another failure")(mockT, err),
+		"result of ErrorContainsAllAssertion should return true")
+	True(t, ErrorContainsAllAssertion("some error", "yet another failure")(mockT, err),
+		"result of ErrorContainsAllAssertion should return true")
+	True(t, ErrorContainsAllAssertion("yet another failure")(mockT, err),
+		"result of ErrorContainsAllAssertion should return true")
+	True(t, ErrorContainsAllAssertion("")(mockT, err),
+		"result of ErrorContainsAllAssertion should return true on empty substring")
+	True(t, ErrorContainsAllAssertion()(mockT, err),
+		"result of ErrorContainsAllAssertion should return true when no substrings were provided")
+	False(t, ErrorContainsAllAssertion("another error", "some error", "yet another failure")(mockT, err),
+		"result of ErrorContainsAllAssertion should return false if sequence of errors is reversed")
+	False(t, ErrorContainsAllAssertion("some error", "error that does not exist")(mockT, err),
+		"result of ErrorContainsAllAssertion should return false if error does not contain one of the substrings")
+	False(t, ErrorContainsAllAssertion("error that does not exist")(mockT, err),
+		"result of ErrorContainsAllAssertion should return false if error does not contain the only provided substring")
 
 	err = errors.New("SomeErrorAnotherErrorYetAnotherFailure")
-	True(t, ErrorContainsAll("SomeError", "AnotherError", "YetAnotherFailure")(mockT, err),
-		"result of ErrorContainsAll should return true even if texts are glued together")
+	True(t, ErrorContainsAllAssertion("SomeError", "AnotherError", "YetAnotherFailure")(mockT, err),
+		"result of ErrorContainsAllAssertion should return true even if texts are glued together")
 }
 
 func Test_isEmpty(t *testing.T) {


### PR DESCRIPTION
## Summary
Added ErrorContainsAllAssertion function to help with table driven tests.

## Changes
Added ErrorContainsAllAssertion function.
Added unit tests for ErrorContainsAllAssertion function.

## Motivation
There was no way to check for particular message in the error text that would comply with `NoError` function i.e. `ErrorAssertionFunc` for table driven tests. At the same time writing a lambda for this is cumbersome and produces unreadable code.

## Example usage
```
tests := []struct {
  input      int
  assertion  assert.ErrorAssertionFunc
}{
  {
    name:       "OK",
    input:      1,
    assertion:  assert.NoError,
  },
  {
    name:       "FAIL",
    input:      -1,
    assertion:  assert.ErrorContainsAllAssertion(expectedWrappingErrorSubString, expectedWrappedErrorSubString),
  },
}
for _, tt := range tests {
  t.Run(tt.name, func(t *testing.T) {
    tt.assertion(t, SomeFunction(tt.input))
  }
}
```

## Related issues
n/a
