### PR TITLE
assert: improve unsafe.Pointer tests

### DIFF
--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -16,7 +16,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-	"unsafe"
 )
 
 var (
@@ -3136,12 +3135,5 @@ func TestErrorAs(t *testing.T) {
 				t.Errorf("ErrorAs(%#v,%#v) should return %t)", tt.err, target, tt.result)
 			}
 		})
-	}
-}
-
-func TestIsNil(t *testing.T) {
-	var n unsafe.Pointer = nil
-	if !isNil(n) {
-		t.Fatal("fail")
 	}
 }

--- a/assert/internal/unsafetests/doc.go
+++ b/assert/internal/unsafetests/doc.go
@@ -1,0 +1,4 @@
+// This package exists just to isolate tests that reference the [unsafe] package.
+//
+// The tests in this package are totally safe.
+package unsafetests

--- a/assert/internal/unsafetests/unsafetests_test.go
+++ b/assert/internal/unsafetests/unsafetests_test.go
@@ -1,0 +1,34 @@
+package unsafetests_test
+
+import (
+	"fmt"
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type ignoreTestingT struct{}
+
+var _ assert.TestingT = ignoreTestingT{}
+
+func (ignoreTestingT) Helper() {}
+
+func (ignoreTestingT) Errorf(format string, args ...interface{}) {
+	// Run the formatting, but ignore the result
+	msg := fmt.Sprintf(format, args...)
+	_ = msg
+}
+
+func TestUnsafePointers(t *testing.T) {
+	var ignore ignoreTestingT
+
+	assert.True(t, assert.Nil(t, unsafe.Pointer(nil), "unsafe.Pointer(nil) is nil"))
+	assert.False(t, assert.NotNil(ignore, unsafe.Pointer(nil), "unsafe.Pointer(nil) is nil"))
+
+	assert.True(t, assert.Nil(t, unsafe.Pointer((*int)(nil)), "unsafe.Pointer((*int)(nil)) is nil"))
+	assert.False(t, assert.NotNil(ignore, unsafe.Pointer((*int)(nil)), "unsafe.Pointer((*int)(nil)) is nil"))
+
+	assert.False(t, assert.Nil(ignore, unsafe.Pointer(new(int)), "unsafe.Pointer(new(int)) is NOT nil"))
+	assert.True(t, assert.NotNil(t, unsafe.Pointer(new(int)), "unsafe.Pointer(new(int)) is NOT nil"))
+}


### PR DESCRIPTION
## Summary

1. Add infrastructure to split tests that use `unsafe` from other tests.
2. Improve testing of package `assert` with `unsafe.Pointer` values.

## Changes
1. Isolate tests that use the "unsafe" package in a separate package `./assert/internal/unsafetests`. That way the assert package is not tainted with unsafe.
3. Remove one reference to the private `assert.isNil()` in assert tests.
4. Add more tests of `assert.Nil` and `assert.NotNil` with `unsafe.Pointer`.

## Motivation

`assert/assertions_test.go` is tainted with `unsafe` just because of a single test added in #1319.
