### PR TITLE
fix: fix bug for check unsafe.Pointer isNil

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -530,7 +530,7 @@ func isNil(object interface{}) bool {
 		[]reflect.Kind{
 			reflect.Chan, reflect.Func,
 			reflect.Interface, reflect.Map,
-			reflect.Ptr, reflect.Slice},
+			reflect.Ptr, reflect.Slice, reflect.UnsafePointer},
 		kind)
 
 	if isNilableKind && value.IsNil() {

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unsafe"
 )
 
 var (
@@ -2556,5 +2557,12 @@ func TestErrorAs(t *testing.T) {
 				t.Errorf("ErrorAs(%#v,%#v) should return %t)", tt.err, target, tt.result)
 			}
 		})
+	}
+}
+
+func TestIsNil(t *testing.T) {
+	var n unsafe.Pointer = nil
+	if !isNil(n) {
+		t.Fatal("fail")
 	}
 }


### PR DESCRIPTION
## Summary
fix bug for checking unsafe.Pointer object isNil.

