### PR TITLE
mock: fix map[string]struct{} map[string]interface{} Argument compare panic

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -967,7 +967,7 @@ func (args Arguments) Diff(objects []interface{}) (string, int) {
 			switch expected := expected.(type) {
 			case anythingOfTypeArgument:
 				// type checking
-				if reflect.TypeOf(actual).Name() != string(expected) && reflect.TypeOf(actual).String() != string(expected) {
+				if reflect.TypeOf(actual).Name() != string(expected) && strings.ReplaceAll(reflect.TypeOf(actual).String(), " ", "") != strings.ReplaceAll(string(expected), " ", "") {
 					// not match
 					differences++
 					output = fmt.Sprintf("%s\t%d: FAIL:  type %s != type %s - %s\n", output, i, expected, reflect.TypeOf(actual).Name(), actualFmt)

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -1739,6 +1739,28 @@ func Test_Arguments_Diff_WithAnythingOfTypeArgument(t *testing.T) {
 
 }
 
+func Test_Arguments_Diff_WithAnythingOfTypeArgument_MapInterface(t *testing.T) {
+
+	var args = Arguments([]interface{}{AnythingOfType("*map[string]interface{}")})
+	var count int
+	param := make(map[string]interface{})
+	_, count = args.Diff([]interface{}{&param})
+
+	assert.Equal(t, 0, count)
+
+}
+
+func Test_Arguments_Diff_WithAnythingOfTypeArgument_MapStruct(t *testing.T) {
+
+	var args = Arguments([]interface{}{AnythingOfType("*map[string]struct{}")})
+	var count int
+	param := make(map[string]struct{})
+	_, count = args.Diff([]interface{}{&param})
+
+	assert.Equal(t, 0, count)
+
+}
+
 func Test_Arguments_Diff_WithAnythingOfTypeArgument_Failing(t *testing.T) {
 
 	var args = Arguments([]interface{}{"string", AnythingOfType("string"), true})


### PR DESCRIPTION
## Summary

Panic in https://go.dev/play/p/CPpk9RyaCI1 (test case added by @dolmen)

## Changes
Change `AnythingOfType` matching by ignoring spaces in types names (description added by @dolmen)

## Motivation
<!-- Why were the changes necessary. -->
the case in the mock.go file will case panic
```go
	Mock.On("Unmarshal", AnythingOfType("*map[string]interface{}")).Return().Run(func(args Arguments) {
		arg := args.Get(0).(*map[string]interface{})
		arg["foo"] = "bar"
	})
```

`reflect.TypeOf(actual).String()` will print `*map[string]interface {}`，not `*map[string]interface{}`, there will be an additional space  in the former.
<!-- ## Example usage (if applicable) -->

## Related issues
<!-- Put `Closes #XXXX` for each issue number this PR fixes/closes -->
