### PR TITLE
assert.InEpsilonSlice: fix expected/actual order and other improvements

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1484,9 +1484,8 @@ func InEpsilonSlice(t TestingT, expected, actual interface{}, epsilon float64, m
 	}
 
 	for i := 0; i < expectedLen; i++ {
-		result := InEpsilon(t, expectedSlice.Index(i).Interface(), actualSlice.Index(i).Interface(), epsilon)
-		if !result {
-			return result
+		if !InEpsilon(t, expectedSlice.Index(i).Interface(), actualSlice.Index(i).Interface(), epsilon) {
+			return false
 		}
 	}
 

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1466,14 +1466,18 @@ func InEpsilonSlice(t TestingT, expected, actual interface{}, epsilon float64, m
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	if expected == nil || actual == nil ||
-		reflect.TypeOf(actual).Kind() != reflect.Slice ||
-		reflect.TypeOf(expected).Kind() != reflect.Slice {
+
+	if expected == nil || actual == nil {
 		return Fail(t, "Parameters must be slice", msgAndArgs...)
 	}
 
-	actualSlice := reflect.ValueOf(actual)
 	expectedSlice := reflect.ValueOf(expected)
+	actualSlice := reflect.ValueOf(actual)
+
+	if expectedSlice.Type().Kind() != reflect.Slice ||
+		actualSlice.Type().Kind() != reflect.Slice {
+		return Fail(t, "Parameters must be slice", msgAndArgs...)
+	}
 
 	for i := 0; i < actualSlice.Len(); i++ {
 		result := InEpsilon(t, actualSlice.Index(i).Interface(), expectedSlice.Index(i).Interface(), epsilon)

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1484,7 +1484,7 @@ func InEpsilonSlice(t TestingT, expected, actual interface{}, epsilon float64, m
 	}
 
 	for i := 0; i < expectedLen; i++ {
-		if !InEpsilon(t, expectedSlice.Index(i).Interface(), actualSlice.Index(i).Interface(), epsilon) {
+		if !InEpsilon(t, expectedSlice.Index(i).Interface(), actualSlice.Index(i).Interface(), epsilon, "at index %d", i) {
 			return false
 		}
 	}

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1484,7 +1484,7 @@ func InEpsilonSlice(t TestingT, expected, actual interface{}, epsilon float64, m
 	}
 
 	for i := 0; i < expectedLen; i++ {
-		result := InEpsilon(t, actualSlice.Index(i).Interface(), expectedSlice.Index(i).Interface(), epsilon)
+		result := InEpsilon(t, expectedSlice.Index(i).Interface(), actualSlice.Index(i).Interface(), epsilon)
 		if !result {
 			return result
 		}

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1479,11 +1479,12 @@ func InEpsilonSlice(t TestingT, expected, actual interface{}, epsilon float64, m
 		return Fail(t, "Parameters must be slice", msgAndArgs...)
 	}
 
-	if !IsType(t, expected, actual) || !Len(t, actual, expectedSlice.Len()) {
+	expectedLen := expectedSlice.Len()
+	if !IsType(t, expected, actual) || !Len(t, actual, expectedLen) {
 		return false
 	}
 
-	for i := 0; i < actualSlice.Len(); i++ {
+	for i := 0; i < expectedLen; i++ {
 		result := InEpsilon(t, actualSlice.Index(i).Interface(), expectedSlice.Index(i).Interface(), epsilon)
 		if !result {
 			return result

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1474,9 +1474,8 @@ func InEpsilonSlice(t TestingT, expected, actual interface{}, epsilon float64, m
 	expectedSlice := reflect.ValueOf(expected)
 	actualSlice := reflect.ValueOf(actual)
 
-	if expectedSlice.Type().Kind() != reflect.Slice ||
-		actualSlice.Type().Kind() != reflect.Slice {
-		return Fail(t, "Parameters must be slice", msgAndArgs...)
+	if expectedSlice.Type().Kind() != reflect.Slice {
+		return Fail(t, "Expected value must be slice", msgAndArgs...)
 	}
 
 	expectedLen := expectedSlice.Len()

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1479,6 +1479,10 @@ func InEpsilonSlice(t TestingT, expected, actual interface{}, epsilon float64, m
 		return Fail(t, "Parameters must be slice", msgAndArgs...)
 	}
 
+	if !IsType(t, expected, actual) || !Len(t, actual, expectedSlice.Len()) {
+		return false
+	}
+
 	for i := 0; i < actualSlice.Len(); i++ {
 		result := InEpsilon(t, actualSlice.Index(i).Interface(), expectedSlice.Index(i).Interface(), epsilon)
 		if !result {


### PR DESCRIPTION
## Summary

Fix multiple issues in `assert.InEpsilonSlice`.


## Changes

* Fix #1231
* Report the index of the error in the slice
* Stricter checks of arguments
  * enforce that slices are of the same type
  * check slices length before checking content
* Refactor for less allocations (reuse of reflect.Value)

Cc: @lazywei

## Motivation

Multiple issues in `assert.InEpsilonSlice`.

## Related issues

Closes #1231
#1454 must be adapted @VladPetriv