### PR TITLE
suite: fix TestSubtestPanic failure (#1501)

### DIFF
--- a/suite/suite_test.go
+++ b/suite/suite_test.go
@@ -669,9 +669,14 @@ func (s *subtestPanicSuite) TearDownSubTest() {
 }
 
 func (s *subtestPanicSuite) TestSubtestPanic() {
-	s.Run("subtest", func() {
+	ok := s.Run("subtest", func() {
 		panic("panic")
 	})
+	// The panic must have the test reported as failed
+	if s.False(ok, "TestSubtestPanic/subtest failure is expected") {
+		// But we still want to success here, so just skip.
+		s.T().Skip("Subtest failure is expected")
+	}
 }
 
 func TestSubtestPanic(t *testing.T) {


### PR DESCRIPTION
## Summary

The [subtest of `TestSubtestPanic`](https://github.com/stretchr/testify/blob/331c520966e81450aef3b50956ea4a5db5e0ccdf/suite/suite_test.go#L673) is expected to fail, but that must not make the testuite of package 'suite' to fail. So call [`Skip`](https://pkg.go.dev/testing#T.Skip) to make `go test` to ignore that expected failure.

## Changes
<!-- * Check failure of the subtest -->
<!-- * Call [`testing.T.Skip()`](https://pkg.go.dev/testing#T.Skip) to not affect `go test` result -->

## Motivation
`suite` testsuite failure (#1501).

## Related issues
* #1501
* #1471

Cc: @linusbarth @xwjdsh