### PR TITLE
mock: fix FunctionalOptions docs

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -819,11 +819,12 @@ func (f *FunctionalOptionsArgument) String() string {
 	return strings.Replace(fmt.Sprintf("%#v", f.value), "[]interface {}", name, 1)
 }
 
-// FunctionalOptions returns an FunctionalOptionsArgument object containing the functional option type
-// and the values to check of
+// FunctionalOptions returns an [FunctionalOptionsArgument] object containing
+// the expected functional-options to check for.
 //
 // For example:
-// Assert(t, FunctionalOptions("[]foo.FunctionalOption", foo.Opt1(), foo.Opt2()))
+//
+//	Assert(t, FunctionalOptions(foo.Opt1("strValue"), foo.Opt2(613)))
 func FunctionalOptions(value ...interface{}) *FunctionalOptionsArgument {
 	return &FunctionalOptionsArgument{
 		value: value,


### PR DESCRIPTION
## Summary
the comment about this function is not updated with the final implementation

## Changes
just the comment above the func

## Motivation
its misleading

## Related issues
some relevant links to the PR that added `FunctionalOptions`
https://github.com/stretchr/testify/pull/1023
[suggestion 1](https://github.com/stretchr/testify/pull/1023/files/3b93fae0ea161f8d0ca47dd7aa3d8a949799d261#r1065311500)
[suggestion 2](https://github.com/stretchr/testify/pull/1023/files/3b93fae0ea161f8d0ca47dd7aa3d8a949799d261#r1065309374)
