### PR TITLE
assert: add `NotZeroThenSetZero` and `NotNilThenSetNil`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,6 @@ jobs:
     strategy:
       matrix:
         go_version:
-          - "1.17"
           - "1.18"
           - "1.19"
           - "1.20"

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -628,28 +628,12 @@ func NotZeroThenSetZero[X any](t TestingT, x *X) bool {
 		h.Helper()
 	}
 
-	if ok := NotZero(t, *x); !ok {
+	if !NotZero(t, *x) {
 		return false
 	}
 
 	var zeroValue X
 	*x = zeroValue
-	return true
-}
-
-// NotNilThenSetNil asserts that the specified pointer is not nil and then sets it to nil.
-//
-//	assert.NotNilThenSetNil(t, &x)
-func NotNilThenSetNil[X any](t TestingT, x **X) bool {
-	if h, ok := t.(tHelper); ok {
-		h.Helper()
-	}
-
-	if ok := NotNil(t, *x); !ok {
-		return false
-	}
-
-	*x = nil
 	return true
 }
 

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -620,6 +620,39 @@ func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
 	return Fail(t, "Expected value not to be nil.", msgAndArgs...)
 }
 
+// NotNilThenSetNil asserts that the specified object is not zero and then sets it to zero.
+//
+//	assert.NotZeroThenSetZero(t, &x)
+func NotZeroThenSetZero[X any](t TestingT, x *X) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	if ok := NotZero(t, *x); !ok {
+		return false
+	}
+
+	var zeroValue X
+	*x = zeroValue
+	return true
+}
+
+// NotNilThenSetNil asserts that the specified pointer is not nil and then sets it to nil.
+//
+//	assert.NotNilThenSetNil(t, &x)
+func NotNilThenSetNil[X any](t TestingT, x **X) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	if ok := NotNil(t, *x); !ok {
+		return false
+	}
+
+	*x = nil
+	return true
+}
+
 // containsKind checks if a specified kind in the slice of kinds.
 func containsKind(kinds []reflect.Kind, kind reflect.Kind) bool {
 	for i := 0; i < len(kinds); i++ {

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -712,39 +712,37 @@ func TestNil(t *testing.T) {
 
 }
 
+func assertValuesChanged(t *testing.T, res, result, valueToBeChanged, afterValue any) {
+	if res != result {
+		t.Errorf("NotZeroThenSetZero(%#v) should return %#v", valueToBeChanged, result)
+	}
+	if valueToBeChanged != afterValue {
+		t.Errorf("Value should be changed to %#v, instead was %#v", afterValue, valueToBeChanged)
+	}
+}
+
 func TestNotZeroThenSetZero(t *testing.T) {
 
 	mockT := new(testing.T)
 
-	cases := []struct {
+	valueCases := []struct {
 		beforeValue string
 		result      bool
-		afterValue  interface{}
+		afterValue  string
 	}{
 		{"", false, ""},
 		{"hello", true, ""},
 	}
 
-	for _, c := range cases {
+	for _, c := range valueCases {
 		t.Run(fmt.Sprintf("NotZeroThenSetZero(%#v)", c.beforeValue), func(t *testing.T) {
-			valueToBeChanged := c.beforeValue
-			res := NotZeroThenSetZero(mockT, &valueToBeChanged)
-			if res != c.result {
-				t.Errorf("NotZeroThenSetZero(%#v) should return %#v", valueToBeChanged, c.result)
-			}
-			if valueToBeChanged != c.afterValue {
-				t.Errorf("Value should be changed to %#v, instead was %#v", c.afterValue, valueToBeChanged)
-			}
+			res := NotZeroThenSetZero(mockT, &c.beforeValue)
+			assertValuesChanged(t, res, c.result, c.beforeValue, c.afterValue)
 		})
 	}
-}
-
-func TestNotNilThenSetNil(t *testing.T) {
-
-	mockT := new(testing.T)
 
 	a := "hello"
-	cases := []struct {
+	pointerCases := []struct {
 		beforeValue *string
 		result      bool
 		afterValue  *string
@@ -753,16 +751,10 @@ func TestNotNilThenSetNil(t *testing.T) {
 		{&a, true, nil},
 	}
 
-	for _, c := range cases {
-		t.Run(fmt.Sprintf("NotNilThenSetNil(%#v)", c.beforeValue), func(t *testing.T) {
-			valueToBeChanged := c.beforeValue
-			res := NotNilThenSetNil(mockT, &valueToBeChanged)
-			if res != c.result {
-				t.Errorf("NotNilThenSetNil(%#v) should return %#v", valueToBeChanged, c.result)
-			}
-			if valueToBeChanged != c.afterValue {
-				t.Errorf("Value should be changed to %#v, instead was %#v", c.afterValue, valueToBeChanged)
-			}
+	for _, c := range pointerCases {
+		t.Run(fmt.Sprintf("NotZeroThenSetZero(%#v)", c.beforeValue), func(t *testing.T) {
+			res := NotZeroThenSetZero(mockT, &c.beforeValue)
+			assertValuesChanged(t, res, c.result, c.beforeValue, c.afterValue)
 		})
 	}
 }

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -712,6 +712,61 @@ func TestNil(t *testing.T) {
 
 }
 
+func TestNotZeroThenSetZero(t *testing.T) {
+
+	mockT := new(testing.T)
+
+	cases := []struct {
+		beforeValue string
+		result      bool
+		afterValue  interface{}
+	}{
+		{"", false, ""},
+		{"hello", true, ""},
+	}
+
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("NotZeroThenSetZero(%#v)", c.beforeValue), func(t *testing.T) {
+			valueToBeChanged := c.beforeValue
+			res := NotZeroThenSetZero(mockT, &valueToBeChanged)
+			if res != c.result {
+				t.Errorf("NotZeroThenSetZero(%#v) should return %#v", valueToBeChanged, c.result)
+			}
+			if valueToBeChanged != c.afterValue {
+				t.Errorf("Value should be changed to %#v, instead was %#v", c.afterValue, valueToBeChanged)
+			}
+		})
+	}
+}
+
+func TestNotNilThenSetNil(t *testing.T) {
+
+	mockT := new(testing.T)
+
+	a := "hello"
+	cases := []struct {
+		beforeValue *string
+		result      bool
+		afterValue  *string
+	}{
+		{nil, false, nil},
+		{&a, true, nil},
+	}
+
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("NotNilThenSetNil(%#v)", c.beforeValue), func(t *testing.T) {
+			valueToBeChanged := c.beforeValue
+			res := NotNilThenSetNil(mockT, &valueToBeChanged)
+			if res != c.result {
+				t.Errorf("NotNilThenSetNil(%#v) should return %#v", valueToBeChanged, c.result)
+			}
+			if valueToBeChanged != c.afterValue {
+				t.Errorf("Value should be changed to %#v, instead was %#v", c.afterValue, valueToBeChanged)
+			}
+		})
+	}
+}
+
 func TestTrue(t *testing.T) {
 
 	mockT := new(testing.T)

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/stretchr/testify
 
 // This should match the minimum supported version that is tested in
 // .github/workflows/main.yml
-go 1.17
+go 1.18
 
 require (
 	github.com/davecgh/go-spew v1.1.1


### PR DESCRIPTION
I have used similar versions in my own code for many years. It helps to do assertions of API responses, like this:

```go
clientResponse := someApiRequest(request)

assert.NotZeroThenSetZero(t, &clientResponse.CreateTime)
assert.NotZeroThenSetZero(t, &clientResponse.UpdateTime)

assert.Equal(t, expected, clientResponse)
```

Could resolve the issue brought up in https://github.com/stretchr/testify/issues/1432.