### PR TITLE
CI: add go 1.21 in GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,8 +7,8 @@ jobs:
     strategy:
       matrix:
         go_version:
-          - "1.20"
-          - "1.21"
+          - stable
+          - oldstable
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go


### PR DESCRIPTION
## Summary
Add Go 1.21 in CI.

Note: #1408 must be merged first because `stable` and `oldstable` are supported starting with `setup-go@v4`.

## Changes

## Motivation

Go 1.21 is released.

## Related issues

See also #1420 and #1408