### PR TITLE
Add PanicWithErrorIs assertions (#1350)

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1103,6 +1103,28 @@ func PanicsWithError(t TestingT, errString string, f PanicTestFunc, msgAndArgs .
 	return true
 }
 
+// PanicsWithErrorIs asserts that the code inside the specified PanicTestFunc
+// panics, and that the recovered panic value is an error that satisfies the
+// errors.Is() method
+//
+//   assert.PanicsWithErrorIs(t, expectedError, func(){ GoCrazy() })
+func PanicsWithErrorIs(t TestingT, expectedError error, f PanicTestFunc, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	funcDidPanic, panicValue, panickedStack := didPanic(f)
+	if !funcDidPanic {
+		return Fail(t, fmt.Sprintf("func %#v should panic\n\tPanic value:\t%#v", f, panicValue), msgAndArgs...)
+	}
+	panicErr, ok := panicValue.(error)
+	if !ok || !errors.Is(panicErr, expectedError) {
+		return Fail(t, fmt.Sprintf("func %#v should panic with error that has this error in its chain:\t%#v\n\tPanic value:\t%#v\n\tPanic stack:\t%s", f, expectedError, panicValue, panickedStack), msgAndArgs...)
+	}
+
+	return true
+}
+
 // NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
 //
 //   assert.NotPanics(t, func(){ RemainCalm() })

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -1048,6 +1048,36 @@ func TestPanicsWithError(t *testing.T) {
 	}
 }
 
+func TestPanicsWithErrorIs(t *testing.T) {
+
+	mockT := new(testing.T)
+
+	expectedError := errors.New("expected error")
+	anotherError := errors.New("not expected error")
+
+	if !PanicsWithErrorIs(mockT, expectedError, func() {
+		panic(expectedError)
+	}) {
+		t.Error("PanicsWithErrorIs should return true")
+	}
+
+	if !PanicsWithErrorIs(mockT, expectedError, func() {
+		panic(fmt.Errorf("Wrapped Error %w", expectedError))
+	}) {
+		t.Error("PanicsWithErrorIs should return true")
+	}
+
+	if PanicsWithErrorIs(mockT, expectedError, func() {
+	}) {
+		t.Error("PanicsWithErrorIs should return false")
+	}
+
+	if PanicsWithErrorIs(mockT, expectedError, func() {
+	}) {
+		t.Error(anotherError)
+	}
+}
+
 func TestNotPanics(t *testing.T) {
 
 	mockT := new(testing.T)


### PR DESCRIPTION
## Summary
Adds new assertion method to test if a paniced error has a specific error in its chain

## Changes

- Add PanicWithErrorIs functions/methods
- Add tests for base assert function

## Motivation
See my `Issue #1350 `

I have some code that wraps a database error with fmt.Errorf() and panics it. Now I want to assert that this error is paniced.

The current method PanicsWithError only compares the error message, but does not use a error chain comparison.

Example:

func foo(source err) {
    panic(fmt.Errorf("Wrapping error %w", source))
}

func Test(t *testing.T) {
    expectedError := errors.New("some error")
    require.PanicsWithErrorIs(t, expectedError, func() { foo(expectedError) }) // This functionality is missing
}