### PR TITLE
Added ErrorContainsAllAssertion function.

### DIFF
--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -1145,6 +1145,36 @@ func TestErrorContains(t *testing.T) {
 		"ErrorContains should return true")
 }
 
+func TestErrorContainsAllAssertion(t *testing.T) {
+	mockT := new(testing.T)
+
+	var err error
+	False(t, ErrorContainsAllAssertion("some error")(mockT, err),
+		"result of ErrorContainsAllAssertion should return false for nil argument")
+
+	err = errors.New("some error: another error: yet another failure")
+	True(t, ErrorContainsAllAssertion("some error", "another error", "yet another failure")(mockT, err),
+		"result of ErrorContainsAllAssertion should return true")
+	True(t, ErrorContainsAllAssertion("some error", "yet another failure")(mockT, err),
+		"result of ErrorContainsAllAssertion should return true")
+	True(t, ErrorContainsAllAssertion("yet another failure")(mockT, err),
+		"result of ErrorContainsAllAssertion should return true")
+	True(t, ErrorContainsAllAssertion("")(mockT, err),
+		"result of ErrorContainsAllAssertion should return true on empty substring")
+	True(t, ErrorContainsAllAssertion()(mockT, err),
+		"result of ErrorContainsAllAssertion should return true when no substrings were provided")
+	False(t, ErrorContainsAllAssertion("another error", "some error", "yet another failure")(mockT, err),
+		"result of ErrorContainsAllAssertion should return false if sequence of errors is reversed")
+	False(t, ErrorContainsAllAssertion("some error", "error that does not exist")(mockT, err),
+		"result of ErrorContainsAllAssertion should return false if error does not contain one of the substrings")
+	False(t, ErrorContainsAllAssertion("error that does not exist")(mockT, err),
+		"result of ErrorContainsAllAssertion should return false if error does not contain the only provided substring")
+
+	err = errors.New("SomeErrorAnotherErrorYetAnotherFailure")
+	True(t, ErrorContainsAllAssertion("SomeError", "AnotherError", "YetAnotherFailure")(mockT, err),
+		"result of ErrorContainsAllAssertion should return true even if texts are glued together")
+}
+
 func Test_isEmpty(t *testing.T) {
 
 	chWithValue := make(chan struct{}, 1)


### PR DESCRIPTION
## Summary
Added ErrorContainsAllAssertion function to help with table driven tests.

## Changes
Added ErrorContainsAllAssertion function.
Added unit tests for ErrorContainsAllAssertion function.

## Motivation
There was no way to check for particular message in the error text that would comply with `NoError` function i.e. `ErrorAssertionFunc` for table driven tests. At the same time writing a lambda for this is cumbersome and produces unreadable code.

## Example usage
```
tests := []struct {
  input      int
  assertion  assert.ErrorAssertionFunc
}{
  {
    name:       "OK",
    input:      1,
    assertion:  assert.NoError,
  },
  {
    name:       "FAIL",
    input:      -1,
    assertion:  assert.ErrorContainsAllAssertion(expectedWrappingErrorSubString, expectedWrappedErrorSubString),
  },
}
for _, tt := range tests {
  t.Run(tt.name, func(t *testing.T) {
    tt.assertion(t, SomeFunction(tt.input))
  }
}
```

## Related issues
n/a
