### PR TITLE
Fix time.Time compare

### DIFF
--- a/assert/assertion_compare.go
+++ b/assert/assertion_compare.go
@@ -328,7 +328,13 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (compareResult, bool) {
 				timeObj2 = obj2Value.Convert(timeType).Interface().(time.Time)
 			}
 
-			return compare(timeObj1.UnixNano(), timeObj2.UnixNano(), reflect.Int64)
+			if timeObj1.Before(timeObj2) {
+				return compareLess, true
+			}
+			if timeObj1.Equal(timeObj2) {
+				return compareEqual, true
+			}
+			return compareGreater, true
 		}
 	case reflect.Slice:
 		{

--- a/assert/assertion_compare_test.go
+++ b/assert/assertion_compare_test.go
@@ -59,6 +59,7 @@ func TestCompare(t *testing.T) {
 		{less: uintptr(1), greater: uintptr(2), cType: "uintptr"},
 		{less: customUintptr(1), greater: customUintptr(2), cType: "uint64"},
 		{less: time.Now(), greater: time.Now().Add(time.Hour), cType: "time.Time"},
+		{less: time.Date(2024, 0, 0, 0, 0, 0, 0, time.Local), greater: time.Date(2263, 0, 0, 0, 0, 0, 0, time.Local), cType: "time.Time"},
 		{less: customTime(time.Now()), greater: customTime(time.Now().Add(time.Hour)), cType: "time.Time"},
 		{less: []byte{1, 1}, greater: []byte{1, 2}, cType: "[]byte"},
 		{less: customBytes([]byte{1, 1}), greater: customBytes([]byte{1, 2}), cType: "[]byte"},


### PR DESCRIPTION
fix #1581

I was eager to use [Time.Compare](https://pkg.go.dev/time#Time.Compare), but it was added only in go 1.20