### PR TITLE
fix Subset/NotSubset (issue #1270)

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -843,7 +843,13 @@ func Subset(t TestingT, list, subset interface{}, msgAndArgs ...interface{}) (ok
 		for i := 0; i < len(subsetKeys); i++ {
 			subsetKey := subsetKeys[i]
 			subsetElement := subsetValue.MapIndex(subsetKey).Interface()
-			listElement := listValue.MapIndex(subsetKey).Interface()
+			listValue := listValue.MapIndex(subsetKey)
+
+			if !listValue.IsValid() {
+				return Fail(t, fmt.Sprintf("\"%s\" does not contain \"%s\"", list, subsetElement), msgAndArgs...)
+			}
+
+			listElement := listValue.Interface()
 
 			if !ObjectsAreEqual(subsetElement, listElement) {
 				return Fail(t, fmt.Sprintf("\"%s\" does not contain \"%s\"", list, subsetElement), msgAndArgs...)
@@ -904,7 +910,13 @@ func NotSubset(t TestingT, list, subset interface{}, msgAndArgs ...interface{}) 
 		for i := 0; i < len(subsetKeys); i++ {
 			subsetKey := subsetKeys[i]
 			subsetElement := subsetValue.MapIndex(subsetKey).Interface()
-			listElement := listValue.MapIndex(subsetKey).Interface()
+			listValue := listValue.MapIndex(subsetKey)
+
+			if !listValue.IsValid() {
+				return true
+			}
+
+			listElement := listValue.Interface()
 
 			if !ObjectsAreEqual(subsetElement, listElement) {
 				return true

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -706,6 +706,14 @@ func TestSubsetNotSubset(t *testing.T) {
 			"a": "x",
 			"b": "z",
 		}, false, `{ "a": "x", "b": "y", "c": "z"} does not contain { "a": "x", "b": "z"}`},
+		{map[string]string{
+			"a": "a",
+			"b": "b",
+		}, map[string]string{
+			"c": "c",
+			"b": "b",
+			"a": "a",
+		}, false, `{ "a": "a", "b": "b"} does not contain { "a": "a","b": "b", "c": "c"}`},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
## Summary
<!-- High-level, one sentence summary of what this PR accomplishes -->
This PR fixes Subset/NotSubset , which is not handled correctly when Map key doesn't exist #1270 
## Changes
<!-- * Description of change 1 -->
When calling Interface(), judge whether the current Value is zero Value
Fixed exception being caught and function results not being printed correctly
<!-- * Description of change 2 -->
<!-- ... -->

## Motivation
<!-- Why were the changes necessary. -->
Hope this function works
<!-- ## Example usage (if applicable) -->

## Related issues
<!-- Put `Closes #XXXX` for each issue number this PR fixes/closes -->
Closes #1270
