### PR TITLE
assert: deprecate CompareType

### DIFF
--- a/assert/assertion_compare.go
+++ b/assert/assertion_compare.go
@@ -7,10 +7,10 @@ import (
 	"time"
 )
 
-type CompareType int
+type compareResult int
 
 const (
-	compareLess CompareType = iota - 1
+	compareLess compareResult = iota - 1
 	compareEqual
 	compareGreater
 )
@@ -39,7 +39,7 @@ var (
 	bytesType = reflect.TypeOf([]byte{})
 )
 
-func compare(obj1, obj2 interface{}, kind reflect.Kind) (CompareType, bool) {
+func compare(obj1, obj2 interface{}, kind reflect.Kind) (compareResult, bool) {
 	obj1Value := reflect.ValueOf(obj1)
 	obj2Value := reflect.ValueOf(obj2)
 
@@ -345,7 +345,7 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (CompareType, bool) {
 				bytesObj2 = obj2Value.Convert(bytesType).Interface().([]byte)
 			}
 
-			return CompareType(bytes.Compare(bytesObj1, bytesObj2)), true
+			return compareResult(bytes.Compare(bytesObj1, bytesObj2)), true
 		}
 	case reflect.Uintptr:
 		{
@@ -381,7 +381,7 @@ func Greater(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	return compareTwoValues(t, e1, e2, []CompareType{compareGreater}, "\"%v\" is not greater than \"%v\"", msgAndArgs...)
+	return compareTwoValues(t, e1, e2, []compareResult{compareGreater}, "\"%v\" is not greater than \"%v\"", msgAndArgs...)
 }
 
 // GreaterOrEqual asserts that the first element is greater than or equal to the second
@@ -394,7 +394,7 @@ func GreaterOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...in
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	return compareTwoValues(t, e1, e2, []CompareType{compareGreater, compareEqual}, "\"%v\" is not greater than or equal to \"%v\"", msgAndArgs...)
+	return compareTwoValues(t, e1, e2, []compareResult{compareGreater, compareEqual}, "\"%v\" is not greater than or equal to \"%v\"", msgAndArgs...)
 }
 
 // Less asserts that the first element is less than the second
@@ -406,7 +406,7 @@ func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{})
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	return compareTwoValues(t, e1, e2, []CompareType{compareLess}, "\"%v\" is not less than \"%v\"", msgAndArgs...)
+	return compareTwoValues(t, e1, e2, []compareResult{compareLess}, "\"%v\" is not less than \"%v\"", msgAndArgs...)
 }
 
 // LessOrEqual asserts that the first element is less than or equal to the second
@@ -419,7 +419,7 @@ func LessOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...inter
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	return compareTwoValues(t, e1, e2, []CompareType{compareLess, compareEqual}, "\"%v\" is not less than or equal to \"%v\"", msgAndArgs...)
+	return compareTwoValues(t, e1, e2, []compareResult{compareLess, compareEqual}, "\"%v\" is not less than or equal to \"%v\"", msgAndArgs...)
 }
 
 // Positive asserts that the specified element is positive
@@ -431,7 +431,7 @@ func Positive(t TestingT, e interface{}, msgAndArgs ...interface{}) bool {
 		h.Helper()
 	}
 	zero := reflect.Zero(reflect.TypeOf(e))
-	return compareTwoValues(t, e, zero.Interface(), []CompareType{compareGreater}, "\"%v\" is not positive", msgAndArgs...)
+	return compareTwoValues(t, e, zero.Interface(), []compareResult{compareGreater}, "\"%v\" is not positive", msgAndArgs...)
 }
 
 // Negative asserts that the specified element is negative
@@ -443,10 +443,10 @@ func Negative(t TestingT, e interface{}, msgAndArgs ...interface{}) bool {
 		h.Helper()
 	}
 	zero := reflect.Zero(reflect.TypeOf(e))
-	return compareTwoValues(t, e, zero.Interface(), []CompareType{compareLess}, "\"%v\" is not negative", msgAndArgs...)
+	return compareTwoValues(t, e, zero.Interface(), []compareResult{compareLess}, "\"%v\" is not negative", msgAndArgs...)
 }
 
