### PR TITLE
assert: Add new assertion InEpsilonMapValues

### DIFF
--- a/assert/assertion_format.go
+++ b/assert/assertion_format.go
@@ -382,6 +382,14 @@ func InEpsilonf(t TestingT, expected interface{}, actual interface{}, epsilon fl
 	return InEpsilon(t, expected, actual, epsilon, append([]interface{}{msg}, args...)...)
 }
 
+// InEpsilonMapValuesf is the same as InEpsilon, but it compares all values between two maps. Both maps must have exactly the same keys.
+func InEpsilonMapValuesf(t TestingT, expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return InEpsilonMapValues(t, expected, actual, epsilon, append([]interface{}{msg}, args...)...)
+}
+
 // InEpsilonSlicef is the same as InEpsilon, except it compares each value from two slices.
 func InEpsilonSlicef(t TestingT, expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {

--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -748,6 +748,22 @@ func (a *Assertions) InEpsilon(expected interface{}, actual interface{}, epsilon
 	return InEpsilon(a.t, expected, actual, epsilon, msgAndArgs...)
 }
 
+// InEpsilonMapValues is the same as InEpsilon, but it compares all values between two maps. Both maps must have exactly the same keys.
+func (a *Assertions) InEpsilonMapValues(expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return InEpsilonMapValues(a.t, expected, actual, epsilon, msgAndArgs...)
+}
+
+// InEpsilonMapValuesf is the same as InEpsilon, but it compares all values between two maps. Both maps must have exactly the same keys.
+func (a *Assertions) InEpsilonMapValuesf(expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return InEpsilonMapValuesf(a.t, expected, actual, epsilon, msg, args...)
+}
+
 // InEpsilonSlice is the same as InEpsilon, except it compares each value from two slices.
 func (a *Assertions) InEpsilonSlice(expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1531,6 +1531,50 @@ func InEpsilonSlice(t TestingT, expected, actual interface{}, epsilon float64, m
 	return true
 }
 
+// InEpsilonMapValues is the same as InEpsilon, but it compares all values between two maps. Both maps must have exactly the same keys.
+func InEpsilonMapValues(t TestingT, expected, actual interface{}, epsilon float64, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if expected == nil || actual == nil ||
+		reflect.TypeOf(actual).Kind() != reflect.Map ||
+		reflect.TypeOf(expected).Kind() != reflect.Map {
+		return Fail(t, "Arguments must be maps", msgAndArgs...)
+	}
+
+	actualMap := reflect.ValueOf(actual)
+	expectedMap := reflect.ValueOf(expected)
+
+	if expectedMap.Len() != actualMap.Len() {
+		return Fail(t, "Arguments must have the same number of keys", msgAndArgs...)
+	}
+
+	for _, k := range expectedMap.MapKeys() {
+		ev := expectedMap.MapIndex(k)
+		av := actualMap.MapIndex(k)
+
+		if !ev.IsValid() {
+			return Fail(t, fmt.Sprintf("missing key %q in expected map", k), msgAndArgs...)
+		}
+
+		if !av.IsValid() {
+			return Fail(t, fmt.Sprintf("missing key %q in actual map", k), msgAndArgs...)
+		}
+
+		if !InEpsilon(
+			t,
+			ev.Interface(),
+			av.Interface(),
+			epsilon,
+			msgAndArgs...,
+		) {
+			return false
+		}
+	}
+
+	return true
+}
+
 /*
 	Errors
 */

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1537,9 +1537,11 @@ func InEpsilonMapValues(t TestingT, expected, actual interface{}, epsilon float6
 		h.Helper()
 	}
 	if expected == nil || actual == nil ||
-		reflect.TypeOf(actual).Kind() != reflect.Map ||
 		reflect.TypeOf(expected).Kind() != reflect.Map {
 		return Fail(t, "Arguments must be maps", msgAndArgs...)
+	}
+	if !IsType(t, expected, actual) {
+		return Fail(t, "Both values must be of the same type", msgAndArgs...)
 	}
 
 	actualMap := reflect.ValueOf(actual)

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -1971,7 +1971,7 @@ func TestInEpsilonMapValues(t *testing.T) {
 		title    string
 		expected interface{}
 		actual   interface{}
-		f        func(TestingT, bool, ...interface{}) bool
+		f        BoolAssertionFunc
 		epsilon  float64
 	}{
 		{
@@ -2005,7 +2005,7 @@ func TestInEpsilonMapValues(t *testing.T) {
 			f:       False,
 		},
 		{
-			title: "With different map keys",
+			title: "Within epsilon with different map keys",
 			expected: map[string]float64{
 				"foo": 2.2,
 				"baz": 2.0,
@@ -2018,7 +2018,7 @@ func TestInEpsilonMapValues(t *testing.T) {
 			f:       False,
 		},
 		{
-			title: "With different number of keys",
+			title: "Within epsilon with different number of map keys",
 			expected: map[string]float64{
 				"foo": 2.2,
 				"baz": 2.0,
@@ -2030,7 +2030,7 @@ func TestInEpsilonMapValues(t *testing.T) {
 			f:       False,
 		},
 		{
-			title: "With zero value on expected",
+			title: "Within epsilon with zero value on expected",
 			expected: map[string]float64{
 				"foo": 0,
 			},
@@ -2084,6 +2084,39 @@ func TestInEpsilonMapValues(t *testing.T) {
 				"foo": 2.1,
 			},
 			actual:  nil,
+			epsilon: 0.1,
+			f:       False,
+		},
+		{
+			title: "When expected and actual are not the same type",
+			expected: map[string]float64{
+				"foo": 2.1,
+			},
+			actual: map[string]string{
+				"foo": "2.0",
+			},
+			epsilon: 0.1,
+			f:       False,
+		},
+		{
+			title: "When expected and actual map value are string",
+			expected: map[string]string{
+				"foo": "2.1",
+			},
+			actual: map[string]string{
+				"foo": "2.0",
+			},
+			epsilon: 0.1,
+			f:       False,
+		},
+		{
+			title: "When expected and actual map value are struct",
+			expected: map[string]struct{}{
+				"foo": {},
+			},
+			actual: map[string]struct{}{
+				"foo": {},
+			},
 			epsilon: 0.1,
 			f:       False,
 		},

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -1964,6 +1964,134 @@ func TestInEpsilonSlice(t *testing.T) {
 	False(t, InEpsilonSlice(mockT, "", nil, 1), "Expected non numeral slices to fail")
 }
 
+func TestInEpsilonMapValues(t *testing.T) {
+	mockT := new(testing.T)
+
+	for _, tc := range []struct {
+		title    string
+		expected interface{}
+		actual   interface{}
+		f        func(TestingT, bool, ...interface{}) bool
+		epsilon  float64
+	}{
+		{
+			title: "Within epsilon with exactly the same keys",
+			expected: map[string]float64{
+				"foo": 2.2,
+				"bar": math.NaN(),
+				"baz": 2.0,
+			},
+			actual: map[string]float64{
+				"foo": 2.1,
+				"bar": math.NaN(),
+				"baz": 2.1,
+			},
+			epsilon: 0.06,
+			f:       True,
+		},
+		{
+			title: "Outside epsilon with exactly the same keys",
+			expected: map[string]float64{
+				"foo": 2.2,
+				"bar": math.NaN(),
+				"baz": 2.0,
+			},
+			actual: map[string]float64{
+				"foo": 2.1,
+				"bar": math.NaN(),
+				"baz": 2.1,
+			},
+			epsilon: 0.03,
+			f:       False,
+		},
+		{
+			title: "With different map keys",
+			expected: map[string]float64{
+				"foo": 2.2,
+				"baz": 2.0,
+			},
+			actual: map[string]float64{
+				"baz": 2.1,
+				"bar": 2.1,
+			},
+			epsilon: 0.06,
+			f:       False,
+		},
+		{
+			title: "With different number of keys",
+			expected: map[string]float64{
+				"foo": 2.2,
+				"baz": 2.0,
+			},
+			actual: map[string]float64{
+				"baz": 2.1,
+			},
+			epsilon: 0.06,
+			f:       False,
+		},
+		{
+			title: "With zero value on expected",
+			expected: map[string]float64{
+				"foo": 0,
+			},
+			actual: map[string]float64{
+				"foo": 0.1,
+			},
+			epsilon: 0.06,
+			f:       False,
+		},
+		{
+			title: "Within epsilon with zero value on actual",
+			expected: map[string]float64{
+				"foo": 0.1,
+			},
+			actual: map[string]float64{
+				"foo": 0,
+			},
+			epsilon: 1,
+			f:       True,
+		},
+		{
+			title:    "When expected is not a map",
+			expected: []float64{2.1},
+			actual: map[string]float64{
+				"foo": 2.0,
+			},
+			epsilon: 0.1,
+			f:       False,
+		},
+		{
+			title: "When actual is not a map",
+			expected: map[string]float64{
+				"foo": 2.1,
+			},
+			actual:  []float64{2.0},
+			epsilon: 0.1,
+			f:       False,
+		},
+		{
+			title:    "When expected is nil",
+			expected: nil,
+			actual: map[string]float64{
+				"foo": 2.0,
+			},
+			epsilon: 0.1,
+			f:       False,
+		},
+		{
+			title: "When actual is nil",
+			expected: map[string]float64{
+				"foo": 2.1,
+			},
+			actual:  nil,
+			epsilon: 0.1,
+			f:       False,
+		},
+	} {
+		tc.f(t, InEpsilonMapValues(mockT, tc.expected, tc.actual, tc.epsilon), tc.title)
+	}
+}
+
 func TestRegexp(t *testing.T) {
 	mockT := new(testing.T)
 

--- a/require/require.go
+++ b/require/require.go
@@ -944,6 +944,28 @@ func InEpsilon(t TestingT, expected interface{}, actual interface{}, epsilon flo
 	t.FailNow()
 }
 
+// InEpsilonMapValues is the same as InEpsilon, but it compares all values between two maps. Both maps must have exactly the same keys.
+func InEpsilonMapValues(t TestingT, expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InEpsilonMapValues(t, expected, actual, epsilon, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InEpsilonMapValuesf is the same as InEpsilon, but it compares all values between two maps. Both maps must have exactly the same keys.
+func InEpsilonMapValuesf(t TestingT, expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InEpsilonMapValuesf(t, expected, actual, epsilon, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
 // InEpsilonSlice is the same as InEpsilon, except it compares each value from two slices.
 func InEpsilonSlice(t TestingT, expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {

--- a/require/require_forward.go
+++ b/require/require_forward.go
@@ -749,6 +749,22 @@ func (a *Assertions) InEpsilon(expected interface{}, actual interface{}, epsilon
 	InEpsilon(a.t, expected, actual, epsilon, msgAndArgs...)
 }
 
+// InEpsilonMapValues is the same as InEpsilon, but it compares all values between two maps. Both maps must have exactly the same keys.
+func (a *Assertions) InEpsilonMapValues(expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InEpsilonMapValues(a.t, expected, actual, epsilon, msgAndArgs...)
+}
+
+// InEpsilonMapValuesf is the same as InEpsilon, but it compares all values between two maps. Both maps must have exactly the same keys.
+func (a *Assertions) InEpsilonMapValuesf(expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InEpsilonMapValuesf(a.t, expected, actual, epsilon, msg, args...)
+}
+
 // InEpsilonSlice is the same as InEpsilon, except it compares each value from two slices.
 func (a *Assertions) InEpsilonSlice(expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {


### PR DESCRIPTION
## Summary
Add new assertion `InEpsilonMapValues` which is the same as InEpsilon, but it compares all values between two maps.

## Changes
- Add new assertion `InEpsilonMapValues`

## Motivation
Quoting https://github.com/stretchr/testify/issues/1497
> To be consistent with [InDeltaMapValues](https://pkg.go.dev/github.com/stretchr/testify@master/assert#InDeltaMapValues) package could provide InEpsilonMapValues

## Example
```
expected := map[string]float64{
	"foo": 2.2,
	"baz": 2.0,
}
actual := map[string]float64{
	"foo": 2.1,
	"baz": 2.1,
}
InEpsilonMapValues(mockT, expected, actual, 0.06, "InEpsilonMapValues example")
```

## Related issues
Closes https://github.com/stretchr/testify/issues/1497
