### PR TITLE
ci: Add go 1.22 to ci matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,7 @@ jobs:
           - "1.19"
           - "1.20"
           - "1.21"
+          - "1.22"
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go


### PR DESCRIPTION
## Summary
This PR introduces GoLang 1.22 to our CI Matrix to ensure package compatibility with this new version of Go.

## Changes
- Added GoLang 1.22 to the CI Matrix in `.github/workflows/ci.yml`.

## Motivation
This change is crucial to validate our package against the newest version of the language to guarantee that it functions as expected.

## Related issues
Closes #1554