### PR TITLE
assert: Remove the struct type constraint on 'TestEqualExportedValues' to support pointer comparisons

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -576,14 +576,6 @@ func EqualExportedValues(t TestingT, expected, actual interface{}, msgAndArgs ..
 		return Fail(t, fmt.Sprintf("Types expected to match exactly\n\t%v != %v", aType, bType), msgAndArgs...)
 	}
 
-	if aType.Kind() != reflect.Struct {
-		return Fail(t, fmt.Sprintf("Types expected to both be struct \n\t%v != %v", aType.Kind(), reflect.Struct), msgAndArgs...)
-	}
-
-	if bType.Kind() != reflect.Struct {
-		return Fail(t, fmt.Sprintf("Types expected to both be struct \n\t%v != %v", bType.Kind(), reflect.Struct), msgAndArgs...)
-	}
-
 	expected = copyExportedFields(expected)
 	actual = copyExportedFields(actual)
 

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -190,7 +190,7 @@ type S6 struct {
 	unexported string
 }
 
-func TestObjectsExportedFieldsAreEqual(t *testing.T) {
+func TestEqualExportedValues(t *testing.T) {
 
 	intValue := 1
 
@@ -225,6 +225,8 @@ func TestObjectsExportedFieldsAreEqual(t *testing.T) {
 		{Nested{&intValue, 2}, Nested{&intValue, 2}, true},
 		{Nested{&Nested{1, 2}, 3}, Nested{&Nested{1, "b"}, 3}, true},
 		{Nested{&Nested{1, 2}, 3}, Nested{nil, 3}, false},
+		{&Nested{1, 2}, &Nested{1, "b"}, true},
+		{&Nested{1, 2}, &Nested{"a", 2}, false},
 
 		{
 			Nested{map[interface{}]*Nested{nil: nil}, 2},
@@ -254,11 +256,12 @@ func TestObjectsExportedFieldsAreEqual(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		t.Run(fmt.Sprintf("ObjectsExportedFieldsAreEqual(%#v, %#v)", c.expected, c.actual), func(t *testing.T) {
-			res := ObjectsExportedFieldsAreEqual(c.expected, c.actual)
+		t.Run(fmt.Sprintf("EqualExportedValues(%#v, %#v)", c.expected, c.actual), func(t *testing.T) {
+			mockT := new(testing.T)
+			res := EqualExportedValues(mockT, c.expected, c.actual)
 
 			if res != c.result {
-				t.Errorf("ObjectsExportedFieldsAreEqual(%#v, %#v) should return %#v", c.expected, c.actual, c.result)
+				t.Errorf("EqualExportedValues(%#v, %#v) should return %#v", c.expected, c.actual, c.result)
 			}
 
 		})
@@ -348,7 +351,7 @@ func TestCopyExportedFields(t *testing.T) {
 	}
 }
 
-func TestEqualExportedValues(t *testing.T) {
+func TestEqualExportedValuesDiffs(t *testing.T) {
 	cases := []struct {
 		value1        interface{}
 		value2        interface{}


### PR DESCRIPTION
Pointer comparisons are supported already, just as long as the are not the top-level element. Logically, if two item or sub-items have different unexported field, then they cannot have the same underlying address. With this change, the top-level will be treated no differently from the rest of the struct fields which also makes the logic simpler.

The normal use case here is when asserting any response data that has a pointer type. As the code currently stands on `master`, you have get the underlying values and compare those instead, otherwise it fails:

```go
require.NotNil(t, actual)
assert.EqualExportedValues(t, *expected, *actual)
```

I'm adding a test case that would have failed with the old logic.

I am also getting rid of the duplicated `ObjectsExportedFieldsAreEqual`. Since each assert function return a boolean result, we can achieve exactly the same without the extra function. This was discussed when adding the original code (https://github.com/stretchr/testify/pull/1309#discussion_r1063031396), which made sense then but now I think the time is right to remove it.