### PR TITLE
Ensure that subtest name is set in SetupSubTest/TearDownSubTest

### DIFF
--- a/suite/suite.go
+++ b/suite/suite.go
@@ -96,19 +96,20 @@ func failOnPanic(t *testing.T, r interface{}) {
 func (suite *Suite) Run(name string, subtest func()) bool {
 	oldT := suite.T()
 
-	if setupSubTest, ok := suite.s.(SetupSubTest); ok {
-		setupSubTest.SetupSubTest()
-	}
-
-	defer func() {
-		suite.SetT(oldT)
-		if tearDownSubTest, ok := suite.s.(TearDownSubTest); ok {
-			tearDownSubTest.TearDownSubTest()
-		}
-	}()
-
 	return oldT.Run(name, func(t *testing.T) {
 		suite.SetT(t)
+
+		if setupSubTest, ok := suite.s.(SetupSubTest); ok {
+			setupSubTest.SetupSubTest()
+		}
+
+		defer func() {
+			if tearDownSubTest, ok := suite.s.(TearDownSubTest); ok {
+				tearDownSubTest.TearDownSubTest()
+			}
+			suite.SetT(oldT)
+		}()
+
 		subtest()
 	})
 }


### PR DESCRIPTION
## Summary
Ensure that subtest name is set in SetupSubTest/TearDownSubTest

## Changes
- Ensures that suite.SetT() (with the subtest T) is called before SetupSubTest
- Ensures that the original T is restored after TearDownSubTest

## Motivation
One common usecase of SetupSubTest is to set up mocks and expectations for a table test. In this usecase, the current behavior does not set the test name until *after* SetupSubTest is run. This makes test failure reporting substantially less informative.
