### PR TITLE
Add mock.ElementsMatch argument matcher

### DIFF
--- a/internal/check/checks.go
+++ b/internal/check/checks.go
@@ -1,0 +1,192 @@
+package check
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"reflect"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
+var SpewConfig = spew.ConfigState{
+	Indent:                  " ",
+	DisablePointerAddresses: true,
+	DisableCapacities:       true,
+	SortKeys:                true,
+	DisableMethods:          true,
+	MaxDepth:                10,
+}
+
+var SpewConfigStringerEnabled = spew.ConfigState{
+	Indent:                  " ",
+	DisablePointerAddresses: true,
+	DisableCapacities:       true,
+	SortKeys:                true,
+	MaxDepth:                10,
+}
+
+// IsEmpty gets whether the specified object is considered empty or not.
+func IsEmpty(object interface{}) bool {
+
+	// get nil case out of the way
+	if object == nil {
+		return true
+	}
+
+	objValue := reflect.ValueOf(object)
+
+	switch objValue.Kind() {
+	// collection types are empty when they have no element
+	case reflect.Chan, reflect.Map, reflect.Slice:
+		return objValue.Len() == 0
+	// pointers are empty if nil or if the value they point to is empty
+	case reflect.Ptr:
+		if objValue.IsNil() {
+			return true
+		}
+		deref := objValue.Elem().Interface()
+		return IsEmpty(deref)
+	// for all other types, compare against the zero value
+	// array types are empty when they match their zero-initialized state
+	default:
+		zero := reflect.Zero(objValue.Type())
+		return reflect.DeepEqual(object, zero.Interface())
+	}
+}
+
+// DiffLists diffs two arrays/slices and returns slices of elements that are only in A and only in B.
+// If some element is present multiple times, each instance is counted separately (e.g. if something is 2x in A and
+// 5x in B, it will be 0x in extraA and 3x in extraB). The order of items in both lists is ignored.
+func DiffLists(listA, listB interface{}) (extraA, extraB []interface{}) {
+	aValue := reflect.ValueOf(listA)
+	bValue := reflect.ValueOf(listB)
+
+	aLen := aValue.Len()
+	bLen := bValue.Len()
+
+	// Mark indexes in bValue that we already used
+	visited := make([]bool, bLen)
+	for i := 0; i < aLen; i++ {
+		element := aValue.Index(i).Interface()
+		found := false
+		for j := 0; j < bLen; j++ {
+			if visited[j] {
+				continue
+			}
+			if ObjectsAreEqual(bValue.Index(j).Interface(), element) {
+				visited[j] = true
+				found = true
+				break
+			}
+		}
+		if !found {
+			extraA = append(extraA, element)
+		}
+	}
+
+	for j := 0; j < bLen; j++ {
+		if visited[j] {
+			continue
+		}
+		extraB = append(extraB, bValue.Index(j).Interface())
+	}
+
+	return
+}
+
+// ObjectsAreEqual determines if two objects are considered equal.
+//
+// This function does no assertion of any kind.
+func ObjectsAreEqual(expected, actual interface{}) bool {
+	if expected == nil || actual == nil {
+		return expected == actual
+	}
+
+	exp, ok := expected.([]byte)
+	if !ok {
+		return reflect.DeepEqual(expected, actual)
+	}
+
+	act, ok := actual.([]byte)
+	if !ok {
+		return false
+	}
+	if exp == nil || act == nil {
+		return exp == nil && act == nil
+	}
+	return bytes.Equal(exp, act)
+}
+
+// ObjectsAreEqualValues gets whether two objects are equal, or if their
+// values are equal.
+func ObjectsAreEqualValues(expected, actual interface{}) bool {
+	if ObjectsAreEqual(expected, actual) {
+		return true
+	}
+
+	actualType := reflect.TypeOf(actual)
+	if actualType == nil {
+		return false
+	}
+	expectedValue := reflect.ValueOf(expected)
+	if expectedValue.IsValid() && expectedValue.Type().ConvertibleTo(actualType) {
+		// Attempt comparison after type conversion
+		return reflect.DeepEqual(expectedValue.Convert(actualType).Interface(), actual)
+	}
+
+	return false
+}
+
+// ElementsMatch returns nil if listA has the same number of the same elements
+// as listB. It returns an error with a printable message if it does not.
+func ElementsMatch(listA, listB interface{}) error {
+	if IsEmpty(listA) && IsEmpty(listB) {
+		return nil
+	}
+
+	if err := IsList(listA); err != nil {
+		return err
+	}
+	if err := IsList(listB); err != nil {
+		return err
+	}
+
+	extraA, extraB := DiffLists(listA, listB)
+
+	if len(extraA) == 0 && len(extraB) == 0 {
+		return nil
+	}
+
+	return errors.New(formatListDiff(listA, listB, extraA, extraB))
+}
+
+func formatListDiff(listA, listB interface{}, extraA, extraB []interface{}) string {
+	var msg bytes.Buffer
+
+	msg.WriteString("elements differ")
+	if len(extraA) > 0 {
+		msg.WriteString("\n\nextra elements in list A:\n")
+		msg.WriteString(SpewConfig.Sdump(extraA))
+	}
+	if len(extraB) > 0 {
+		msg.WriteString("\n\nextra elements in list B:\n")
+		msg.WriteString(SpewConfig.Sdump(extraB))
+	}
+	msg.WriteString("\n\nlistA:\n")
+	msg.WriteString(SpewConfig.Sdump(listA))
+	msg.WriteString("\n\nlistB:\n")
+	msg.WriteString(SpewConfig.Sdump(listB))
+
+	return msg.String()
+}
+
+// IsList checks that the provided value is array or slice and returns a
+// printable error if it is not
+func IsList(list interface{}) error {
+	kind := reflect.TypeOf(list).Kind()
+	if kind != reflect.Array && kind != reflect.Slice {
+		return fmt.Errorf("%q has an unsupported type %s, expecting array or slice", list, kind)
+	}
+	return nil
+}

