### PR TITLE
Add helper method in tests

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1864,6 +1864,9 @@ type CollectT struct {
 	errors []error
 }
 
+// Helper is like [testing.T.Helper] but does nothing.
+func (CollectT) Helper() {}
+
 // Errorf collects the error.
 func (c *CollectT) Errorf(format string, args ...interface{}) {
 	c.errors = append(c.errors, fmt.Errorf(format, args...))

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -585,6 +585,9 @@ type bufferT struct {
 	buf bytes.Buffer
 }
 
+// Helper is like [testing.T.Helper] but does nothing.
+func (bufferT) Helper() {}
+
 func (t *bufferT) Errorf(format string, args ...interface{}) {
 	// implementation of decorate is copied from testing.T
 	decorate := func(s string) string {
@@ -2474,6 +2477,9 @@ type mockTestingT struct {
 	args     []interface{}
 }
 
+// Helper is like [testing.T.Helper] but does nothing.
+func (mockTestingT) Helper() {}
+
 func (m *mockTestingT) errorString() string {
 	return fmt.Sprintf(m.errorFmt, m.args...)
 }
@@ -2493,6 +2499,9 @@ func TestFailNowWithPlainTestingT(t *testing.T) {
 
 type mockFailNowTestingT struct {
 }
+
+// Helper is like [testing.T.Helper] but does nothing.
+func (mockFailNowTestingT) Helper() {}
 
 func (m *mockFailNowTestingT) Errorf(format string, args ...interface{}) {}
 

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -121,6 +121,9 @@ type MockTestingT struct {
 	logfCount, errorfCount, failNowCount int
 }
 
+// Helper is like [testing.T.Helper] but does nothing.
+func (MockTestingT) Helper() {}
+
 const mockTestingTFailNowCalled = "FailNow was called"
 
 func (m *MockTestingT) Logf(string, ...interface{}) {

--- a/require/requirements_test.go
+++ b/require/requirements_test.go
@@ -27,6 +27,9 @@ type MockT struct {
 	Failed bool
 }
 
+// Helper is like [testing.T.Helper] but does nothing.
+func (MockT) Helper() {}
+
 func (t *MockT) FailNow() {
 	t.Failed = true
 }


### PR DESCRIPTION
## Summary
Start to extend our definition of `testing.TB` to include its `Helper()` method. See #1422 for details.

## Changes
* Add an `Helper()` method on all internal mocks of `testing.T`.
* Add an `Helper()` method on type `assert.CollectT`.

## Motivation

These are steps 1 and 2 of #1422.
