### PR TITLE
Add function for supporting JSON equality checks using byte slices

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1717,7 +1717,7 @@ func NoDirExists(t TestingT, path string, msgAndArgs ...interface{}) bool {
 	return Fail(t, fmt.Sprintf("directory %q exists", path), msgAndArgs...)
 }
 
-// JSONEqBytes asserts that two JSON byte arrays are equivalent.
+// JSONEqBytes asserts that two JSON byte slices are equivalent.
 //
 //	assert.JSONEqBytes(t, []byte(`{"hello": "world", "foo": "bar"}`), []byte(`{"foo": "bar", "hello": "world"}`))
 func JSONEqBytes(t TestingT, expected, actual []byte, msgAndArgs ...interface{}) bool {

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1717,24 +1717,31 @@ func NoDirExists(t TestingT, path string, msgAndArgs ...interface{}) bool {
 	return Fail(t, fmt.Sprintf("directory %q exists", path), msgAndArgs...)
 }
 
-// JSONEq asserts that two JSON strings are equivalent.
+// JSONEqBytes asserts that two JSON byte arrays are equivalent.
 //
-//	assert.JSONEq(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
-func JSONEq(t TestingT, expected string, actual string, msgAndArgs ...interface{}) bool {
+//	assert.JSONEqBytes(t, []byte(`{"hello": "world", "foo": "bar"}`), []byte(`{"foo": "bar", "hello": "world"}`))
+func JSONEqBytes(t TestingT, expected, actual []byte, msgAndArgs ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
 	var expectedJSONAsInterface, actualJSONAsInterface interface{}
 
-	if err := json.Unmarshal([]byte(expected), &expectedJSONAsInterface); err != nil {
+	if err := json.Unmarshal(expected, &expectedJSONAsInterface); err != nil {
 		return Fail(t, fmt.Sprintf("Expected value ('%s') is not valid json.\nJSON parsing error: '%s'", expected, err.Error()), msgAndArgs...)
 	}
 
-	if err := json.Unmarshal([]byte(actual), &actualJSONAsInterface); err != nil {
+	if err := json.Unmarshal(actual, &actualJSONAsInterface); err != nil {
 		return Fail(t, fmt.Sprintf("Input ('%s') needs to be valid json.\nJSON parsing error: '%s'", actual, err.Error()), msgAndArgs...)
 	}
 
 	return Equal(t, expectedJSONAsInterface, actualJSONAsInterface, msgAndArgs...)
+}
+
+// JSONEq asserts that two JSON strings are equivalent.
+//
+//	assert.JSONEq(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
+func JSONEq(t TestingT, expected, actual string, msgAndArgs ...interface{}) bool {
+	return JSONEqBytes(t, []byte(expected), []byte(actual), msgAndArgs)
 }
 
 // YAMLEq asserts that two YAML strings are equivalent.

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -2210,6 +2210,57 @@ func TestJSONEq_ArraysOfDifferentOrder(t *testing.T) {
 	False(t, JSONEq(mockT, `["foo", {"hello": "world", "nested": "hash"}]`, `[{ "hello": "world", "nested": "hash"}, "foo"]`))
 }
 
+func TestJSONEqBytes_EqualSONString(t *testing.T) {
+	mockT := new(testing.T)
+	True(t, JSONEqBytes(mockT, []byte(`{"hello": "world", "foo": "bar"}`), []byte(`{"hello": "world", "foo": "bar"}`)))
+}
+
+func TestJSONEqBytes_EquivalentButNotEqual(t *testing.T) {
+	mockT := new(testing.T)
+	True(t, JSONEqBytes(mockT, []byte(`{"hello": "world", "foo": "bar"}`), []byte(`{"foo": "bar", "hello": "world"}`)))
+}
+
+func TestJSONEqBytes_HashOfArraysAndHashes(t *testing.T) {
+	mockT := new(testing.T)
+	True(t, JSONEqBytes(mockT, []byte("{\r\n\t\"numeric\": 1.5,\r\n\t\"array\": [{\"foo\": \"bar\"}, 1, \"string\", [\"nested\", \"array\", 5.5]],\r\n\t\"hash\": {\"nested\": \"hash\", \"nested_slice\": [\"this\", \"is\", \"nested\"]},\r\n\t\"string\": \"foo\"\r\n}"),
+		[]byte("{\r\n\t\"numeric\": 1.5,\r\n\t\"hash\": {\"nested\": \"hash\", \"nested_slice\": [\"this\", \"is\", \"nested\"]},\r\n\t\"string\": \"foo\",\r\n\t\"array\": [{\"foo\": \"bar\"}, 1, \"string\", [\"nested\", \"array\", 5.5]]\r\n}")))
+}
+
+func TestJSONEqBytes_Array(t *testing.T) {
+	mockT := new(testing.T)
+	True(t, JSONEqBytes(mockT, []byte(`["foo", {"hello": "world", "nested": "hash"}]`), []byte(`["foo", {"nested": "hash", "hello": "world"}]`)))
+}
+
+func TestJSONEqBytes_HashAndArrayNotEquivalent(t *testing.T) {
+	mockT := new(testing.T)
+	False(t, JSONEqBytes(mockT, []byte(`["foo", {"hello": "world", "nested": "hash"}]`), []byte(`{"foo": "bar", {"nested": "hash", "hello": "world"}}`)))
+}
+
+func TestJSONEqBytes_HashesNotEquivalent(t *testing.T) {
+	mockT := new(testing.T)
+	False(t, JSONEqBytes(mockT, []byte(`{"foo": "bar"}`), []byte(`{"foo": "bar", "hello": "world"}`)))
+}
+
+func TestJSONEqBytes_ActualIsNotJSON(t *testing.T) {
+	mockT := new(testing.T)
+	False(t, JSONEqBytes(mockT, []byte(`{"foo": "bar"}`), []byte("Not JSON")))
+}
+
+func TestJSONEqBytes_ExpectedIsNotJSON(t *testing.T) {
+	mockT := new(testing.T)
+	False(t, JSONEqBytes(mockT, []byte("Not JSON"), []byte(`{"foo": "bar", "hello": "world"}`)))
+}
+
+func TestJSONEqBytes_ExpectedAndActualNotJSON(t *testing.T) {
+	mockT := new(testing.T)
+	False(t, JSONEqBytes(mockT, []byte("Not JSON"), []byte("Not JSON")))
+}
+
+func TestJSONEqBytes_ArraysOfDifferentOrder(t *testing.T) {
+	mockT := new(testing.T)
+	False(t, JSONEqBytes(mockT, []byte(`["foo", {"hello": "world", "nested": "hash"}]`), []byte(`[{ "hello": "world", "nested": "hash"}, "foo"]`)))
+}
+
 func TestYAMLEq_EqualYAMLString(t *testing.T) {
 	mockT := new(testing.T)
 	True(t, YAMLEq(mockT, `{"hello": "world", "foo": "bar"}`, `{"hello": "world", "foo": "bar"}`))


### PR DESCRIPTION
## Summary
This PR adds a new function into the `assert` package, `JSONEqBytes`, that does the same as `JSONEq`, but by receiving `[]byte` values as parameter instead of `string` ones.

## Changes
`assert/assertions.go`:
The implementation of `JSONEqBytes` is pretty much what was in `JSONEq`, but having it receive `[]byte` values and then not needing to convert these values to `[]byte` when calling `json.Unmarshal` inside it.

Then, the implementation of `JSONEq` was changed such that it just calls `JSONEqBytes` by converting its original arguments to `[]byte` values (which it already did when calling `json.Unmarshal`)

`assert/assertions_test.go`:
Tests for `JSONEqBytes` function were replicated from the tests from `JSONEq`.

## Motivation
It is common in Go to store JSON text in `[]byte` variables instead of `string` values, so having a function that allows to receive these values when doing JSON-equality checks without having to cast them to string can be useful.

Maybe not as important, it would also avoid unnecessary `[]byte`-to-`string` conversions, which could add up when dealing with big JSON payloads.

Example of usage:
```go
package main

import (
    "fmt"
    "testing"
    "github.com/stretchr/testify/assert"
    "github.com/stretchr/testify/require"
)


func TestIntMinBasic(t *testing.T) {
    actualFile := "/path/to/file.json"
    byteValue, err := ioutil.ReadAll(jsonFile)
    require.NoError(t, err)

    expectedContentsFile := "/path/to/expected.json"
    byteValue, err = ioutil.ReadAll(jsonFile)
    require.NoError(t, err)

    assert.JSONEqBytes(t, expected, byteValue)
}
```
