### PR TITLE
README: replace Testify V2 notice with @dolmen's V2 manifesto

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 Testify - Thou Shalt Write Tests
 ================================
 
-Notice about Testify V2:
-It won't happen due to various reasons. You can read more about it on the maintainer's manifesto [here](https://github.com/stretchr/testify/issues/1089#issuecomment-1812734472).
+> [!NOTE]
+> Testify is being maintained at v1, no breaking changes will be accepted in this repo.  
+> [See discussion about v2](https://github.com/stretchr/testify/discussions/1560).
 
 [![Build Status](https://github.com/stretchr/testify/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/stretchr/testify/actions/workflows/main.yml) [![Go Report Card](https://goreportcard.com/badge/github.com/stretchr/testify)](https://goreportcard.com/report/github.com/stretchr/testify) [![PkgGoDev](https://pkg.go.dev/badge/github.com/stretchr/testify)](https://pkg.go.dev/github.com/stretchr/testify)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 Testify - Thou Shalt Write Tests
 ================================
 
-ℹ️ We are working on testify v2 and would love to hear what you'd like to see in it, have your say here: https://cutt.ly/testify
+Notice about Testify V2:
+It won't happen due to various reasons. You can read more about it on the maintainer's manifesto [here](https://github.com/stretchr/testify/issues/1089#issuecomment-1812734472).
 
 [![Build Status](https://github.com/stretchr/testify/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/stretchr/testify/actions/workflows/main.yml) [![Go Report Card](https://goreportcard.com/badge/github.com/stretchr/testify)](https://goreportcard.com/report/github.com/stretchr/testify) [![PkgGoDev](https://pkg.go.dev/badge/github.com/stretchr/testify)](https://pkg.go.dev/github.com/stretchr/testify)
 

--- a/doc.go
+++ b/doc.go
@@ -1,4 +1,3 @@
-// ** We are working on testify v2 and would love to hear what you'd like to see in it, have your say here: https://cutt.ly/testify **
 // Package testify is a set of packages that provide many tools for testifying that your code will behave as you intend.
 //
 // testify contains the following packages:


### PR DESCRIPTION
## Summary
Remove Testify V2 notice on `README.md` since it won't happen

## Changes
- Remove Testify V2 notice on `README.md`

## Motivation
According to this announcement https://github.com/stretchr/testify/issues/1089#issuecomment-1812734472 from @dolmen 

> So, as the current only active maintainer, I'm declaring that v2 will never happen. Or at least a v2 of the github.com/stretchr/testify module with such major breaking changes.

## Related issues
Issues that can be closed:
https://github.com/stretchr/testify/issues/1089
