### PR TITLE
.gitignore: ignore "go test -c" binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,9 @@ _testmain.go
 *.exe
 
 .DS_Store
+
+# Output of "go test -c"
+/assert/assert.test
+/require/require.test
+/suite/suite.test
+/mock/mock.test


### PR DESCRIPTION
## Summary
Ignore binaries produced by `go test -c`.

## Changes
* Add `assert/assert.test`, `require/require.test`... to `.gitignore`.

## Motivation
Ease maintenance as there is no risk of committing those files by mistake.

## Related issues
N/A