### PR TITLE
assert: fix httpCode and HTTPBody occur panic when http.Handler read Body

### DIFF
--- a/assert/http_assertions.go
+++ b/assert/http_assertions.go
@@ -12,7 +12,7 @@ import (
 // an error if building a new request fails.
 func httpCode(handler http.HandlerFunc, method, url string, values url.Values) (int, error) {
 	w := httptest.NewRecorder()
-	req, err := http.NewRequest(method, url, nil)
+	req, err := http.NewRequest(method, url, http.NoBody)
 	if err != nil {
 		return -1, err
 	}
@@ -116,7 +116,7 @@ func HTTPBody(handler http.HandlerFunc, method, url string, values url.Values) s
 	if len(values) > 0 {
 		url += "?" + values.Encode()
 	}
-	req, err := http.NewRequest(method, url, nil)
+	req, err := http.NewRequest(method, url, http.NoBody)
 	if err != nil {
 		return ""
 	}


### PR DESCRIPTION
http.Request.Body  should be `http.NoBoy` not `nil` when no body.

https://github.com/stretchr/testify/blob/11a6452626f0eacefe8a99889ca4b36f9340488c/assert/http_assertions.go#L15

Test:

```go
func httpReadBody(w http.ResponseWriter, r *http.Request) {
	_, _ = io.ReadAll(r.Body)  // will panic
}

assert.HTTPStatusCode(t, httpReadBody, "GET", "/", nil, 200)
```

## Summary
<!-- High-level, one sentence summary of what this PR accomplishes -->

## Changes
<!-- * Description of change 1 -->
<!-- * Description of change 2 -->
<!-- ... -->

## Motivation
<!-- Why were the changes necessary. -->

<!-- ## Example usage (if applicable) -->

## Related issues
<!-- Put `Closes #XXXX` for each issue number this PR fixes/closes -->
