### PR TITLE
assert: Add HTTP builder to combine request x response using builder.

### DIFF
--- a/assert/assertion_format.go
+++ b/assert/assertion_format.go
@@ -264,6 +264,18 @@ func GreaterOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, arg
 	return GreaterOrEqual(t, e1, e2, append([]interface{}{msg}, args...)...)
 }
 
+// HTTPf asserts that a specfied handler returns set of expected values given by HttpOptions.
+//
+//	assert.HTTPf(t, myHandler, "www.google.com", nil, WithCode(200), WithBody("I'm Feeling Lucky"), WithRequestHeader(http.Header{"a": []string{"b"}}, WithExpectedBody(bytes.NewBuffer("c"))), "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, options ...HttpOption) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return HTTP(t, handler, method, url, values, options...)
+}
+
 // HTTPBodyContainsf asserts that a specified handler returns a
 // body that contains a string.
 //

--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -520,6 +520,18 @@ func (a *Assertions) Greaterf(e1 interface{}, e2 interface{}, msg string, args .
 	return Greaterf(a.t, e1, e2, msg, args...)
 }
 
+// HTTP asserts that a specfied handler returns set of expected values given by HttpOptions.
+//
+//	a.HTTP(myHandler, "www.google.com", nil, WithCode(200), WithBody("I'm Feeling Lucky"), WithRequestHeader(http.Header{"a": []string{"b"}}, WithExpectedBody(bytes.NewBuffer("c"))))
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTP(handler http.HandlerFunc, method string, url string, values url.Values, options ...HttpOption) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return HTTP(a.t, handler, method, url, values, options...)
+}
+
 // HTTPBodyContains asserts that a specified handler returns a
 // body that contains a string.
 //
@@ -666,6 +678,18 @@ func (a *Assertions) HTTPSuccessf(handler http.HandlerFunc, method string, url s
 		h.Helper()
 	}
 	return HTTPSuccessf(a.t, handler, method, url, values, msg, args...)
+}
+
+// HTTPf asserts that a specfied handler returns set of expected values given by HttpOptions.
+//
+//	a.HTTPf(myHandler, "www.google.com", nil, WithCode(200), WithBody("I'm Feeling Lucky"), WithRequestHeader(http.Header{"a": []string{"b"}}, WithExpectedBody(bytes.NewBuffer("c"))), "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPf(handler http.HandlerFunc, method string, url string, values url.Values, options ...HttpOption) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return HTTPf(a.t, handler, method, url, values, options...)
 }
 
 // Implements asserts that an object is implemented by the specified interface.

--- a/assert/http_assertions.go
+++ b/assert/http_assertions.go
@@ -175,6 +175,11 @@ func HTTP(t TestingT, handler http.HandlerFunc, method, url string, values url.V
 		h.Helper()
 	}
 
+	if options == nil {
+		Fail(t, fmt.Sprintf("No options selected, no assertions can be executed"))
+		return false
+	}
+
 	b := &builder{}
 	for _, option := range options {
 		err := option(b)
@@ -194,7 +199,7 @@ func HTTP(t TestingT, handler http.HandlerFunc, method, url string, values url.V
 	req.Header = b.requestHeader
 	req.URL.RawQuery = values.Encode()
 	handler(w, req)
-	if w.Code != b.code {
+	if b.code != nil && w.Code != *b.code {
 		Fail(t, fmt.Sprintf("Expected HTTP success status code for %q but received %d", url+"?"+values.Encode(), w.Code))
 		return false
 	}

--- a/assert/http_options.go
+++ b/assert/http_options.go
@@ -8,7 +8,7 @@ import (
 )
 
 type builder struct {
-	code           int
+	code           *int
 	body           io.ReadCloser
 	expectedBody   bytes.Buffer
 	requestHeader  http.Header
@@ -24,7 +24,7 @@ func WithCode(code int) HttpOption {
 			return errors.New("Given HTTP code is outside range of possible values assignement")
 		}
 
-		b.code = code
+		b.code = &code
 		return nil
 	}
 }

--- a/assert/http_options.go
+++ b/assert/http_options.go
@@ -1,0 +1,65 @@
+package assert
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	http "net/http"
+)
+
+type builder struct {
+	code           int
+	body           io.ReadCloser
+	expectedBody   bytes.Buffer
+	requestHeader  http.Header
+	responseHeader http.Header
+	err            error
+}
+
+type HttpOption func(*builder) error
+
+func WithCode(code int) HttpOption {
+	return func(b *builder) error {
+		if code < 100 || code > 511 {
+			return errors.New("Given HTTP code is outside range of possible values assignement")
+		}
+
+		b.code = code
+		return nil
+	}
+}
+
+func WithErr(err error) HttpOption {
+	return func(b *builder) error {
+		b.err = err
+		return nil
+	}
+}
+
+func WithBody(body io.ReadCloser) HttpOption {
+	return func(b *builder) error {
+		b.body = body
+		return nil
+	}
+}
+
+func WithExpectedBody(expectedBody bytes.Buffer) HttpOption {
+	return func(b *builder) error {
+		b.expectedBody = expectedBody
+		return nil
+	}
+}
+
+func WithRequestHeader(requestHeader http.Header) HttpOption {
+	return func(b *builder) error {
+		b.requestHeader = requestHeader
+		return nil
+	}
+}
+
+func WithResponseHeader(responseHeader http.Header) HttpOption {
+	return func(b *builder) error {
+		b.responseHeader = responseHeader
+		return nil
+	}
+}

--- a/require/require.go
+++ b/require/require.go
@@ -653,6 +653,21 @@ func Greaterf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...in
 	t.FailNow()
 }
 
