### PR TITLE
docs: Fix deprecation comments for http package

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -5,19 +5,7 @@
 //
 // The assert package provides a comprehensive set of assertion functions that tie in to the Go testing system.
 //
-// The http package contains tools to make it easier to test http activity using the Go testing system.
-//
 // The mock package provides a system by which it is possible to mock your objects and verify calls are happening as expected.
 //
 // The suite package provides a basic structure for using structs as testing suites, and methods on those structs as tests.  It includes setup/teardown functionality in the way of interfaces.
 package testify
-
-// blank imports help docs.
-import (
-	// assert package
-	_ "github.com/stretchr/testify/assert"
-	// http package
-	_ "github.com/stretchr/testify/http"
-	// mock package
-	_ "github.com/stretchr/testify/mock"
-)

--- a/http/doc.go
+++ b/http/doc.go
@@ -1,2 +1,2 @@
-// Deprecated: Use net/http/httptest instead.
+// Deprecated: Use [net/http/httptest] instead.
 package http

--- a/http/doc.go
+++ b/http/doc.go
@@ -1,2 +1,2 @@
-// Package http DEPRECATED USE net/http/httptest
+// Deprecated: Use net/http/httptest instead.
 package http

--- a/http/test_response_writer.go
+++ b/http/test_response_writer.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 )
 
-// TestResponseWriter DEPRECATED: We recommend you use http://golang.org/pkg/net/http/httptest instead.
+// Deprecated: Use https://pkg.go.dev/net/http/httptest instead.
 type TestResponseWriter struct {
 
 	// StatusCode is the last int written by the call to WriteHeader(int)
@@ -17,7 +17,7 @@ type TestResponseWriter struct {
 	header http.Header
 }
 
-// Header DEPRECATED: We recommend you use http://golang.org/pkg/net/http/httptest instead.
+// Deprecated: Use https://pkg.go.dev/net/http/httptest instead.
 func (rw *TestResponseWriter) Header() http.Header {
 
 	if rw.header == nil {
@@ -27,7 +27,7 @@ func (rw *TestResponseWriter) Header() http.Header {
 	return rw.header
 }
 
-// Write DEPRECATED: We recommend you use http://golang.org/pkg/net/http/httptest instead.
+// Deprecated: Use https://pkg.go.dev/net/http/httptest instead.
 func (rw *TestResponseWriter) Write(bytes []byte) (int, error) {
 
 	// assume 200 success if no header has been set
@@ -43,7 +43,7 @@ func (rw *TestResponseWriter) Write(bytes []byte) (int, error) {
 
 }
 
-// WriteHeader DEPRECATED: We recommend you use http://golang.org/pkg/net/http/httptest instead.
+// Deprecated: Use https://pkg.go.dev/net/http/httptest instead.
 func (rw *TestResponseWriter) WriteHeader(i int) {
 	rw.StatusCode = i
 }

--- a/http/test_response_writer.go
+++ b/http/test_response_writer.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 )
 
-// Deprecated: Use https://pkg.go.dev/net/http/httptest instead.
+// Deprecated: Use [net/http/httptest] instead.
 type TestResponseWriter struct {
 
 	// StatusCode is the last int written by the call to WriteHeader(int)
@@ -17,7 +17,7 @@ type TestResponseWriter struct {
 	header http.Header
 }
 
-// Deprecated: Use https://pkg.go.dev/net/http/httptest instead.
+// Deprecated: Use [net/http/httptest] instead.
 func (rw *TestResponseWriter) Header() http.Header {
 
 	if rw.header == nil {
@@ -27,7 +27,7 @@ func (rw *TestResponseWriter) Header() http.Header {
 	return rw.header
 }
 
-// Deprecated: Use https://pkg.go.dev/net/http/httptest instead.
+// Deprecated: Use [net/http/httptest] instead.
 func (rw *TestResponseWriter) Write(bytes []byte) (int, error) {
 
 	// assume 200 success if no header has been set
@@ -43,7 +43,7 @@ func (rw *TestResponseWriter) Write(bytes []byte) (int, error) {
 
 }
 
-// Deprecated: Use https://pkg.go.dev/net/http/httptest instead.
+// Deprecated: Use [net/http/httptest] instead.
 func (rw *TestResponseWriter) WriteHeader(i int) {
 	rw.StatusCode = i
 }

--- a/http/test_round_tripper.go
+++ b/http/test_round_tripper.go
@@ -6,12 +6,12 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-// TestRoundTripper DEPRECATED USE net/http/httptest
+// Deprecated: Use https://pkg.go.dev/net/http/httptest instead.
 type TestRoundTripper struct {
 	mock.Mock
 }
 
-// RoundTrip DEPRECATED USE net/http/httptest
+// Deprecated: Use https://pkg.go.dev/net/http/httptest instead.
 func (t *TestRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	args := t.Called(req)
 	return args.Get(0).(*http.Response), args.Error(1)

--- a/http/test_round_tripper.go
+++ b/http/test_round_tripper.go
@@ -6,12 +6,12 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-// Deprecated: Use https://pkg.go.dev/net/http/httptest instead.
+// Deprecated: Use [net/http/httptest] instead.
 type TestRoundTripper struct {
 	mock.Mock
 }
 
-// Deprecated: Use https://pkg.go.dev/net/http/httptest instead.
+// Deprecated: Use [net/http/httptest] instead.
 func (t *TestRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	args := t.Called(req)
 	return args.Get(0).(*http.Response), args.Error(1)


### PR DESCRIPTION
## Summary

Fix deprecation comments for `http`, so the package will be automatically marked as  "Deprecated" on https://pkg.go.dev/github.com/stretchr/testify/http.

## Changes

- Update comments in the `http` package.

## Motivation

[The official documentation](https://pkg.go.dev) has a special deprecation syntax. It adds yellow background and "Deprecated" tag to the deprecated functions, so the deprecated types and functions are more clearly visible to readers.

Without changes:

<img width="693" alt="image" src="https://user-images.githubusercontent.com/3228886/215545879-5e712cb2-0c68-4198-80d6-cb7f6482d678.png">

<img width="819" alt="image" src="https://user-images.githubusercontent.com/3228886/215547365-b6f863d2-5115-41a9-b210-fcd4a3a903d0.png">

With changes in the PR:

<img width="771" alt="image" src="https://user-images.githubusercontent.com/3228886/215546378-86836e82-c5cd-4943-84df-1bac51ffb458.png">

<img width="810" alt="image" src="https://user-images.githubusercontent.com/3228886/215547242-268edba5-9995-4a47-bfd2-4a16db15ebdb.png">

### How to take these screenshots

- Run [pkgsite](https://pkg.go.dev/golang.org/x/pkgsite/cmd/pkgsite) in `testify` repo.
- Open in browser http://localhost:8080/github.com/stretchr/testify@v0.0.0/http.
