### PR TITLE
fix: object formatting in Len message

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -753,11 +753,11 @@ func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) 
 	}
 	ok, l := getLen(object)
 	if !ok {
-		return Fail(t, fmt.Sprintf("\"%s\" could not be applied builtin len()", object), msgAndArgs...)
+		return Fail(t, fmt.Sprintf(`"%s" could not be applied builtin len()`, spew.Sdump(object)), msgAndArgs...)
 	}
 
 	if l != length {
-		return Fail(t, fmt.Sprintf("\"%s\" should have %d item(s), but has %d", object, length, l), msgAndArgs...)
+		return Fail(t, fmt.Sprintf(`"%s" should have %d item(s), but has %d`, spew.Sdump(object), length, l), msgAndArgs...)
 	}
 	return true
 }


### PR DESCRIPTION
## Summary
<!-- High-level, one sentence summary of what this PR accomplishes -->

## Changes
<!-- * Description of change 1 -->
<!-- * Description of change 2 -->
<!-- ... -->
Change formatting in `Len` method from `%s` to `spew.Dump`

## Motivation
<!-- Why were the changes necessary. -->
Old code prints:
```go
Error: "map[@errors:[def] @message:abc field1:%!s(int=1) field2:2 field3:%!s(float64=3.3)]" should have 6 item(s), but has 5
```
which contains invalid formatting `%!s(int=1)`

<!-- ## Example usage (if applicable) -->

## Related issues
<!-- Put `Closes #XXXX` for each issue number this PR fixes/closes -->
