### PR TITLE
mock: make (mock.Call).Times(int) add expectations for each expected call

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -148,6 +148,12 @@ func (c *Call) Times(i int) *Call {
 	c.lock()
 	defer c.unlock()
 	c.Repeatability = i
+
+	// Add expected calls to the parent mock.
+	for j := 1; j < i; j++ {
+		c.Parent.ExpectedCalls = append(c.Parent.ExpectedCalls, c)
+	}
+
 	return c
 }
 

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -857,7 +857,7 @@ func Test_Mock_Return_Twice(t *testing.T) {
 		Return(1, "two", true).
 		Twice()
 
-	require.Equal(t, []*Call{c}, mockedService.ExpectedCalls)
+	require.Equal(t, []*Call{c, c}, mockedService.ExpectedCalls)
 
 	call := mockedService.ExpectedCalls[0]
 
@@ -882,7 +882,7 @@ func Test_Mock_Return_Times(t *testing.T) {
 		Return(1, "two", true).
 		Times(5)
 
-	require.Equal(t, []*Call{c}, mockedService.ExpectedCalls)
+	require.Equal(t, []*Call{c, c, c, c, c}, mockedService.ExpectedCalls)
 
 	call := mockedService.ExpectedCalls[0]
 
@@ -948,7 +948,7 @@ func Test_Mock_Return_NotBefore_Out_Of_Order(t *testing.T) {
 		Return().
 		NotBefore(b)
 
-	require.Equal(t, []*Call{b, c}, mockedService.ExpectedCalls)
+	require.Equal(t, []*Call{b, b, c}, mockedService.ExpectedCalls)
 
 	expectedPanicString := `mock: Unexpected Method Call
 -----------------------------
@@ -978,7 +978,7 @@ func Test_Mock_Return_NotBefore_Not_Enough_Times(t *testing.T) {
 		Return().
 		NotBefore(b)
 
-	require.Equal(t, []*Call{b, c}, mockedService.ExpectedCalls)
+	require.Equal(t, []*Call{b, b, c}, mockedService.ExpectedCalls)
 
 	require.NotPanics(t, func() {
 		mockedService.TheExampleMethod(1, 2, 3)


### PR DESCRIPTION
## Summary

See this [playground example that highlights the issue](https://go.dev/play/p/qFs9z0T2LLb).

The current behavior of `Times(int)` is that if the expectation of X calls being made is not met, the error message that gets written is `The code you are testing needs to make 1 more call(s).` which is very confusing, because there might be more than 1 call missing.

For example if you expect 50 calls and that only 5 are made, one would expect the message to be `The code you are testing needs to make 45 more call(s).`.

This pull request addresses that, by making the `Times(int)` method append one expectation per call, on the mock.

## Changes

* Makes the (mock.Call).Times() method append expectations for each expected call, on the call's parent.
* Updates unit tests accordingly.

## Motivation

The current mock error output is misleading.

## Related issues

Closes #1383.
