### PR TITLE
Document that require is not safe to call in created goroutines

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ func TestSomething(t *testing.T) {
 ---------------------------------------------------------------------------------------------
 
 The `require` package provides same global functions as the `assert` package, but instead of returning a boolean result they terminate current test.
+These functions must be called from the goroutine running the test or benchmark function, not from other goroutines created during the test.
+Otherwise race conditions may occur.
 
 See [t.FailNow](http://golang.org/pkg/testing/#T.FailNow) for details.
 


### PR DESCRIPTION
## Summary

Document explicitly in section about require package that

> These functions must be called from the goroutine running the test or benchmark function, not from other goroutines created during the test. Otherwise race conditions may occur.

## Motivation

It's documented in the official [t.FailNow](http://golang.org/pkg/testing/#T.FailNow), but when someone uses testify and encounters this problem e.g. (my real-world example)

```log
==================
WARNING: DATA RACE
Read at 0x00c0001033c3 by goroutine 44:
  testing.(*common).logDepth()
      /opt/homebrew/Cellar/go/1.20.4/libexec/src/testing/testing.go:998 +0x35c
  testing.(*common).log()
      /opt/homebrew/Cellar/go/1.20.4/libexec/src/testing/testing.go:985 +0x80
  testing.(*common).Errorf()
      /opt/homebrew/Cellar/go/1.20.4/libexec/src/testing/testing.go:1049 +0x58
  testing.(*T).Errorf()
      <autogenerated>:1 +0x5c
  github.com/stretchr/testify/assert.Fail()
      /Users/jakub.warczarek/go/pkg/mod/github.com/stretchr/testify@v1.8.3/assert/assertions.go:333 +0x358
  github.com/stretchr/testify/assert.NoError()
      /Users/jakub.warczarek/go/pkg/mod/github.com/stretchr/testify@v1.8.3/assert/assertions.go:1495 +0xe0
  github.com/stretchr/testify/require.NoError()
      /Users/jakub.warczarek/go/pkg/mod/github.com/stretchr/testify@v1.8.3/require/require.go:1357 +0x88
  github.com/kong/kubernetes-ingress-controller/v2/internal/cmd/rootcmd_test.TestTelemetry.func1()
      /Users/jakub.warczarek/Documents/work/kubernetes-ingress-controller/internal/cmd/rootcmd/telemetry_test.go:59 +0x78

Previous write at 0x00c0001033c3 by main goroutine:
  testing.tRunner.func1()
      /opt/homebrew/Cellar/go/1.20.4/libexec/src/testing/testing.go:1563 +0x570
  runtime.deferreturn()
      /opt/homebrew/Cellar/go/1.20.4/libexec/src/runtime/panic.go:476 +0x30
  testing.runTests()
      /opt/homebrew/Cellar/go/1.20.4/libexec/src/testing/testing.go:2034 +0x700
  testing.(*M).Run()
      /opt/homebrew/Cellar/go/1.20.4/libexec/src/testing/testing.go:1906 +0x950
  main.main()
      _testmain.go:59 +0x300
```

searching in testify docs whether it is safe for concurrent use (e.g. grepping for words gouroutine, race condition, etc.) doesn't give any answer. You have to go to the official docs, which makes it harder to discover.


