### PR TITLE
assert: collect.FailNow() should not panic

### DIFF
--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -2923,16 +2923,15 @@ func TestEventuallyWithTFalse(t *testing.T) {
 func TestEventuallyWithTTrue(t *testing.T) {
 	mockT := new(errorsCapturingT)
 
-	state := 0
+	counter := 0
 	condition := func(collect *CollectT) {
-		defer func() {
-			state += 1
-		}()
-		True(collect, state == 2)
+		counter += 1
+		True(collect, counter == 2)
 	}
 
 	True(t, EventuallyWithT(mockT, condition, 100*time.Millisecond, 20*time.Millisecond))
 	Len(t, mockT.errors, 0)
+	Equal(t, 2, counter, "Condition is expected to be called 2 times")
 }
 
 func TestEventuallyWithT_ConcurrencySafe(t *testing.T) {
@@ -2968,6 +2967,17 @@ func TestEventuallyWithT_ReturnsTheLatestFinishedConditionErrors(t *testing.T) {
 	mockT := new(errorsCapturingT)
 	False(t, EventuallyWithT(mockT, condition, 100*time.Millisecond, 20*time.Millisecond))
 	Len(t, mockT.errors, 2)
+}
+
+func TestEventuallyWithTFailNow(t *testing.T) {
+	mockT := new(CollectT)
+
+	condition := func(collect *CollectT) {
+		collect.FailNow()
+	}
+
+	False(t, EventuallyWithT(mockT, condition, 100*time.Millisecond, 20*time.Millisecond))
+	Len(t, mockT.errors, 1)
 }
 
 func TestNeverFalse(t *testing.T) {

--- a/require/requirements_test.go
+++ b/require/requirements_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // AssertionTesterInterface defines an interface to be used for testing assertion methods
@@ -680,4 +682,31 @@ func TestErrorAssertionFunc(t *testing.T) {
 			tt.assertion(t, tt.err)
 		})
 	}
+}
+
+func TestEventuallyWithTFalse(t *testing.T) {
+	mockT := new(MockT)
+
+	condition := func(collect *assert.CollectT) {
+		True(collect, false)
+	}
+
+	EventuallyWithT(mockT, condition, 100*time.Millisecond, 20*time.Millisecond)
+	True(t, mockT.Failed, "Check should fail")
+}
+
+func TestEventuallyWithTTrue(t *testing.T) {
+	mockT := new(MockT)
+
+	counter := 0
+	condition := func(collect *assert.CollectT) {
+		defer func() {
+			counter += 1
+		}()
+		True(collect, counter == 1)
+	}
+
+	EventuallyWithT(mockT, condition, 100*time.Millisecond, 20*time.Millisecond)
+	False(t, mockT.Failed, "Check should pass")
+	Equal(t, 2, counter, "Condition is expected to be called 2 times")
 }


### PR DESCRIPTION
## Summary
`collect.FailNow()` should exit goroutine without a panic to be usable with `require` package.

## Changes
`collect.FailNow()` just does `runtime.Goexit()` instead of `panic()`. For example `FailNow()` from `testing` package [behaves similarly](https://cs.opensource.google/go/go/+/refs/tags/go1.21.2:src/testing/testing.go;l=973).

## Motivation

I just want `require` package to be usable with `EventuallyWithT` e.g. I want this example to pass but it panics:

```go
package main

import (
	"testing"
	"time"

	"github.com/stretchr/testify/assert"
	"github.com/stretchr/testify/require"
)

func TestRequireEventuallyWithT(t *testing.T) {
	state := 0
	require.EventuallyWithT(t, func(c *assert.CollectT) {
		defer func() { state += 1 }()
		require.True(c, state == 2)
	}, 100*time.Millisecond, 10*time.Millisecond)
}
```

See https://go.dev/play/p/Oqd95IT7qxQ

## Related issues
Fixes https://github.com/stretchr/testify/issues/1396
Fixes https://github.com/stretchr/testify/issues/1457
