### PR TITLE
Remove myself from MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,5 +5,4 @@ pull requests.
 
   * @glesica
   * @boyan-soubachov
-  * @mvdkleijn
 


### PR DESCRIPTION
As I am supposed to be a maintainer but have almost zero access to actually manage the project, I've found it difficult to help out. Since then my time has become fragmented and as such I'm removing myself as maintainer.