### PR TITLE
Fix Go modules version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/stretchr/testify
 
-go 1.20
+// This should match the minimum supported version that is tested in
+// .github/workflows/main.yml
+go 1.19
 
 require (
 	github.com/davecgh/go-spew v1.1.1


### PR DESCRIPTION

## Summary
The `go` directive in go.mod is meant to indicate the minimum supported version.

See: https://go.dev/doc/modules/gomod-ref#go

## Changes
<!-- * Description of change 1 -->
<!-- * Description of change 2 -->
<!-- ... -->

## Motivation
This allows downstream projects to know what minimum Go version they need for all supported dependencies.

## Related issues
<!-- Put `Closes #XXXX` for each issue number this PR fixes/closes -->
