### PR TITLE
Update Github workflows setup-go to V5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v4.1.0
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go_version }}
       - run: ./.ci.gogenerate.sh
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v4.1.0
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go_version }}
       - run: go test -v -race ./...


### PR DESCRIPTION
## Summary
Update the github workflows `setup-go` to V5

## Changes
Update the github workflows `setup-go` to V5

## Motivation
Deprecation warning https://github.com/stretchr/testify/actions/runs/7971877138

Why V5? The upgrade including node16 to node20 is in V5
https://github.com/actions/setup-go/releases/tag/v5.0.0

## Result
No warning https://github.com/stretchr/testify/actions/runs/7991605261

![image](https://github.com/stretchr/testify/assets/19802534/0af1d448-cc4c-42bd-9feb-b89cab829f6b)

## Related issues
Closes #1541 