### PR TITLE
Create GitHub release when new release tag is pushed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: Create release from new tag
+
+# this flow will be run only when new tags are pushed that match our pattern
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Create GitHub release from tag
+        uses: softprops/action-gh-release@v1


### PR DESCRIPTION
This GitHub workflow addition will create new GitHub [release](https://github.com/stretchr/testify/releases) for library when new [tag](https://github.com/stretchr/testify/tags), with matching pattern is pushed.

It does not change current "release process" - developer needs to create tag and push it.

Closes #1295
