### PR TITLE
Print underlying object in ptr comparison (issue #1118)

### DIFF
--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -2475,15 +2475,38 @@ func Test_validateEqualArgs(t *testing.T) {
 func Test_truncatingFormat(t *testing.T) {
 
 	original := strings.Repeat("a", bufio.MaxScanTokenSize-102)
-	result := truncatingFormat(original)
+	result := truncatingFormat(original, false)
 	Equal(t, fmt.Sprintf("%#v", original), result, "string should not be truncated")
 
 	original = original + "x"
-	result = truncatingFormat(original)
+	result = truncatingFormat(original, false)
 	NotEqual(t, fmt.Sprintf("%#v", original), result, "string should have been truncated.")
 
 	if !strings.HasSuffix(result, "<... truncated>") {
 		t.Error("truncated string should have <... truncated> suffix")
+	}
+}
+
+func Test_truncatingFormat_PrintValueOfBasicTypes(t *testing.T) {
+	i := 5
+	iPtr := &i
+	result := truncatingFormat(iPtr, true)
+	if !strings.HasSuffix(result, "5") {
+		t.Error("format should have printed the underlying value of int pointer")
+	}
+
+	b := false
+	bPtr := &b
+	result = truncatingFormat(bPtr, true)
+	if !strings.HasSuffix(result, "false") {
+		t.Error("format should have printed the underlying value of bool pointer")
+	}
+
+	s := "testingString"
+	sPtr := &s
+	result = truncatingFormat(sPtr, true)
+	if !strings.HasSuffix(result, "testingString") {
+		t.Error("format should have printed the underlying value of string pointer")
 	}
 }
 


### PR DESCRIPTION
## Summary
Prints out the underlying value of a pointer to a basic type in addition to the pointer address when the comparison between two basic type pointers fails. 

## Changes
- Updated `truncatingFormat` function in `assert/assertions.go` with a flag that control whether or not the underlying value of basic types are also printed in addition to their address
- Updated `assert/assertions_test.go` to fix unit tests that were broken and added additional unit test to cover added code

## Motivation
As described in Issue #1118, when the comparison between two pointers fails, the underlying value is not always printed. This gives the impression that it is the address of the pointers that are being compared, which is incorrect, since it is actually the underlying values of the pointers that are being compared. 

After further research, we discovered that non-basic types such as maps and structs already print the underlying value when the `%#v` specifier is used for formatting, so their underlying value is already being printed. However, for basic types such as int, bool, and string, the `%#v` specifier only prints out the pointer address. Our change will ensure that the underlying value of these basic type pointers are printed as well.

For example, this is the original output when comparing two int pointers:
```
Error:          Not equal: 
                    expected: (*int)(0x14000120df0)
                    actual  : (*int)(0x14000120df8)
```
And this is the new output when comparing two int pointers:
```
Error:          Not equal: 
                                expected: (*int)(0x14000120df0) 5
                                actual  : (*int)(0x14000120df8) 0
```

Similarly, this is the new output when comparing two string and bool pointers:
```
Error:          Not equal: 
                                expected: (*string)(0x140001132d0) hello
                                actual  : (*string)(0x140001132e0) 
```
```
 Error:          Not equal: 
                                expected: (*bool)(0x14000120fa8) true
                                actual  : (*bool)(0x14000120fa9) false
```

However, we do not print out the underlying value of basic type pointers when a comparison is being made between two different pointer types. This is the same behaviour as before. For example, for a comparison between an int pointer and a string pointer, this is the output:
```
Error:          Not equal: 
                                expected: *string((*string)(0x140000997c0))
                                actual  : *int((*int)(0x140000a7608))
```

## Related issues
Closes #1118
Closes #1273