+// HTTP asserts that a specfied handler returns set of expected values given by HttpOptions.
+//
+//	assert.HTTP(t, myHandler, "www.google.com", nil, WithCode(200), WithBody("I'm Feeling Lucky"), WithRequestHeader(http.Header{"a": []string{"b"}}, WithExpectedBody(bytes.NewBuffer("c"))))
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTP(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, options ...assert.HttpOption) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTP(t, handler, method, url, values, options...) {
+		return
+	}
+	t.FailNow()
+}
+
 // HTTPBodyContains asserts that a specified handler returns a
 // body that contains a string.
 //
@@ -832,6 +847,21 @@ func HTTPSuccessf(t TestingT, handler http.HandlerFunc, method string, url strin
 		h.Helper()
 	}
 	if assert.HTTPSuccessf(t, handler, method, url, values, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPf asserts that a specfied handler returns set of expected values given by HttpOptions.
+//
+//	assert.HTTPf(t, myHandler, "www.google.com", nil, WithCode(200), WithBody("I'm Feeling Lucky"), WithRequestHeader(http.Header{"a": []string{"b"}}, WithExpectedBody(bytes.NewBuffer("c"))), "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, options ...assert.HttpOption) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPf(t, handler, method, url, values, options...) {
 		return
 	}
 	t.FailNow()

--- a/require/require_forward.go
+++ b/require/require_forward.go
@@ -521,6 +521,18 @@ func (a *Assertions) Greaterf(e1 interface{}, e2 interface{}, msg string, args .
 	Greaterf(a.t, e1, e2, msg, args...)
 }
 
+// HTTP asserts that a specfied handler returns set of expected values given by HttpOptions.
+//
+//	a.HTTP(myHandler, "www.google.com", nil, WithCode(200), WithBody("I'm Feeling Lucky"), WithRequestHeader(http.Header{"a": []string{"b"}}, WithExpectedBody(bytes.NewBuffer("c"))))
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTP(handler http.HandlerFunc, method string, url string, values url.Values, options ...assert.HttpOption) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTP(a.t, handler, method, url, values, options...)
+}
+
 // HTTPBodyContains asserts that a specified handler returns a
 // body that contains a string.
 //
@@ -667,6 +679,18 @@ func (a *Assertions) HTTPSuccessf(handler http.HandlerFunc, method string, url s
 		h.Helper()
 	}
 	HTTPSuccessf(a.t, handler, method, url, values, msg, args...)
+}
+
+// HTTPf asserts that a specfied handler returns set of expected values given by HttpOptions.
+//
+//	a.HTTPf(myHandler, "www.google.com", nil, WithCode(200), WithBody("I'm Feeling Lucky"), WithRequestHeader(http.Header{"a": []string{"b"}}, WithExpectedBody(bytes.NewBuffer("c"))), "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPf(handler http.HandlerFunc, method string, url string, values url.Values, options ...assert.HttpOption) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPf(a.t, handler, method, url, values, options...)
 }
 
 // Implements asserts that an object is implemented by the specified interface.


### PR DESCRIPTION
## Summary
Adds new method into assert http_assertions.go. Should be used as generic solution for testing request parameters to response possibilities using 1 method with options.
Previous solutions did not have response header check method. However implementing that it would be necessary to create single test with 3 assert conditions. 
Now it is possible to use single function to test typical HTTP response values(status, body, headers).

## Changes
Add new function `HTTP(...)` that can be customized based on user needs.
Use `go generate ./...` to update generated code.
Add new test `TestHTTPBuilder` without example usage.

## Motivation
Impossible to test HTTP response headers.

`assert.True(mockAssert.HTTP(httpHelloName, "GET", "/", url.Values{"name": []string{"World"}}, WithCode(200), WithResponseHeader(http.Header{"Content-Type": []string{"text/plain; charset=utf-8"}}), WithExpectedBody(*bytes.NewBufferString("Hello, World!"))))`

## Related issues
Closes #598
