### PR TITLE
assert: fix error message formatting for NotContains

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -877,10 +877,10 @@ func NotContains(t TestingT, s, contains interface{}, msgAndArgs ...interface{})
 
 	ok, found := containsElement(s, contains)
 	if !ok {
-		return Fail(t, fmt.Sprintf("\"%s\" could not be applied builtin len()", s), msgAndArgs...)
+		return Fail(t, fmt.Sprintf("%#v could not be applied builtin len()", s), msgAndArgs...)
 	}
 	if found {
-		return Fail(t, fmt.Sprintf("\"%s\" should not contain \"%s\"", s, contains), msgAndArgs...)
+		return Fail(t, fmt.Sprintf("%#v should not contain %#v", s, contains), msgAndArgs...)
 	}
 
 	return true


### PR DESCRIPTION
## Summary
The `assert.NotContains` error messages now uses `GoString()` for formatting instead of `Stringer()`.

## Changes

1. Renamed `TestContainsFailMessage` to `TestContainsNotContainsFailMessage` and refactored the test case to use a "test cases" structure.
2. Changed `\"%s\"` to `%#v` in `assert.NotContains`.
3. Added test cases covering both the "len()" / iterable failure messages as well as the Contains/NotContains failure message.

## Motivation
The existing `NotContains` error messages are hard to read.

WAS:

    "map[one:%!s(int=1)]" should not contain "one"

IS:

    map[string]int{"one":1} should not contain "one"
