### PR TITLE
Update maintainers

### DIFF
--- a/EMERITUS.md
+++ b/EMERITUS.md
@@ -1,0 +1,8 @@
+# Emeritus
+
+We would like to acknowledge previous testify maintainers and their huge contributions to our collective success:
+
+  * @matryer
+  * @glesica
+
+We thank these members for their service to this community.

--- a/EMERITUS.md
+++ b/EMERITUS.md
@@ -4,5 +4,9 @@ We would like to acknowledge previous testify maintainers and their huge contrib
 
   * @matryer
   * @glesica
+  * @ernesto-jimenez
+  * @mvdkleijn
+  * @georgelesica-wf
+  * @bencampbell-wf
 
 We thank these members for their service to this community.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -3,6 +3,8 @@
 The individuals listed below are active in the project and have the ability to approve and merge
 pull requests.
 
-  * @glesica
   * @boyan-soubachov
-
+  * @dolmen
+  * @MovieStoreGuy
+  * @arjunmahishi
+  * @brackendawson


### PR DESCRIPTION
I think I've captured the current list of active committers.

## Summary
There have been changes to maintainers, update MAINTAINTERS.md.

## Changes
* Added current and new maintainers.
* Moved maintainers who aren't active to EMERITUS.md, they still have committer access.

## Motivation
Properly reflect the people you should look to for advice/PRs/etc..

## Related issues
<!-- Put `Closes #XXXX` for each issue number this PR fixes/closes -->
