### PR TITLE
Revert "assert: ObjectsAreEqual: use time.Equal for time.Time type"

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -59,25 +59,20 @@ func ObjectsAreEqual(expected, actual interface{}) bool {
 	if expected == nil || actual == nil {
 		return expected == actual
 	}
-	switch exp := expected.(type) {
-	case []byte:
-		act, ok := actual.([]byte)
-		if !ok {
-			return false
-		}
-		if exp == nil || act == nil {
-			return exp == nil && act == nil
-		}
-		return bytes.Equal(exp, act)
-	case time.Time:
-		act, ok := actual.(time.Time)
-		if !ok {
-			return false
-		}
-		return exp.Equal(act)
-	default:
+
+	exp, ok := expected.([]byte)
+	if !ok {
 		return reflect.DeepEqual(expected, actual)
 	}
+
+	act, ok := actual.([]byte)
+	if !ok {
+		return false
+	}
+	if exp == nil || act == nil {
+		return exp == nil && act == nil
+	}
+	return bytes.Equal(exp, act)
 }
 
 // copyExportedFields iterates downward through nested data structures and creates a copy

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -148,8 +148,8 @@ func TestObjectsAreEqualValues(t *testing.T) {
 		{uint32(10), int32(10), true},
 		{0, nil, false},
 		{nil, 0, false},
-		{now, now.In(time.Local), true}, // should be time zone independent
-		{int(270), int8(14), false},     // should handle overflow/underflow
+		{now, now.In(time.Local), false}, // should not be time zone independent
+		{int(270), int8(14), false},      // should handle overflow/underflow
 		{int8(14), int(270), false},
 		{[]int{270, 270}, []int8{14, 14}, false},
 		{complex128(1e+100 + 1e+100i), complex64(complex(math.Inf(0), math.Inf(0))), false},


### PR DESCRIPTION
## Summary
This reverts commit 34763e0df3d560ca247996a0e9291fa919a3abc6.

time.Time.Equal only tests that the two instances refer to the same instant, but time.Time also carries zone information, so this caused two non-equal instances to be considered equal.

## Changes
Revert the change which cases assert.Equal to consider time.Time objects with different zones equal.

## Motivation
* We can't assume the user doesn't care avout the zone information, we should support testing for state first.
* This would be a breaking change.
* WithinDuration already covered the desired case.

## Related issues
Fixes #1536 
