### PR TITLE
Remove functional option caller name match expectation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go_version: ["1.20", "1.19"]
+        go_version:
+          - "1.19"
+          - "1.20"
     steps:
       - uses: actions/checkout@v3
       - name: Setup Go
@@ -16,4 +18,20 @@ jobs:
       - run: ./.ci.gogenerate.sh
       - run: ./.ci.gofmt.sh
       - run: ./.ci.govet.sh
+      - run: go test -v -race ./...
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go_version:
+          - "1.17"
+          - "1.18"
+          - "1.19"
+          - "1.20"
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Go
+        uses: actions/setup-go@v3.2.0
+        with:
+          go-version: ${{ matrix.go_version }}
       - run: go test -v -race ./...

--- a/assert/http_assertions.go
+++ b/assert/http_assertions.go
@@ -113,7 +113,10 @@ func HTTPStatusCode(t TestingT, handler http.HandlerFunc, method, url string, va
 // empty string if building a new request fails.
 func HTTPBody(handler http.HandlerFunc, method, url string, values url.Values) string {
 	w := httptest.NewRecorder()
-	req, err := http.NewRequest(method, url+"?"+values.Encode(), nil)
+	if len(values) > 0 {
+		url += "?" + values.Encode()
+	}
+	req, err := http.NewRequest(method, url, nil)
 	if err != nil {
 		return ""
 	}

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/stretchr/testify
 
 // This should match the minimum supported version that is tested in
 // .github/workflows/main.yml
-go 1.19
+go 1.17
 
 require (
 	github.com/davecgh/go-spew v1.1.1


### PR DESCRIPTION
## Summary
Fixes #1380 by removing expectations around optional functions calling function names. These assertions are not necessary to satisfy the testing use case for functional options and are in fact just outright incorrect due to the curried nature of the optional function. The time at which the return function from the optional function is evaluated, the optional function name is no longer accessible/in-scope.

## Changes
* Removes expectation around functional options caller name matching as it is not guaranteed and not truly asserting the functional options function name.
* Adds test to cover additional use case.
* Introduces a strict length check on the function options.

## Motivation
Fix bug and improve test to cover additional use cases.

## Related issues
Closes #1380 
