### PR TITLE
Fix adding ? when no values passed

### DIFF
--- a/assert/http_assertions.go
+++ b/assert/http_assertions.go
@@ -113,7 +113,10 @@ func HTTPStatusCode(t TestingT, handler http.HandlerFunc, method, url string, va
 // empty string if building a new request fails.
 func HTTPBody(handler http.HandlerFunc, method, url string, values url.Values) string {
 	w := httptest.NewRecorder()
-	req, err := http.NewRequest(method, url+"?"+values.Encode(), nil)
+	if len(values) > 0 {
+		url += "?" + values.Encode()
+	}
+	req, err := http.NewRequest(method, url, nil)
 	if err != nil {
 		return ""
 	}


### PR DESCRIPTION
## Summary
Fix adding ? when no values passed

## Changes
Small fix of incorrect URL generation

## Motivation
When no values pased to the HTTPBody method, a ? is incorrectly added, when not essentially required

## Related issues
<!-- Put `Closes #XXXX` for each issue number this PR fixes/closes -->
