### PR TITLE
CI: upgrade setup-go to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup Go
-        uses: actions/setup-go@v3.2.0
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go_version }}
       - run: ./.ci.gogenerate.sh
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup Go
-        uses: actions/setup-go@v3.2.0
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go_version }}
       - run: go test -v -race ./...


### PR DESCRIPTION
## Summary

Upgrade CI to use [setup-go v4](https://github.com/actions/setup-go)

## Motivation

Use latest features such as module cache.