### PR TITLE
fix: make EventuallyWithT concurrency safe

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1930,8 +1930,10 @@ func EventuallyWithT(t TestingT, condition func(collect *CollectT), waitFor time
 			tick = nil
 			go func() {
 				collect := new(CollectT)
+				defer func() {
+					ch <- collect.errors
+				}()
 				condition(collect)
-				ch <- collect.errors
 			}()
 		case errs := <-ch:
 			if len(errs) == 0 {

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -2766,11 +2766,22 @@ func TestEventuallyTrue(t *testing.T) {
 	True(t, Eventually(t, condition, 100*time.Millisecond, 20*time.Millisecond))
 }
 
+// errorsCapturingT is a mock implementation of TestingT that captures errors reported with Errorf.
+type errorsCapturingT struct {
+	errors []error
+}
+
+func (t *errorsCapturingT) Errorf(format string, args ...interface{}) {
+	t.errors = append(t.errors, fmt.Errorf(format, args...))
+}
+
+func (t *errorsCapturingT) Helper() {}
+
 func TestEventuallyWithTFalse(t *testing.T) {
-	mockT := new(CollectT)
+	mockT := new(errorsCapturingT)
 
 	condition := func(collect *CollectT) {
-		True(collect, false)
+		Fail(collect, "condition fixed failure")
 	}
 
 	False(t, EventuallyWithT(mockT, condition, 100*time.Millisecond, 20*time.Millisecond))
@@ -2778,7 +2789,7 @@ func TestEventuallyWithTFalse(t *testing.T) {
 }
 
 func TestEventuallyWithTTrue(t *testing.T) {
-	mockT := new(CollectT)
+	mockT := new(errorsCapturingT)
 
 	state := 0
 	condition := func(collect *CollectT) {
@@ -2790,6 +2801,41 @@ func TestEventuallyWithTTrue(t *testing.T) {
 
 	True(t, EventuallyWithT(mockT, condition, 100*time.Millisecond, 20*time.Millisecond))
 	Len(t, mockT.errors, 0)
+}
+
+func TestEventuallyWithT_ConcurrencySafe(t *testing.T) {
+	mockT := new(errorsCapturingT)
+
+	condition := func(collect *CollectT) {
+		Fail(collect, "condition fixed failure")
+	}
+
+	// To trigger race conditions, we run EventuallyWithT with a nanosecond tick.
+	False(t, EventuallyWithT(mockT, condition, 100*time.Millisecond, time.Nanosecond))
+	Len(t, mockT.errors, 2)
+}
+
+func TestEventuallyWithT_ReturnsTheLatestFinishedConditionErrors(t *testing.T) {
+	// We'll use a channel to control whether a condition should sleep or not.
+	mustSleep := make(chan bool, 2)
+	mustSleep <- false
+	mustSleep <- true
+	close(mustSleep)
+
+	condition := func(collect *CollectT) {
+		if <-mustSleep {
+			// Sleep to ensure that the second condition runs longer than timeout.
+			time.Sleep(time.Second)
+			return
+		}
+
+		// The first condition will fail. We expect to get this error as a result.
+		Fail(collect, "condition fixed failure")
+	}
+
+	mockT := new(errorsCapturingT)
+	False(t, EventuallyWithT(mockT, condition, 100*time.Millisecond, 20*time.Millisecond))
+	Len(t, mockT.errors, 2)
 }
 
 func TestNeverFalse(t *testing.T) {


### PR DESCRIPTION
## Summary

In `assert.EventuallyWithT`, `assert.CollectT` is used in a concurrent context which may lead to races as explained in https://github.com/stretchr/testify/issues/1391.

## Changes

We create a `CollectT` per every condition tick and send its errors over a channel. On the reader side of the channel, we cache the `lastTickErrs` so they can be copied over to t once the timeout is fired. The only access to `lastTickErrs` happens in the reader case and the timeout case which both run in the same goroutine.

## Motivation

We cannot use `EventuallyWithT` family of functions/methods in our codebase due to data races it causes.

<!-- ## Example usage (if applicable) -->

## Related issues
Closes https://github.com/stretchr/testify/issues/1391.