### PR TITLE
fix: update Empty()'s error message

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -705,7 +705,7 @@ func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
 		if h, ok := t.(tHelper); ok {
 			h.Helper()
 		}
-		Fail(t, fmt.Sprintf("Should be empty, but was %v", object), msgAndArgs...)
+		Fail(t, fmt.Sprintf("Should be empty, but isn't %v", object), msgAndArgs...)
 	}
 
 	return pass
@@ -724,7 +724,7 @@ func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
 		if h, ok := t.(tHelper); ok {
 			h.Helper()
 		}
-		Fail(t, fmt.Sprintf("Should NOT be empty, but was %v", object), msgAndArgs...)
+		Fail(t, fmt.Sprintf("Should NOT be empty, but is %v", object), msgAndArgs...)
 	}
 
 	return pass


### PR DESCRIPTION
## Summary
The message returned by `Empty()` is a bit confusing because it states the following: `Should be empty, but was [1, 2].`

## Changes
* Update the error message thrown/panicked by `assert.Empty()`
* Update the error message thrown/panicked by `assert.NotEmpty()`

## Testcase
https://go.dev/play/p/Rx_KYuAQe2J