### PR TITLE
assert: make tHelper a type alias

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1872,7 +1872,7 @@ var spewConfigStringerEnabled = spew.ConfigState{
 	MaxDepth:                10,
 }
 
-type tHelper interface {
+type tHelper = interface {
 	Helper()
 }
 

--- a/require/requirements.go
+++ b/require/requirements.go
@@ -6,7 +6,7 @@ type TestingT interface {
 	FailNow()
 }
 
-type tHelper interface {
+type tHelper = interface {
 	Helper()
 }
 


### PR DESCRIPTION
## Summary
The tHelper interface is defined only for internal usage. We don't need a "hard" type for it as we don't define methods on it. Let's make is just a alias to the anonymous interface it represents.

Note: we are already using type aliases elswhere, and type aliases were introduced a long time ago in Go 1.9.

## Changes
* assert: `tHelper` becomes a type alias
* require: `tHelper` becomes a type alias

## Motivation
The `tHelper` symbol is not needed at runtime. This should reduce resource usage (yes, negligible).

## Related issues
* #1422 is also related to the `interface { Helper() }` type, but not dependent