--- a/internal/check/checks_test.go
+++ b/internal/check/checks_test.go
@@ -1,0 +1,170 @@
+package check_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/internal/check"
+)
+
+func Test_IsEmpty(t *testing.T) {
+
+	chWithValue := make(chan struct{}, 1)
+	chWithValue <- struct{}{}
+
+	assert.True(t, check.IsEmpty(""))
+	assert.True(t, check.IsEmpty(nil))
+	assert.True(t, check.IsEmpty([]string{}))
+	assert.True(t, check.IsEmpty(0))
+	assert.True(t, check.IsEmpty(int32(0)))
+	assert.True(t, check.IsEmpty(int64(0)))
+	assert.True(t, check.IsEmpty(false))
+	assert.True(t, check.IsEmpty(map[string]string{}))
+	assert.True(t, check.IsEmpty(new(time.Time)))
+	assert.True(t, check.IsEmpty(time.Time{}))
+	assert.True(t, check.IsEmpty(make(chan struct{})))
+	assert.True(t, check.IsEmpty([1]int{}))
+	assert.False(t, check.IsEmpty("something"))
+	assert.False(t, check.IsEmpty(errors.New("something")))
+	assert.False(t, check.IsEmpty([]string{"something"}))
+	assert.False(t, check.IsEmpty(1))
+	assert.False(t, check.IsEmpty(true))
+	assert.False(t, check.IsEmpty(map[string]string{"Hello": "World"}))
+	assert.False(t, check.IsEmpty(chWithValue))
+	assert.False(t, check.IsEmpty([1]int{42}))
+}
+
+func TestObjectsAreEqual(t *testing.T) {
+	cases := []struct {
+		expected interface{}
+		actual   interface{}
+		result   bool
+	}{
+		// cases that are expected to be equal
+		{"Hello World", "Hello World", true},
+		{123, 123, true},
+		{123.5, 123.5, true},
+		{[]byte("Hello World"), []byte("Hello World"), true},
+		{nil, nil, true},
+
+		// cases that are expected not to be equal
+		{map[int]int{5: 10}, map[int]int{10: 20}, false},
+		{'x', "x", false},
+		{"x", 'x', false},
+		{0, 0.1, false},
+		{0.1, 0, false},
+		{time.Now, time.Now, false},
+		{func() {}, func() {}, false},
+		{uint32(10), int32(10), false},
+	}
+
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("ObjectsAreEqual(%#v, %#v)", c.expected, c.actual), func(t *testing.T) {
+			res := check.ObjectsAreEqual(c.expected, c.actual)
+
+			if res != c.result {
+				t.Errorf("ObjectsAreEqual(%#v, %#v) should return %#v", c.expected, c.actual, c.result)
+			}
+
+		})
+	}
+
+	// Cases where type differ but values are equal
+	if !check.ObjectsAreEqualValues(uint32(10), int32(10)) {
+		t.Error("ObjectsAreEqualValues should return true")
+	}
+	if check.ObjectsAreEqualValues(0, nil) {
+		t.Fail()
+	}
+	if check.ObjectsAreEqualValues(nil, 0) {
+		t.Fail()
+	}
+
+}
+
+func TestDiffLists(t *testing.T) {
+	tests := []struct {
+		name   string
+		listA  interface{}
+		listB  interface{}
+		extraA []interface{}
+		extraB []interface{}
+	}{
+		{
+			name:   "equal empty",
+			listA:  []string{},
+			listB:  []string{},
+			extraA: nil,
+			extraB: nil,
+		},
+		{
+			name:   "equal same order",
+			listA:  []string{"hello", "world"},
+			listB:  []string{"hello", "world"},
+			extraA: nil,
+			extraB: nil,
+		},
+		{
+			name:   "equal different order",
+			listA:  []string{"hello", "world"},
+			listB:  []string{"world", "hello"},
+			extraA: nil,
+			extraB: nil,
+		},
+		{
+			name:   "extra A",
+			listA:  []string{"hello", "hello", "world"},
+			listB:  []string{"hello", "world"},
+			extraA: []interface{}{"hello"},
+			extraB: nil,
+		},
+		{
+			name:   "extra A twice",
+			listA:  []string{"hello", "hello", "hello", "world"},
+			listB:  []string{"hello", "world"},
+			extraA: []interface{}{"hello", "hello"},
+			extraB: nil,
+		},
+		{
+			name:   "extra B",
+			listA:  []string{"hello", "world"},
+			listB:  []string{"hello", "hello", "world"},
+			extraA: nil,
+			extraB: []interface{}{"hello"},
+		},
+		{
+			name:   "extra B twice",
+			listA:  []string{"hello", "world"},
+			listB:  []string{"hello", "hello", "world", "hello"},
+			extraA: nil,
+			extraB: []interface{}{"hello", "hello"},
+		},
+		{
+			name:   "integers 1",
+			listA:  []int{1, 2, 3, 4, 5},
+			listB:  []int{5, 4, 3, 2, 1},
+			extraA: nil,
+			extraB: nil,
+		},
+		{
+			name:   "integers 2",
+			listA:  []int{1, 2, 1, 2, 1},
+			listB:  []int{2, 1, 2, 1, 2},
+			extraA: []interface{}{1},
+			extraB: []interface{}{2},
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			actualExtraA, actualExtraB := check.DiffLists(test.listA, test.listB)
+			assert.Equal(t, test.extraA, actualExtraA, "extra A does not match for listA=%v listB=%v",
+				test.listA, test.listB)
+			assert.Equal(t, test.extraB, actualExtraB, "extra B does not match for listA=%v listB=%v",
+				test.listA, test.listB)
+		})
+	}
+}

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -1705,6 +1705,26 @@ func Test_Arguments_Diff_WithIsTypeArgument_Failing(t *testing.T) {
 	assert.Contains(t, diff, `string != type int - (int=123)`)
 }
 
