### PR TITLE
assert: ObjectsAreEqual: use time.Equal for time.Time types

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -59,20 +59,25 @@ func ObjectsAreEqual(expected, actual interface{}) bool {
 	if expected == nil || actual == nil {
 		return expected == actual
 	}
-
-	exp, ok := expected.([]byte)
-	if !ok {
+	switch exp := expected.(type) {
+	case []byte:
+		act, ok := actual.([]byte)
+		if !ok {
+			return false
+		}
+		if exp == nil || act == nil {
+			return exp == nil && act == nil
+		}
+		return bytes.Equal(exp, act)
+	case time.Time:
+		act, ok := actual.(time.Time)
+		if !ok {
+			return false
+		}
+		return exp.Equal(act)
+	default:
 		return reflect.DeepEqual(expected, actual)
 	}
-
-	act, ok := actual.([]byte)
-	if !ok {
-		return false
-	}
-	if exp == nil || act == nil {
-		return exp == nil && act == nil
-	}
-	return bytes.Equal(exp, act)
 }
 
 // copyExportedFields iterates downward through nested data structures and creates a copy

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -148,6 +148,12 @@ func TestObjectsAreEqual(t *testing.T) {
 		t.Fail()
 	}
 
+	tm := time.Now()
+	tz := tm.In(time.Local)
+	if !ObjectsAreEqualValues(tm, tz) {
+		t.Error("ObjectsAreEqualValues should return true for time.Time objects with different time zones")
+	}
+
 }
 
 type Nested struct {


### PR DESCRIPTION
## Summary
`reflect.DeepEqual` fails for `time.Time` instances where `time.Equal` would succeed. This is because `reflect.DeepEqual` is checking against some unexported fields, specifically `wall` and `ext`, that change when you add a time zone.  `time.Equal` accounts for this with some bitwise operations as far as I can tell.  

## Changes
Adds a type switch statement to `ObjectsAreEqual` so special cases can be checked. Default is to use `reflect.DeepEqual`

## Motivation
make `assert.Equal`  match `time.Equal` response.

## Related issues
Closes #1461 
