### PR TITLE
assert: clarify Eventually documentation

### DIFF
--- a/assert/assertion_format.go
+++ b/assert/assertion_format.go
@@ -158,8 +158,9 @@ func ErrorIsf(t TestingT, err error, target error, msg string, args ...interface
 	return ErrorIs(t, err, target, append([]interface{}{msg}, args...)...)
 }
 
-// Eventuallyf asserts that given condition will be met in waitFor time,
-// periodically checking target function each tick.
+// Eventuallyf asserts that given condition will be met in waitFor time. The target function
+// is checked each tick, unless its execution takes longer than one tick.
+// If so, it will be called again on the next multiple of tick after it returns.
 //
 //	assert.Eventuallyf(t, func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
 func Eventuallyf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) bool {

--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -308,8 +308,9 @@ func (a *Assertions) Errorf(err error, msg string, args ...interface{}) bool {
 	return Errorf(a.t, err, msg, args...)
 }
 
-// Eventually asserts that given condition will be met in waitFor time,
-// periodically checking target function each tick.
+// Eventually asserts that given condition will be met in waitFor time. The target function
+// is checked each tick, unless its execution takes longer than one tick.
+// If so, it will be called again on the next multiple of tick after it returns.
 //
 //	a.Eventually(func() bool { return true; }, time.Second, 10*time.Millisecond)
 func (a *Assertions) Eventually(condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) bool {
@@ -369,8 +370,9 @@ func (a *Assertions) EventuallyWithTf(condition func(collect *CollectT), waitFor
 	return EventuallyWithTf(a.t, condition, waitFor, tick, msg, args...)
 }
 
-// Eventuallyf asserts that given condition will be met in waitFor time,
-// periodically checking target function each tick.
+// Eventuallyf asserts that given condition will be met in waitFor time. The target function
+// is checked each tick, unless its execution takes longer than one tick.
+// If so, it will be called again on the next multiple of tick after it returns.
 //
 //	a.Eventuallyf(func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
 func (a *Assertions) Eventuallyf(condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) bool {

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1855,8 +1855,9 @@ type tHelper interface {
 	Helper()
 }
 
-// Eventually asserts that given condition will be met in waitFor time,
-// periodically checking target function each tick.
+// Eventually asserts that given condition will be met in waitFor time. The target function
+// is checked each tick, unless its execution takes longer than one tick.
+// If so, it will be called again on the next multiple of tick after it returns.
 //
 //	assert.Eventually(t, func() bool { return true; }, time.Second, 10*time.Millisecond)
 func Eventually(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) bool {

--- a/require/require.go
+++ b/require/require.go
@@ -387,8 +387,9 @@ func Errorf(t TestingT, err error, msg string, args ...interface{}) {
 	t.FailNow()
 }
 
-// Eventually asserts that given condition will be met in waitFor time,
-// periodically checking target function each tick.
+// Eventually asserts that given condition will be met in waitFor time. The target function
+// is checked each tick, unless its execution takes longer than one tick.
+// If so, it will be called again on the next multiple of tick after it returns.
 //
 //	assert.Eventually(t, func() bool { return true; }, time.Second, 10*time.Millisecond)
 func Eventually(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
@@ -457,8 +458,9 @@ func EventuallyWithTf(t TestingT, condition func(collect *assert.CollectT), wait
 	t.FailNow()
 }
 
-// Eventuallyf asserts that given condition will be met in waitFor time,
-// periodically checking target function each tick.
+// Eventuallyf asserts that given condition will be met in waitFor time. The target function
+// is checked each tick, unless its execution takes longer than one tick.
+// If so, it will be called again on the next multiple of tick after it returns.
 //
 //	assert.Eventuallyf(t, func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
 func Eventuallyf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {

--- a/require/require_forward.go
+++ b/require/require_forward.go
@@ -309,8 +309,9 @@ func (a *Assertions) Errorf(err error, msg string, args ...interface{}) {
 	Errorf(a.t, err, msg, args...)
 }
 
-// Eventually asserts that given condition will be met in waitFor time,
-// periodically checking target function each tick.
+// Eventually asserts that given condition will be met in waitFor time. The target function
+// is checked each tick, unless its execution takes longer than one tick.
+// If so, it will be called again on the next multiple of tick after it returns.
 //
 //	a.Eventually(func() bool { return true; }, time.Second, 10*time.Millisecond)
 func (a *Assertions) Eventually(condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
@@ -370,8 +371,9 @@ func (a *Assertions) EventuallyWithTf(condition func(collect *assert.CollectT), 
 	EventuallyWithTf(a.t, condition, waitFor, tick, msg, args...)
 }
 
-// Eventuallyf asserts that given condition will be met in waitFor time,
-// periodically checking target function each tick.
+// Eventuallyf asserts that given condition will be met in waitFor time. The target function
+// is checked each tick, unless its execution takes longer than one tick.
+// If so, it will be called again on the next multiple of tick after it returns.
 //
 //	a.Eventuallyf(func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
 func (a *Assertions) Eventuallyf(condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {


### PR DESCRIPTION
## Summary
The documentation of the `Eventually` function is a bit ambiguous, not specifying what happens when the execution of the condition function takes longer than one tick.

## Changes
Clarify the `Eventually` function description by describing the behavior of the condition function execution in the above scenario.

## Related issues
Closes #1443 
