### PR TITLE
Fix case of NotBefore() name in comment

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -243,7 +243,7 @@ func (c *Call) Unset() *Call {
 // calls have been called as expected. The referenced calls may be from the
 // same mock instance and/or other mock instances.
 //
-//     Mock.On("Do").Return(nil).Notbefore(
+//     Mock.On("Do").Return(nil).NotBefore(
 //         Mock.On("Init").Return(nil)
 //     )
 func (c *Call) NotBefore(calls ...*Call) *Call {


### PR DESCRIPTION
## Summary
Rocket science based fix to make documentation of using `mock.Call.NotBefore()` great again.

## Changes
`Notbefore()` -> `NotBefore()` in doc's comment

## Motivation
The typo could make someone frustrated and ruin a day because of possible copy&paste of incorrect code snippet.

## Related issues

