### PR TITLE
http_assertions: honour the msgAndArgs provided with each assertion

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1463,7 +1463,7 @@ func InEpsilon(t TestingT, expected, actual interface{}, epsilon float64, msgAnd
 		h.Helper()
 	}
 	if math.IsNaN(epsilon) {
-		return Fail(t, "epsilon must not be NaN")
+		return Fail(t, "epsilon must not be NaN", msgAndArgs...)
 	}
 	actualEpsilon, err := calcRelativeError(expected, actual)
 	if err != nil {

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -2514,6 +2514,10 @@ func (m *mockTestingT) Errorf(format string, args ...interface{}) {
 	m.args = args
 }
 
+func (m *mockTestingT) Failed() bool {
+	return m.errorFmt != ""
+}
+
 func TestFailNowWithPlainTestingT(t *testing.T) {
 	mockT := &mockTestingT{}
 

--- a/assert/http_assertions.go
+++ b/assert/http_assertions.go
@@ -32,12 +32,12 @@ func HTTPSuccess(t TestingT, handler http.HandlerFunc, method, url string, value
 	}
 	code, err := httpCode(handler, method, url, values)
 	if err != nil {
-		Fail(t, fmt.Sprintf("Failed to build test request, got error: %s", err))
+		Fail(t, fmt.Sprintf("Failed to build test request, got error: %s", err), msgAndArgs...)
 	}
 
 	isSuccessCode := code >= http.StatusOK && code <= http.StatusPartialContent
 	if !isSuccessCode {
-		Fail(t, fmt.Sprintf("Expected HTTP success status code for %q but received %d", url+"?"+values.Encode(), code))
+		Fail(t, fmt.Sprintf("Expected HTTP success status code for %q but received %d", url+"?"+values.Encode(), code), msgAndArgs...)
 	}
 
 	return isSuccessCode
@@ -54,12 +54,12 @@ func HTTPRedirect(t TestingT, handler http.HandlerFunc, method, url string, valu
 	}
 	code, err := httpCode(handler, method, url, values)
 	if err != nil {
-		Fail(t, fmt.Sprintf("Failed to build test request, got error: %s", err))
+		Fail(t, fmt.Sprintf("Failed to build test request, got error: %s", err), msgAndArgs...)
 	}
 
 	isRedirectCode := code >= http.StatusMultipleChoices && code <= http.StatusTemporaryRedirect
 	if !isRedirectCode {
-		Fail(t, fmt.Sprintf("Expected HTTP redirect status code for %q but received %d", url+"?"+values.Encode(), code))
+		Fail(t, fmt.Sprintf("Expected HTTP redirect status code for %q but received %d", url+"?"+values.Encode(), code), msgAndArgs...)
 	}
 
 	return isRedirectCode
@@ -76,12 +76,12 @@ func HTTPError(t TestingT, handler http.HandlerFunc, method, url string, values 
 	}
 	code, err := httpCode(handler, method, url, values)
 	if err != nil {
-		Fail(t, fmt.Sprintf("Failed to build test request, got error: %s", err))
+		Fail(t, fmt.Sprintf("Failed to build test request, got error: %s", err), msgAndArgs...)
 	}
 
 	isErrorCode := code >= http.StatusBadRequest
 	if !isErrorCode {
-		Fail(t, fmt.Sprintf("Expected HTTP error status code for %q but received %d", url+"?"+values.Encode(), code))
+		Fail(t, fmt.Sprintf("Expected HTTP error status code for %q but received %d", url+"?"+values.Encode(), code), msgAndArgs...)
 	}
 
 	return isErrorCode
@@ -98,12 +98,12 @@ func HTTPStatusCode(t TestingT, handler http.HandlerFunc, method, url string, va
 	}
 	code, err := httpCode(handler, method, url, values)
 	if err != nil {
-		Fail(t, fmt.Sprintf("Failed to build test request, got error: %s", err))
+		Fail(t, fmt.Sprintf("Failed to build test request, got error: %s", err), msgAndArgs...)
 	}
 
 	successful := code == statuscode
 	if !successful {
-		Fail(t, fmt.Sprintf("Expected HTTP status code %d for %q but received %d", statuscode, url+"?"+values.Encode(), code))
+		Fail(t, fmt.Sprintf("Expected HTTP status code %d for %q but received %d", statuscode, url+"?"+values.Encode(), code), msgAndArgs...)
 	}
 
 	return successful
@@ -138,7 +138,7 @@ func HTTPBodyContains(t TestingT, handler http.HandlerFunc, method, url string, 
 
 	contains := strings.Contains(body, fmt.Sprint(str))
 	if !contains {
-		Fail(t, fmt.Sprintf("Expected response body for \"%s\" to contain \"%s\" but found \"%s\"", url+"?"+values.Encode(), str, body))
+		Fail(t, fmt.Sprintf("Expected response body for \"%s\" to contain \"%s\" but found \"%s\"", url+"?"+values.Encode(), str, body), msgAndArgs...)
 	}
 
 	return contains
@@ -158,7 +158,7 @@ func HTTPBodyNotContains(t TestingT, handler http.HandlerFunc, method, url strin
 
 	contains := strings.Contains(body, fmt.Sprint(str))
 	if contains {
-		Fail(t, fmt.Sprintf("Expected response body for \"%s\" to NOT contain \"%s\" but found \"%s\"", url+"?"+values.Encode(), str, body))
+		Fail(t, fmt.Sprintf("Expected response body for \"%s\" to NOT contain \"%s\" but found \"%s\"", url+"?"+values.Encode(), str, body), msgAndArgs...)
 	}
 
 	return !contains

--- a/assert/http_assertions_test.go
+++ b/assert/http_assertions_test.go
@@ -42,7 +42,10 @@ func TestHTTPSuccess(t *testing.T) {
 	assert.True(mockT2.Failed())
 
 	mockT3 := new(testing.T)
-	assert.Equal(HTTPSuccess(mockT3, httpError, "GET", "/", nil), false)
+	assert.Equal(HTTPSuccess(
+		mockT3, httpError, "GET", "/", nil,
+		"was not expecting a failure here",
+	), false)
 	assert.True(mockT3.Failed())
 
 	mockT4 := new(testing.T)
@@ -58,7 +61,10 @@ func TestHTTPRedirect(t *testing.T) {
 	assert := New(t)
 
 	mockT1 := new(testing.T)
-	assert.Equal(HTTPRedirect(mockT1, httpOK, "GET", "/", nil), false)
+	assert.Equal(HTTPRedirect(
+		mockT1, httpOK, "GET", "/", nil,
+		"was expecting a 3xx status code. Got 200.",
+	), false)
 	assert.True(mockT1.Failed())
 
 	mockT2 := new(testing.T)
@@ -82,7 +88,10 @@ func TestHTTPError(t *testing.T) {
 	assert.True(mockT1.Failed())
 
 	mockT2 := new(testing.T)
-	assert.Equal(HTTPError(mockT2, httpRedirect, "GET", "/", nil), false)
+	assert.Equal(HTTPError(
+		mockT2, httpRedirect, "GET", "/", nil,
+		"Expected this request to error out. But it didn't",
+	), false)
 	assert.True(mockT2.Failed())
 
 	mockT3 := new(testing.T)
@@ -106,7 +115,10 @@ func TestHTTPStatusCode(t *testing.T) {
 	assert.True(mockT2.Failed())
 
 	mockT3 := new(testing.T)
-	assert.Equal(HTTPStatusCode(mockT3, httpError, "GET", "/", nil, http.StatusSwitchingProtocols), false)
+	assert.Equal(HTTPStatusCode(
+		mockT3, httpError, "GET", "/", nil, http.StatusSwitchingProtocols,
+		"Expected the status code to be %d", http.StatusSwitchingProtocols,
+	), false)
 	assert.True(mockT3.Failed())
 
 	mockT4 := new(testing.T)
@@ -174,7 +186,10 @@ func TestHttpBody(t *testing.T) {
 	assert.False(HTTPBodyContains(mockT, httpHelloName, "GET", "/", url.Values{"name": []string{"World"}}, "world"))
 
 	assert.False(HTTPBodyNotContains(mockT, httpHelloName, "GET", "/", url.Values{"name": []string{"World"}}, "Hello, World!"))
-	assert.False(HTTPBodyNotContains(mockT, httpHelloName, "GET", "/", url.Values{"name": []string{"World"}}, "World"))
+	assert.False(HTTPBodyNotContains(
+		mockT, httpHelloName, "GET", "/", url.Values{"name": []string{"World"}}, "World",
+		"Expected the request body to not contain 'World'. But it did.",
+	))
 	assert.True(HTTPBodyNotContains(mockT, httpHelloName, "GET", "/", url.Values{"name": []string{"World"}}, "world"))
 
 	assert.True(HTTPBodyContains(mockT, httpReadBody, "GET", "/", nil, "hello"))

--- a/assert/http_assertions_test.go
+++ b/assert/http_assertions_test.go
@@ -41,12 +41,13 @@ func TestHTTPSuccess(t *testing.T) {
 	assert.Equal(HTTPSuccess(mockT2, httpRedirect, "GET", "/", nil), false)
 	assert.True(mockT2.Failed())
 
-	mockT3 := new(testing.T)
+	mockT3 := new(mockTestingT)
 	assert.Equal(HTTPSuccess(
 		mockT3, httpError, "GET", "/", nil,
 		"was not expecting a failure here",
 	), false)
 	assert.True(mockT3.Failed())
+	assert.Contains(mockT3.errorString(), "was not expecting a failure here")
 
 	mockT4 := new(testing.T)
 	assert.Equal(HTTPSuccess(mockT4, httpStatusCode, "GET", "/", nil), false)
@@ -60,12 +61,13 @@ func TestHTTPSuccess(t *testing.T) {
 func TestHTTPRedirect(t *testing.T) {
 	assert := New(t)
 
-	mockT1 := new(testing.T)
+	mockT1 := new(mockTestingT)
 	assert.Equal(HTTPRedirect(
 		mockT1, httpOK, "GET", "/", nil,
 		"was expecting a 3xx status code. Got 200.",
 	), false)
 	assert.True(mockT1.Failed())
+	assert.Contains(mockT1.errorString(), "was expecting a 3xx status code. Got 200.")
 
 	mockT2 := new(testing.T)
 	assert.Equal(HTTPRedirect(mockT2, httpRedirect, "GET", "/", nil), true)
@@ -87,12 +89,13 @@ func TestHTTPError(t *testing.T) {
 	assert.Equal(HTTPError(mockT1, httpOK, "GET", "/", nil), false)
 	assert.True(mockT1.Failed())
 
-	mockT2 := new(testing.T)
+	mockT2 := new(mockTestingT)
 	assert.Equal(HTTPError(
 		mockT2, httpRedirect, "GET", "/", nil,
 		"Expected this request to error out. But it didn't",
 	), false)
 	assert.True(mockT2.Failed())
+	assert.Contains(mockT2.errorString(), "Expected this request to error out. But it didn't")
 
 	mockT3 := new(testing.T)
 	assert.Equal(HTTPError(mockT3, httpError, "GET", "/", nil), true)
@@ -114,12 +117,13 @@ func TestHTTPStatusCode(t *testing.T) {
 	assert.Equal(HTTPStatusCode(mockT2, httpRedirect, "GET", "/", nil, http.StatusSwitchingProtocols), false)
 	assert.True(mockT2.Failed())
 
-	mockT3 := new(testing.T)
+	mockT3 := new(mockTestingT)
 	assert.Equal(HTTPStatusCode(
 		mockT3, httpError, "GET", "/", nil, http.StatusSwitchingProtocols,
 		"Expected the status code to be %d", http.StatusSwitchingProtocols,
 	), false)
 	assert.True(mockT3.Failed())
+	assert.Contains(mockT3.errorString(), "Expected the status code to be 101")
 
 	mockT4 := new(testing.T)
 	assert.Equal(HTTPStatusCode(mockT4, httpStatusCode, "GET", "/", nil, http.StatusSwitchingProtocols), true)
@@ -179,7 +183,7 @@ func TestHTTPRequestWithParams(t *testing.T) {
 
 func TestHttpBody(t *testing.T) {
 	assert := New(t)
-	mockT := new(testing.T)
+	mockT := new(mockTestingT)
 
 	assert.True(HTTPBodyContains(mockT, httpHelloName, "GET", "/", url.Values{"name": []string{"World"}}, "Hello, World!"))
 	assert.True(HTTPBodyContains(mockT, httpHelloName, "GET", "/", url.Values{"name": []string{"World"}}, "World"))
@@ -191,6 +195,7 @@ func TestHttpBody(t *testing.T) {
 		"Expected the request body to not contain 'World'. But it did.",
 	))
 	assert.True(HTTPBodyNotContains(mockT, httpHelloName, "GET", "/", url.Values{"name": []string{"World"}}, "world"))
+	assert.Contains(mockT.errorString(), "Expected the request body to not contain 'World'. But it did.")
 
 	assert.True(HTTPBodyContains(mockT, httpReadBody, "GET", "/", nil, "hello"))
 }


### PR DESCRIPTION
## Summary

The http assertions do not use the `msgAndArgs` at all. This commit fixes that.

## Related issues

Not directly related, but stemmed from looking into #316 

Closes #1324 