### PR TITLE
README: link out to the excellent testifylint

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Get started:
   * Install testify with [one line of code](#installation), or [update it with another](#staying-up-to-date)
   * For an introduction to writing test code in Go, see https://go.dev/doc/code#Testing
   * Check out the API Documentation https://pkg.go.dev/github.com/stretchr/testify
-  * Use [testifylint](https://github.com/Antonboom/testifylint) to avoid common mistakes
+  * Use [testifylint](https://github.com/Antonboom/testifylint) (via [golanci-lint](https://golangci-lint.run/)) to avoid common mistakes
   * A little about [Test-Driven Development (TDD)](https://en.wikipedia.org/wiki/Test-driven_development)
 
 [`assert`](https://pkg.go.dev/github.com/stretchr/testify/assert "API documentation") package

--- a/README.md
+++ b/README.md
@@ -18,9 +18,8 @@ Get started:
   * Install testify with [one line of code](#installation), or [update it with another](#staying-up-to-date)
   * For an introduction to writing test code in Go, see https://go.dev/doc/code#Testing
   * Check out the API Documentation https://pkg.go.dev/github.com/stretchr/testify
+  * Use [testifylint](https://github.com/Antonboom/testifylint) to avoid common mistakes
   * A little about [Test-Driven Development (TDD)](https://en.wikipedia.org/wiki/Test-driven_development)
-
-
 
 [`assert`](https://pkg.go.dev/github.com/stretchr/testify/assert "API documentation") package
 -------------------------------------------------------------------------------------------

--- a/doc.go
+++ b/doc.go
@@ -8,4 +8,9 @@
 // The mock package provides a system by which it is possible to mock your objects and verify calls are happening as expected.
 //
 // The suite package provides a basic structure for using structs as testing suites, and methods on those structs as tests.  It includes setup/teardown functionality in the way of interfaces.
+//
+// A [golangci-lint] compatible linter for testify is available called [testifylint].
+//
+// [golangci-lint]: https://golangci-lint.run/
+// [testifylint]: https://github.com/Antonboom/testifylint
 package testify


### PR DESCRIPTION
## Summary
Add a call to action to the README to use [testifylint](https://github.com/Antonboom/testifylint).

## Changes
<!-- * Description of change 1 -->
<!-- * Description of change 2 -->
<!-- ... -->

## Motivation
Testify has many pitfalls due to the quality of some parts of the API, a lot of these cannot be fixed in testify without breaking the Go modules compatibility promise. [testifylint](https://github.com/Antonboom/testifylint) can warn users when they fall in these pits.
