### PR TITLE
assert: Fail `Subset`/`NotSubset` when a map superset is missing elements

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -843,10 +843,10 @@ func Subset(t TestingT, list, subset interface{}, msgAndArgs ...interface{}) (ok
 		for i := 0; i < len(subsetKeys); i++ {
 			subsetKey := subsetKeys[i]
 			subsetElement := subsetValue.MapIndex(subsetKey).Interface()
-			listElement := listValue.MapIndex(subsetKey).Interface()
+			listEntry := listValue.MapIndex(subsetKey)
 
-			if !ObjectsAreEqual(subsetElement, listElement) {
-				return Fail(t, fmt.Sprintf("\"%s\" does not contain \"%s\"", list, subsetElement), msgAndArgs...)
+			if !listEntry.IsValid() || !ObjectsAreEqual(subsetElement, listEntry.Interface()) {
+				return Fail(t, fmt.Sprintf("%q is a not subset of %q", subset, list), msgAndArgs...)
 			}
 		}
 
@@ -904,9 +904,9 @@ func NotSubset(t TestingT, list, subset interface{}, msgAndArgs ...interface{}) 
 		for i := 0; i < len(subsetKeys); i++ {
 			subsetKey := subsetKeys[i]
 			subsetElement := subsetValue.MapIndex(subsetKey).Interface()
-			listElement := listValue.MapIndex(subsetKey).Interface()
+			listEntry := listValue.MapIndex(subsetKey)
 
-			if !ObjectsAreEqual(subsetElement, listElement) {
+			if !listEntry.IsValid() || !ObjectsAreEqual(subsetElement, listEntry.Interface()) {
 				return true
 			}
 		}

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -706,6 +706,14 @@ func TestSubsetNotSubset(t *testing.T) {
 			"a": "x",
 			"b": "z",
 		}, false, `{ "a": "x", "b": "y", "c": "z"} does not contain { "a": "x", "b": "z"}`},
+		{map[string]string{
+			"a": "x",
+			"b": "y",
+		}, map[string]string{
+			"a": "x",
+			"b": "y",
+			"c": "z",
+		}, false, `{"a": "x", "b": "y"} does not contain {"a": "x", "b": "y", "c": "z"}`},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
## Summary
Avoid panics in `assert.Subset`/`assert.NotSubset` and properly fail the test when a superset map is missing elements from the subset map.

## Changes
- Check whether the value reflected at the `subsetKey` of the superset reflection `listValue` `.isValid`, before attempting to get its interface value for use in `ObjectsAreEqual` assertion.
- Align the `Subset` failure message with the corresponding `NotSubset` failure message.

## Motivation
When a subset map contains an item with a key that is not present in the superset map, attempts to reflect the interface of the value at the absent key cause panics, which return `false` on recovery but do not properly fail the test with a message.

## Related issues
Closes #1270
