### PR TITLE
use hexops/gotextdiff instead

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -18,7 +18,8 @@ import (
 	"unicode/utf8"
 
 	"github.com/davecgh/go-spew/spew"
-	"github.com/pmezard/go-difflib/difflib"
+	"github.com/hexops/gotextdiff"
+	"github.com/hexops/gotextdiff/myers"
 	"gopkg.in/yaml.v3"
 )
 
@@ -1791,15 +1792,8 @@ func diff(expected interface{}, actual interface{}) string {
 		a = spewConfig.Sdump(actual)
 	}
 
-	diff, _ := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
-		A:        difflib.SplitLines(e),
-		B:        difflib.SplitLines(a),
-		FromFile: "Expected",
-		FromDate: "",
-		ToFile:   "Actual",
-		ToDate:   "",
-		Context:  1,
-	})
+	edits := myers.ComputeEdits("Expected", e, a)
+	diff := fmt.Sprint(gotextdiff.ToUnified("Expected", "Actual", e, edits))
 
 	return "\n\nDiff:\n" + diff
 }

--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,11 @@ go 1.17
 
 require (
 	github.com/davecgh/go-spew v1.1.1
-	github.com/pmezard/go-difflib v1.0.0
 	github.com/stretchr/objx v0.5.1
 	gopkg.in/yaml.v3 v3.0.1
 )
+
+require github.com/hexops/gotextdiff v1.0.3
 
 // Break dependency cycle with objx.
 // See https://github.com/stretchr/objx/pull/140

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
+github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/stretchr/objx v0.5.1 h1:4VhoImhV/Bm0ToFkXFi8hXNXwpDRZ/ynw3amt82mzq0=
 github.com/stretchr/objx v0.5.1/go.mod h1:/iHQpkQwBD6DLUmQ4pE+s1TXdob1mORJ4/UFdrifcy0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -12,7 +12,8 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
-	"github.com/pmezard/go-difflib/difflib"
+	"github.com/hexops/gotextdiff"
+	"github.com/hexops/gotextdiff/myers"
 	"github.com/stretchr/objx"
 
 	"github.com/stretchr/testify/assert"
@@ -1151,15 +1152,8 @@ func diff(expected interface{}, actual interface{}) string {
 	e := spewConfig.Sdump(expected)
 	a := spewConfig.Sdump(actual)
 
-	diff, _ := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
-		A:        difflib.SplitLines(e),
-		B:        difflib.SplitLines(a),
-		FromFile: "Expected",
-		FromDate: "",
-		ToFile:   "Actual",
-		ToDate:   "",
-		Context:  1,
-	})
+	edits := myers.ComputeEdits("Expected", e, a)
+	diff := fmt.Sprint(gotextdiff.ToUnified("Expected", "Actual", e, edits))
 
 	return diff
 }


### PR DESCRIPTION
## Summary

This came up before [here](https://github.com/stretchr/testify/pull/1198). But I am taking a different approach.
Instead of using https://github.com/pmezard/go-difflib I am using https://github.com/hexops/gotextdiff. gotextdiff is a copy of a internal gopls [package](https://github.com/golang/tools/tree/master/internal/diff)


## Motivation
go-difflib is not maintained anymore. And the interface is more complex than gotextdiff

<!-- ## Example usage (if applicable) -->

## Related issues
<!-- Put `Closes #XXXX` for each issue number this PR fixes/closes -->
