### PR TITLE
Update the build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Testify - Thou Shalt Write Tests
 
 ℹ️ We are working on testify v2 and would love to hear what you'd like to see in it, have your say here: https://cutt.ly/testify
 
-[![Build Status](https://travis-ci.org/stretchr/testify.svg)](https://travis-ci.org/stretchr/testify) [![Go Report Card](https://goreportcard.com/badge/github.com/stretchr/testify)](https://goreportcard.com/report/github.com/stretchr/testify) [![PkgGoDev](https://pkg.go.dev/badge/github.com/stretchr/testify)](https://pkg.go.dev/github.com/stretchr/testify)
+[![Build Status](https://github.com/stretchr/testify/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/stretchr/testify/actions/workflows/main.yml) [![Go Report Card](https://goreportcard.com/badge/github.com/stretchr/testify)](https://goreportcard.com/report/github.com/stretchr/testify) [![PkgGoDev](https://pkg.go.dev/badge/github.com/stretchr/testify)](https://pkg.go.dev/github.com/stretchr/testify)
 
 Go code (golang) set of packages that provide many tools for testifying that your code will behave as you intend.
 


### PR DESCRIPTION
## Summary
Our build status badge is pointing to a defunct Travis, make it point at the Github workflow.

## Changes
* Change our build status badge on README.md to point at our actual tests.

## Motivation
I want the badge to be green.

## Related issues
<!-- Put `Closes #XXXX` for each issue number this PR fixes/closes -->
