### PR TITLE
assert: make *AssertionFunc types just aliases

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -32,19 +32,19 @@ type TestingT interface {
 
 // ComparisonAssertionFunc is a common function prototype when comparing two values.  Can be useful
 // for table driven tests.
-type ComparisonAssertionFunc func(TestingT, interface{}, interface{}, ...interface{}) bool
+type ComparisonAssertionFunc = func(TestingT, interface{}, interface{}, ...interface{}) bool
 
 // ValueAssertionFunc is a common function prototype when validating a single value.  Can be useful
 // for table driven tests.
-type ValueAssertionFunc func(TestingT, interface{}, ...interface{}) bool
+type ValueAssertionFunc = func(TestingT, interface{}, ...interface{}) bool
 
 // BoolAssertionFunc is a common function prototype when validating a bool value.  Can be useful
 // for table driven tests.
-type BoolAssertionFunc func(TestingT, bool, ...interface{}) bool
+type BoolAssertionFunc = func(TestingT, bool, ...interface{}) bool
 
 // ErrorAssertionFunc is a common function prototype when validating an error value.  Can be useful
 // for table driven tests.
-type ErrorAssertionFunc func(TestingT, error, ...interface{}) bool
+type ErrorAssertionFunc = func(TestingT, error, ...interface{}) bool
 
 // PanicAssertionFunc is a common function prototype when validating a panic value.  Can be useful
 // for table driven tests.

--- a/require/requirements.go
+++ b/require/requirements.go
@@ -12,18 +12,18 @@ type tHelper = interface {
 
 // ComparisonAssertionFunc is a common function prototype when comparing two values.  Can be useful
 // for table driven tests.
-type ComparisonAssertionFunc func(TestingT, interface{}, interface{}, ...interface{})
+type ComparisonAssertionFunc = func(TestingT, interface{}, interface{}, ...interface{})
 
 // ValueAssertionFunc is a common function prototype when validating a single value.  Can be useful
 // for table driven tests.
-type ValueAssertionFunc func(TestingT, interface{}, ...interface{})
+type ValueAssertionFunc = func(TestingT, interface{}, ...interface{})
 
 // BoolAssertionFunc is a common function prototype when validating a bool value.  Can be useful
 // for table driven tests.
-type BoolAssertionFunc func(TestingT, bool, ...interface{})
+type BoolAssertionFunc = func(TestingT, bool, ...interface{})
 
 // ErrorAssertionFunc is a common function prototype when validating an error value.  Can be useful
 // for table driven tests.
-type ErrorAssertionFunc func(TestingT, error, ...interface{})
+type ErrorAssertionFunc = func(TestingT, error, ...interface{})
 
 //go:generate sh -c "cd ../_codegen && go build && cd - && ../_codegen/_codegen -output-package=require -template=require.go.tmpl -include-format-funcs"


### PR DESCRIPTION
## Summary
We don't need to define "hard" types for `*AssertionFunc` types as we don't attach methods to them. Also, making them just type aliases will give more flexibility to users of our API.
So [ComparisonAssertionFunc](https://pkg.go.dev/github.com/stretchr/testify/assert#ComparisonAssertionFunc) and other `*AssertionFunc` types are now just type aliases.

## Changes
Make [`ComparisonAssertionFunc`](https://pkg.go.dev/github.com/stretchr/testify/assert#ComparisonAssertionFunc), [`ValueAssertionFunc`](https://pkg.go.dev/github.com/stretchr/testify/assert#ValueAssertionFunc), [`BoolAssertionFunc`](https://pkg.go.dev/github.com/stretchr/testify/assert#BoolAssertionFunc) and [`ErrorAssertionFunc`](https://pkg.go.dev/github.com/stretchr/testify/assert#ErrorAssertionFunc) just type aliases instead of "hard" types.

## Motivation
* More flexibility for API users
* Less resource usage at runtime (type aliases are used only for compile step) (yes, negligible difference)

## Related issues
* #1337
* #1562