### PR TITLE
Updated didPanic to work with Go tip.

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1037,6 +1037,13 @@ func didPanic(f PanicTestFunc) (didPanic bool, message interface{}, stack string
 		if didPanic {
 			stack = string(debug.Stack())
 		}
+		// Go 1.21 introduces runtime.PanicNilError on panic(nil),
+		// so maintain the same logic going forward (https://github.com/golang/go/issues/25448).
+		if err, ok := message.(error); ok {
+			if err.Error() == "panic called with nil argument" {
+				message = nil
+			}
+		}
 	}()
 
 	// call the target function


### PR DESCRIPTION
I know it's not released yet, but new Go version will have new behaviour on `panic(nil)`. Fixing to make it work, if you don't want to merge until current tip is released, feel free to close.

See behaviour by changing "dev" to "1.20":  https://go.dev/play/p/Cevh9AJdhC6?v=gotip


