### PR TITLE
Adapt EqualExportedValues to accept ptr types on top of struct types

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -596,12 +596,12 @@ func EqualExportedValues(t TestingT, expected, actual interface{}, msgAndArgs ..
 		return Fail(t, fmt.Sprintf("Types expected to match exactly\n\t%v != %v", aType, bType), msgAndArgs...)
 	}
 
-	if aType.Kind() != reflect.Struct {
-		return Fail(t, fmt.Sprintf("Types expected to both be struct \n\t%v != %v", aType.Kind(), reflect.Struct), msgAndArgs...)
+	if aType.Kind() != reflect.Struct && aType.Kind() != reflect.Ptr {
+		return Fail(t, fmt.Sprintf("Types expected to both be struct or ptr \n\t%v != %v", aType.Kind(), reflect.Struct), msgAndArgs...)
 	}
 
-	if bType.Kind() != reflect.Struct {
-		return Fail(t, fmt.Sprintf("Types expected to both be struct \n\t%v != %v", bType.Kind(), reflect.Struct), msgAndArgs...)
+	if bType.Kind() != reflect.Struct && bType.Kind() != reflect.Ptr {
+		return Fail(t, fmt.Sprintf("Types expected to both be struct or ptr \n\t%v != %v", bType.Kind(), reflect.Struct), msgAndArgs...)
 	}
 
 	expected = copyExportedFields(expected)

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -430,6 +430,36 @@ func TestEqualExportedValues(t *testing.T) {
 			value2:        S{[2]int{1, 2}, Nested{2, nil}, nil, Nested{}},
 			expectedEqual: true,
 		},
+		{
+			value1:        &S{Exported1: 1, Exported2: Nested{Exported: 2, notExported: 3}, notExported1: 4, notExported2: Nested{5, 6}},
+			value2:        &S{Exported1: 1, Exported2: Nested{Exported: 2, notExported: nil}, notExported1: nil, notExported2: Nested{}},
+			expectedEqual: true,
+		},
+		{
+			value1:        (*S)(nil),
+			value2:        (*S)(nil),
+			expectedEqual: true,
+		},
+		{
+			value1: &S4{[]*Nested{
+				{1, 2},
+				{3, 4},
+			}},
+			value2: &S4{[]*Nested{
+				{1, "a"},
+				{2, "b"},
+			}},
+			expectedEqual: false,
+			expectedFail: `
+	            	Diff:
+	            	--- Expected
+	            	+++ Actual
+	            	@@ -7,3 +7,3 @@
+	            	   (*assert.Nested)({
+	            	-   Exported: (int) 3,
+	            	+   Exported: (int) 2,
+	            	    notExported: (interface {}) <nil>`,
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
Disclaimer: This is my first pull request on an open-source project.

## Summary

This PR adapts the `EqualExportedValues` method to also handle pointer types, on top of struct types.

## Changes

The function `copyExportedFields` already handles pointer types correctly. Therefore it is only necessary to make the validation include pointer types.
The added tests pass, which validates this hypothesis.

## Motivation

It is useful for proto message equality. Using `Equal` often fails because unexported values of proto messages are different.

## Related issues

Closes #758 
