### PR TITLE
Ensure AssertExpectations does not fail in skipped tests

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -594,6 +594,9 @@ func AssertExpectationsForObjects(t TestingT, testObjects ...interface{}) bool {
 // AssertExpectations asserts that everything specified with On and Return was
 // in fact called as expected.  Calls may have occurred in any order.
 func (m *Mock) AssertExpectations(t TestingT) bool {
+	if s, ok := t.(interface{ Skipped() bool }); ok && s.Skipped() {
+		return true
+	}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -1493,6 +1493,16 @@ func Test_Mock_AssertExpectations_With_Repeatability(t *testing.T) {
 
 }
 
+func Test_Mock_AssertExpectations_Skipped_Test(t *testing.T) {
+
+	var mockedService = new(TestExampleImplementation)
+
+	mockedService.On("Test_Mock_AssertExpectations_Skipped_Test", 1, 2, 3).Return(5, 6, 7)
+	defer mockedService.AssertExpectations(t)
+
+	t.Skip("skipping test to ensure AssertExpectations does not fail")
+}
+
 func Test_Mock_TwoCallsWithDifferentArguments(t *testing.T) {
 
 	var mockedService = new(TestExampleImplementation)


### PR DESCRIPTION
## Summary

Prevent `(*Mock).AssertExpectations` from failing if test expectations are not met but the test has already been marked as "Skipped".

## Changes
* Add check to `(*Mock).AssertExpectations` such that if the `*testing.T` is already marked skipped, we just return true immediately.
* Add a unit test (`Test_Mock_AssertExpectations_Skipped_Test`) for the new behavior.

## Motivation
Normally the decision to skip a test is made early in the test function, but on occasion it might be the case that you have already set up some mock expectations _before_ you call `t.Skip`.  If that's the case, then a call to `AssertExpectations` will fail, which is not intended.

## Example usage (if applicable)
```go
func TestExample(t *testing.T) {
	val := new(MockedValue)
	val.On("DoThing", 1, 2).Return(3, 4)
	defer val.AssertExpectations(t)

	if os.GetEnv("foo") == "" {
		// This will cause the test to exit, which will run the deferred AssertExpections call above
		t.Skip("nevermind")
	}
	...
}
```

## Related issues
Closes https://github.com/stretchr/testify/issues/1329
