### PR TITLE
Use WaitGroup to ensure suite.Run() doesn't exit until all tests are done

### DIFF
--- a/suite/suite.go
+++ b/suite/suite.go
@@ -216,7 +216,7 @@ func Run(t *testing.T, suite TestingSuite) {
 		}()
 	}
 
-	go runTests(t, tests)
+	runTests(t, tests)
 
 	// Wait until all tests are finished before returning, so that the stats handling in the `defer` statement above
 	// will always return accurate results, even if the tests are running in parallel.

--- a/suite/suite.go
+++ b/suite/suite.go
@@ -131,7 +131,7 @@ func Run(t *testing.T, suite TestingSuite) {
 	tests := []testing.InternalTest{}
 	methodFinder := reflect.TypeOf(suite)
 	suiteName := methodFinder.Elem().Name()
-	wg := &sync.WaitGroup{}
+	wg := new(sync.WaitGroup)
 
 	for i := 0; i < methodFinder.NumMethod(); i++ {
 		method := methodFinder.Method(i)
@@ -158,14 +158,14 @@ func Run(t *testing.T, suite TestingSuite) {
 			suiteSetupDone = true
 		}
 
-		wg.Add(1)
-
 		test := testing.InternalTest{
 			Name: method.Name,
 			F: func(t *testing.T) {
+				wg.Add(1)
+				defer wg.Done()
+
 				parentT := suite.T()
 				suite.SetT(t)
-				defer wg.Done()
 				defer recoverAndFailOnPanic(t)
 				defer func() {
 					r := recover()


### PR DESCRIPTION
## Summary
Add a `WaitGroup` to `suite`'s `Run` function to better support parallel tests 

## Changes
- Added a `WaitGroup` in `suite`'s `Run` function
- Add to the `WaitGroup` for each test in the suite
- Use `defer wg.Done()` as the very last defer of each test to appropriately mark it as done
- Add a call to `wg.Wait()` before returning from `Run` to ensure that `Run`'s `defer` statement are only executed after all tests have completed 

## Motivation
When using a suite with multiple tests that are defined as parallel tests (`t.Parallel()` called), the suite's stats reporting is inaccurate because the `WithStats` method is called from a `defer` in the `Run` method, which exits before all tests have completed.

## Related issues
<!-- Put `Closes #XXXX` for each issue number this PR fixes/closes -->
