### PR TITLE
Compare public elements of struct

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -76,6 +76,47 @@ func ObjectsAreEqual(expected, actual interface{}) bool {
 	return bytes.Equal(exp, act)
 }
 
+// ObjectsExportedFieldsAreEqual determines if the exported (public) fields of two structs are considered equal.
+// If the two objects are not of the same type, or if either of them are not a struct, they are not considered equal.
+//
+// This function does no assertion of any kind.
+func ObjectsExportedFieldsAreEqual(expected, actual interface{}) bool {
+	if expected == nil || actual == nil {
+		return expected == actual
+	}
+
+	expectedType := reflect.TypeOf(expected)
+	actualType := reflect.TypeOf(actual)
+
+	if expectedType != actualType {
+		return false
+	}
+
+	if expectedType.Kind() != reflect.Struct || actualType.Kind() != reflect.Struct {
+		return false
+	}
+
+	expectedValue := reflect.ValueOf(expected)
+	actualValue := reflect.ValueOf(actual)
+
+	for i := 0; i < expectedType.NumField(); i++ {
+		field := expectedType.Field(i)
+		if field.IsExported() {
+			var equal bool
+			if field.Type.Kind() == reflect.Struct {
+				equal = ObjectsExportedFieldsAreEqual(expectedValue.Field(i).Interface(), actualValue.Field(i).Interface())
+			} else {
+				equal = ObjectsAreEqualValues(expectedValue.Field(i).Interface(), actualValue.Field(i).Interface())
+			}
+
+			if !equal {
+				return false
+			}
+		}
+	}
+	return true
+}
+
 // ObjectsAreEqualValues gets whether two objects are equal, or if their
 // values are equal.
 func ObjectsAreEqualValues(expected, actual interface{}) bool {
@@ -351,7 +392,6 @@ func Equal(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) 
 	}
 
 	return true
-
 }
 
 // validateEqualArgs checks whether provided arguments can be safely used in the
@@ -472,7 +512,42 @@ func EqualValues(t TestingT, expected, actual interface{}, msgAndArgs ...interfa
 	}
 
 	return true
+}
 
