### PR TITLE
Fix `CallerInfo()` source file paths

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"math"
 	"os"
-	"path/filepath"
 	"reflect"
 	"regexp"
 	"runtime"
@@ -141,12 +140,11 @@ func CallerInfo() []string {
 		}
 
 		parts := strings.Split(file, "/")
-		file = parts[len(parts)-1]
 		if len(parts) > 1 {
+			filename := parts[len(parts)-1]
 			dir := parts[len(parts)-2]
-			if (dir != "assert" && dir != "mock" && dir != "require") || file == "mock_test.go" {
-				path, _ := filepath.Abs(file)
-				callers = append(callers, fmt.Sprintf("%s:%d", path, line))
+			if (dir != "assert" && dir != "mock" && dir != "require") || filename == "mock_test.go" {
+				callers = append(callers, fmt.Sprintf("%s:%d", file, line))
 			}
 		}
 


### PR DESCRIPTION
## Summary
`Error Trace` produce strange output with invalid file paths: it join current execution directory and base source filename, but source file can be located in another directory.

It is especially strange that these path conversions are not needed, since the desired path initially got from stacktrace.

## Related issues
Fix https://github.com/stretchr/testify/issues/1230
Fix https://github.com/stretchr/testify/issues/1268
