### PR TITLE
codegen: use standard header for generated files

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ Please feel free to submit issues, fork the repository and send pull requests!
 
 When submitting an issue, we ask that you please include a complete test function that demonstrates the issue. Extra credit for those using Testify to write the test code that demonstrates it.
 
-Code generation is used. Look for `CODE GENERATED AUTOMATICALLY` at the top of some files. Run `go generate ./...` to update generated files.
+Code generation is used. [Look for `Code generated with`](https://github.com/search?q=repo%3Astretchr%2Ftestify%20%22Code%20generated%20with%22&type=code) at the top of some files. Run `go generate ./...` to update generated files.
 
 We also chat on the [Gophers Slack](https://gophers.slack.com) group in the `#testify` and `#testify-dev` channels.
 

--- a/_codegen/main.go
+++ b/_codegen/main.go
@@ -297,10 +297,8 @@ func (f *testFunc) CommentWithoutT(receiver string) string {
 	return strings.Replace(f.Comment(), search, replace, -1)
 }
 
-var headerTemplate = `/*
-* CODE GENERATED AUTOMATICALLY WITH github.com/stretchr/testify/_codegen
-* THIS FILE MUST NOT BE EDITED BY HAND
-*/
+// Standard header https://go.dev/s/generatedcode.
+var headerTemplate = `// Code generated with github.com/stretchr/testify/_codegen; DO NOT EDIT.
 
 package {{.Name}}
 

--- a/assert/assertion_format.go
+++ b/assert/assertion_format.go
@@ -1,7 +1,4 @@
-/*
-* CODE GENERATED AUTOMATICALLY WITH github.com/stretchr/testify/_codegen
-* THIS FILE MUST NOT BE EDITED BY HAND
- */
+// Code generated with github.com/stretchr/testify/_codegen; DO NOT EDIT.
 
 package assert
 

--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -1,7 +1,4 @@
-/*
-* CODE GENERATED AUTOMATICALLY WITH github.com/stretchr/testify/_codegen
-* THIS FILE MUST NOT BE EDITED BY HAND
- */
+// Code generated with github.com/stretchr/testify/_codegen; DO NOT EDIT.
 
 package assert
 

--- a/require/require.go
+++ b/require/require.go
@@ -1,7 +1,4 @@
-/*
-* CODE GENERATED AUTOMATICALLY WITH github.com/stretchr/testify/_codegen
-* THIS FILE MUST NOT BE EDITED BY HAND
- */
+// Code generated with github.com/stretchr/testify/_codegen; DO NOT EDIT.
 
 package require
 

--- a/require/require_forward.go
+++ b/require/require_forward.go
@@ -1,7 +1,4 @@
-/*
-* CODE GENERATED AUTOMATICALLY WITH github.com/stretchr/testify/_codegen
-* THIS FILE MUST NOT BE EDITED BY HAND
- */
+// Code generated with github.com/stretchr/testify/_codegen; DO NOT EDIT.
 
 package require
 


### PR DESCRIPTION

## Summary

Modify _codegen to use the standard header in generated Go sources.
See https://go.dev/s/generatedcode.

## Motivation

This enables editor support for blocking manual changes in generated sources.