### PR TITLE
Fix #1399: Always report error message on PanicsWithError mismatch

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1212,7 +1212,15 @@ func PanicsWithError(t TestingT, errString string, f PanicTestFunc, msgAndArgs .
 	}
 	panicErr, ok := panicValue.(error)
 	if !ok || panicErr.Error() != errString {
-		return Fail(t, fmt.Sprintf("func %#v should panic with error message:\t%#v\n\tPanic value:\t%#v\n\tPanic stack:\t%s", f, errString, panicValue, panickedStack), msgAndArgs...)
+		errorMsg := ""
+		if ok {
+			errorMsg = fmt.Sprintf("\tError message:\t%#v\n", panicErr.Error())
+		}
+		msg := fmt.Sprintf(
+			"func %#v should panic with error message:\t%#v\n\tPanic value:\t%#v\n%s\tPanic stack:\t%s",
+			f, errString, panicValue, errorMsg, panickedStack,
+		)
+		return Fail(t, msg, msgAndArgs...)
 	}
 
 	return true

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -1339,29 +1339,56 @@ func TestPanicsWithValue(t *testing.T) {
 
 func TestPanicsWithError(t *testing.T) {
 
-	mockT := new(testing.T)
-
+	mockT := new(CollectT)
 	if !PanicsWithError(mockT, "panic", func() {
 		panic(errors.New("panic"))
 	}) {
 		t.Error("PanicsWithError should return true")
 	}
+	Len(t, mockT.errors, 0)
 
+	mockT = new(CollectT)
 	if PanicsWithError(mockT, "Panic!", func() {
 	}) {
 		t.Error("PanicsWithError should return false")
 	}
+	if Len(t, mockT.errors, 1) {
+		actual := mockT.errors[0].Error()
+		Contains(t, actual, "Panic value:	<nil>")
+	}
 
+	mockT = new(CollectT)
 	if PanicsWithError(mockT, "at the disco", func() {
-		panic(errors.New("panic"))
+		panic(errors.New("actual err msg"))
 	}) {
 		t.Error("PanicsWithError should return false")
 	}
+	if Len(t, mockT.errors, 1) {
+		actual := mockT.errors[0].Error()
+		Contains(t, actual, `Error message:	"actual err msg"`)
+	}
 
+	mockT = new(CollectT)
+	if PanicsWithError(mockT, "at the disco", func() {
+		panic(errors.Join(errors.New("wrapped err msg"), errors.New("other err msg")))
+	}) {
+		t.Error("PanicsWithError should return false")
+	}
+	if Len(t, mockT.errors, 1) {
+		actual := mockT.errors[0].Error()
+		Contains(t, actual, `Error message:	"wrapped err msg\nother err msg"`)
+	}
+
+	mockT = new(CollectT)
 	if PanicsWithError(mockT, "Panic!", func() {
 		panic("panic")
 	}) {
 		t.Error("PanicsWithError should return false")
+	}
+	if Len(t, mockT.errors, 1) {
+		actual := mockT.errors[0].Error()
+		Contains(t, actual, `Panic value:	"panic"`)
+		NotContains(t, actual, "Error message:", "PanicsWithError should not report error message if not due an error")
 	}
 }
 


### PR DESCRIPTION
## Summary
Always report error message on `PanicsWithError` error message mismatch.

## Changes
Add `Error message` field to the failure message, that reports `panicErr.Error()` IFF it panicked with an error its message is different from expected.

## Motivation
Better defect localization in case of nested errors causing panic.

Before:
```
Error: func (assert.PanicTestFunc)(0x627a80) should panic with error message:	"at the disco"
	Panic value:	&errors.joinError{errs:[]error{(*errors.errorString)(0xc0000a1540), (*errors.errorString)(0xc0000a1550)}}
	Panic stack:	goroutine 19 [running]:
	...
```
After:
```
Error: func (assert.PanicTestFunc)(0x627b20) should panic with error message:	"at the disco"
	Panic value:	&errors.joinError{errs:[]error{(*errors.errorString)(0xc000065550), (*errors.errorString)(0xc000065560)}}
	Error message:	"wrapped err msg\nother err msg"
	Panic stack:	goroutine 6 [running]:
	...
```

## Related issues
Closes https://github.com/stretchr/testify/issues/1399
