### PR TITLE
assert: better formatting for Len() error

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -772,11 +772,11 @@ func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) 
 	}
 	l, ok := getLen(object)
 	if !ok {
-		return Fail(t, fmt.Sprintf("\"%s\" could not be applied builtin len()", object), msgAndArgs...)
+		return Fail(t, fmt.Sprintf("\"%v\" could not be applied builtin len()", object), msgAndArgs...)
 	}
 
 	if l != length {
-		return Fail(t, fmt.Sprintf("\"%s\" should have %d item(s), but has %d", object, length, l), msgAndArgs...)
+		return Fail(t, fmt.Sprintf("\"%v\" should have %d item(s), but has %d", object, length, l), msgAndArgs...)
 	}
 	return true
 }

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -1705,6 +1705,33 @@ func TestLen(t *testing.T) {
 	for _, c := range cases {
 		False(t, Len(mockT, c.v, c.l), "%#v have %d items", c.v, c.l)
 	}
+
+	formatCases := []struct {
+		in      interface{}
+		wantLen int
+		want    string
+	}{
+		{[]int{1, 2, 3}, 3, "[1 2 3]"},
+		{[...]int{1, 2, 3}, 3, "[1 2 3]"},
+		{"ABC", 3, "ABC"},
+		{map[int]int{1: 2, 2: 4, 3: 6}, 3, "map[1:2 2:4 3:6]"},
+
+		{[]int{}, 0, "[]"},
+		{map[int]int{}, 0, "map[]"},
+
+		{[]int(nil), 0, "[]"},
+		{map[int]int(nil), 0, "map[]"},
+		{(chan int)(nil), 0, "<nil>"},
+	}
+
+	t.Run("Len() error message formatting", func(t *testing.T) {
+		for _, tt := range formatCases {
+			msgMock := new(mockTestingT)
+			Len(msgMock, tt.in, 1234567)
+			want := fmt.Sprintf(`"%s" should have 1234567 item(s), but has %d`, tt.want, tt.wantLen)
+			Contains(t, msgMock.errorString(), want)
+		}
+	})
 }
 
 func TestWithinDuration(t *testing.T) {

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -1661,77 +1661,35 @@ func TestLen(t *testing.T) {
 	ch <- 3
 
 	cases := []struct {
-		v interface{}
-		l int
-	}{
-		{[]int{1, 2, 3}, 3},
-		{[...]int{1, 2, 3}, 3},
-		{"ABC", 3},
-		{map[int]int{1: 2, 2: 4, 3: 6}, 3},
-		{ch, 3},
-
-		{[]int{}, 0},
-		{map[int]int{}, 0},
-		{make(chan int), 0},
-
-		{[]int(nil), 0},
-		{map[int]int(nil), 0},
-		{(chan int)(nil), 0},
-	}
-
-	for _, c := range cases {
-		True(t, Len(mockT, c.v, c.l), "%#v have %d items", c.v, c.l)
-	}
-
-	cases = []struct {
-		v interface{}
-		l int
-	}{
-		{[]int{1, 2, 3}, 4},
-		{[...]int{1, 2, 3}, 2},
-		{"ABC", 2},
-		{map[int]int{1: 2, 2: 4, 3: 6}, 4},
-		{ch, 2},
-
-		{[]int{}, 1},
-		{map[int]int{}, 1},
-		{make(chan int), 1},
-
-		{[]int(nil), 1},
-		{map[int]int(nil), 1},
-		{(chan int)(nil), 1},
-	}
-
-	for _, c := range cases {
-		False(t, Len(mockT, c.v, c.l), "%#v have %d items", c.v, c.l)
-	}
-
-	formatCases := []struct {
-		in      interface{}
-		wantLen int
-		want    string
+		v      interface{}
+		l      int
+		format string
 	}{
 		{[]int{1, 2, 3}, 3, "[1 2 3]"},
 		{[...]int{1, 2, 3}, 3, "[1 2 3]"},
 		{"ABC", 3, "ABC"},
 		{map[int]int{1: 2, 2: 4, 3: 6}, 3, "map[1:2 2:4 3:6]"},
+		{ch, 3, ""},
 
 		{[]int{}, 0, "[]"},
 		{map[int]int{}, 0, "map[]"},
+		{make(chan int), 0, ""},
 
 		{[]int(nil), 0, "[]"},
 		{map[int]int(nil), 0, "map[]"},
 		{(chan int)(nil), 0, "<nil>"},
 	}
 
-	t.Run("Len() error message formatting", func(t *testing.T) {
-		for _, tt := range formatCases {
+	for _, c := range cases {
+		True(t, Len(mockT, c.v, c.l), "%#v have %d items", c.v, c.l)
+		False(t, Len(mockT, c.v, c.l+1), "%#v have %d items", c.v, c.l)
+		if c.format != "" {
 			msgMock := new(mockTestingT)
-			Len(msgMock, tt.in, 1234567)
-			want := fmt.Sprintf(`"%s" should have 1234567 item(s), but has %d`, tt.want, tt.wantLen)
+			Len(msgMock, c.v, 1234567)
+			want := fmt.Sprintf(`"%s" should have 1234567 item(s), but has %d`, c.format, c.l)
 			Contains(t, msgMock.errorString(), want)
 		}
-	})
+	}
 }
 
 func TestWithinDuration(t *testing.T) {

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -1661,33 +1661,32 @@ func TestLen(t *testing.T) {
 	ch <- 3
 
 	cases := []struct {
-		v      interface{}
-		l      int
-		format string
+		v               interface{}
+		l               int
+		expected1234567 string // message when expecting 1234567 items
 	}{
-		{[]int{1, 2, 3}, 3, "[1 2 3]"},
-		{[...]int{1, 2, 3}, 3, "[1 2 3]"},
-		{"ABC", 3, "ABC"},
-		{map[int]int{1: 2, 2: 4, 3: 6}, 3, "map[1:2 2:4 3:6]"},
+		{[]int{1, 2, 3}, 3, `"[1 2 3]" should have 1234567 item(s), but has 3`},
+		{[...]int{1, 2, 3}, 3, `"[1 2 3]" should have 1234567 item(s), but has 3`},
+		{"ABC", 3, `"ABC" should have 1234567 item(s), but has 3`},
+		{map[int]int{1: 2, 2: 4, 3: 6}, 3, `"map[1:2 2:4 3:6]" should have 1234567 item(s), but has 3`},
 		{ch, 3, ""},
 
-		{[]int{}, 0, "[]"},
-		{map[int]int{}, 0, "map[]"},
+		{[]int{}, 0, `"[]" should have 1234567 item(s), but has 0`},
+		{map[int]int{}, 0, `"map[]" should have 1234567 item(s), but has 0`},
 		{make(chan int), 0, ""},
 
-		{[]int(nil), 0, "[]"},
-		{map[int]int(nil), 0, "map[]"},
-		{(chan int)(nil), 0, "<nil>"},
+		{[]int(nil), 0, `"[]" should have 1234567 item(s), but has 0`},
+		{map[int]int(nil), 0, `"map[]" should have 1234567 item(s), but has 0`},
+		{(chan int)(nil), 0, `"<nil>" should have 1234567 item(s), but has 0`},
 	}
 
 	for _, c := range cases {
 		True(t, Len(mockT, c.v, c.l), "%#v have %d items", c.v, c.l)
 		False(t, Len(mockT, c.v, c.l+1), "%#v have %d items", c.v, c.l)
-		if c.format != "" {
+		if c.expected1234567 != "" {
 			msgMock := new(mockTestingT)
 			Len(msgMock, c.v, 1234567)
-			want := fmt.Sprintf(`"%s" should have 1234567 item(s), but has %d`, c.format, c.l)
-			Contains(t, msgMock.errorString(), want)
+			Contains(t, msgMock.errorString(), c.expected1234567)
 		}
 	}
 }


### PR DESCRIPTION
Previously, the use of %s with array objects meant you would get an error like this:

    "[%!s(int=1) %!s(int=2) %!s(int=3)]\" should have 4 item(s), but has 3

Use %v instead, which provides a much nicer error.

    "[1 2 3]" should have 4 item(s), but has 3

Fixes #1482.
