### PR TITLE
assert: deprecate and move exported internal comparison functions

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -19,8 +19,9 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/pmezard/go-difflib/difflib"
-	"github.com/stretchr/testify/internal/check"
 	"gopkg.in/yaml.v3"
+
+	"github.com/stretchr/testify/internal/check"
 )
 
 //go:generate sh -c "cd ../_codegen && go build && cd - && ../_codegen/_codegen -output-package=assert -template=assertion_format.go.tmpl"

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -56,7 +56,7 @@ type Comparison func() (success bool)
 
 // ObjectsAreEqual determines if two objects are considered equal.
 //
-// Deprecated: This function does no assertion of any kind. Use Equal instead.
+// Deprecated: This function does no assertion of any kind. Use [Equal] instead.
 func ObjectsAreEqual(expected, actual interface{}) bool {
 	return check.ObjectsAreEqual(expected, actual)
 }
@@ -66,7 +66,7 @@ func ObjectsAreEqual(expected, actual interface{}) bool {
 // structures.
 //
 // Deprecated: This function does no assertion of any kind. Use
-// EqualExportedValues instead.
+// [EqualExportedValues] instead.
 func ObjectsExportedFieldsAreEqual(expected, actual interface{}) bool {
 	return check.ObjectsExportedFieldsAreEqual(expected, actual)
 }
@@ -74,7 +74,7 @@ func ObjectsExportedFieldsAreEqual(expected, actual interface{}) bool {
 // ObjectsAreEqualValues gets whether two objects are equal, or if their
 // values are equal.
 //
-// Deprecated: This function does no assertion of any kind. Use EqualValues
+// Deprecated: This function does no assertion of any kind. Use [EqualValues]
 // instead.
 func ObjectsAreEqualValues(expected, actual interface{}) bool {
 	return check.ObjectsAreEqualValues(expected, actual)

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -17,6 +17,8 @@ import (
 	"testing"
 	"time"
 	"unsafe"
+
+	"github.com/stretchr/testify/internal/check"
 )
 
 var (
@@ -102,54 +104,6 @@ func (a *AssertionTesterConformingObject) TestMethod() {
 type AssertionTesterNonConformingObject struct {
 }
 
-func TestObjectsAreEqual(t *testing.T) {
-	cases := []struct {
-		expected interface{}
-		actual   interface{}
-		result   bool
-	}{
-		// cases that are expected to be equal
-		{"Hello World", "Hello World", true},
-		{123, 123, true},
-		{123.5, 123.5, true},
-		{[]byte("Hello World"), []byte("Hello World"), true},
-		{nil, nil, true},
-
-		// cases that are expected not to be equal
-		{map[int]int{5: 10}, map[int]int{10: 20}, false},
-		{'x', "x", false},
-		{"x", 'x', false},
-		{0, 0.1, false},
-		{0.1, 0, false},
-		{time.Now, time.Now, false},
-		{func() {}, func() {}, false},
-		{uint32(10), int32(10), false},
-	}
-
-	for _, c := range cases {
-		t.Run(fmt.Sprintf("ObjectsAreEqual(%#v, %#v)", c.expected, c.actual), func(t *testing.T) {
-			res := ObjectsAreEqual(c.expected, c.actual)
-
-			if res != c.result {
-				t.Errorf("ObjectsAreEqual(%#v, %#v) should return %#v", c.expected, c.actual, c.result)
-			}
-
-		})
-	}
-
-	// Cases where type differ but values are equal
-	if !ObjectsAreEqualValues(uint32(10), int32(10)) {
-		t.Error("ObjectsAreEqualValues should return true")
-	}
-	if ObjectsAreEqualValues(0, nil) {
-		t.Fail()
-	}
-	if ObjectsAreEqualValues(nil, 0) {
-		t.Fail()
-	}
-
-}
-
 type Nested struct {
 	Exported    interface{}
 	notExported interface{}
@@ -162,10 +116,6 @@ type S struct {
 	notExported2 Nested
 }
 
-type S2 struct {
-	foo interface{}
-}
-
 type S3 struct {
 	Exported1 *Nested
 	Exported2 *Nested
@@ -173,173 +123,6 @@ type S3 struct {
 
 type S4 struct {
 	Exported1 []*Nested
-}
-
-type S5 struct {
-	Exported Nested
-}
-
-type S6 struct {
-	Exported   string
-	unexported string
-}
-
-func TestObjectsExportedFieldsAreEqual(t *testing.T) {
-
-	intValue := 1
-
-	cases := []struct {
-		expected interface{}
-		actual   interface{}
-		result   bool
-	}{
-		{S{1, Nested{2, 3}, 4, Nested{5, 6}}, S{1, Nested{2, 3}, 4, Nested{5, 6}}, true},
-		{S{1, Nested{2, 3}, 4, Nested{5, 6}}, S{1, Nested{2, 3}, "a", Nested{5, 6}}, true},
-		{S{1, Nested{2, 3}, 4, Nested{5, 6}}, S{1, Nested{2, 3}, 4, Nested{5, "a"}}, true},
-		{S{1, Nested{2, 3}, 4, Nested{5, 6}}, S{1, Nested{2, 3}, 4, Nested{"a", "a"}}, true},
-		{S{1, Nested{2, 3}, 4, Nested{5, 6}}, S{1, Nested{2, "a"}, 4, Nested{5, 6}}, true},
-		{S{1, Nested{2, 3}, 4, Nested{5, 6}}, S{"a", Nested{2, 3}, 4, Nested{5, 6}}, false},
-		{S{1, Nested{2, 3}, 4, Nested{5, 6}}, S{1, Nested{"a", 3}, 4, Nested{5, 6}}, false},
-		{S{1, Nested{2, 3}, 4, Nested{5, 6}}, S2{1}, false},
-		{1, S{1, Nested{2, 3}, 4, Nested{5, 6}}, false},
-
-		{S3{&Nested{1, 2}, &Nested{3, 4}}, S3{&Nested{1, 2}, &Nested{3, 4}}, true},
-		{S3{nil, &Nested{3, 4}}, S3{nil, &Nested{3, 4}}, true},
-		{S3{&Nested{1, 2}, &Nested{3, 4}}, S3{&Nested{1, 2}, &Nested{3, "b"}}, true},
-		{S3{&Nested{1, 2}, &Nested{3, 4}}, S3{&Nested{1, "a"}, &Nested{3, "b"}}, true},
-		{S3{&Nested{1, 2}, &Nested{3, 4}}, S3{&Nested{"a", 2}, &Nested{3, 4}}, false},
-		{S3{&Nested{1, 2}, &Nested{3, 4}}, S3{}, false},
-		{S3{}, S3{}, true},
-
-		{S4{[]*Nested{{1, 2}}}, S4{[]*Nested{{1, 2}}}, true},
-		{S4{[]*Nested{{1, 2}}}, S4{[]*Nested{{1, 3}}}, true},
-		{S4{[]*Nested{{1, 2}, {3, 4}}}, S4{[]*Nested{{1, "a"}, {3, "b"}}}, true},
-		{S4{[]*Nested{{1, 2}, {3, 4}}}, S4{[]*Nested{{1, "a"}, {2, "b"}}}, false},
-
-		{Nested{&intValue, 2}, Nested{&intValue, 2}, true},
-		{Nested{&Nested{1, 2}, 3}, Nested{&Nested{1, "b"}, 3}, true},
-		{Nested{&Nested{1, 2}, 3}, Nested{nil, 3}, false},
-
-		{
-			Nested{map[interface{}]*Nested{nil: nil}, 2},
-			Nested{map[interface{}]*Nested{nil: nil}, 2},
-			true,
-		},
-		{
-			Nested{map[interface{}]*Nested{"a": nil}, 2},
-			Nested{map[interface{}]*Nested{"a": nil}, 2},
-			true,
-		},
-		{
-			Nested{map[interface{}]*Nested{"a": nil}, 2},
-			Nested{map[interface{}]*Nested{"a": {1, 2}}, 2},
-			false,
-		},
-		{
-			Nested{map[interface{}]Nested{"a": {1, 2}, "b": {3, 4}}, 2},
-			Nested{map[interface{}]Nested{"a": {1, 5}, "b": {3, 7}}, 2},
-			true,
-		},
-		{
-			Nested{map[interface{}]Nested{"a": {1, 2}, "b": {3, 4}}, 2},
-			Nested{map[interface{}]Nested{"a": {2, 2}, "b": {3, 4}}, 2},
-			false,
-		},
-	}
-
-	for _, c := range cases {
-		t.Run(fmt.Sprintf("ObjectsExportedFieldsAreEqual(%#v, %#v)", c.expected, c.actual), func(t *testing.T) {
-			res := ObjectsExportedFieldsAreEqual(c.expected, c.actual)
-
-			if res != c.result {
-				t.Errorf("ObjectsExportedFieldsAreEqual(%#v, %#v) should return %#v", c.expected, c.actual, c.result)
-			}
-
-		})
-	}
-}
-
-func TestCopyExportedFields(t *testing.T) {
-	intValue := 1
-
-	cases := []struct {
-		input    interface{}
-		expected interface{}
-	}{
-		{
-			input:    Nested{"a", "b"},
-			expected: Nested{"a", nil},
-		},
-		{
-			input:    Nested{&intValue, 2},
-			expected: Nested{&intValue, nil},
-		},
-		{
-			input:    Nested{nil, 3},
-			expected: Nested{nil, nil},
-		},
-		{
-			input:    S{1, Nested{2, 3}, 4, Nested{5, 6}},
-			expected: S{1, Nested{2, nil}, nil, Nested{}},
-		},
-		{
-			input:    S3{},
-			expected: S3{},
-		},
-		{
-			input:    S3{&Nested{1, 2}, &Nested{3, 4}},
-			expected: S3{&Nested{1, nil}, &Nested{3, nil}},
-		},
-		{
-			input:    S3{Exported1: &Nested{"a", "b"}},
-			expected: S3{Exported1: &Nested{"a", nil}},
-		},
-		{
-			input: S4{[]*Nested{
-				nil,
-				{1, 2},
-			}},
-			expected: S4{[]*Nested{
-				nil,
-				{1, nil},
-			}},
-		},
-		{
-			input: S4{[]*Nested{
-				{1, 2}},
-			},
-			expected: S4{[]*Nested{
-				{1, nil}},
-			},
-		},
-		{
-			input: S4{[]*Nested{
-				{1, 2},
-				{3, 4},
-			}},
-			expected: S4{[]*Nested{
-				{1, nil},
-				{3, nil},
-			}},
-		},
-		{
-			input:    S5{Exported: Nested{"a", "b"}},
-			expected: S5{Exported: Nested{"a", nil}},
-		},
-		{
-			input:    S6{"a", "b"},
-			expected: S6{"a", ""},
-		},
-	}
-
-	for _, c := range cases {
-		t.Run("", func(t *testing.T) {
-			output := copyExportedFields(c.input)
-			if !ObjectsAreEqualValues(c.expected, output) {
-				t.Errorf("%#v, %#v should be equal", c.expected, output)
-			}
-		})
-	}
 }
 
 func TestEqualExportedValues(t *testing.T) {
@@ -2515,7 +2298,7 @@ func TestBytesEqual(t *testing.T) {
 		{nil, make([]byte, 0)},
 	}
 	for i, c := range cases {
-		Equal(t, reflect.DeepEqual(c.a, c.b), ObjectsAreEqual(c.a, c.b), "case %d failed", i+1)
+		Equal(t, reflect.DeepEqual(c.a, c.b), check.ObjectsAreEqual(c.a, c.b), "case %d failed", i+1)
 	}
 }
 
@@ -2919,7 +2702,7 @@ func TestErrorAs(t *testing.T) {
 
 func TestIsNil(t *testing.T) {
 	var n unsafe.Pointer = nil
-	if !isNil(n) {
+	if !check.IsNil(n) {
 		t.Fatal("fail")
 	}
 }

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -16,7 +16,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-	"unsafe"
 
 	"github.com/stretchr/testify/internal/check"
 )
@@ -2697,12 +2696,5 @@ func TestErrorAs(t *testing.T) {
 				t.Errorf("ErrorAs(%#v,%#v) should return %t)", tt.err, target, tt.result)
 			}
 		})
-	}
-}
-
-func TestIsNil(t *testing.T) {
-	var n unsafe.Pointer = nil
-	if !check.IsNil(n) {
-		t.Fatal("fail")
 	}
 }

--- a/internal/check/checks.go
+++ b/internal/check/checks.go
@@ -1,0 +1,149 @@
+package check
+
+import (
+	"bytes"
+	"reflect"
+)
+
+// ObjectsAreEqual determines if two objects are considered equal.
+func ObjectsAreEqual(expected, actual interface{}) bool {
+	if expected == nil || actual == nil {
+		return expected == actual
+	}
+
+	exp, ok := expected.([]byte)
+	if !ok {
+		return reflect.DeepEqual(expected, actual)
+	}
+
+	act, ok := actual.([]byte)
+	if !ok {
+		return false
+	}
+	if exp == nil || act == nil {
+		return exp == nil && act == nil
+	}
+	return bytes.Equal(exp, act)
+}
+
+// CopyExportedFields iterates downward through nested data structures and creates a copy
+// that only contains the exported struct fields.
+func CopyExportedFields(expected interface{}) interface{} {
+	if IsNil(expected) {
+		return expected
+	}
+
+	expectedType := reflect.TypeOf(expected)
+	expectedKind := expectedType.Kind()
+	expectedValue := reflect.ValueOf(expected)
+
+	switch expectedKind {
+	case reflect.Struct:
+		result := reflect.New(expectedType).Elem()
+		for i := 0; i < expectedType.NumField(); i++ {
+			field := expectedType.Field(i)
+			isExported := field.IsExported()
+			if isExported {
+				fieldValue := expectedValue.Field(i)
+				if IsNil(fieldValue) || IsNil(fieldValue.Interface()) {
+					continue
+				}
+				newValue := CopyExportedFields(fieldValue.Interface())
+				result.Field(i).Set(reflect.ValueOf(newValue))
+			}
+		}
+		return result.Interface()
+
+	case reflect.Ptr:
+		result := reflect.New(expectedType.Elem())
+		unexportedRemoved := CopyExportedFields(expectedValue.Elem().Interface())
+		result.Elem().Set(reflect.ValueOf(unexportedRemoved))
+		return result.Interface()
+
+	case reflect.Array, reflect.Slice:
+		result := reflect.MakeSlice(expectedType, expectedValue.Len(), expectedValue.Len())
+		for i := 0; i < expectedValue.Len(); i++ {
+			index := expectedValue.Index(i)
+			if IsNil(index) {
+				continue
+			}
+			unexportedRemoved := CopyExportedFields(index.Interface())
+			result.Index(i).Set(reflect.ValueOf(unexportedRemoved))
+		}
+		return result.Interface()
+
+	case reflect.Map:
+		result := reflect.MakeMap(expectedType)
+		for _, k := range expectedValue.MapKeys() {
+			index := expectedValue.MapIndex(k)
+			unexportedRemoved := CopyExportedFields(index.Interface())
+			result.SetMapIndex(k, reflect.ValueOf(unexportedRemoved))
+		}
+		return result.Interface()
+
+	default:
+		return expected
+	}
+}
+
+// ObjectsExportedFieldsAreEqual determines if the exported (public) fields of two objects are
+// considered equal. This comparison of only exported fields is applied recursively to nested data
+// structures.
+func ObjectsExportedFieldsAreEqual(expected, actual interface{}) bool {
+	expectedCleaned := CopyExportedFields(expected)
+	actualCleaned := CopyExportedFields(actual)
+	return ObjectsAreEqualValues(expectedCleaned, actualCleaned)
+}
+
+// ObjectsAreEqualValues gets whether two objects are equal, or if their
+// values are equal.
+func ObjectsAreEqualValues(expected, actual interface{}) bool {
+	if ObjectsAreEqual(expected, actual) {
+		return true
+	}
+
+	actualType := reflect.TypeOf(actual)
+	if actualType == nil {
+		return false
+	}
+	expectedValue := reflect.ValueOf(expected)
+	if expectedValue.IsValid() && expectedValue.Type().ConvertibleTo(actualType) {
+		// Attempt comparison after type conversion
+		return reflect.DeepEqual(expectedValue.Convert(actualType).Interface(), actual)
+	}
+
+	return false
+}
+
+// containsKind checks if a specified kind in the slice of kinds.
+func containsKind(kinds []reflect.Kind, kind reflect.Kind) bool {
+	for i := 0; i < len(kinds); i++ {
+		if kind == kinds[i] {
+			return true
+		}
+	}
+
+	return false
+}
+
+// IsNil checks if a specified object is nil or not, without Failing.
+func IsNil(object interface{}) bool {
+	if object == nil {
+		return true
+	}
+
+	value := reflect.ValueOf(object)
+	kind := value.Kind()
+	isNilableKind := containsKind(
+		[]reflect.Kind{
+			reflect.Chan, reflect.Func,
+			reflect.Interface, reflect.Map,
+			reflect.Ptr, reflect.Slice, reflect.UnsafePointer},
+		kind)
+
+	if isNilableKind && value.IsNil() {
+		return true
+	}
+
+	return false
+}

--- a/internal/check/checks_test.go
+++ b/internal/check/checks_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 	"time"
+	"unsafe"
 )
 
 func TestObjectsAreEqual(t *testing.T) {
@@ -243,5 +244,12 @@ func TestCopyExportedFields(t *testing.T) {
 				t.Errorf("%#v, %#v should be equal", c.expected, output)
 			}
 		})
+	}
+}
+
+func TestIsNil(t *testing.T) {
+	var n unsafe.Pointer = nil
+	if !IsNil(n) {
+		t.Fatal("fail")
 	}
 }

--- a/internal/check/checks_test.go
+++ b/internal/check/checks_test.go
@@ -1,0 +1,247 @@
+package check
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestObjectsAreEqual(t *testing.T) {
+	cases := []struct {
+		expected interface{}
+		actual   interface{}
+		result   bool
+	}{
+		// cases that are expected to be equal
+		{"Hello World", "Hello World", true},
+		{123, 123, true},
+		{123.5, 123.5, true},
+		{[]byte("Hello World"), []byte("Hello World"), true},
+		{nil, nil, true},
+
+		// cases that are expected not to be equal
+		{map[int]int{5: 10}, map[int]int{10: 20}, false},
+		{'x', "x", false},
+		{"x", 'x', false},
+		{0, 0.1, false},
+		{0.1, 0, false},
+		{time.Now, time.Now, false},
+		{func() {}, func() {}, false},
+		{uint32(10), int32(10), false},
+	}
+
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("ObjectsAreEqual(%#v, %#v)", c.expected, c.actual), func(t *testing.T) {
+			res := ObjectsAreEqual(c.expected, c.actual)
+
+			if res != c.result {
+				t.Errorf("ObjectsAreEqual(%#v, %#v) should return %#v", c.expected, c.actual, c.result)
+			}
+
+		})
+	}
+
+	// Cases where type differ but values are equal
+	if !ObjectsAreEqualValues(uint32(10), int32(10)) {
+		t.Error("ObjectsAreEqualValues should return true")
+	}
+	if ObjectsAreEqualValues(0, nil) {
+		t.Fail()
+	}
+	if ObjectsAreEqualValues(nil, 0) {
+		t.Fail()
+	}
+
+}
+
+type Nested struct {
+	Exported    interface{}
+	notExported interface{}
+}
+
+type S struct {
+	Exported1    interface{}
+	Exported2    Nested
+	notExported1 interface{}
+	notExported2 Nested
+}
+
+type S2 struct {
+	foo interface{}
+}
+
+type S3 struct {
+	Exported1 *Nested
+	Exported2 *Nested
+}
+
+type S4 struct {
+	Exported1 []*Nested
+}
+
+type S5 struct {
+	Exported Nested
+}
+
+type S6 struct {
+	Exported   string
+	unexported string
+}
+
+func TestObjectsExportedFieldsAreEqual(t *testing.T) {
+
+	intValue := 1
+
+	cases := []struct {
+		expected interface{}
+		actual   interface{}
+		result   bool
+	}{
+		{S{1, Nested{2, 3}, 4, Nested{5, 6}}, S{1, Nested{2, 3}, 4, Nested{5, 6}}, true},
+		{S{1, Nested{2, 3}, 4, Nested{5, 6}}, S{1, Nested{2, 3}, "a", Nested{5, 6}}, true},
+		{S{1, Nested{2, 3}, 4, Nested{5, 6}}, S{1, Nested{2, 3}, 4, Nested{5, "a"}}, true},
+		{S{1, Nested{2, 3}, 4, Nested{5, 6}}, S{1, Nested{2, 3}, 4, Nested{"a", "a"}}, true},
+		{S{1, Nested{2, 3}, 4, Nested{5, 6}}, S{1, Nested{2, "a"}, 4, Nested{5, 6}}, true},
+		{S{1, Nested{2, 3}, 4, Nested{5, 6}}, S{"a", Nested{2, 3}, 4, Nested{5, 6}}, false},
+		{S{1, Nested{2, 3}, 4, Nested{5, 6}}, S{1, Nested{"a", 3}, 4, Nested{5, 6}}, false},
+		{S{1, Nested{2, 3}, 4, Nested{5, 6}}, S2{1}, false},
+		{1, S{1, Nested{2, 3}, 4, Nested{5, 6}}, false},
+
+		{S3{&Nested{1, 2}, &Nested{3, 4}}, S3{&Nested{1, 2}, &Nested{3, 4}}, true},
+		{S3{nil, &Nested{3, 4}}, S3{nil, &Nested{3, 4}}, true},
+		{S3{&Nested{1, 2}, &Nested{3, 4}}, S3{&Nested{1, 2}, &Nested{3, "b"}}, true},
+		{S3{&Nested{1, 2}, &Nested{3, 4}}, S3{&Nested{1, "a"}, &Nested{3, "b"}}, true},
+		{S3{&Nested{1, 2}, &Nested{3, 4}}, S3{&Nested{"a", 2}, &Nested{3, 4}}, false},
+		{S3{&Nested{1, 2}, &Nested{3, 4}}, S3{}, false},
+		{S3{}, S3{}, true},
+
+		{S4{[]*Nested{{1, 2}}}, S4{[]*Nested{{1, 2}}}, true},
+		{S4{[]*Nested{{1, 2}}}, S4{[]*Nested{{1, 3}}}, true},
+		{S4{[]*Nested{{1, 2}, {3, 4}}}, S4{[]*Nested{{1, "a"}, {3, "b"}}}, true},
+		{S4{[]*Nested{{1, 2}, {3, 4}}}, S4{[]*Nested{{1, "a"}, {2, "b"}}}, false},
+
+		{Nested{&intValue, 2}, Nested{&intValue, 2}, true},
+		{Nested{&Nested{1, 2}, 3}, Nested{&Nested{1, "b"}, 3}, true},
+		{Nested{&Nested{1, 2}, 3}, Nested{nil, 3}, false},
+
+		{
+			Nested{map[interface{}]*Nested{nil: nil}, 2},
+			Nested{map[interface{}]*Nested{nil: nil}, 2},
+			true,
+		},
+		{
+			Nested{map[interface{}]*Nested{"a": nil}, 2},
+			Nested{map[interface{}]*Nested{"a": nil}, 2},
+			true,
+		},
+		{
+			Nested{map[interface{}]*Nested{"a": nil}, 2},
+			Nested{map[interface{}]*Nested{"a": {1, 2}}, 2},
+			false,
+		},
+		{
+			Nested{map[interface{}]Nested{"a": {1, 2}, "b": {3, 4}}, 2},
+			Nested{map[interface{}]Nested{"a": {1, 5}, "b": {3, 7}}, 2},
+			true,
+		},
+		{
+			Nested{map[interface{}]Nested{"a": {1, 2}, "b": {3, 4}}, 2},
+			Nested{map[interface{}]Nested{"a": {2, 2}, "b": {3, 4}}, 2},
+			false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("ObjectsExportedFieldsAreEqual(%#v, %#v)", c.expected, c.actual), func(t *testing.T) {
+			res := ObjectsExportedFieldsAreEqual(c.expected, c.actual)
+
+			if res != c.result {
+				t.Errorf("ObjectsExportedFieldsAreEqual(%#v, %#v) should return %#v", c.expected, c.actual, c.result)
+			}
+
+		})
+	}
+}
+
+func TestCopyExportedFields(t *testing.T) {
+	intValue := 1
+
+	cases := []struct {
+		input    interface{}
+		expected interface{}
+	}{
+		{
+			input:    Nested{"a", "b"},
+			expected: Nested{"a", nil},
+		},
+		{
+			input:    Nested{&intValue, 2},
+			expected: Nested{&intValue, nil},
+		},
+		{
+			input:    Nested{nil, 3},
+			expected: Nested{nil, nil},
+		},
+		{
+			input:    S{1, Nested{2, 3}, 4, Nested{5, 6}},
+			expected: S{1, Nested{2, nil}, nil, Nested{}},
+		},
+		{
+			input:    S3{},
+			expected: S3{},
+		},
+		{
+			input:    S3{&Nested{1, 2}, &Nested{3, 4}},
+			expected: S3{&Nested{1, nil}, &Nested{3, nil}},
+		},
+		{
+			input:    S3{Exported1: &Nested{"a", "b"}},
+			expected: S3{Exported1: &Nested{"a", nil}},
+		},
+		{
+			input: S4{[]*Nested{
+				nil,
+				{1, 2},
+			}},
+			expected: S4{[]*Nested{
+				nil,
+				{1, nil},
+			}},
+		},
+		{
+			input: S4{[]*Nested{
+				{1, 2}},
+			},
+			expected: S4{[]*Nested{
+				{1, nil}},
+			},
+		},
+		{
+			input: S4{[]*Nested{
+				{1, 2},
+				{3, 4},
+			}},
+			expected: S4{[]*Nested{
+				{1, nil},
+				{3, nil},
+			}},
+		},
+		{
+			input:    S5{Exported: Nested{"a", "b"}},
+			expected: S5{Exported: Nested{"a", nil}},
+		},
+		{
+			input:    S6{"a", "b"},
+			expected: S6{"a", ""},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run("", func(t *testing.T) {
+			output := CopyExportedFields(c.input)
+			if !ObjectsAreEqualValues(c.expected, output) {
+				t.Errorf("%#v, %#v should be equal", c.expected, output)
+			}
+		})
+	}
+}

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/objx"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/internal/check"
 )
 
 // TestingT is an interface wrapper around *testing.T
