### PR TITLE
Add PanicAssertionFunc

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -45,6 +45,10 @@ type BoolAssertionFunc func(TestingT, bool, ...interface{}) bool
 // for table driven tests.
 type ErrorAssertionFunc func(TestingT, error, ...interface{}) bool
 
+// PanicAssertionFunc is a common function prototype when validating a panic value.  Can be useful
+// for table driven tests.
+type PanicAssertionFunc func(t TestingT, f PanicTestFunc, msgAndArgs ...interface{}) bool
+
 // Comparison is a custom function that returns true on success and false on failure
 type Comparison func() (success bool)
 

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -47,7 +47,7 @@ type ErrorAssertionFunc func(TestingT, error, ...interface{}) bool
 
 // PanicAssertionFunc is a common function prototype when validating a panic value.  Can be useful
 // for table driven tests.
-type PanicAssertionFunc func(t TestingT, f PanicTestFunc, msgAndArgs ...interface{}) bool
+type PanicAssertionFunc = func(t TestingT, f PanicTestFunc, msgAndArgs ...interface{}) bool
 
 // Comparison is a custom function that returns true on success and false on failure
 type Comparison func() (success bool)

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -2789,6 +2789,42 @@ func TestErrorAssertionFunc(t *testing.T) {
 	}
 }
 
+func ExamplePanicAssertionFunc() {
+	t := &testing.T{} // provided by test
+
+	tests := []struct {
+		name      string
+		panicFn   func()
+		assertion PanicAssertionFunc
+	}{
+		{"with panic", func() { panic(nil) }, Panics},
+		{"without panic", func() {}, NotPanics},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.assertion(t, tt.panicFn)
+		})
+	}
+}
+
+func TestPanicAssertionFunc(t *testing.T) {
+	tests := []struct {
+		name      string
+		panicFn   func()
+		assertion PanicAssertionFunc
+	}{
+		{"not panic", func() {}, NotPanics},
+		{"panic", func() { panic(nil) }, Panics},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.assertion(t, tt.panicFn)
+		})
+	}
+}
+
 func TestEventuallyFalse(t *testing.T) {
 	mockT := new(testing.T)
 

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -2794,7 +2794,7 @@ func ExamplePanicAssertionFunc() {
 
 	tests := []struct {
 		name      string
-		panicFn   func()
+		panicFn   PanicTestFunc
 		assertion PanicAssertionFunc
 	}{
 		{"with panic", func() { panic(nil) }, Panics},
@@ -2811,7 +2811,7 @@ func ExamplePanicAssertionFunc() {
 func TestPanicAssertionFunc(t *testing.T) {
 	tests := []struct {
 		name      string
-		panicFn   func()
+		panicFn   PanicTestFunc
 		assertion PanicAssertionFunc
 	}{
 		{"not panic", func() {}, NotPanics},


### PR DESCRIPTION
## Summary
Add a `PanicAssertionFunc` to ease writing table-driven tests for panic assertion.

## Changes
- Add `PanicAssertionFunc` for table driven.

## Motivation
- My team uses panic assertion a lot :smile: 
- Useful for building panic assertion
- There is an issue reported for this one as well: #730

```go
func ExamplePanicAssertionFunc() {
	t := &testing.T{} // provided by test

	tests := []struct {
		name      string
		panicFn   func()
		assertion PanicAssertionFunc
	}{
		{"with panic", func() { panic(nil) }, Panics},
		{"without panic", func() {}, NotPanics},
	}

	for _, tt := range tests {
		t.Run(tt.name, func(t *testing.T) {
			tt.assertion(t, tt.panicFn)
		})
	}
}
```
https://github.com/fahimbagar/testify/blob/cb954e70769531b0462ae2f713c12c74e64ad69c/assert/assertions_test.go#L2410-L2427

## Related issues
Closes #730
