### PR TITLE
mock: refactor TestIsArgsEqual

### DIFF
--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -1616,17 +1616,14 @@ func Test_Mock_IsMethodCallable(t *testing.T) {
 
 func TestIsArgsEqual(t *testing.T) {
 	var expected = Arguments{5, 3, 4, 6, 7, 2}
-	var args = make([]interface{}, 5)
-	for i := 1; i < len(expected); i++ {
-		args[i-1] = expected[i]
-	}
+
+	// Copy elements 1 to 5
+	args := append(([]interface{})(nil), expected[1:]...)
 	args[2] = expected[1]
 	assert.False(t, isArgsEqual(expected, args))
 
-	var arr = make([]interface{}, 6)
-	for i := 0; i < len(expected); i++ {
-		arr[i] = expected[i]
-	}
+	// Clone
+	arr := append(([]interface{})(nil), expected...)
 	assert.True(t, isArgsEqual(expected, arr))
 }
 


### PR DESCRIPTION
## Summary
Refactor tests to use 'append' to build copies of slices instead of manual loops.


## Motivation
Thanks golangci-lint for reporting the style issue.