+func Test_Arguments_Diff_WithAnyOrder(t *testing.T) {
+	args := Arguments([]interface{}{ElementsMatch([]int{1, 2, 3})})
+	_, count := args.Diff([]interface{}{[]int{2, 1, 3}})
+	assert.Equal(t, 0, count)
+}
+
+func Test_Arguments_Diff_WithAnyOrder_Failing(t *testing.T) {
+	args := Arguments([]interface{}{ElementsMatch([]int{1, 2, 3})})
+	s, count := args.Diff([]interface{}{[]int{1, 2, 4}})
+	assert.Equal(t, 1, count)
+	assert.Equal(t, "\n\t0: FAIL:  ([]int=[1 2 4]) not matched by (elements of []int=[1 2 3])\n", s)
+}
+
+func Test_Arguments_Diff_WithAnyOrder_WrongType(t *testing.T) {
+	args := Arguments([]interface{}{ElementsMatch([]string{"a", "b"})})
+	s, count := args.Diff([]interface{}{1})
+	assert.Equal(t, 1, count)
+	assert.Equal(t, "\n\t0: FAIL:  (int=1) not matched by (elements of []string=[a b])\n", s)
+}
+
 func Test_Arguments_Diff_WithArgMatcher(t *testing.T) {
 	matchFn := func(a int) bool {
 		return a == 123
@@ -1916,7 +1936,7 @@ func TestArgumentMatcherToPrintMismatch(t *testing.T) {
 	defer func() {
 		if r := recover(); r != nil {
 			matchingExp := regexp.MustCompile(
-				`\s+mock: Unexpected Method Call\s+-*\s+GetTime\(int\)\s+0: 1\s+The closest call I have is:\s+GetTime\(mock.argumentMatcher\)\s+0: mock.argumentMatcher\{.*?\}\s+Diff:.*\(int=1\) not matched by func\(int\) bool`)
+				`\s+mock: Unexpected Method Call\s+-*\s+GetTime\(int\)\s+0: 1\s+The closest call I have is:\s+GetTime\(mock.matchedByFn\)\s+0: mock.matchedByFn\{.*?\}\s+Diff:.*\(int=1\) not matched by func\(int\) bool`)
 			assert.Regexp(t, matchingExp, r)
 		}
 	}()
@@ -1933,7 +1953,7 @@ func TestArgumentMatcherToPrintMismatchWithReferenceType(t *testing.T) {
 	defer func() {
 		if r := recover(); r != nil {
 			matchingExp := regexp.MustCompile(
-				`\s+mock: Unexpected Method Call\s+-*\s+GetTimes\(\[\]int\)\s+0: \[\]int\{1\}\s+The closest call I have is:\s+GetTimes\(mock.argumentMatcher\)\s+0: mock.argumentMatcher\{.*?\}\s+Diff:.*\(\[\]int=\[1\]\) not matched by func\(\[\]int\) bool`)
+				`\s+mock: Unexpected Method Call\s+-*\s+GetTimes\(\[\]int\)\s+0: \[\]int\{1\}\s+The closest call I have is:\s+GetTimes\(mock.matchedByFn\)\s+0: mock.matchedByFn\{.*?\}\s+Diff:.*\(\[\]int=\[1\]\) not matched by func\(\[\]int\) bool`)
 			assert.Regexp(t, matchingExp, r)
 		}
 	}()


### PR DESCRIPTION
## Summary
Add an argument marcher to mock which matches if array/slice elements match.

## Changes
- Add `mock.ElementsMatch()` argument matcher.
- Refactor `mock.argumentMatcher` to be an interface, it pretty much already was.
- Move common code used by both assert and mock into an internal package.

## Motivation
There is already `mock.MatchedBy` which allows users to write this themselves, but it's not trivial and a lot of people seem to need this specific matcher.

```go
func TestIfy(t *testing.T) {
	m := &myMock{}
	m.On("Do", mock.ElementsMatch([]int{1, 2, 3})).Return()
	m.Do([]int{2, 3, 1})
}
```

## Related issues
Closes #1117 
Closes #1180 