+// EqualExportedValues asserts that the types of two objects are equal and their public
+// fields are also equal. This is useful for comparing structs that have private fields
+// that could potentially differ.
+//
+//	assert.EqualValues(t, uint32(123), int32(123))
+func EqualExportedValues(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	aType := reflect.TypeOf(expected)
+	bType := reflect.TypeOf(actual)
+
+	if aType != bType {
+		return Fail(t, fmt.Sprintf("Types expected to match exactly\n\t%v != %v", aType, bType), msgAndArgs...)
+	}
+
+	if aType.Kind() != reflect.Struct {
+		return Fail(t, fmt.Sprintf("Types expected to both be struct \n\t%v != %v", aType.Kind(), reflect.Struct), msgAndArgs...)
+	}
+
+	if bType.Kind() != reflect.Struct {
+		return Fail(t, fmt.Sprintf("Types expected to both be struct \n\t%v != %v", bType.Kind(), reflect.Struct), msgAndArgs...)
+	}
+
+	if !ObjectsExportedFieldsAreEqual(expected, actual) {
+		diff := diff(expected, actual)
+		expected, actual = formatUnequalValues(expected, actual)
+		return Fail(t, fmt.Sprintf("Not equal (comparing only exported fields): \n"+
+			"expected: %s\n"+
+			"actual  : %s%s", expected, actual, diff), msgAndArgs...)
+	}
+
+	return true
 }
 
 // Exactly asserts that two objects are equal in value and type.

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -518,7 +518,12 @@ func EqualValues(t TestingT, expected, actual interface{}, msgAndArgs ...interfa
 // fields are also equal. This is useful for comparing structs that have private fields
 // that could potentially differ.
 //
-//	assert.EqualValues(t, uint32(123), int32(123))
+//	 type S struct {
+//		Exported     	int
+//		notExported   	int
+//	 }
+//	 assert.EqualExportedValues(t, S{1, 2}, S{1, 3}) => true
+//	 assert.EqualExportedValues(t, S{1, 2}, S{2, 3}) => false
 func EqualExportedValues(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -148,6 +148,51 @@ func TestObjectsAreEqual(t *testing.T) {
 
 }
 
+func TestObjectsExportedFieldsAreEqual(t *testing.T) {
+	type Nested struct {
+		Exported    interface{}
+		notExported interface{}
+	}
+
+	type S struct {
+		Exported1    interface{}
+		Exported2    Nested
+		notExported1 interface{}
+		notExported2 Nested
+	}
+
+	type S2 struct {
+		foo interface{}
+	}
+
+	cases := []struct {
+		expected interface{}
+		actual   interface{}
+		result   bool
+	}{
+		{S{1, Nested{2, 3}, 4, Nested{5, 6}}, S{1, Nested{2, 3}, 4, Nested{5, 6}}, true},
+		{S{1, Nested{2, 3}, 4, Nested{5, 6}}, S{1, Nested{2, 3}, "a", Nested{5, 6}}, true},
+		{S{1, Nested{2, 3}, 4, Nested{5, 6}}, S{1, Nested{2, 3}, 4, Nested{5, "a"}}, true},
+		{S{1, Nested{2, 3}, 4, Nested{5, 6}}, S{1, Nested{2, 3}, 4, Nested{"a", "a"}}, true},
+		{S{1, Nested{2, 3}, 4, Nested{5, 6}}, S{1, Nested{2, "a"}, 4, Nested{5, 6}}, true},
+		{S{1, Nested{2, 3}, 4, Nested{5, 6}}, S{"a", Nested{2, 3}, 4, Nested{5, 6}}, false},
+		{S{1, Nested{2, 3}, 4, Nested{5, 6}}, S{1, Nested{"a", 3}, 4, Nested{5, 6}}, false},
+		{S{1, Nested{2, 3}, 4, Nested{5, 6}}, S2{1}, false},
+		{1, S{1, Nested{2, 3}, 4, Nested{5, 6}}, false},
+	}
+
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("ObjectsExportedFieldsAreEqual(%#v, %#v)", c.expected, c.actual), func(t *testing.T) {
+			res := ObjectsExportedFieldsAreEqual(c.expected, c.actual)
+
+			if res != c.result {
+				t.Errorf("ObjectsExportedFieldsAreEqual(%#v, %#v) should return %#v", c.expected, c.actual, c.result)
+			}
+
+		})
+	}
+}
+
 func TestImplements(t *testing.T) {
 
 	mockT := new(testing.T)


### PR DESCRIPTION
## Summary
Adds a method to check for equality of two structs of the same type by checking ONLY the exported (public) fields.

## Changes
- Added `ObjectsExportedFieldsAreEqual` method in `assert/assertions.go` that contains core code for the functionality (loops through fields of the struct using the `reflect` library and only compares fields that are exported
- Added `EqualExportedValues` method in `assert/assertions.go` that calls the `ObjectsExportedFieldsAreEqual` method and contains assertion related code that logs the appropriate message on failure
- Added corresponding unit test `TestObjectsExportedFieldsAreEqual` in `assert/assertions_test.go`

## Motivation
There are use cases where users want to compare only the public fields of two struct objects (when they only care about the public interface of the object and the internal private representation does not matter). This added method provides users the ability to do this with the `testify` library.

Example Usage:
```go
type S struct {
	Exported int
        notExported int
}

ObjectsExportedFieldsAreEqual(S{1, 2}, S{1, 2}) => true
ObjectsExportedFieldsAreEqual(S{1, 2}, S{1, 3}) => true
ObjectsExportedFieldsAreEqual(S{1, 2}, S{2, 3}) => false
```
The method also works with nested structures, where `ObjectsExportedFieldsAreEqual` is recursively called for nested fields that are of type struct, or `ObjectsAreEqualValues` are called on non-struct type fields.
```go
type Nested struct {
	Exported    interface{}
	notExported interface{}
}

type S struct {
	Exported1    interface{}
	Exported2    Nested
	notExported1 interface{}
	notExported2 Nested
}

ObjectsExportedFieldsAreEqual(S{1, Nested{2, 3}, 4, Nested{5, 6}}, S{1, Nested{2, "a"}, 4, Nested{5, 6}}) => true
ObjectsExportedFieldsAreEqual(S{1, Nested{2, 3}, 4, Nested{5, 6}}, S{"a", Nested{2, 3}, 4, Nested{5, 6}}) => false
```

## Related issues
Closes #1033
