### PR TITLE
fix: test failures

### DIFF
--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -2453,7 +2453,7 @@ func TestEventuallyIssue805(t *testing.T) {
 	mockT := new(testing.T)
 
 	NotPanics(t, func() {
-		condition := func() bool { <-time.After(time.Millisecond); return true }
+		condition := func() bool { <-time.After(time.Millisecond * 2); return true }
 		False(t, Eventually(mockT, condition, time.Millisecond, time.Microsecond))
 	})
 }

--- a/suite/suite_test.go
+++ b/suite/suite_test.go
@@ -559,14 +559,44 @@ func TestFailfastSuite(t *testing.T) {
 		}},
 	)
 	assert.Equal(t, false, ok)
+	var expect []string
 	if failFast {
 		// Test A Fails and because we are running with failfast Test B never runs and we proceed straight to TearDownSuite
-		assert.Equal(t, "SetupSuite;SetupTest;Test A Fails;TearDownTest;TearDownSuite", strings.Join(s.callOrder, ";"))
+		expect = []string{"SetupSuite", "SetupTest", "Test A Fails", "TearDownTest", "TearDownSuite"}
 	} else {
 		// Test A Fails and because we are running without failfast we continue and run Test B and then proceed to TearDownSuite
-		assert.Equal(t, "SetupSuite;SetupTest;Test A Fails;TearDownTest;SetupTest;Test B Passes;TearDownTest;TearDownSuite", strings.Join(s.callOrder, ";"))
+		expect = []string{"SetupSuite", "SetupTest", "Test A Fails", "TearDownTest", "SetupTest", "Test B Passes", "TearDownTest", "TearDownSuite"}
 	}
+	callOrderAssert(t, expect, s.callOrder)
 }
+
+type tHelper interface {
+	Helper()
+}
+
+// callOrderAssert is a help with confirms that asserts that expect
+// matches one or more times in callOrder. This makes it compatible
+// with go test flag -count=X where X > 1.
+func callOrderAssert(t *testing.T, expect, callOrder []string) {
+	var ti interface{} = t
+	if h, ok := ti.(tHelper); ok {
+		h.Helper()
+	}
+
+	callCount := len(callOrder)
+	expectCount := len(expect)
+	if callCount > expectCount && callCount%expectCount == 0 {
+		// Command line flag -count=X where X > 1.
+		for len(callOrder) >= expectCount {
+			assert.Equal(t, expect, callOrder[:expectCount])
+			callOrder = callOrder[expectCount:]
+		}
+		return
+	}
+
+	assert.Equal(t, expect, callOrder)
+}
+
 func TestFailfastSuiteFailFastOn(t *testing.T) {
 	// To test this with failfast on (and isolated from other intended test failures in our test suite) we launch it in its own process
 	cmd := exec.Command("go", "test", "-v", "-race", "-run", "TestFailfastSuite", "-failfast")


### PR DESCRIPTION
## Summary
Fix random test failure and compatibility with `go test -count=X` where `X > 1`.

## Changes
* Fix random failure TestEventuallyIssue805 due to timing dependency.
* Fix `TestFailfastSuite` when run with `go test` flag `-count=X` where `X > 1`.

## Motivation
So we don't get false test failures causing confusion.