### PR TITLE
suite: fix SetupSubTest and TearDownSubTest execution order

### DIFF
--- a/suite/suite.go
+++ b/suite/suite.go
@@ -96,19 +96,23 @@ func failOnPanic(t *testing.T, r interface{}) {
 func (suite *Suite) Run(name string, subtest func()) bool {
 	oldT := suite.T()
 
-	if setupSubTest, ok := suite.s.(SetupSubTest); ok {
-		setupSubTest.SetupSubTest()
-	}
-
-	defer func() {
-		suite.SetT(oldT)
-		if tearDownSubTest, ok := suite.s.(TearDownSubTest); ok {
-			tearDownSubTest.TearDownSubTest()
-		}
-	}()
-
 	return oldT.Run(name, func(t *testing.T) {
 		suite.SetT(t)
+
+		defer func() {
+			suite.SetT(oldT)
+		}()
+
+		if setupSubTest, ok := suite.s.(SetupSubTest); ok {
+			setupSubTest.SetupSubTest()
+		}
+
+		defer func() {
+			if tearDownSubTest, ok := suite.s.(TearDownSubTest); ok {
+				tearDownSubTest.TearDownSubTest()
+			}
+		}()
+
 		subtest()
 	})
 }

--- a/suite/suite.go
+++ b/suite/suite.go
@@ -98,8 +98,9 @@ func (suite *Suite) Run(name string, subtest func()) bool {
 
 	return oldT.Run(name, func(t *testing.T) {
 		suite.SetT(t)
-
 		defer suite.SetT(oldT)
+
+		defer recoverAndFailOnPanic(t)
 
 		if setupSubTest, ok := suite.s.(SetupSubTest); ok {
 			setupSubTest.SetupSubTest()

--- a/suite/suite.go
+++ b/suite/suite.go
@@ -99,19 +99,15 @@ func (suite *Suite) Run(name string, subtest func()) bool {
 	return oldT.Run(name, func(t *testing.T) {
 		suite.SetT(t)
 
-		defer func() {
-			suite.SetT(oldT)
-		}()
+		defer suite.SetT(oldT)
 
 		if setupSubTest, ok := suite.s.(SetupSubTest); ok {
 			setupSubTest.SetupSubTest()
 		}
 
-		defer func() {
-			if tearDownSubTest, ok := suite.s.(TearDownSubTest); ok {
-				tearDownSubTest.TearDownSubTest()
-			}
-		}()
+		if tearDownSubTest, ok := suite.s.(TearDownSubTest); ok {
+			defer tearDownSubTest.TearDownSubTest()
+		}
 
 		subtest()
 	})

--- a/suite/suite_test.go
+++ b/suite/suite_test.go
@@ -242,8 +242,8 @@ func (suite *SuiteTester) TestSubtest() {
 	for _, t := range []struct {
 		testName string
 	}{
-		{"first"},
-		{"second"},
+		{"first-subtest"},
+		{"second-subtest"},
 	} {
 		suiteT := suite.T()
 		suite.Run(t.testName, func() {
@@ -259,10 +259,14 @@ func (suite *SuiteTester) TestSubtest() {
 
 func (suite *SuiteTester) TearDownSubTest() {
 	suite.TearDownSubTestRunCount++
+	// We should get the *testing.T for the test that is to be torn down
+	suite.Contains(suite.T().Name(), "subtest")
 }
 
 func (suite *SuiteTester) SetupSubTest() {
 	suite.SetupSubTestRunCount++
+	// We should get the *testing.T for the test that is to be set up
+	suite.Contains(suite.T().Name(), "subtest")
 }
 
 type SuiteSkipTester struct {

--- a/suite/suite_test.go
+++ b/suite/suite_test.go
@@ -162,6 +162,9 @@ type SuiteTester struct {
 	SetupSubTestRunCount    int
 	TearDownSubTestRunCount int
 
+	SetupSubTestNames    []string
+	TearDownSubTestNames []string
+
 	SuiteNameBefore []string
 	TestNameBefore  []string
 
@@ -242,8 +245,8 @@ func (suite *SuiteTester) TestSubtest() {
 	for _, t := range []struct {
 		testName string
 	}{
-		{"first-subtest"},
-		{"second-subtest"},
+		{"first"},
+		{"second"},
 	} {
 		suiteT := suite.T()
 		suite.Run(t.testName, func() {
@@ -258,13 +261,13 @@ func (suite *SuiteTester) TestSubtest() {
 }
 
 func (suite *SuiteTester) TearDownSubTest() {
+	suite.TearDownSubTestNames = append(suite.TearDownSubTestNames, suite.T().Name())
 	suite.TearDownSubTestRunCount++
-	suite.Contains(suite.T().Name(), "subtest", "We should get the *testing.T for the test that is to be torn down")
 }
 
 func (suite *SuiteTester) SetupSubTest() {
+	suite.SetupSubTestNames = append(suite.SetupSubTestNames, suite.T().Name())
 	suite.SetupSubTestRunCount++
-	suite.Contains(suite.T().Name(), "subtest", "We should get the *testing.T for the test that is to be set up")
 }
 
 type SuiteSkipTester struct {
@@ -320,6 +323,12 @@ func TestRunSuite(t *testing.T) {
 	assert.Contains(t, suiteTester.TestNameBefore, "TestTwo")
 	assert.Contains(t, suiteTester.TestNameBefore, "TestSkip")
 	assert.Contains(t, suiteTester.TestNameBefore, "TestSubtest")
+
+	assert.Contains(t, suiteTester.SetupSubTestNames, "TestRunSuite/TestSubtest/first")
+	assert.Contains(t, suiteTester.SetupSubTestNames, "TestRunSuite/TestSubtest/second")
+
+	assert.Contains(t, suiteTester.TearDownSubTestNames, "TestRunSuite/TestSubtest/first")
+	assert.Contains(t, suiteTester.TearDownSubTestNames, "TestRunSuite/TestSubtest/second")
 
 	for _, suiteName := range suiteTester.SuiteNameAfter {
 		assert.Equal(t, "SuiteTester", suiteName)

--- a/suite/suite_test.go
+++ b/suite/suite_test.go
@@ -481,7 +481,7 @@ func (s *CallOrderSuite) SetupSuite() {
 
 func (s *CallOrderSuite) TearDownSuite() {
 	s.call("TearDownSuite")
-	assert.Equal(s.T(), "SetupSuite;SetupTest;Test A;TearDownTest;SetupTest;Test B;TearDownTest;TearDownSuite", strings.Join(s.callOrder, ";"))
+	assert.Equal(s.T(), "SetupSuite;SetupTest;Test A;SetupSubTest;SubTest A1;TearDownSubTest;SetupSubTest;SubTest A2;TearDownSubTest;TearDownTest;SetupTest;Test B;SetupSubTest;SubTest B1;TearDownSubTest;SetupSubTest;SubTest B2;TearDownSubTest;TearDownTest;TearDownSuite", strings.Join(s.callOrder, ";"))
 }
 func (s *CallOrderSuite) SetupTest() {
 	s.call("SetupTest")
@@ -491,12 +491,32 @@ func (s *CallOrderSuite) TearDownTest() {
 	s.call("TearDownTest")
 }
 
+func (s *CallOrderSuite) SetupSubTest() {
+	s.call("SetupSubTest")
+}
+
+func (s *CallOrderSuite) TearDownSubTest() {
+	s.call("TearDownSubTest")
+}
+
 func (s *CallOrderSuite) Test_A() {
 	s.call("Test A")
+	s.Run("SubTest A1", func() {
+		s.call("SubTest A1")
+	})
+	s.Run("SubTest A2", func() {
+		s.call("SubTest A2")
+	})
 }
 
 func (s *CallOrderSuite) Test_B() {
 	s.call("Test B")
+	s.Run("SubTest B1", func() {
+		s.call("SubTest B1")
+	})
+	s.Run("SubTest B2", func() {
+		s.call("SubTest B2")
+	})
 }
 
 type suiteWithStats struct {

--- a/suite/suite_test.go
+++ b/suite/suite_test.go
@@ -259,14 +259,12 @@ func (suite *SuiteTester) TestSubtest() {
 
 func (suite *SuiteTester) TearDownSubTest() {
 	suite.TearDownSubTestRunCount++
-	// We should get the *testing.T for the test that is to be torn down
-	suite.Contains(suite.T().Name(), "subtest")
+	suite.Contains(suite.T().Name(), "subtest", "We should get the *testing.T for the test that is to be torn down")
 }
 
 func (suite *SuiteTester) SetupSubTest() {
 	suite.SetupSubTestRunCount++
-	// We should get the *testing.T for the test that is to be set up
-	suite.Contains(suite.T().Name(), "subtest")
+	suite.Contains(suite.T().Name(), "subtest", "We should get the *testing.T for the test that is to be set up")
 }
 
 type SuiteSkipTester struct {

--- a/suite/suite_test.go
+++ b/suite/suite_test.go
@@ -648,3 +648,45 @@ func (s *FailfastSuite) Test_B_Passes() {
 	s.call("Test B Passes")
 	s.Require().True(true)
 }
+
+type subtestPanicSuite struct {
+	Suite
+	inTearDownSuite   bool
+	inTearDownTest    bool
+	inTearDownSubTest bool
+}
+
+func (s *subtestPanicSuite) TearDownSuite() {
+	s.inTearDownSuite = true
+}
+
+func (s *subtestPanicSuite) TearDownTest() {
+	s.inTearDownTest = true
+}
+
+func (s *subtestPanicSuite) TearDownSubTest() {
+	s.inTearDownSubTest = true
+}
+
+func (s *subtestPanicSuite) TestSubtestPanic() {
+	s.Run("subtest", func() {
+		panic("panic")
+	})
+}
+
+func TestSubtestPanic(t *testing.T) {
+	suite := new(subtestPanicSuite)
+	ok := testing.RunTests(
+		allTestsFilter,
+		[]testing.InternalTest{{
+			Name: "TestSubtestPanic",
+			F: func(t *testing.T) {
+				Run(t, suite)
+			},
+		}},
+	)
+	assert.False(t, ok)
+	assert.True(t, suite.inTearDownSubTest)
+	assert.True(t, suite.inTearDownTest)
+	assert.True(t, suite.inTearDownSuite)
+}


### PR DESCRIPTION
## Summary
The order of execution of SetupSubTest and TearDownSubTest methods was changed so that the testing context inside these methods is correct.

## Changes
* The SetupSubTest was moved to after the SetT that set the child testing context
* The TearDownSubTest was moved to before the deferred SetT that reset the testing context (execution wise)
* The TearDownSubTest and SetT were deferred in one block. This was fine beforehand because a panic in the TearDownSubTest would have had no influence on the "suite.SetT(oldT)". Now since a panic in the TearDownSubTest would lead to omitting the "suite.SetT(oldT)" this defer was split into two separate defers.

## Motivation
There were two problems with the order of execution in the Suite.Run() method:
* One could not access the correct testing context ("s.T()") inside the SetupSubTest and TearDownSubTest methods. If the testing context was used for e.g. assertions of mocks in the TearDownSubTest, the results would not be "attached" to the correct test in the test output.
* The behavior was different to the order of execution for "root" tests regarding the SetupTest and TearDownTest methods (see lines 167-201). This could confuse users of the library.

## Related issues
Closes #1465
