### PR TITLE
ci: update go versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,14 +6,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go_version: ["1.18.1", "1.17.6", "1.16.5"]
+        go_version: ["1.20", "1.21"]
     steps:
       - uses: actions/checkout@v3
       - name: Setup Go
         uses: actions/setup-go@v3.2.0
         with:
           go-version: ${{ matrix.go_version }}
-      - run: ./.ci.gogenerate.sh    
+      - run: ./.ci.gogenerate.sh
       - run: ./.ci.gofmt.sh
       - run: ./.ci.govet.sh
       - run: go test -v -race ./...


### PR DESCRIPTION
## Summary
Update go versions to 1.20 and 1.21.

## Changes
Update go versions to 1.20 and 1.21, which are the supported versions.

## Motivation
This fixes the issue with 1.18 generating files in a different way than later versions causing the CI tests to fail.
