### PR TITLE
assert.ErrorAs: log target type

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -2146,8 +2146,8 @@ func ErrorAs(t TestingT, err error, target interface{}, msgAndArgs ...interface{
 	chain := buildErrorChainString(err, true)
 
 	return Fail(t, fmt.Sprintf("Should be in error chain:\n"+
-		"expected: %T\n"+
-		"in chain: %s", target, chain,
+		"expected: %s\n"+
+		"in chain: %s", reflect.ValueOf(target).Elem().Type(), chain,
 	), msgAndArgs...)
 }
 
@@ -2164,8 +2164,8 @@ func NotErrorAs(t TestingT, err error, target interface{}, msgAndArgs ...interfa
 	chain := buildErrorChainString(err, true)
 
 	return Fail(t, fmt.Sprintf("Target error should not be in err chain:\n"+
-		"found: %T\n"+
-		"in chain: %s", target, chain,
+		"found: %s\n"+
+		"in chain: %s", reflect.ValueOf(target).Elem().Type(), chain,
 	), msgAndArgs...)
 }
 

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -2102,7 +2102,7 @@ func ErrorIs(t TestingT, err, target error, msgAndArgs ...interface{}) bool {
 		expectedText = target.Error()
 	}
 
-	chain := buildErrorChainString(err)
+	chain := buildErrorChainString(err, false)
 
 	return Fail(t, fmt.Sprintf("Target error should be in err chain:\n"+
 		"expected: %q\n"+
@@ -2125,7 +2125,7 @@ func NotErrorIs(t TestingT, err, target error, msgAndArgs ...interface{}) bool {
 		expectedText = target.Error()
 	}
 
-	chain := buildErrorChainString(err)
+	chain := buildErrorChainString(err, false)
 
 	return Fail(t, fmt.Sprintf("Target error should not be in err chain:\n"+
 		"found: %q\n"+
@@ -2143,10 +2143,10 @@ func ErrorAs(t TestingT, err error, target interface{}, msgAndArgs ...interface{
 		return true
 	}
 
-	chain := buildErrorChainString(err)
+	chain := buildErrorChainString(err, true)
 
 	return Fail(t, fmt.Sprintf("Should be in error chain:\n"+
-		"expected: %q\n"+
+		"expected: %T\n"+
 		"in chain: %s", target, chain,
 	), msgAndArgs...)
 }
@@ -2161,24 +2161,49 @@ func NotErrorAs(t TestingT, err error, target interface{}, msgAndArgs ...interfa
 		return true
 	}
 
-	chain := buildErrorChainString(err)
+	chain := buildErrorChainString(err, true)
 
 	return Fail(t, fmt.Sprintf("Target error should not be in err chain:\n"+
-		"found: %q\n"+
+		"found: %T\n"+
 		"in chain: %s", target, chain,
 	), msgAndArgs...)
 }
 
-func buildErrorChainString(err error) string {
+func unwrapAll(err error) (errs []error) {
+	errs = append(errs, err)
+	switch x := err.(type) {
+	case interface{ Unwrap() error }:
+		err = x.Unwrap()
+		if err == nil {
+			return
+		}
+		errs = append(errs, unwrapAll(err)...)
+	case interface{ Unwrap() []error }:
+		for _, err := range x.Unwrap() {
+			errs = append(errs, unwrapAll(err)...)
+		}
+		return
+	default:
+		return
+	}
+	return
+}
+
+func buildErrorChainString(err error, withType bool) string {
 	if err == nil {
 		return ""
 	}
 
-	e := errors.Unwrap(err)
-	chain := fmt.Sprintf("%q", err.Error())
-	for e != nil {
-		chain += fmt.Sprintf("\n\t%q", e.Error())
-		e = errors.Unwrap(e)
+	var chain string
+	errs := unwrapAll(err)
+	for i := range errs {
+		if i != 0 {
+			chain += "\n\t"
+		}
+		chain += fmt.Sprintf("%q", errs[i].Error())
+		if withType {
+			chain += fmt.Sprintf(" (%T)", errs[i])
+		}
 	}
 	return chain
 }

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -2182,9 +2182,6 @@ func unwrapAll(err error) (errs []error) {
 		for _, err := range x.Unwrap() {
 			errs = append(errs, unwrapAll(err)...)
 		}
-		return
-	default:
-		return
 	}
 	return
 }

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -3192,6 +3192,7 @@ func (ctt *captureTestingT) checkResultAndErrMsg(t *testing.T, expectedRes, res 
 	}
 	if res == ctt.failed {
 		t.Errorf("The test result (%t) should be reflected in the testing.T type (%t)", res, !ctt.failed)
+		return
 	}
 	contents := parseLabeledOutput(ctt.msg)
 	if res == true {

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -3367,7 +3367,7 @@ func TestErrorAs(t *testing.T) {
 			result: false,
 			resultErrMsg: "" +
 				"Should be in error chain:\n" +
-				"expected: **assert.customError\n" +
+				"expected: *assert.customError\n" +
 				"in chain: \"EOF\" (*errors.errorString)\n",
 		},
 		{
@@ -3375,7 +3375,7 @@ func TestErrorAs(t *testing.T) {
 			result: false,
 			resultErrMsg: "" +
 				"Should be in error chain:\n" +
-				"expected: **assert.customError\n" +
+				"expected: *assert.customError\n" +
 				"in chain: \n",
 		},
 		{
@@ -3383,7 +3383,7 @@ func TestErrorAs(t *testing.T) {
 			result: false,
 			resultErrMsg: "" +
 				"Should be in error chain:\n" +
-				"expected: **assert.customError\n" +
+				"expected: *assert.customError\n" +
 				"in chain: \"abc: def\" (*fmt.wrapError)\n" +
 				"\t\"def\" (*errors.errorString)\n",
 		},
@@ -3410,7 +3410,7 @@ func TestNotErrorAs(t *testing.T) {
 			result: false,
 			resultErrMsg: "" +
 				"Target error should not be in err chain:\n" +
-				"found: **assert.customError\n" +
+				"found: *assert.customError\n" +
 				"in chain: \"wrap: fail\" (*fmt.wrapError)\n" +
 				"\t\"fail\" (*assert.customError)\n",
 		},


### PR DESCRIPTION
## Summary
When an assertion fails in assert.ErrorAs, log the target error type rather than its value.

## Changes
Passes the target error type, rather than the target itself, to the Fail() call in assert.ErrorAs. Also, modifies buildErrorChainString to support go 1.20 error wrapping, and to include the error type in its output when called by assert.ErrorAs.

## Motivation
The existing error message was confusing - see #1343 

<!-- ## Example usage (if applicable) -->

## Related issues
Closes #1343