-func compareTwoValues(t TestingT, e1 interface{}, e2 interface{}, allowedComparesResults []CompareType, failMessage string, msgAndArgs ...interface{}) bool {
+func compareTwoValues(t TestingT, e1 interface{}, e2 interface{}, allowedComparesResults []compareResult, failMessage string, msgAndArgs ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -469,7 +469,7 @@ func compareTwoValues(t TestingT, e1 interface{}, e2 interface{}, allowedCompare
 	return true
 }
 
-func containsValue(values []CompareType, value CompareType) bool {
+func containsValue(values []compareResult, value compareResult) bool {
 	for _, v := range values {
 		if v == value {
 			return true

--- a/assert/assertion_compare.go
+++ b/assert/assertion_compare.go
@@ -7,6 +7,9 @@ import (
 	"time"
 )
 
+// Deprecated: CompareType has only ever been for internal use and has accidently been published since v1.6.0. Do not use it.
+type CompareType = compareResult
+
 type compareResult int
 
 const (

--- a/assert/assertion_compare_test.go
+++ b/assert/assertion_compare_test.go
@@ -392,7 +392,7 @@ func Test_compareTwoValuesDifferentValuesTypes(t *testing.T) {
 		{v1: float64(12), v2: "123"},
 		{v1: "float(12)", v2: float64(1)},
 	} {
-		result := compareTwoValues(mockT, currCase.v1, currCase.v2, []CompareType{compareLess, compareEqual, compareGreater}, "testFailMessage")
+		result := compareTwoValues(mockT, currCase.v1, currCase.v2, []compareResult{compareLess, compareEqual, compareGreater}, "testFailMessage")
 		False(t, result)
 	}
 }
@@ -411,7 +411,7 @@ func Test_compareTwoValuesNotComparableValues(t *testing.T) {
 		{v1: map[string]int{}, v2: map[string]int{}},
 		{v1: make([]int, 5), v2: make([]int, 5)},
 	} {
-		result := compareTwoValues(mockT, currCase.v1, currCase.v2, []CompareType{compareLess, compareEqual, compareGreater}, "testFailMessage")
+		result := compareTwoValues(mockT, currCase.v1, currCase.v2, []compareResult{compareLess, compareEqual, compareGreater}, "testFailMessage")
 		False(t, result)
 	}
 }
@@ -422,14 +422,14 @@ func Test_compareTwoValuesCorrectCompareResult(t *testing.T) {
 	for _, currCase := range []struct {
 		v1             interface{}
 		v2             interface{}
-		allowedResults []CompareType
+		allowedResults []compareResult
 	}{
-		{v1: 1, v2: 2, allowedResults: []CompareType{compareLess}},
-		{v1: 1, v2: 2, allowedResults: []CompareType{compareLess, compareEqual}},
-		{v1: 2, v2: 2, allowedResults: []CompareType{compareGreater, compareEqual}},
-		{v1: 2, v2: 2, allowedResults: []CompareType{compareEqual}},
-		{v1: 2, v2: 1, allowedResults: []CompareType{compareEqual, compareGreater}},
-		{v1: 2, v2: 1, allowedResults: []CompareType{compareGreater}},
+		{v1: 1, v2: 2, allowedResults: []compareResult{compareLess}},
+		{v1: 1, v2: 2, allowedResults: []compareResult{compareLess, compareEqual}},
+		{v1: 2, v2: 2, allowedResults: []compareResult{compareGreater, compareEqual}},
+		{v1: 2, v2: 2, allowedResults: []compareResult{compareEqual}},
+		{v1: 2, v2: 1, allowedResults: []compareResult{compareEqual, compareGreater}},
+		{v1: 2, v2: 1, allowedResults: []compareResult{compareGreater}},
 	} {
 		result := compareTwoValues(mockT, currCase.v1, currCase.v2, currCase.allowedResults, "testFailMessage")
 		True(t, result)
@@ -438,14 +438,14 @@ func Test_compareTwoValuesCorrectCompareResult(t *testing.T) {
 
 func Test_containsValue(t *testing.T) {
 	for _, currCase := range []struct {
-		values []CompareType
-		value  CompareType
+		values []compareResult
+		value  compareResult
 		result bool
 	}{
-		{values: []CompareType{compareGreater}, value: compareGreater, result: true},
-		{values: []CompareType{compareGreater, compareLess}, value: compareGreater, result: true},
-		{values: []CompareType{compareGreater, compareLess}, value: compareLess, result: true},
-		{values: []CompareType{compareGreater, compareLess}, value: compareEqual, result: false},
+		{values: []compareResult{compareGreater}, value: compareGreater, result: true},
+		{values: []compareResult{compareGreater, compareLess}, value: compareGreater, result: true},
+		{values: []compareResult{compareGreater, compareLess}, value: compareLess, result: true},
+		{values: []compareResult{compareGreater, compareLess}, value: compareEqual, result: false},
 	} {
 		result := containsValue(currCase.values, currCase.value)
 		Equal(t, currCase.result, result)

--- a/assert/assertion_compare_test.go
+++ b/assert/assertion_compare_test.go
@@ -420,18 +420,18 @@ func Test_compareTwoValuesCorrectCompareResult(t *testing.T) {
 	mockT := new(testing.T)
 
 	for _, currCase := range []struct {
-		v1           interface{}
-		v2           interface{}
-		compareTypes []CompareType
+		v1             interface{}
+		v2             interface{}
+		allowedResults []CompareType
 	}{
-		{v1: 1, v2: 2, compareTypes: []CompareType{compareLess}},
-		{v1: 1, v2: 2, compareTypes: []CompareType{compareLess, compareEqual}},
-		{v1: 2, v2: 2, compareTypes: []CompareType{compareGreater, compareEqual}},
-		{v1: 2, v2: 2, compareTypes: []CompareType{compareEqual}},
-		{v1: 2, v2: 1, compareTypes: []CompareType{compareEqual, compareGreater}},
-		{v1: 2, v2: 1, compareTypes: []CompareType{compareGreater}},
+		{v1: 1, v2: 2, allowedResults: []CompareType{compareLess}},
+		{v1: 1, v2: 2, allowedResults: []CompareType{compareLess, compareEqual}},
+		{v1: 2, v2: 2, allowedResults: []CompareType{compareGreater, compareEqual}},
+		{v1: 2, v2: 2, allowedResults: []CompareType{compareEqual}},
+		{v1: 2, v2: 1, allowedResults: []CompareType{compareEqual, compareGreater}},
+		{v1: 2, v2: 1, allowedResults: []CompareType{compareGreater}},
 	} {
-		compareResult := compareTwoValues(mockT, currCase.v1, currCase.v2, currCase.compareTypes, "testFailMessage")
+		compareResult := compareTwoValues(mockT, currCase.v1, currCase.v2, currCase.allowedResults, "testFailMessage")
 		True(t, compareResult)
 	}
 }

--- a/assert/assertion_compare_test.go
+++ b/assert/assertion_compare_test.go
@@ -392,8 +392,8 @@ func Test_compareTwoValuesDifferentValuesTypes(t *testing.T) {
 		{v1: float64(12), v2: "123"},
 		{v1: "float(12)", v2: float64(1)},
 	} {
-		compareResult := compareTwoValues(mockT, currCase.v1, currCase.v2, []CompareType{compareLess, compareEqual, compareGreater}, "testFailMessage")
-		False(t, compareResult)
+		result := compareTwoValues(mockT, currCase.v1, currCase.v2, []CompareType{compareLess, compareEqual, compareGreater}, "testFailMessage")
+		False(t, result)
 	}
 }
 
@@ -411,8 +411,8 @@ func Test_compareTwoValuesNotComparableValues(t *testing.T) {
 		{v1: map[string]int{}, v2: map[string]int{}},
 		{v1: make([]int, 5), v2: make([]int, 5)},
 	} {
-		compareResult := compareTwoValues(mockT, currCase.v1, currCase.v2, []CompareType{compareLess, compareEqual, compareGreater}, "testFailMessage")
-		False(t, compareResult)
+		result := compareTwoValues(mockT, currCase.v1, currCase.v2, []CompareType{compareLess, compareEqual, compareGreater}, "testFailMessage")
+		False(t, result)
 	}
 }
 
@@ -431,8 +431,8 @@ func Test_compareTwoValuesCorrectCompareResult(t *testing.T) {
 		{v1: 2, v2: 1, allowedResults: []CompareType{compareEqual, compareGreater}},
 		{v1: 2, v2: 1, allowedResults: []CompareType{compareGreater}},
 	} {
-		compareResult := compareTwoValues(mockT, currCase.v1, currCase.v2, currCase.allowedResults, "testFailMessage")
-		True(t, compareResult)
+		result := compareTwoValues(mockT, currCase.v1, currCase.v2, currCase.allowedResults, "testFailMessage")
+		True(t, result)
 	}
 }
 
@@ -447,8 +447,8 @@ func Test_containsValue(t *testing.T) {
 		{values: []CompareType{compareGreater, compareLess}, value: compareLess, result: true},
 		{values: []CompareType{compareGreater, compareLess}, value: compareEqual, result: false},
 	} {
-		compareResult := containsValue(currCase.values, currCase.value)
-		Equal(t, currCase.result, compareResult)
+		result := containsValue(currCase.values, currCase.value)
+		Equal(t, currCase.result, result)
 	}
 }
 

--- a/assert/assertion_order.go
+++ b/assert/assertion_order.go
@@ -6,7 +6,7 @@ import (
 )
 
 // isOrdered checks that collection contains orderable elements.
-func isOrdered(t TestingT, object interface{}, allowedComparesResults []CompareType, failMessage string, msgAndArgs ...interface{}) bool {
+func isOrdered(t TestingT, object interface{}, allowedComparesResults []compareResult, failMessage string, msgAndArgs ...interface{}) bool {
 	objKind := reflect.TypeOf(object).Kind()
 	if objKind != reflect.Slice && objKind != reflect.Array {
 		return false
@@ -50,7 +50,7 @@ func isOrdered(t TestingT, object interface{}, allowedComparesResults []CompareT
 //	assert.IsIncreasing(t, []float{1, 2})
 //	assert.IsIncreasing(t, []string{"a", "b"})
 func IsIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
-	return isOrdered(t, object, []CompareType{compareLess}, "\"%v\" is not less than \"%v\"", msgAndArgs...)
+	return isOrdered(t, object, []compareResult{compareLess}, "\"%v\" is not less than \"%v\"", msgAndArgs...)
 }
 
 // IsNonIncreasing asserts that the collection is not increasing
@@ -59,7 +59,7 @@ func IsIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) boo
 //	assert.IsNonIncreasing(t, []float{2, 1})
 //	assert.IsNonIncreasing(t, []string{"b", "a"})
 func IsNonIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
-	return isOrdered(t, object, []CompareType{compareEqual, compareGreater}, "\"%v\" is not greater than or equal to \"%v\"", msgAndArgs...)
+	return isOrdered(t, object, []compareResult{compareEqual, compareGreater}, "\"%v\" is not greater than or equal to \"%v\"", msgAndArgs...)
 }
 
 // IsDecreasing asserts that the collection is decreasing
@@ -68,7 +68,7 @@ func IsNonIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) 
 //	assert.IsDecreasing(t, []float{2, 1})
 //	assert.IsDecreasing(t, []string{"b", "a"})
 func IsDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
-	return isOrdered(t, object, []CompareType{compareGreater}, "\"%v\" is not greater than \"%v\"", msgAndArgs...)
+	return isOrdered(t, object, []compareResult{compareGreater}, "\"%v\" is not greater than \"%v\"", msgAndArgs...)
 }
 
 // IsNonDecreasing asserts that the collection is not decreasing
@@ -77,5 +77,5 @@ func IsDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) boo
 //	assert.IsNonDecreasing(t, []float{1, 2})
 //	assert.IsNonDecreasing(t, []string{"a", "b"})
 func IsNonDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
-	return isOrdered(t, object, []CompareType{compareLess, compareEqual}, "\"%v\" is not less than or equal to \"%v\"", msgAndArgs...)
+	return isOrdered(t, object, []compareResult{compareLess, compareEqual}, "\"%v\" is not less than or equal to \"%v\"", msgAndArgs...)
 }


### PR DESCRIPTION
## Summary
Mark [`assert.CompareType`](https://pkg.go.dev/github.com/stretchr/testify/assert#CompareType) as _deprecated_.

## Changes

Commits step by step:
* Refactor tests to free the `compareResult` symbol name: d75ed1dbce63d7f994be0afb3eabe1886c722844, 539cfd9c2763e2dab63926ed9fc435e478346f2b
* Rename `CompareType` to `compareResult`: fc30ce69c521b8b47adaf4f812bde58bc677767a
* Reinstate `CompareType` but mark it as _deprecated_: 05f46a65dc8c220d160a5dac12d81fe97b51c0be

## Motivation
[`assert.CompareType`](https://pkg.go.dev/github.com/stretchr/testify/assert#CompareType) has been introduced by 0b4ff03cda5c8eb0150a14ffbaaa088fd777d6ba and published since v1.6.0, but it is in fact only for internal usage and should never have been exposed.

A search of usage of `assert.CompareType` on GitHub shows no results: https://github.com/search?q=assert.CompareType%20language%3AGo%20&type=repositories

## Related issues
N/A