### PR TITLE
avoid panic on ObjectsAreEqualValues

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -88,7 +88,7 @@ func ObjectsAreEqualValues(expected, actual interface{}) bool {
 		return false
 	}
 	expectedValue := reflect.ValueOf(expected)
-	if expectedValue.IsValid() && expectedValue.Type().ConvertibleTo(actualType) {
+	if expectedValue.IsValid() && expectedValue.CanConvert(actualType) {
 		// Attempt comparison after type conversion
 		return reflect.DeepEqual(expectedValue.Convert(actualType).Interface(), actual)
 	}

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -148,6 +148,14 @@ func TestObjectsAreEqual(t *testing.T) {
 
 }
 
+func TestObjectsAreEqualValues_WhenConvertSliceToArrayPtr_NeverPanics(t *testing.T) {
+	arrayPtr := new([3]int)
+	slice := make([]int, 0, 3)
+	if ObjectsAreEqualValues(slice, arrayPtr) {
+		t.Fail()
+	}
+}
+
 func TestImplements(t *testing.T) {
 
 	mockT := new(testing.T)


### PR DESCRIPTION
Avoid panics when converting slice to array pointer.