@@ -989,7 +990,7 @@ func (args Arguments) Diff(objects []interface{}) (string, int) {
 		} else {
 			// normal checking
 
-			if assert.ObjectsAreEqual(expected, Anything) || assert.ObjectsAreEqual(actual, Anything) || assert.ObjectsAreEqual(actual, expected) {
+			if check.ObjectsAreEqual(expected, Anything) || check.ObjectsAreEqual(actual, Anything) || check.ObjectsAreEqual(actual, expected) {
 				// match
 				output = fmt.Sprintf("%s\t%d: PASS:  %s == %s\n", output, i, actualFmt, expectedFmt)
 			} else {
@@ -1174,7 +1175,7 @@ func assertOpts(expected, actual interface{}) (expectedFmt, actualFmt string) {
 	for i := 0; i < actualOpts.Len(); i++ {
 		actualNames = append(actualNames, funcName(actualOpts.Index(i).Interface()))
 	}
-	if !assert.ObjectsAreEqual(expectedNames, actualNames) {
+	if !check.ObjectsAreEqual(expectedNames, actualNames) {
 		expectedFmt = fmt.Sprintf("%v", expectedNames)
 		actualFmt = fmt.Sprintf("%v", actualNames)
 		return
@@ -1209,7 +1210,7 @@ func assertOpts(expected, actual interface{}) (expectedFmt, actualFmt string) {
 		reflect.ValueOf(actualOpt).Call(actualValues)
 
 		for i := 0; i < ot.NumIn(); i++ {
-			if !assert.ObjectsAreEqual(expectedValues[i].Interface(), actualValues[i].Interface()) {
+			if !check.ObjectsAreEqual(expectedValues[i].Interface(), actualValues[i].Interface()) {
 				expectedFmt = fmt.Sprintf("%s %+v", expectedNames[i], expectedValues[i].Interface())
 				actualFmt = fmt.Sprintf("%s %+v", expectedNames[i], actualValues[i].Interface())
 				return


### PR DESCRIPTION
## Summary
These functions should not have been exported, but we must maintain the compatibility promise until v2.

## Changes
* Depreacate all the non-assertion functions exported by assert.
* Move the above functions to a new internal package.

## Motivation
These functions look like assertions but are not, they can never cause any test to fail.

## Related issues
Closes #1180 
