### PR TITLE
README: fix typos "set up" vs "setup"

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ func TestSomething(t *testing.T) {
   // create an instance of our test object
   testObj := new(MyMockedObject)
 
-  // setup expectations
+  // set up expectations
   testObj.On("DoSomething", 123).Return(true, nil)
 
   // call the code we are testing
@@ -181,7 +181,7 @@ func TestSomethingWithPlaceholder(t *testing.T) {
   // create an instance of our test object
   testObj := new(MyMockedObject)
 
-  // setup expectations with a placeholder in the argument list
+  // set up expectations with a placeholder in the argument list
   testObj.On("DoSomething", mock.Anything).Return(true, nil)
 
   // call the code we are testing
@@ -200,7 +200,7 @@ func TestSomethingElse2(t *testing.T) {
   // create an instance of our test object
   testObj := new(MyMockedObject)
 
-  // setup expectations with a placeholder in the argument list
+  // set up expectations with a placeholder in the argument list
   mockCall := testObj.On("DoSomething", mock.Anything).Return(true, nil)
 
   // call the code we are testing


### PR DESCRIPTION
"Setup" means an existing arrangement while "set up" is an action.

## Summary
I wanted to bring to your attention some minor typos in the readme.md file. By fixing these, we can ensure that the intention of the sample code is communicated clearly.

## Changes
Readme.md has been updated with some spaces.

## Motivation
I'm eager to begin contributing to the testify project, and while acquainting myself with the readme, I noticed a minor typo I'd like to correct. Moving forward, I hope to implement more substantial changes, thus aiding the enhancement of this testing library package that I greatly admire.

## Related issues
<!-- Put `Closes #XXXX` for each issue number this PR fixes/closes -->
