### PR TITLE
assert: handle array case in copyExportedFields #1404

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -109,7 +109,19 @@ func copyExportedFields(expected interface{}) interface{} {
 		result.Elem().Set(reflect.ValueOf(unexportedRemoved))
 		return result.Interface()
 
-	case reflect.Array, reflect.Slice:
+	case reflect.Array:
+		result := reflect.New(expectedType).Elem()
+		for i := 0; i < expectedValue.Len(); i++ {
+			index := expectedValue.Index(i)
+			if isNil(index.Interface()) {
+				continue
+			}
+			unexportedRemoved := copyExportedFields(index.Interface())
+			result.Index(i).Set(reflect.ValueOf(unexportedRemoved))
+		}
+		return result.Interface()
+
+	case reflect.Slice:
 		result := reflect.MakeSlice(expectedType, expectedValue.Len(), expectedValue.Len())
 		for i := 0; i < expectedValue.Len(); i++ {
 			index := expectedValue.Index(i)

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -184,6 +184,11 @@ type S6 struct {
 	unexported string
 }
 
+type S7 struct {
+	Exported   Nested
+	unexported Nested
+}
+
 func TestObjectsExportedFieldsAreEqual(t *testing.T) {
 
 	intValue := 1
@@ -401,6 +406,72 @@ func TestEqualExportedValues(t *testing.T) {
 	            	-   Exported: (int) 3,
 	            	+   Exported: (int) 2,
 	            	    notExported: (interface {}) <nil>`,
+		},
+		{
+			value1: S7{
+				Nested{[2]int{1, 2}, [2]int{1, 2}},
+				Nested{[2]int{1, 2}, [2]int{3, 4}},
+			},
+			value2: S7{
+				Nested{[3]int{1, 2, 3}, [2]int{3, 4}},
+				Nested{[2]int{5, 6}, [2]int{7, 8}},
+			},
+			expectedEqual: false,
+			expectedFail: `
+	            	Diff:
+	            	--- Expected
+	            	+++ Actual
+	            	@@ -2,5 +2,6 @@
+	            	  Exported: (assert.Nested) {
+	            	-  Exported: ([2]int) (len=2) {
+	            	+  Exported: ([3]int) (len=3) {
+	            	    (int) 1,
+	            	-   (int) 2
+	            	+   (int) 2,
+	            	+   (int) 3
+	            	   },`,
+		},
+		{
+			value1: S7{
+				Nested{[2]int{1, 2}, [2]int{1, 2}},
+				Nested{[2]int{1, 2}, [2]int{3, 4}},
+			},
+			value2: S7{
+				Nested{[2]int{1, 3}, [2]int{3, 4}},
+				Nested{[2]int{5, 6}, [2]int{7, 8}},
+			},
+			expectedEqual: false,
+			expectedFail: `
+	            	Diff:
+	            	--- Expected
+	            	+++ Actual
+	            	@@ -4,3 +4,3 @@
+	            	    (int) 1,
+	            	-   (int) 2
+	            	+   (int) 3
+	            	   },`,
+		},
+		{
+			value1: S7{
+				Nested{[2]interface{}{nil, 2}, [2]int{1, 2}},
+				Nested{[2]int{1, 2}, [2]int{3, 4}},
+			},
+			value2: S7{
+				Nested{[2]interface{}{nil, 2}, [2]int{3, 4}},
+				Nested{[2]int{5, 6}, [2]int{7, 8}},
+			},
+			expectedEqual: true,
+		},
+		{
+			value1: S7{
+				Nested{[2]int{1, 2}, [2]int{1, 2}},
+				Nested{[2]int{1, 2}, [2]int{3, 4}},
+			},
+			value2: S7{
+				Nested{[2]int{1, 2}, [2]int{3, 4}},
+				Nested{[2]int{5, 6}, [2]int{7, 8}},
+			},
+			expectedEqual: true,
 		},
 	}
 


### PR DESCRIPTION
## Summary
Implemented reflect.Array handling in the copyExportedFields to prevent panic when trying to make a slice from an array

## Changes
Creating new array and filling it with exported values following the example from reflect.Slice.

I've decide to copy paste some code from the reflect.Slice case to make the code more readable, straightforward and avoid mutating the existing case for reflect.Slice

## Motivation
Fixing a bug described in the issue #1404

## Related issues
#1404
