### PR TITLE
assert: make YAML dependency pluggable via build tags

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -19,7 +19,9 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/pmezard/go-difflib/difflib"
-	"gopkg.in/yaml.v3"
+
+	// Wrapper around gopkg.in/yaml.v3
+	"github.com/stretchr/testify/assert/yaml"
 )
 
 //go:generate sh -c "cd ../_codegen && go build && cd - && ../_codegen/_codegen -output-package=assert -template=assertion_format.go.tmpl"

--- a/assert/yaml/yaml_custom.go
+++ b/assert/yaml/yaml_custom.go
@@ -1,0 +1,25 @@
+//go:build testify_yaml_custom && !testify_yaml_fail && !testify_yaml_default
+// +build testify_yaml_custom,!testify_yaml_fail,!testify_yaml_default
+
+// Package yaml is an implementation of YAML functions that calls a pluggable implementation.
+//
+// This implementation is selected with the testify_yaml_custom build tag.
+//
+//	go test -tags testify_yaml_custom
+//
+// This implementation can be used at build time to replace the default implementation
+// to avoid linking with [gopkg.in/yaml.v3].
+//
+// In your test package:
+//
+//		import assertYaml "github.com/stretchr/testify/assert/yaml"
+//
+//		func init() {
+//			assertYaml.Unmarshall = func (in []byte, out interface{}) error {
+//				// ...
+//	     			return nil
+//			}
+//		}
+package yaml
+
+var Unmarshal func(in []byte, out interface{}) error

--- a/assert/yaml/yaml_default.go
+++ b/assert/yaml/yaml_default.go
@@ -1,0 +1,37 @@
+//go:build !testify_yaml_fail && !testify_yaml_custom
+// +build !testify_yaml_fail,!testify_yaml_custom
+
+// Package yaml is just an indirection to handle YAML deserialization.
+//
+// This package is just an indirection that allows the builder to override the
+// indirection with an alternative implementation of this package that uses
+// another implemantation of YAML deserialization. This allows to not either not
+// use YAML deserialization at all, or to use another implementation than
+// [gopkg.in/yaml.v3] (for example for license compatibility reasons, see [PR #1120]).
+//
+// Alternative implementations are selected using build tags:
+//
+//   - testify_yaml_fail: [Unmarshal] always fails with an error
+//   - testify_yaml_custom: [Unmarshal] is a variable. Caller must initialize it
+//     before calling any of [github.com/stretchr/testify/assert.YAMLEq] or
+//     [github.com/stretchr/testify/assert.YAMLEqf].
+//
+// Usage:
+//
+//	go test -tags testify_yaml_fail
+//
+// You can check with "go list" which implementation is linked:
+//
+//	go list -f '{{.Imports}}' github.com/stretchr/testify/assert/yaml
+//	go list -tags testify_yaml_fail -f '{{.Imports}}' github.com/stretchr/testify/assert/yaml
+//	go list -tags testify_yaml_custom -f '{{.Imports}}' github.com/stretchr/testify/assert/yaml
+//
+// [PR #1120]: https://github.com/stretchr/testify/pull/1120
+package yaml
+
+import goyaml "gopkg.in/yaml.v3"
+
+// Unmarshal is just a wrapper of [gopkg.in/yaml.v3.Unmarshal].
+func Unmarshal(in []byte, out interface{}) error {
+	return goyaml.Unmarshal(in, out)
+}

--- a/assert/yaml/yaml_fail.go
+++ b/assert/yaml/yaml_fail.go
@@ -1,0 +1,18 @@
+//go:build testify_yaml_fail && !testify_yaml_custom && !testify_yaml_default
+// +build testify_yaml_fail,!testify_yaml_custom,!testify_yaml_default
+
+// Package yaml is an implementation of YAML functions that always fail.
+//
+// This implementation can be used at build time to replace the default implementation
+// to avoid linking with [gopkg.in/yaml.v3]:
+//
+//	go test -tags testify_yaml_fail
+package yaml
+
+import "errors"
+
+var errNotImplemented = errors.New("YAML functions are not available (see https://pkg.go.dev/github.com/stretchr/testify/assert/yaml)")
+
+func Unmarshal([]byte, interface{}) error {
+	return errNotImplemented
+}


### PR DESCRIPTION
## Summary

Make the YAML module dependency required for [`assert.YAMLEq`](https://pkg.go.dev/github.com/stretchr/testify/assert.YAMLEq) (and family) pluggable.

## Changes
* Add package `github.com/stretchr/testify/assert/yaml` that wraps the dependency. It exposes just `func Unmarshal([]byte, interface{}) error` (the only function imported from `gopkg.in/yaml.v3` for `assert`).
* Add 3 implementations of that package which are activated by build tags. The default implementation is the existing behavior and just wraps [`gopkg.in/yaml.v3.Unmarshal`](https://pkg.go.dev/gopkg.in/yaml.v3#Unmarshal).

## Motivation

The dependency on `gopkg.in/yaml.v3` for YAML deserialization (used by `assert.YAMLEq`) is causing painful maintenance work. Both for this project, and for downstream projects (end users). Unfortunately we can't just drop `assert.YAMLEq` until `v2`.

However this change allows to mitigate the issue by giving freedom to users to avoid the link constraints. This allows:
* avoid linking constraints of the license of [`gopkg.in/yaml.v3`](https://pkg.go.dev/gopkg.in/yaml.v3): see #1120
* should avoid future shower of irrelevant reports of vulnerabilities related to bugs in `gopkg.in/yaml.v3`: like previous #1192, #1193, #1194, #1280, #1241, #1292, #1532 (I wrote *irrelevant* because [selecting a particular version of a module](https://research.swtch.com/vgo-principles) is the final responsibility of users in downstream projects who assemble a program: downstream projects have all the infrastructure in the Go toolchain to handle such issues without harassing upstream projects' maintainers)

The `github.com/stretchr/testify/assert/yaml` implementation can be selected using build tags:
* `testify_yaml_default` (default): [`gopkg.in/yaml.v3`](https://pkg.go.dev/gopkg.in/yaml.v3) is used, like before
* `testify_yaml_fail`: YAML deserialization is not implemented and always fails. So `assert.YAMLEq` always fails. This is useful if the test suite package doesn't use `assert.YAMLEq` (very common case).
* `testify_yaml_custom`: the (new) `github.com/stretchr/testify/assert/yaml` package exposes an `Unmarshal` variable of type `func([]byte, any) error` (same as [`gopkg.in/yaml.v3.Unmarshal`](https://pkg.go.dev/gopkg.in/yaml.v3#Unmarshal)) that allows to plug any alternate implementation. For example [`github.com/goccy/go-yaml.Unmarshal`](https://pkg.go.dev/github.com/goccy/go-yaml#Unmarshal).


Usage:
```
go test -tags testify_yaml_fail
go test -tags testify_yaml_custom
```

To install an alternate implementation with `testify_yaml_custom` (as requested in #1120):

```go
//go:build testify_yaml_custom

package my_pkg_test

import (
	goyaml "github.com/goccy/go-yaml"
	"github.com/stretchr/testify/assert/yaml"
)

func init() {
	yaml.Unmarshal = goyaml.Unmarshal
}
```

## Related issues
* #1120