### PR TITLE
Upgrade go module version to the minimum go version supported by the Go team

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,11 +6,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go_version: ["1.18.1", "1.17.6", "1.16.5"]
+        go_version: ["1.19", "1.18"]
     steps:
       - uses: actions/checkout@v3
       - name: Setup Go
-        uses: actions/setup-go@v3.2.0
+        uses: actions/setup-go@v3.5.0
         with:
           go-version: ${{ matrix.go_version }}
       - run: ./.ci.gogenerate.sh    

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stretchr/testify
 
-go 1.13
+go 1.18
 
 require (
 	github.com/davecgh/go-spew v1.1.1


### PR DESCRIPTION
## Summary

Fixes #1313 

## Changes
- Upgrading go module version to 1.18 which is the least supported version by the golang team
