### PR TITLE
.github: use latest Go versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,8 +7,8 @@ jobs:
     strategy:
       matrix:
         go_version:
-          - "1.19"
           - "1.20"
+          - "1.21"
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go
@@ -28,6 +28,7 @@ jobs:
           - "1.18"
           - "1.19"
           - "1.20"
+          - "1.21"
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go


### PR DESCRIPTION
Also update the runners to their latest versions.
