### PR TITLE
Include the auto-release notes in releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,3 +17,5 @@ jobs:
 
       - name: Create GitHub release from tag
         uses: softprops/action-gh-release@v1
+        with:
+          generate_release_notes: true


### PR DESCRIPTION
## Summary
Enable the auto generated release notes on the auto-generated releases.

## Changes
* Enable `generate_release_notes` on the release workflow.

## Motivation
To be able to see what is in a release and who contributed.

## Related issues
<!-- Put `Closes #XXXX` for each issue number this PR fixes/closes -->
