### PR TITLE
assert: check early in Eventually, EventuallyWithT, and Never

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1930,6 +1930,10 @@ func Eventually(t TestingT, condition func() bool, waitFor time.Duration, tick t
 		h.Helper()
 	}
 
+	if condition() {
+		return true
+	}
+
 	ch := make(chan bool, 1)
 
 	timer := time.NewTimer(waitFor)

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -3010,19 +3010,10 @@ func TestNeverTrue(t *testing.T) {
 func TestNeverFailQuickly(t *testing.T) {
 	mockT := new(testing.T)
 
-	condition := func() bool { <-time.After(time.Millisecond); return true }
-
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		False(t, Never(mockT, condition, 1000*time.Millisecond, 100*time.Millisecond))
-	}()
-
-	select {
-	case <-done:
-	case <-time.After(10 * time.Millisecond):
-		Fail(t, `condition not satisfied quickly enough`)
-	}
+	// By making the tick longer than the total duration, we expect that this test would fail if
+	// we didn't check the condition before the first tick elapses.
+	condition := func() bool { return true }
+	False(t, Never(mockT, condition, 100*time.Millisecond, time.Second))
 }
 
 // Check that a long running condition doesn't block Eventually.
@@ -3051,37 +3042,21 @@ func TestEventuallyTimeout(t *testing.T) {
 func TestEventuallySucceedQuickly(t *testing.T) {
 	mockT := new(testing.T)
 
-	condition := func() bool { <-time.After(time.Millisecond); return true }
+	condition := func() bool { return true }
 
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		True(t, Eventually(mockT, condition, 1000*time.Millisecond, 100*time.Millisecond))
-	}()
-
-	select {
-	case <-done:
-	case <-time.After(10 * time.Millisecond):
-		Fail(t, `condition not satisfied quickly enough`)
-	}
+	// By making the tick longer than the total duration, we expect that this test would fail if
+	// we didn't check the condition before the first tick elapses.
+	True(t, Eventually(mockT, condition, 100*time.Millisecond, time.Second))
 }
 
 func TestEventuallyWithTSucceedQuickly(t *testing.T) {
 	mockT := new(testing.T)
 
-	condition := func(t *CollectT) { <-time.After(time.Millisecond) }
+	condition := func(t *CollectT) {}
 
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		True(t, EventuallyWithT(mockT, condition, 1000*time.Millisecond, 100*time.Millisecond))
-	}()
-
-	select {
-	case <-done:
-	case <-time.After(10 * time.Millisecond):
-		Fail(t, `condition not satisfied quickly enough`)
-	}
+	// By making the tick longer than the total duration, we expect that this test would fail if
+	// we didn't check the condition before the first tick elapses.
+	True(t, EventuallyWithT(mockT, condition, 100*time.Millisecond, time.Second))
 }
 
 func Test_validateEqualArgs(t *testing.T) {

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -2980,42 +2980,6 @@ func TestEventuallyWithTFailNow(t *testing.T) {
 	Len(t, mockT.errors, 1)
 }
 
-func TestNeverFalse(t *testing.T) {
-	condition := func() bool {
-		return false
-	}
-
-	True(t, Never(t, condition, 100*time.Millisecond, 20*time.Millisecond))
-}
-
-// TestNeverTrue checks Never with a condition that returns true on second call.
-func TestNeverTrue(t *testing.T) {
-	mockT := new(testing.T)
-
-	// A list of values returned by condition.
-	// Channel protects against concurrent access.
-	returns := make(chan bool, 2)
-	returns <- false
-	returns <- true
-	defer close(returns)
-
-	// Will return true on second call.
-	condition := func() bool {
-		return <-returns
-	}
-
-	False(t, Never(mockT, condition, 100*time.Millisecond, 20*time.Millisecond))
-}
-
-func TestNeverFailQuickly(t *testing.T) {
-	mockT := new(testing.T)
-
-	// By making the tick longer than the total duration, we expect that this test would fail if
-	// we didn't check the condition before the first tick elapses.
-	condition := func() bool { return true }
-	False(t, Never(mockT, condition, 100*time.Millisecond, time.Second))
-}
-
 // Check that a long running condition doesn't block Eventually.
 // See issue 805 (and its long tail of following issues)
 func TestEventuallyTimeout(t *testing.T) {
@@ -3057,6 +3021,42 @@ func TestEventuallyWithTSucceedQuickly(t *testing.T) {
 	// By making the tick longer than the total duration, we expect that this test would fail if
 	// we didn't check the condition before the first tick elapses.
 	True(t, EventuallyWithT(mockT, condition, 100*time.Millisecond, time.Second))
+}
+
+func TestNeverFalse(t *testing.T) {
+	condition := func() bool {
+		return false
+	}
+
+	True(t, Never(t, condition, 100*time.Millisecond, 20*time.Millisecond))
+}
+
+// TestNeverTrue checks Never with a condition that returns true on second call.
+func TestNeverTrue(t *testing.T) {
+	mockT := new(testing.T)
+
+	// A list of values returned by condition.
+	// Channel protects against concurrent access.
+	returns := make(chan bool, 2)
+	returns <- false
+	returns <- true
+	defer close(returns)
+
+	// Will return true on second call.
+	condition := func() bool {
+		return <-returns
+	}
+
+	False(t, Never(mockT, condition, 100*time.Millisecond, 20*time.Millisecond))
+}
+
+func TestNeverFailQuickly(t *testing.T) {
+	mockT := new(testing.T)
+
+	// By making the tick longer than the total duration, we expect that this test would fail if
+	// we didn't check the condition before the first tick elapses.
+	condition := func() bool { return true }
+	False(t, Never(mockT, condition, 100*time.Millisecond, time.Second))
 }
 
 func Test_validateEqualArgs(t *testing.T) {


### PR DESCRIPTION
## Summary
Addresses #1424.

`Eventually` and `EventuallyWithT` current must always wait at least the polling duration before they can succeed. This PR starts checking the condition immediately. The assertion still fails if the initial check of the condition takes longer than the configured timeout.

## Changes
<!-- * Description of change 1 -->
<!-- * Description of change 2 -->
<!-- ... -->

## Motivation
This will provide a small optimization to callers, because tests can complete more quickly than they did before if conditions are met already.

## Related issues
<!-- Put `Closes #XXXX` for each issue number this PR fixes/closes -->
