### PR TITLE
fix(InEpsilonSlice): Include msgAndArgs in InEpsilon for improved error visibility on failed assertion

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1466,7 +1466,7 @@ func InEpsilonSlice(t TestingT, expected, actual interface{}, epsilon float64, m
 	expectedSlice := reflect.ValueOf(expected)
 
 	for i := 0; i < actualSlice.Len(); i++ {
-		result := InEpsilon(t, actualSlice.Index(i).Interface(), expectedSlice.Index(i).Interface(), epsilon)
+		result := InEpsilon(t, actualSlice.Index(i).Interface(), expectedSlice.Index(i).Interface(), epsilon, msgAndArgs...)
 		if !result {
 			return result
 		}


### PR DESCRIPTION
## Summary
<!-- High-level, one sentence summary of what this PR accomplishes -->

Added the `msgAndArgs` parameter to the `InEpsilon` function for better error reporting in case of failed assertion.


## Related issues
<!-- Put `Closes #XXXX` for each issue number this PR fixes/closes -->
Closes #1324
