### PR TITLE
Replace io/ioutil with io and os

### DIFF
--- a/_codegen/main.go
+++ b/_codegen/main.go
@@ -16,7 +16,6 @@ import (
 	"go/token"
 	"go/types"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -101,7 +100,7 @@ func parseTemplates() (*template.Template, *template.Template, error) {
 		return nil, nil, err
 	}
 	if *tmplFile != "" {
-		f, err := ioutil.ReadFile(*tmplFile)
+		f, err := os.ReadFile(*tmplFile)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -181,7 +180,7 @@ func parsePackageSource(pkg string) (*types.Scope, *doc.Package, error) {
 	files := make(map[string]*ast.File)
 	fileList := make([]*ast.File, len(pd.GoFiles))
 	for i, fname := range pd.GoFiles {
-		src, err := ioutil.ReadFile(path.Join(pd.Dir, fname))
+		src, err := os.ReadFile(path.Join(pd.Dir, fname))
 		if err != nil {
 			return nil, nil, err
 		}

--- a/suite/suite_test.go
+++ b/suite/suite_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"flag"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -429,7 +429,7 @@ func (sc *StdoutCapture) StopCapture() (string, error) {
 	}
 	os.Stdout.Close()
 	os.Stdout = sc.oldStdout
-	bytes, err := ioutil.ReadAll(sc.readPipe)
+	bytes, err := io.ReadAll(sc.readPipe)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Summary

This PR replaces function usages from `io/ioutil` with the same functions from `io` and `os`. 

## Changes

- replace `ioutil.ReadFile` with `os.ReadFile`
- replace `ioutil.ReadAll` with `io.ReadAll`

## Motivation
[io/ioutil](https://pkg.go.dev/io/ioutil) is deprecated:

> Deprecated: As of Go 1.16, the same functionality is now provided by package [io](https://pkg.go.dev/io) or package [os](https://pkg.go.dev/os), and those implementations should be preferred in new code. See the specific function documentation for details.


## Related issues

#1305 #1386 #1407