### PR TITLE
assert: fix doc for Empty, Emptyf, NotEmpty and NotEmptyf

### DIFF
--- a/assert/assertion_format.go
+++ b/assert/assertion_format.go
@@ -51,7 +51,7 @@ func ElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string
 }
 
 // Emptyf asserts that the specified object is empty.  I.e. nil, "", false, 0 or either
-// a slice or a channel with len == 0.
+// a slice or a channel or map with len == 0.
 //
 //	assert.Emptyf(t, obj, "error message %s", "formatted")
 func Emptyf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
@@ -569,7 +569,7 @@ func NotContainsf(t TestingT, s interface{}, contains interface{}, msg string, a
 }
 
 // NotEmptyf asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or either
-// a slice or a channel with len == 0.
+// a slice or a channel or map with len == 0.
 //
 //	if assert.NotEmptyf(t, obj, "error message %s", "formatted") {
 //	  assert.Equal(t, "two", obj[1])

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -723,7 +723,7 @@ func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
 }
 
 // NotEmpty asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or either
-// a slice or a channel with len == 0.
+// a slice or a channel or a map with len == 0.
 //
 //	if assert.NotEmpty(t, obj) {
 //	  assert.Equal(t, "two", obj[1])

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -706,7 +706,7 @@ func isEmpty(object interface{}) bool {
 }
 
 // Empty asserts that the specified object is empty.  I.e. nil, "", false, 0 or either
-// a slice or a channel with len == 0.
+// a slice or a channel or a map with len == 0.
 //
 //	assert.Empty(t, obj)
 func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {


### PR DESCRIPTION
## Summary
Eventhough Empty, Emptyf, NotEmpty and NotEmptyf method supports a map type still the description of the function didn't specify that explicitly. Updated the description to make it clear.

## Changes
Update the description of the Empty, Emptyf, NotEmpty and NotEmptyf methods

## Motivation
To make documentation reflect the reality

## Related issues
None