### PR TITLE
EqualExportedValues: Support nested structs and time.Time fields

### DIFF
--- a/assert/assertion_format.go
+++ b/assert/assertion_format.go
@@ -93,6 +93,7 @@ func EqualErrorf(t TestingT, theError error, errString string, msg string, args 
 // EqualExportedValuesf asserts that the types of two objects are equal and their public
 // fields are also equal. This is useful for comparing structs that have private fields
 // that could potentially differ. Types of time.Time are compared using time.Time.Equal.
+// Recursive data structures are not supported and may result in an infinite loop.
 //
 // 	 type S struct {
 // 		Exported     	int

--- a/assert/assertion_format.go
+++ b/assert/assertion_format.go
@@ -92,7 +92,7 @@ func EqualErrorf(t TestingT, theError error, errString string, msg string, args 
 
 // EqualExportedValuesf asserts that the types of two objects are equal and their public
 // fields are also equal. This is useful for comparing structs that have private fields
-// that could potentially differ.
+// that could potentially differ. Types of time.Time are compared using time.Time.Equal.
 //
 // 	 type S struct {
 // 		Exported     	int

--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -158,6 +158,7 @@ func (a *Assertions) EqualErrorf(theError error, errString string, msg string, a
 // EqualExportedValues asserts that the types of two objects are equal and their public
 // fields are also equal. This is useful for comparing structs that have private fields
 // that could potentially differ. Types of time.Time are compared using time.Time.Equal.
+// Recursive data structures are not supported and may result in an infinite loop.
 //
 // 	 type S struct {
 // 		Exported     	int
@@ -175,6 +176,7 @@ func (a *Assertions) EqualExportedValues(expected interface{}, actual interface{
 // EqualExportedValuesf asserts that the types of two objects are equal and their public
 // fields are also equal. This is useful for comparing structs that have private fields
 // that could potentially differ. Types of time.Time are compared using time.Time.Equal.
+// Recursive data structures are not supported and may result in an infinite loop.
 //
 // 	 type S struct {
 // 		Exported     	int

--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -157,7 +157,7 @@ func (a *Assertions) EqualErrorf(theError error, errString string, msg string, a
 
 // EqualExportedValues asserts that the types of two objects are equal and their public
 // fields are also equal. This is useful for comparing structs that have private fields
-// that could potentially differ.
+// that could potentially differ. Types of time.Time are compared using time.Time.Equal.
 //
 // 	 type S struct {
 // 		Exported     	int
@@ -174,7 +174,7 @@ func (a *Assertions) EqualExportedValues(expected interface{}, actual interface{
 
 // EqualExportedValuesf asserts that the types of two objects are equal and their public
 // fields are also equal. This is useful for comparing structs that have private fields
-// that could potentially differ.
+// that could potentially differ. Types of time.Time are compared using time.Time.Equal.
 //
 // 	 type S struct {
 // 		Exported     	int

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -60,19 +60,19 @@ func ObjectsAreEqual(expected, actual interface{}) bool {
 		return expected == actual
 	}
 
-	switch exp := expected.(type) {
-	case []byte:
-		act, ok := actual.([]byte)
-		if !ok {
-			return false
-		}
-		if exp == nil || act == nil {
-			return exp == nil && act == nil
-		}
-		return bytes.Equal(exp, act)
-	default:
+	exp, ok := expected.([]byte)
+	if !ok {
 		return reflect.DeepEqual(expected, actual)
 	}
+
+	act, ok := actual.([]byte)
+	if !ok {
+		return false
+	}
+	if exp == nil || act == nil {
+		return exp == nil && act == nil
+	}
+	return bytes.Equal(exp, act)
 }
 
 // ObjectsExportedFieldsAreEqual determines if the exported (public) fields of two structs are considered equal.

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -548,7 +548,7 @@ func EqualValues(t TestingT, expected, actual interface{}, msgAndArgs ...interfa
 
 // EqualExportedValues asserts that the types of two objects are equal and their public
 // fields are also equal. This is useful for comparing structs that have private fields
-// that could potentially differ.
+// that could potentially differ. Types of time.Time are compared using time.Time.Equal.
 //
 //	 type S struct {
 //		Exported     	int

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -60,19 +60,42 @@ func ObjectsAreEqual(expected, actual interface{}) bool {
 		return expected == actual
 	}
 
-	exp, ok := expected.([]byte)
-	if !ok {
+	switch exp := expected.(type) {
+	case []byte:
+		act, ok := actual.([]byte)
+		if !ok {
+			return false
+		}
+		if exp == nil || act == nil {
+			return exp == nil && act == nil
+		}
+		return bytes.Equal(exp, act)
+	case time.Time:
+		act, ok := actual.(time.Time)
+		if !ok {
+			return false
+		}
+		return exp.Equal(act)
+	case *time.Time:
+		act, ok := actual.(*time.Time)
+		if !ok {
+			return false
+		}
+		if exp == nil || act == nil {
+			return exp == nil && act == nil
+		}
+		return exp.Equal(*act)
+	default:
+		if reflect.TypeOf(expected) == reflect.TypeOf(actual) {
+			v := reflect.ValueOf(expected)
+			k := v.Kind()
+			if k == reflect.Struct || (k == reflect.Ptr && v.Elem().Kind() == reflect.Struct) {
+				// TODO
+				return false
+			}
+		}
 		return reflect.DeepEqual(expected, actual)
 	}
-
-	act, ok := actual.([]byte)
-	if !ok {
-		return false
-	}
-	if exp == nil || act == nil {
-		return exp == nil && act == nil
-	}
-	return bytes.Equal(exp, act)
 }
 
 // ObjectsExportedFieldsAreEqual determines if the exported (public) fields of two structs are considered equal.
@@ -101,17 +124,59 @@ func ObjectsExportedFieldsAreEqual(expected, actual interface{}) bool {
 	for i := 0; i < expectedType.NumField(); i++ {
 		field := expectedType.Field(i)
 		isExported := field.PkgPath == "" // should use field.IsExported() but it's not available in Go 1.16.5
-		if isExported {
-			var equal bool
-			if field.Type.Kind() == reflect.Struct {
-				equal = ObjectsExportedFieldsAreEqual(expectedValue.Field(i).Interface(), actualValue.Field(i).Interface())
-			} else {
-				equal = ObjectsAreEqualValues(expectedValue.Field(i).Interface(), actualValue.Field(i).Interface())
-			}
+		if !isExported {
+			continue
+		}
 
-			if !equal {
-				return false
+		expFieldVal := expectedValue.Field(i)
+		actFieldVal := actualValue.Field(i)
+
+		var equal bool
+		switch field.Type.Kind() {
+		case reflect.Struct:
+			// Handle time.Time comparison.
+			exp := expFieldVal.Interface()
+			act := actFieldVal.Interface()
+			switch exp.(type) {
+			case time.Time:
+				expT := exp.(time.Time)
+				actT, ok := act.(time.Time)
+				if !ok {
+					return false
+				}
+				equal = expT.Equal(actT)
+			case *time.Time:
+				expT := exp.(*time.Time)
+				actT, ok := act.(*time.Time)
+				if !ok {
+					return false
+				}
+				if expT == nil || actT == nil {
+					equal = expT == nil && actT == nil
+				} else {
+					equal = expT.Equal(*actT)
+				}
+			default:
+				equal = ObjectsExportedFieldsAreEqual(exp, act)
 			}
+		case reflect.Ptr:
+			// Handle struct pointers.
+			if expFieldVal.Elem().Kind() == reflect.Struct {
+				if expFieldVal.IsNil() || actFieldVal.IsNil() {
+					equal = expFieldVal.IsNil() && actFieldVal.IsNil()
+				} else {
+					equal = ObjectsExportedFieldsAreEqual(expFieldVal.Elem().Interface(), actFieldVal.Elem().Interface())
+				}
+				break
+			}
+			// Not a struct pointer, fallthrough to default case.
+			fallthrough
+		default:
+			equal = ObjectsAreEqualValues(expFieldVal.Interface(), actFieldVal.Interface())
+		}
+
+		if !equal {
+			return false
 		}
 	}
 	return true

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -77,7 +77,8 @@ func ObjectsAreEqual(expected, actual interface{}) bool {
 
 // ObjectsExportedFieldsAreEqual determines if the exported (public) fields of two structs are considered equal.
 // If the two objects are not of the same type, or if either of them are not a struct, they are not considered equal.
-// If the structs happen to be time.Time, then they're compared using time.Time.Equal.
+// If the structs happen to be time.Time, then they're compared using time.Time.Equal. Recursive data structures are not
+// supported.
 //
 // This function does no assertion of any kind.
 func ObjectsExportedFieldsAreEqual(expected, actual interface{}) bool {
@@ -549,6 +550,7 @@ func EqualValues(t TestingT, expected, actual interface{}, msgAndArgs ...interfa
 // EqualExportedValues asserts that the types of two objects are equal and their public
 // fields are also equal. This is useful for comparing structs that have private fields
 // that could potentially differ. Types of time.Time are compared using time.Time.Equal.
+// Recursive data structures are not supported and may result in an infinite loop.
 //
 //	 type S struct {
 //		Exported     	int

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -102,9 +102,6 @@ type AssertionTesterNonConformingObject struct {
 }
 
 func TestObjectsAreEqual(t *testing.T) {
-	t1 := time.Date(2023, time.April, 7, 12, 56, 32, 0, time.UTC)
-	t2 := time.Date(2023, time.April, 7, 7, 56, 32, 0, time.FixedZone("UTC-5", -5*60*60))
-
 	cases := []struct {
 		expected interface{}
 		actual   interface{}
@@ -115,10 +112,6 @@ func TestObjectsAreEqual(t *testing.T) {
 		{123, 123, true},
 		{123.5, 123.5, true},
 		{[]byte("Hello World"), []byte("Hello World"), true},
-		{map[int]int{5: 10, 10: 20}, map[int]int{10: 20, 5: 10}, true},
-		{time.Time{}, time.Time{}, true},
-		{t1, t2, true},
-		{&t1, &t2, true},
 		{nil, nil, true},
 
 		// cases that are expected not to be equal
@@ -127,8 +120,6 @@ func TestObjectsAreEqual(t *testing.T) {
 		{"x", 'x', false},
 		{0, 0.1, false},
 		{0.1, 0, false},
-		{t1, &t2, false},
-		{t1, t1.Add(time.Microsecond), false},
 		{time.Now, time.Now, false},
 		{func() {}, func() {}, false},
 		{uint32(10), int32(10), false},

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -201,20 +201,6 @@ func TestObjectsExportedFieldsAreEqual(t *testing.T) {
 
 		})
 	}
-
-	t.Run("recursion", func(t *testing.T) {
-		type R struct {
-			Recurse *R
-		}
-
-		r := R{}
-		r.Recurse = &r
-
-		res := ObjectsExportedFieldsAreEqual(r, r)
-		if res != true {
-			t.Errorf("ObjectsExportedFieldsAreEqual(%#v, %#v) should return %#v", r, r, true)
-		}
-	})
 }
 
 func TestImplements(t *testing.T) {

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -201,6 +201,20 @@ func TestObjectsExportedFieldsAreEqual(t *testing.T) {
 
 		})
 	}
+
+	t.Run("recursion", func(t *testing.T) {
+		type R struct {
+			Recurse *R
+		}
+
+		r := R{}
+		r.Recurse = &r
+
+		res := ObjectsExportedFieldsAreEqual(r, r)
+		if res != true {
+			t.Errorf("ObjectsExportedFieldsAreEqual(%#v, %#v) should return %#v", r, r, true)
+		}
+	})
 }
 
 func TestImplements(t *testing.T) {

--- a/require/require.go
+++ b/require/require.go
@@ -197,7 +197,7 @@ func EqualErrorf(t TestingT, theError error, errString string, msg string, args 
 
 // EqualExportedValues asserts that the types of two objects are equal and their public
 // fields are also equal. This is useful for comparing structs that have private fields
-// that could potentially differ.
+// that could potentially differ. Types of time.Time are compared using time.Time.Equal.
 //
 // 	 type S struct {
 // 		Exported     	int
@@ -217,7 +217,7 @@ func EqualExportedValues(t TestingT, expected interface{}, actual interface{}, m
 
 // EqualExportedValuesf asserts that the types of two objects are equal and their public
 // fields are also equal. This is useful for comparing structs that have private fields
-// that could potentially differ.
+// that could potentially differ. Types of time.Time are compared using time.Time.Equal.
 //
 // 	 type S struct {
 // 		Exported     	int

--- a/require/require.go
+++ b/require/require.go
@@ -198,6 +198,7 @@ func EqualErrorf(t TestingT, theError error, errString string, msg string, args 
 // EqualExportedValues asserts that the types of two objects are equal and their public
 // fields are also equal. This is useful for comparing structs that have private fields
 // that could potentially differ. Types of time.Time are compared using time.Time.Equal.
+// Recursive data structures are not supported and may result in an infinite loop.
 //
 // 	 type S struct {
 // 		Exported     	int
@@ -218,6 +219,7 @@ func EqualExportedValues(t TestingT, expected interface{}, actual interface{}, m
 // EqualExportedValuesf asserts that the types of two objects are equal and their public
 // fields are also equal. This is useful for comparing structs that have private fields
 // that could potentially differ. Types of time.Time are compared using time.Time.Equal.
+// Recursive data structures are not supported and may result in an infinite loop.
 //
 // 	 type S struct {
 // 		Exported     	int

--- a/require/require_forward.go
+++ b/require/require_forward.go
@@ -158,7 +158,7 @@ func (a *Assertions) EqualErrorf(theError error, errString string, msg string, a
 
 // EqualExportedValues asserts that the types of two objects are equal and their public
 // fields are also equal. This is useful for comparing structs that have private fields
-// that could potentially differ.
+// that could potentially differ. Types of time.Time are compared using time.Time.Equal.
 //
 // 	 type S struct {
 // 		Exported     	int
@@ -175,7 +175,7 @@ func (a *Assertions) EqualExportedValues(expected interface{}, actual interface{
 
 // EqualExportedValuesf asserts that the types of two objects are equal and their public
 // fields are also equal. This is useful for comparing structs that have private fields
-// that could potentially differ.
+// that could potentially differ. Types of time.Time are compared using time.Time.Equal.
 //
 // 	 type S struct {
 // 		Exported     	int

--- a/require/require_forward.go
+++ b/require/require_forward.go
@@ -159,6 +159,7 @@ func (a *Assertions) EqualErrorf(theError error, errString string, msg string, a
 // EqualExportedValues asserts that the types of two objects are equal and their public
 // fields are also equal. This is useful for comparing structs that have private fields
 // that could potentially differ. Types of time.Time are compared using time.Time.Equal.
+// Recursive data structures are not supported and may result in an infinite loop.
 //
 // 	 type S struct {
 // 		Exported     	int
@@ -176,6 +177,7 @@ func (a *Assertions) EqualExportedValues(expected interface{}, actual interface{
 // EqualExportedValuesf asserts that the types of two objects are equal and their public
 // fields are also equal. This is useful for comparing structs that have private fields
 // that could potentially differ. Types of time.Time are compared using time.Time.Equal.
+// Recursive data structures are not supported and may result in an infinite loop.
 //
 // 	 type S struct {
 // 		Exported     	int


### PR DESCRIPTION
## Summary

Updates the new `EqualExportedValues` function to support comparing nested struct fields and `time.Time` values. The function explicitly no longer supports recursive data structures (see [this since removed test case](https://github.com/stretchr/testify/pull/1373/commits/96a3ee0f09fbe55b8802ea351cd20979d0742b54) for example).

## Changes

#1309 introduced `EqualExportedValues`. I was looking to add support for comparing structs containing `time.Time` fields, and this seemed like an ideal function to adjust for that since:
1. The explicit comparison of only exported values suggests the caller doesn't want a typical deep equality check, so comparing times using `time.Time.Equal` is likely more in line with the desired behavior.
2. `EqualExportedValues` is not yet in a tagged release, and so this behavior change should not affect many real users. 
3. Past PRs have tried to add time.Time equality support to functions like `assert.Equal`, but that task was found to be more complicated (for example, see #985). Adding this support to only `EqualExportedValues` is more easily achieved.

## Motivation

There is currently no good method for comparing structs that contain `time.Time` fields that don't have matching timezones or monotonic clock readings.

Example Usage:

```go
type Q struct {
	TS *time.Time
}
type R struct {
	Nested Q
}
type S struct {
	Nested R
	CreatedAt time.Time
}

t1 := time.Date(2023, time.April, 7, 12, 56, 32, 0, time.UTC)
t2 := time.Date(2023, time.April, 7, 7, 56, 32, 0, time.FixedZone("UTC-5", -5*60*60))

s1 := S{Nested: R{Nested: Q{TS: &t1}}, CreatedAt: t1}
s2 := S{Nested: R{Nested: Q{TS: &t2}}, CreatedAt: t2}

ObjectsExportedFieldsAreEqual(S1, S2) => true
```

## Related issues

Potentially closes #984, assuming we're okay with requiring use of `EqualExportedValues` to compare structs with `time.Time` fields and don't expect `assert.Equal` to handle that.