### PR TITLE
Recover from the panic in suite subtest

### DIFF
--- a/suite/suite.go
+++ b/suite/suite.go
@@ -108,6 +108,7 @@ func (suite *Suite) Run(name string, subtest func()) bool {
 	}()
 
 	return oldT.Run(name, func(t *testing.T) {
+		defer recoverAndFailOnPanic(t)
 		suite.SetT(t)
 		subtest()
 	})

--- a/suite/suite_test.go
+++ b/suite/suite_test.go
@@ -617,3 +617,39 @@ func (s *FailfastSuite) Test_B_Passes() {
 	s.call("Test B Passes")
 	s.Require().True(true)
 }
+
+type subtestPanicSuite struct {
+	Suite
+	inTeardownTest bool
+	inTeardown     bool
+}
+
+func (s *subtestPanicSuite) TearDownSuite() {
+	s.inTeardown = true
+}
+
+func (s *subtestPanicSuite) TearDownTest() {
+	s.inTeardownTest = true
+}
+
+func (s *subtestPanicSuite) TestSubtestPanic() {
+	s.Run("subtest", func() {
+		panic("panic")
+	})
+}
+
+func TestSubtestPanic(t *testing.T) {
+	suite := new(subtestPanicSuite)
+	ok := testing.RunTests(
+		allTestsFilter,
+		[]testing.InternalTest{{
+			Name: "TestSubtestPanic",
+			F: func(t *testing.T) {
+				Run(t, suite)
+			},
+		}},
+	)
+	assert.False(t, ok)
+	assert.True(t, suite.inTeardownTest)
+	assert.True(t, suite.inTeardown)
+}


### PR DESCRIPTION
## Summary
<!-- High-level, one-sentence summary of what this PR accomplishes -->
Example Playground: https://go.dev/play/p/MOJuXPikRMU
Recover from the panic in the suite subtest.

## Changes
<!-- * Description of change 1 -->
<!-- * Description of change 2 -->
<!-- ... -->
Add `defer recoverAndFailOnPanic(t)` into the implement of `func (suite *Suite) Run`.
## Motivation
<!-- Why were the changes necessary. -->
<!-- ## Example usage (if applicable) -->
If the subtest panicked and it's not recovered, then the `TearDownTest` and `TearDownSuite` will be skipped, we should make sure that the TearDown methods are executed.

## Related issues
<!-- Put `Closes #XXXX` for each issue number this PR fixes/closes -->
Close #764
