### PR TITLE
mock: document more alternatives to deprecated AnythingOfTypeArgument

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -766,7 +766,25 @@ const (
 // AnythingOfTypeArgument contains the type of an argument
 // for use when type checking.  Used in Diff and Assert.
 //
-// Deprecated: this is an implementation detail that must not be used. Use [AnythingOfType] instead.
+// Deprecated: this is an implementation detail that must not be used. Use the [AnythingOfType] constructor instead.
+//
+// If AnythingOfTypeArgument is used as a function return value type you can usually replace
+// the function with a variable. Example:
+//
+//	func anyString() mock.AnythingOfTypeArgument {
+//	    return mock.AnythingOfType("string")
+//	}
+//
+// Can be replaced by:
+//
+//	func anyString() interface{} {
+//	    return mock.IsType("")
+//	}
+//
+// It could even be replaced with a variable:
+//
+//	var anyString = mock.AnythingOfType("string")
+//	var anyString = mock.IsType("") // alternative
 type AnythingOfTypeArgument = anythingOfTypeArgument
 
 // anythingOfTypeArgument is a string that contains the type of an argument

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -766,25 +766,15 @@ const (
 // AnythingOfTypeArgument contains the type of an argument
 // for use when type checking.  Used in Diff and Assert.
 //
-// Deprecated: this is an implementation detail that must not be used. Use the [AnythingOfType] constructor instead.
+// Deprecated: this is an implementation detail that must not be used. Use the [AnythingOfType] constructor instead, example:
 //
-// If AnythingOfTypeArgument is used as a function return value type you can usually replace
-// the function with a variable. Example:
+//	m.On("Do", mock.AnythingOfType("string"))
 //
-//	func anyString() mock.AnythingOfTypeArgument {
-//	    return mock.AnythingOfType("string")
+// All explicit type declarations can be replaced with interface{} as is expected by [Mock.On], example:
+//
+//	func anyString interface{} {
+//		return mock.AnythingOfType("string")
 //	}
-//
-// Can be replaced by:
-//
-//	func anyString() interface{} {
-//	    return mock.IsType("")
-//	}
-//
-// It could even be replaced with a variable:
-//
-//	var anyString = mock.AnythingOfType("string")
-//	var anyString = mock.IsType("") // alternative
 type AnythingOfTypeArgument = anythingOfTypeArgument
 
 // anythingOfTypeArgument is a string that contains the type of an argument


### PR DESCRIPTION
## Summary
Follow-up to #1441: more doc for deprecated [`mock.AnythingOfTypeArgument`](https://pkg.go.dev/github.com/stretchr/testify/mock#AnythingOfTypeArgument).


## Changes
Improve go doc.

## Motivation
I had a look to usages of [`mock.AnythingOfTypeArgument`](https://pkg.go.dev/github.com/stretchr/testify/mock#AnythingOfTypeArgument) in the wild on GitHub:
https://github.com/search?q=mock.AnythingOfTypeArgument+language%3Ago+NOT+repo%3Astretchr%2Ftestify&type=code

This change should give more guidance for fixing the issue in downstream projects.

## Related issues
* #1441, #1434
* mattermost/mattermost-plugin-confluence#108, mattermost/mattermost-plugin-cloud#154, mattermost/mattermost-plugin-jira#1030