### PR TITLE
assert.EqualExportedValues: accepts everything

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -619,21 +619,6 @@ func EqualExportedValues(t TestingT, expected, actual interface{}, msgAndArgs ..
 		return Fail(t, fmt.Sprintf("Types expected to match exactly\n\t%v != %v", aType, bType), msgAndArgs...)
 	}
 
-	if aType.Kind() == reflect.Ptr {
-		aType = aType.Elem()
-	}
-	if bType.Kind() == reflect.Ptr {
-		bType = bType.Elem()
-	}
-
-	if aType.Kind() != reflect.Struct {
-		return Fail(t, fmt.Sprintf("Types expected to both be struct or pointer to struct \n\t%v != %v", aType.Kind(), reflect.Struct), msgAndArgs...)
-	}
-
-	if bType.Kind() != reflect.Struct {
-		return Fail(t, fmt.Sprintf("Types expected to both be struct or pointer to struct \n\t%v != %v", bType.Kind(), reflect.Struct), msgAndArgs...)
-	}
-
 	expected = copyExportedFields(expected)
 	actual = copyExportedFields(actual)
 

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -449,6 +449,56 @@ func TestEqualExportedValues(t *testing.T) {
 	            	+  Exported: (int) 1,
 	            	   notExported: (interface {}) <nil>`,
 		},
+		{
+			value1:        []int{1, 2},
+			value2:        []int{1, 2},
+			expectedEqual: true,
+		},
+		{
+			value1:        []int{1, 2},
+			value2:        []int{1, 3},
+			expectedEqual: false,
+			expectedFail: `
+	            	Diff:
+	            	--- Expected
+	            	+++ Actual
+	            	@@ -2,3 +2,3 @@
+	            	  (int) 1,
+	            	- (int) 2
+	            	+ (int) 3
+	            	 }`,
+		},
+		{
+			value1: []*Nested{
+				{1, 2},
+				{3, 4},
+			},
+			value2: []*Nested{
+				{1, "a"},
+				{3, "b"},
+			},
+			expectedEqual: true,
+		},
+		{
+			value1: []*Nested{
+				{1, 2},
+				{3, 4},
+			},
+			value2: []*Nested{
+				{1, "a"},
+				{2, "b"},
+			},
+			expectedEqual: false,
+			expectedFail: `
+	            	Diff:
+	            	--- Expected
+	            	+++ Actual
+	            	@@ -6,3 +6,3 @@
+	            	  (*assert.Nested)({
+	            	-  Exported: (int) 3,
+	            	+  Exported: (int) 2,
+	            	   notExported: (interface {}) <nil>`,
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
Remove type validation in EqualExportedValues

See #1584.