### PR TITLE
assert: Add a self-describing Matcher

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -2071,7 +2071,11 @@ func buildErrorChainString(err error) string {
 // This allows the assert framework to be extended in specialised ways while maintaining
 // clear error reporting.
 type Matcher interface {
+	// Match returns true if the given actual value meets the criteria embodied
+	// in this Matcher.
 	Match(actual interface{}) bool
+	// Describe is called when the test fails to get a descriptive error message.
+	// It should succinctly describe the condition that is being expected.
 	Describe() string
 }
 

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -2071,7 +2071,7 @@ func buildErrorChainString(err error) string {
 // This allows the assert framework to be extended in specialised ways while maintaining
 // clear error reporting.
 type Matcher interface {
-	// Match returns true if the given actual value meets the criteria embodied
+	// Match returns true if the given actual value meets the condition embodied
 	// in this Matcher.
 	Match(actual interface{}) bool
 	// Describe is called when the test fails to get a descriptive error message.
@@ -2079,7 +2079,7 @@ type Matcher interface {
 	Describe() string
 }
 
-// Matches asserts that the actual value meets the criteria specified by matcher.
+// Matches asserts that the actual value meets the condition specified by matcher.
 func Matches(t TestingT, matcher Matcher, actual interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -2066,3 +2066,24 @@ func buildErrorChainString(err error) string {
 	}
 	return chain
 }
+
+// A Matcher is an object that can assert and describe an arbitrary complex condition.
+// This allows the assert framework to be extended in specialised ways while maintaining
+// clear error reporting.
+type Matcher interface {
+	Match(actual interface{}) bool
+	Describe() string
+}
+
+// Matches asserts that the actual value meets the criteria specified by matcher.
+func Matches(t TestingT, matcher Matcher, actual interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	if matcher.Match(actual) {
+		return true
+	}
+	_, act := formatUnequalValues(nil, actual)
+	return Fail(t, fmt.Sprintf("Not matching:\nexpected: %s\nactual  : %s", matcher.Describe(), act), msgAndArgs...)
+}

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -3145,3 +3145,20 @@ func TestIsNil(t *testing.T) {
 		t.Fatal("fail")
 	}
 }
+
+func TestMatcher(t *testing.T) {
+	for _, tt := range []struct {
+		str      string
+		expected bool
+		msg      string
+	}{
+		{"foobar", true, ""},
+		{"wibble", false, "Not matching:\nexpected: a string starting with \"foo\"\nactual  : string(\"wibble\")\n"},
+	} {
+		t.Run(tt.str, func(t *testing.T) {
+			mockT := new(captureTestingT)
+			res := Matches(mockT, StringStarting("foo"), tt.str)
+			mockT.checkResultAndErrMsg(t, res, tt.expected, tt.msg)
+		})
+	}
+}

--- a/assert/example_matcher_test.go
+++ b/assert/example_matcher_test.go
@@ -2,8 +2,8 @@ package assert
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
-	"testing"
 )
 
 // stringStartsWith is a type that implements Matcher to test the actual
@@ -30,8 +30,19 @@ func StringStarting(e string) Matcher {
 	return &stringStartsWith{expected: e}
 }
 
-func ExampleMatcher() {
-	t := &testing.T{} // provided by test
+// Remove trailing whitespace from the message string, because govet
+// removes it from the example comment
+var stripTrailingSpace = regexp.MustCompile("(\\s+)\n")
 
-	Matches(t, StringStarting("hello"), "hello world")
+func ExampleMatcher() {
+	t := &captureTestingT{} // Usually this would be the *testing.T provided by the test
+
+	Matches(t, StringStarting("goodbye"), "hello world")
+
+	fmt.Println(stripTrailingSpace.ReplaceAllString(t.msg, "\n"))
+	// Output:
+	// Error Trace:
+	//	Error:      	Not matching:
+	// 	            	expected: a string starting with "goodbye"
+	// 	            	actual  : string("hello world")
 }

--- a/assert/example_matcher_test.go
+++ b/assert/example_matcher_test.go
@@ -1,0 +1,37 @@
+package assert
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// stringStartsWith is a type that implements Matcher to test the actual
+// string has the expected prefix.
+type stringStartsWith struct {
+	expected string
+}
+
+func (s *stringStartsWith) Match(actual interface{}) bool {
+	str, isStr := actual.(string)
+	return isStr && strings.HasPrefix(str, s.expected)
+}
+
+func (s *stringStartsWith) Describe() string {
+	return fmt.Sprintf("a string starting with %q", s.expected)
+}
+
+// StringStarting returns a Matcher that asserts that the actual value
+// is a string that has the expected prefix.
+//
+// Wrapping the matcher type in a factory function is just a little syntactic sugar for
+// its use in assert.Matches
+func StringStarting(e string) Matcher {
+	return &stringStartsWith{expected: e}
+}
+
+func ExampleMatcher() {
+	t := &testing.T{} // provided by test
+
+	Matches(t, StringStarting("hello"), "hello world")
+}

--- a/require/require.go
+++ b/require/require.go
@@ -2032,3 +2032,14 @@ func Zerof(t TestingT, i interface{}, msg string, args ...interface{}) {
 	}
 	t.FailNow()
 }
+
+func Matches(t TestingT, matcher assert.Matcher, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	if assert.Matches(t, matcher, actual, msgAndArgs) {
+		return
+	}
+	t.FailNow()
+}


### PR DESCRIPTION
## Summary
Add a Matcher interface and associated assert.Matches function

## Changes
Add interface, assertion functoin and an exmaple matcher implementation.

## Motivation
This allows users to extend the assertions in possibly highly domain specific ways, without having to modify the assert package, and provide a suitably descriptive failure message to help pinpoint the problem.

## Related issues

