### PR TITLE
assert: early return recovering on panic in EventuallyWithT

### DIFF
--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -2786,6 +2786,26 @@ func TestEventuallyWithTTrue(t *testing.T) {
 	Len(t, mockT.errors, 0)
 }
 
+func TestEventuallyWithTFailNow(t *testing.T) {
+	mockT := new(CollectT)
+
+	state := 0
+	condition := func(collect *CollectT) {
+		defer func() {
+			state += 1
+		}()
+		if state == 2 {
+			collect.Errorf("early failed")
+			collect.FailNow()
+		}
+		True(collect, state == 2)
+	}
+
+	False(t, EventuallyWithT(mockT, condition, 100*time.Millisecond, 20*time.Millisecond))
+	Len(t, mockT.errors, 2)
+	Equal(t, "early failed", mockT.errors[0].Error())
+}
+
 func TestNeverFalse(t *testing.T) {
 	condition := func() bool {
 		return false


### PR DESCRIPTION
## Summary
<!-- High-level, one sentence summary of what this PR accomplishes -->
Catch and recover from panic on `assert.EventuallyWithT`

## Changes
*  Add `failed` channel to handle early return failures
* Trigger `failed` when recovering from panic in `condition` routine
* Add test to assert early fail on calls to `collect.FailNow`, preserving errors trace 

## Motivation
<!-- Why were the changes necessary. -->
While using `EventuallyWithT` we might want to early return on a never expected condition: in this case, we would call `require` within the `condition` and expect to early return. Currently, calling `require` from a `condition` function panics losing the requirement error trace. Catching and recovering from this `panic` allows for early failing the `EventuallyWithT` assertion and keeping the failed `require` error trace.

<!-- ## Example usage (if applicable) -->
An example of such a use case is an assertion on a network request, where we want to early failed on http error, but we want to eventually assert on the body's properties
```golang
import (
	"errors"
	"testing"
	"time"

	"github.com/stretchr/testify/assert"
	"github.com/stretchr/testify/require"
)

// change shoulMockNetworkError to true to reproduce panic in eventually
var state = 0
const shouldMockNetworkError = false

func mockHttpGet() (ok bool, err error) {
	defer func() {
		state += 1
	}()
	if state > 1 {
		return true, nil
	}
	if shouldMockNetworkError {
		return false, errors.New("network error")
	}
	return false, nil
}

func TestEventuallyHttp(t *testing.T) {
	ret := assert.EventuallyWithT(t, func(c *assert.CollectT) {
		isOK, err := mockHttpGet()
		require.NoError(c, err)
		assert.True(c, isOK)
	}, 5*time.Second, 200*time.Millisecond)
	require.True(t, ret)
}
```

Try it in [Golang Playground](https://goplay.tools/snippet/H7R8wFb98B3) 

## Related issues
<!-- Put `Closes #XXXX` for each issue number this PR fixes/closes -->
Closes #1396
Closes #1457
