### PR TITLE
assert: add NoFieldIsZero

### DIFF
--- a/assert/assertion_format.go
+++ b/assert/assertion_format.go
@@ -556,14 +556,17 @@ func NoErrorf(t TestingT, err error, msg string, args ...interface{}) bool {
 	return NoError(t, err, append([]interface{}{msg}, args...)...)
 }
 
-// NoFieldIsEmptyf asserts that object, which must be a struct or eventually
-// reference to one, has no exported field with a value that is empty (following
-// the definition of empty used in [Empty]).
-func NoFieldIsEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
+// NoFieldIsZerof asserts that object, which must be a struct or eventually
+// reference to one, has no exported field with a value that is zero.
+//
+// The assertion is not recursive, meaning it only checks that the exported
+// fields of the struct (including any embedded structs) are not zero values.
+// It does not check any fields of nested or embedded structs.
+func NoFieldIsZerof(t TestingT, object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	return NoFieldIsEmpty(t, object, append([]interface{}{msg}, args...)...)
+	return NoFieldIsZero(t, object, append([]interface{}{msg}, args...)...)
 }
 
 // NoFileExistsf checks whether a file does not exist in a given path. It fails

--- a/assert/assertion_format.go
+++ b/assert/assertion_format.go
@@ -557,11 +557,11 @@ func NoErrorf(t TestingT, err error, msg string, args ...interface{}) bool {
 }
 
 // NoFieldIsZerof asserts that object, which must be a struct or eventually
-// reference to one, has no exported field with a value that is zero.
+// reference to one, has no field with a value that is zero.
 //
-// The assertion is not recursive, meaning it only checks that the exported
-// fields of the struct (including any embedded structs) are not zero values.
-// It does not check any fields of nested or embedded structs.
+// The assertion is not recursive, meaning it only checks that the fields
+// of the struct (embedded structs are considered fields) are not zero values.
+// It does not check the fields of nested or embedded structs.
 func NoFieldIsZerof(t TestingT, object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()

--- a/assert/assertion_format.go
+++ b/assert/assertion_format.go
@@ -556,7 +556,9 @@ func NoErrorf(t TestingT, err error, msg string, args ...interface{}) bool {
 	return NoError(t, err, append([]interface{}{msg}, args...)...)
 }
 
-// NoFieldIsEmptyf asserts that object, which must be a struct or eventually reference to one, has no empty exported fields.
+// NoFieldIsEmptyf asserts that object, which must be a struct or eventually
+// reference to one, has no exported field with a value that is empty (following
+// the definition of empty used in [Empty]).
 func NoFieldIsEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()

--- a/assert/assertion_format.go
+++ b/assert/assertion_format.go
@@ -556,6 +556,14 @@ func NoErrorf(t TestingT, err error, msg string, args ...interface{}) bool {
 	return NoError(t, err, append([]interface{}{msg}, args...)...)
 }
 
+// NoFieldIsEmptyf asserts that object, which must be a struct or eventually reference to one, has no empty exported fields.
+func NoFieldIsEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return NoFieldIsEmpty(t, object, append([]interface{}{msg}, args...)...)
+}
+
 // NoFileExistsf checks whether a file does not exist in a given path. It fails
 // if the path points to an existing _file_ only.
 func NoFileExistsf(t TestingT, path string, msg string, args ...interface{}) bool {

--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -1104,7 +1104,9 @@ func (a *Assertions) NoErrorf(err error, msg string, args ...interface{}) bool {
 	return NoErrorf(a.t, err, msg, args...)
 }
 
-// NoFieldIsEmpty asserts that object, which must be a struct or eventually reference to one, has no empty exported fields.
+// NoFieldIsEmpty asserts that object, which must be a struct or eventually
+// reference to one, has no exported field with a value that is empty (following
+// the definition of empty used in [Empty]).
 func (a *Assertions) NoFieldIsEmpty(object interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1112,7 +1114,9 @@ func (a *Assertions) NoFieldIsEmpty(object interface{}, msgAndArgs ...interface{
 	return NoFieldIsEmpty(a.t, object, msgAndArgs...)
 }
 
-// NoFieldIsEmptyf asserts that object, which must be a struct or eventually reference to one, has no empty exported fields.
+// NoFieldIsEmptyf asserts that object, which must be a struct or eventually
+// reference to one, has no exported field with a value that is empty (following
+// the definition of empty used in [Empty]).
 func (a *Assertions) NoFieldIsEmptyf(object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()

--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -1105,11 +1105,11 @@ func (a *Assertions) NoErrorf(err error, msg string, args ...interface{}) bool {
 }
 
 // NoFieldIsZero asserts that object, which must be a struct or eventually
-// reference to one, has no exported field with a value that is zero.
+// reference to one, has no field with a value that is zero.
 //
-// The assertion is not recursive, meaning it only checks that the exported
-// fields of the struct (including any embedded structs) are not zero values.
-// It does not check any fields of nested or embedded structs.
+// The assertion is not recursive, meaning it only checks that the fields
+// of the struct (embedded structs are considered fields) are not zero values.
+// It does not check the fields of nested or embedded structs.
 func (a *Assertions) NoFieldIsZero(object interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1118,11 +1118,11 @@ func (a *Assertions) NoFieldIsZero(object interface{}, msgAndArgs ...interface{}
 }
 
 // NoFieldIsZerof asserts that object, which must be a struct or eventually
-// reference to one, has no exported field with a value that is zero.
+// reference to one, has no field with a value that is zero.
 //
-// The assertion is not recursive, meaning it only checks that the exported
-// fields of the struct (including any embedded structs) are not zero values.
-// It does not check any fields of nested or embedded structs.
+// The assertion is not recursive, meaning it only checks that the fields
+// of the struct (embedded structs are considered fields) are not zero values.
+// It does not check the fields of nested or embedded structs.
 func (a *Assertions) NoFieldIsZerof(object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()

--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -1104,24 +1104,30 @@ func (a *Assertions) NoErrorf(err error, msg string, args ...interface{}) bool {
 	return NoErrorf(a.t, err, msg, args...)
 }
 
-// NoFieldIsEmpty asserts that object, which must be a struct or eventually
-// reference to one, has no exported field with a value that is empty (following
-// the definition of empty used in [Empty]).
-func (a *Assertions) NoFieldIsEmpty(object interface{}, msgAndArgs ...interface{}) bool {
+// NoFieldIsZero asserts that object, which must be a struct or eventually
+// reference to one, has no exported field with a value that is zero.
+//
+// The assertion is not recursive, meaning it only checks that the exported
+// fields of the struct (including any embedded structs) are not zero values.
+// It does not check any fields of nested or embedded structs.
+func (a *Assertions) NoFieldIsZero(object interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
-	return NoFieldIsEmpty(a.t, object, msgAndArgs...)
+	return NoFieldIsZero(a.t, object, msgAndArgs...)
 }
 
-// NoFieldIsEmptyf asserts that object, which must be a struct or eventually
-// reference to one, has no exported field with a value that is empty (following
-// the definition of empty used in [Empty]).
-func (a *Assertions) NoFieldIsEmptyf(object interface{}, msg string, args ...interface{}) bool {
+// NoFieldIsZerof asserts that object, which must be a struct or eventually
+// reference to one, has no exported field with a value that is zero.
+//
+// The assertion is not recursive, meaning it only checks that the exported
+// fields of the struct (including any embedded structs) are not zero values.
+// It does not check any fields of nested or embedded structs.
+func (a *Assertions) NoFieldIsZerof(object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
-	return NoFieldIsEmptyf(a.t, object, msg, args...)
+	return NoFieldIsZerof(a.t, object, msg, args...)
 }
 
 // NoFileExists checks whether a file does not exist in a given path. It fails

--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -1104,6 +1104,22 @@ func (a *Assertions) NoErrorf(err error, msg string, args ...interface{}) bool {
 	return NoErrorf(a.t, err, msg, args...)
 }
 
+// NoFieldIsEmpty asserts that object, which must be a struct or eventually reference to one, has no empty exported fields.
+func (a *Assertions) NoFieldIsEmpty(object interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NoFieldIsEmpty(a.t, object, msgAndArgs...)
+}
+
+// NoFieldIsEmptyf asserts that object, which must be a struct or eventually reference to one, has no empty exported fields.
+func (a *Assertions) NoFieldIsEmptyf(object interface{}, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return NoFieldIsEmptyf(a.t, object, msg, args...)
+}
+
 // NoFileExists checks whether a file does not exist in a given path. It fails
 // if the path points to an existing _file_ only.
 func (a *Assertions) NoFileExists(path string, msgAndArgs ...interface{}) bool {

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -2276,11 +2276,11 @@ func buildErrorChainString(err error, withType bool) string {
 }
 
 // NoFieldIsZero asserts that object, which must be a struct or eventually
-// reference to one, has no exported field with a value that is zero.
+// reference to one, has no field with a value that is zero.
 //
-// The assertion is not recursive, meaning it only checks that the exported
-// fields of the struct (including any embedded structs) are not zero values.
-// It does not check any fields of nested or embedded structs.
+// The assertion is not recursive, meaning it only checks that the fields
+// of the struct (embedded structs are considered fields) are not zero values.
+// It does not check the fields of nested or embedded structs.
 func NoFieldIsZero(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2299,10 +2299,6 @@ func NoFieldIsZero(t TestingT, object interface{}, msgAndArgs ...interface{}) bo
 	objectValue := reflect.ValueOf(object)
 	for i := 0; i < objectType.NumField(); i++ {
 		field := objectType.Field(i)
-		if !field.IsExported() {
-			continue
-		}
-
 		if objectValue.Field(i).IsZero() {
 			emptyFields = append(emptyFields, field.Name)
 		}

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -2275,7 +2275,9 @@ func buildErrorChainString(err error, withType bool) string {
 	return chain
 }
 
-// NoFieldIsEmpty asserts that object, which must be a struct or eventually reference to one, has no empty exported fields.
+// NoFieldIsEmpty asserts that object, which must be a struct or eventually
+// reference to one, has no exported field with a value that is empty (following
+// the definition of empty used in [Empty]).
 func NoFieldIsEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
 	if reflect.TypeOf(object).Kind() == reflect.Ptr {
 		return NoFieldIsEmpty(t, reflect.ValueOf(object).Elem().Interface(), msgAndArgs)

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -3679,9 +3679,8 @@ func TestNoFieldIsZero(t *testing.T) {
 		resultErrMsg string
 	}{
 		{
-			name: "success",
+			name: "pass_exported_fields",
 			input: struct {
-				Embeddable
 				Float64   float64
 				Func      func()
 				Int       int
@@ -3691,20 +3690,51 @@ func TestNoFieldIsZero(t *testing.T) {
 				String    string
 				Struct    struct{ StringA, StringB string }
 			}{
-				Embeddable: Embeddable{StringA: "string"}, // For Embeddable to be non-zero, only one field its fields needs to be non-zero
-				Float64:    1.5,
-				Func:       func() {},
-				Int:        1,
-				Interface:  "interface",
-				Pointer:    &str,
-				Slice:      []string{"a", "b"},
-				String:     "a string",
-				Struct:     struct{ StringA, StringB string }{StringA: "a nested string"},
+				Float64:   1.5,
+				Func:      func() {},
+				Int:       1,
+				Interface: "interface",
+				Pointer:   &str,
+				Slice:     []string{"a", "b"},
+				String:    "a string",
+				Struct:    struct{ StringA, StringB string }{StringA: "a nested string"},
 			},
 			result: true,
 		},
 		{
-			name: "success_pointer",
+			name: "pass_unexported_fields",
+			input: struct {
+				aFloat64   float64
+				aFunc      func()
+				aInt       int
+				aInterface interface{}
+				aPointer   *string
+				aSlice     []string
+				aString    string
+				aStruct    struct{ stringA, stringB string }
+			}{
+				aFloat64:   1.5,
+				aFunc:      func() {},
+				aInt:       1,
+				aInterface: "interface",
+				aPointer:   &str,
+				aSlice:     []string{"a", "b"},
+				aString:    "a string",
+				aStruct:    struct{ stringA, stringB string }{stringA: "a nested string"},
+			},
+			result: true,
+		},
+		{
+			name: "pass_embedded",
+			input: struct {
+				Embeddable
+			}{
+				Embeddable: Embeddable{StringA: "string"}, // For Embeddable to be non-zero, only one field its fields needs to be non-zero
+			},
+			result: true,
+		},
+		{
+			name: "pass_pointer",
 			input: &struct {
 				String string
 			}{
@@ -3713,14 +3743,8 @@ func TestNoFieldIsZero(t *testing.T) {
 			result: true,
 		},
 		{
-			name:   "success_unexported",
-			input:  struct{ unexported string }{},
-			result: true,
-		},
-		{
-			name: "failure",
+			name: "fail_exported_fields",
 			input: struct {
-				Embeddable
 				Float64   float64
 				Func      func()
 				Int       int
@@ -3731,10 +3755,33 @@ func TestNoFieldIsZero(t *testing.T) {
 				Struct    struct{ String string }
 			}{},
 			result:       false,
-			resultErrMsg: "Object contained fields with zero values: Embeddable, Float64, Func, Int, Interface, Pointer, Slice, String, Struct\n",
+			resultErrMsg: "Object contained fields with zero values: Float64, Func, Int, Interface, Pointer, Slice, String, Struct\n",
 		},
 		{
-			name: "failure_partial",
+			name: "fail_unexported_fields",
+			input: struct {
+				aFloat64   float64
+				aFunc      func()
+				aInt       int
+				aInterface interface{}
+				aPointer   *string
+				aSlice     []string
+				aString    string
+				aStruct    struct{ stringA, stringB string }
+			}{},
+			result:       false,
+			resultErrMsg: "Object contained fields with zero values: aFloat64, aFunc, aInt, aInterface, aPointer, aSlice, aString, aStruct\n",
+		},
+		{
+			name: "failure_embedded",
+			input: struct {
+				Embeddable
+			}{},
+			result:       false,
+			resultErrMsg: "Object contained fields with zero values: Embeddable\n",
+		},
+		{
+			name: "fail_some_fields_non_zero",
 			input: struct {
 				StringA string
 				StringB string
@@ -3743,7 +3790,7 @@ func TestNoFieldIsZero(t *testing.T) {
 			resultErrMsg: "Object contained fields with zero values: StringB\n",
 		},
 		{
-			name:         "failure_wrong_type",
+			name:         "fail_wrong_type",
 			input:        "a string is not a struct",
 			result:       false,
 			resultErrMsg: "Input must be a struct or eventually reference one\n",

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -3665,8 +3665,13 @@ func TestNotErrorAs(t *testing.T) {
 	}
 }
 
-func TestNoFieldIsEmpty(t *testing.T) {
+func TestNoFieldIsZero(t *testing.T) {
 	str := "a string"
+	type Embeddable struct {
+		StringA string
+		StringB string
+	}
+
 	tests := []struct {
 		name         string
 		input        interface{}
@@ -3676,6 +3681,7 @@ func TestNoFieldIsEmpty(t *testing.T) {
 		{
 			name: "success",
 			input: struct {
+				Embeddable
 				Float64   float64
 				Func      func()
 				Int       int
@@ -3683,16 +3689,17 @@ func TestNoFieldIsEmpty(t *testing.T) {
 				Pointer   *string
 				Slice     []string
 				String    string
-				Struct    struct{ String string }
+				Struct    struct{ StringA, StringB string }
 			}{
-				Float64:   1.5,
-				Func:      func() {},
-				Int:       1,
-				Interface: "interface",
-				Pointer:   &str,
-				Slice:     []string{"a", "b"},
-				String:    "a string",
-				Struct:    struct{ String string }{String: "a nested string"},
+				Embeddable: Embeddable{StringA: "string"}, // For Embeddable to be non-zero, only one field its fields needs to be non-zero
+				Float64:    1.5,
+				Func:       func() {},
+				Int:        1,
+				Interface:  "interface",
+				Pointer:    &str,
+				Slice:      []string{"a", "b"},
+				String:     "a string",
+				Struct:     struct{ StringA, StringB string }{StringA: "a nested string"},
 			},
 			result: true,
 		},
@@ -3713,6 +3720,7 @@ func TestNoFieldIsEmpty(t *testing.T) {
 		{
 			name: "failure",
 			input: struct {
+				Embeddable
 				Float64   float64
 				Func      func()
 				Int       int
@@ -3723,7 +3731,7 @@ func TestNoFieldIsEmpty(t *testing.T) {
 				Struct    struct{ String string }
 			}{},
 			result:       false,
-			resultErrMsg: "Object contained empty fields: Float64, Func, Int, Interface, Pointer, Slice, String, Struct\n",
+			resultErrMsg: "Object contained fields with zero values: Embeddable, Float64, Func, Int, Interface, Pointer, Slice, String, Struct\n",
 		},
 		{
 			name: "failure_partial",
@@ -3732,7 +3740,7 @@ func TestNoFieldIsEmpty(t *testing.T) {
 				StringB string
 			}{StringA: "not_empty"},
 			result:       false,
-			resultErrMsg: "Object contained empty fields: StringB\n",
+			resultErrMsg: "Object contained fields with zero values: StringB\n",
 		},
 		{
 			name:         "failure_wrong_type",
@@ -3744,7 +3752,7 @@ func TestNoFieldIsEmpty(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockT := new(captureTestingT)
-			result := NoFieldIsEmpty(mockT, tt.input)
+			result := NoFieldIsZero(mockT, tt.input)
 			mockT.checkResultAndErrMsg(t, tt.result, result, tt.resultErrMsg)
 		})
 	}

--- a/require/require.go
+++ b/require/require.go
@@ -1399,7 +1399,9 @@ func NoErrorf(t TestingT, err error, msg string, args ...interface{}) {
 	t.FailNow()
 }
 
-// NoFieldIsEmpty asserts that object, which must be a struct or eventually reference to one, has no empty exported fields.
+// NoFieldIsEmpty asserts that object, which must be a struct or eventually
+// reference to one, has no exported field with a value that is empty (following
+// the definition of empty used in [Empty]).
 func NoFieldIsEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1410,7 +1412,9 @@ func NoFieldIsEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	t.FailNow()
 }
 
-// NoFieldIsEmptyf asserts that object, which must be a struct or eventually reference to one, has no empty exported fields.
+// NoFieldIsEmptyf asserts that object, which must be a struct or eventually
+// reference to one, has no exported field with a value that is empty (following
+// the definition of empty used in [Empty]).
 func NoFieldIsEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()

--- a/require/require.go
+++ b/require/require.go
@@ -1399,6 +1399,28 @@ func NoErrorf(t TestingT, err error, msg string, args ...interface{}) {
 	t.FailNow()
 }
 
+// NoFieldIsEmpty asserts that object, which must be a struct or eventually reference to one, has no empty exported fields.
+func NoFieldIsEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NoFieldIsEmpty(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NoFieldIsEmptyf asserts that object, which must be a struct or eventually reference to one, has no empty exported fields.
+func NoFieldIsEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NoFieldIsEmptyf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
 // NoFileExists checks whether a file does not exist in a given path. It fails
 // if the path points to an existing _file_ only.
 func NoFileExists(t TestingT, path string, msgAndArgs ...interface{}) {

--- a/require/require.go
+++ b/require/require.go
@@ -1399,27 +1399,33 @@ func NoErrorf(t TestingT, err error, msg string, args ...interface{}) {
 	t.FailNow()
 }
 
-// NoFieldIsEmpty asserts that object, which must be a struct or eventually
-// reference to one, has no exported field with a value that is empty (following
-// the definition of empty used in [Empty]).
-func NoFieldIsEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+// NoFieldIsZero asserts that object, which must be a struct or eventually
+// reference to one, has no exported field with a value that is zero.
+//
+// The assertion is not recursive, meaning it only checks that the exported
+// fields of the struct (including any embedded structs) are not zero values.
+// It does not check any fields of nested or embedded structs.
+func NoFieldIsZero(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	if assert.NoFieldIsEmpty(t, object, msgAndArgs...) {
+	if assert.NoFieldIsZero(t, object, msgAndArgs...) {
 		return
 	}
 	t.FailNow()
 }
 
-// NoFieldIsEmptyf asserts that object, which must be a struct or eventually
-// reference to one, has no exported field with a value that is empty (following
-// the definition of empty used in [Empty]).
-func NoFieldIsEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
+// NoFieldIsZerof asserts that object, which must be a struct or eventually
+// reference to one, has no exported field with a value that is zero.
+//
+// The assertion is not recursive, meaning it only checks that the exported
+// fields of the struct (including any embedded structs) are not zero values.
+// It does not check any fields of nested or embedded structs.
+func NoFieldIsZerof(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	if assert.NoFieldIsEmptyf(t, object, msg, args...) {
+	if assert.NoFieldIsZerof(t, object, msg, args...) {
 		return
 	}
 	t.FailNow()

--- a/require/require.go
+++ b/require/require.go
@@ -1400,11 +1400,11 @@ func NoErrorf(t TestingT, err error, msg string, args ...interface{}) {
 }
 
 // NoFieldIsZero asserts that object, which must be a struct or eventually
-// reference to one, has no exported field with a value that is zero.
+// reference to one, has no field with a value that is zero.
 //
-// The assertion is not recursive, meaning it only checks that the exported
-// fields of the struct (including any embedded structs) are not zero values.
-// It does not check any fields of nested or embedded structs.
+// The assertion is not recursive, meaning it only checks that the fields
+// of the struct (embedded structs are considered fields) are not zero values.
+// It does not check the fields of nested or embedded structs.
 func NoFieldIsZero(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1416,11 +1416,11 @@ func NoFieldIsZero(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 }
 
 // NoFieldIsZerof asserts that object, which must be a struct or eventually
-// reference to one, has no exported field with a value that is zero.
+// reference to one, has no field with a value that is zero.
 //
-// The assertion is not recursive, meaning it only checks that the exported
-// fields of the struct (including any embedded structs) are not zero values.
-// It does not check any fields of nested or embedded structs.
+// The assertion is not recursive, meaning it only checks that the fields
+// of the struct (embedded structs are considered fields) are not zero values.
+// It does not check the fields of nested or embedded structs.
 func NoFieldIsZerof(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()

--- a/require/require_forward.go
+++ b/require/require_forward.go
@@ -1105,24 +1105,30 @@ func (a *Assertions) NoErrorf(err error, msg string, args ...interface{}) {
 	NoErrorf(a.t, err, msg, args...)
 }
 
-// NoFieldIsEmpty asserts that object, which must be a struct or eventually
-// reference to one, has no exported field with a value that is empty (following
-// the definition of empty used in [Empty]).
-func (a *Assertions) NoFieldIsEmpty(object interface{}, msgAndArgs ...interface{}) {
+// NoFieldIsZero asserts that object, which must be a struct or eventually
+// reference to one, has no exported field with a value that is zero.
+//
+// The assertion is not recursive, meaning it only checks that the exported
+// fields of the struct (including any embedded structs) are not zero values.
+// It does not check any fields of nested or embedded structs.
+func (a *Assertions) NoFieldIsZero(object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
-	NoFieldIsEmpty(a.t, object, msgAndArgs...)
+	NoFieldIsZero(a.t, object, msgAndArgs...)
 }
 
-// NoFieldIsEmptyf asserts that object, which must be a struct or eventually
-// reference to one, has no exported field with a value that is empty (following
-// the definition of empty used in [Empty]).
-func (a *Assertions) NoFieldIsEmptyf(object interface{}, msg string, args ...interface{}) {
+// NoFieldIsZerof asserts that object, which must be a struct or eventually
+// reference to one, has no exported field with a value that is zero.
+//
+// The assertion is not recursive, meaning it only checks that the exported
+// fields of the struct (including any embedded structs) are not zero values.
+// It does not check any fields of nested or embedded structs.
+func (a *Assertions) NoFieldIsZerof(object interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
-	NoFieldIsEmptyf(a.t, object, msg, args...)
+	NoFieldIsZerof(a.t, object, msg, args...)
 }
 
 // NoFileExists checks whether a file does not exist in a given path. It fails

--- a/require/require_forward.go
+++ b/require/require_forward.go
@@ -1105,6 +1105,22 @@ func (a *Assertions) NoErrorf(err error, msg string, args ...interface{}) {
 	NoErrorf(a.t, err, msg, args...)
 }
 
+// NoFieldIsEmpty asserts that object, which must be a struct or eventually reference to one, has no empty exported fields.
+func (a *Assertions) NoFieldIsEmpty(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NoFieldIsEmpty(a.t, object, msgAndArgs...)
+}
+
+// NoFieldIsEmptyf asserts that object, which must be a struct or eventually reference to one, has no empty exported fields.
+func (a *Assertions) NoFieldIsEmptyf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NoFieldIsEmptyf(a.t, object, msg, args...)
+}
+
 // NoFileExists checks whether a file does not exist in a given path. It fails
 // if the path points to an existing _file_ only.
 func (a *Assertions) NoFileExists(path string, msgAndArgs ...interface{}) {

--- a/require/require_forward.go
+++ b/require/require_forward.go
@@ -1105,7 +1105,9 @@ func (a *Assertions) NoErrorf(err error, msg string, args ...interface{}) {
 	NoErrorf(a.t, err, msg, args...)
 }
 
-// NoFieldIsEmpty asserts that object, which must be a struct or eventually reference to one, has no empty exported fields.
+// NoFieldIsEmpty asserts that object, which must be a struct or eventually
+// reference to one, has no exported field with a value that is empty (following
+// the definition of empty used in [Empty]).
 func (a *Assertions) NoFieldIsEmpty(object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1113,7 +1115,9 @@ func (a *Assertions) NoFieldIsEmpty(object interface{}, msgAndArgs ...interface{
 	NoFieldIsEmpty(a.t, object, msgAndArgs...)
 }
 
-// NoFieldIsEmptyf asserts that object, which must be a struct or eventually reference to one, has no empty exported fields.
+// NoFieldIsEmptyf asserts that object, which must be a struct or eventually
+// reference to one, has no exported field with a value that is empty (following
+// the definition of empty used in [Empty]).
 func (a *Assertions) NoFieldIsEmptyf(object interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()

--- a/require/require_forward.go
+++ b/require/require_forward.go
@@ -1106,11 +1106,11 @@ func (a *Assertions) NoErrorf(err error, msg string, args ...interface{}) {
 }
 
 // NoFieldIsZero asserts that object, which must be a struct or eventually
-// reference to one, has no exported field with a value that is zero.
+// reference to one, has no field with a value that is zero.
 //
-// The assertion is not recursive, meaning it only checks that the exported
-// fields of the struct (including any embedded structs) are not zero values.
-// It does not check any fields of nested or embedded structs.
+// The assertion is not recursive, meaning it only checks that the fields
+// of the struct (embedded structs are considered fields) are not zero values.
+// It does not check the fields of nested or embedded structs.
 func (a *Assertions) NoFieldIsZero(object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1119,11 +1119,11 @@ func (a *Assertions) NoFieldIsZero(object interface{}, msgAndArgs ...interface{}
 }
 
 // NoFieldIsZerof asserts that object, which must be a struct or eventually
-// reference to one, has no exported field with a value that is zero.
+// reference to one, has no field with a value that is zero.
 //
-// The assertion is not recursive, meaning it only checks that the exported
-// fields of the struct (including any embedded structs) are not zero values.
-// It does not check any fields of nested or embedded structs.
+// The assertion is not recursive, meaning it only checks that the fields
+// of the struct (embedded structs are considered fields) are not zero values.
+// It does not check the fields of nested or embedded structs.
 func (a *Assertions) NoFieldIsZerof(object interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()


### PR DESCRIPTION
EDIT: 2025-05-29 Originally this PR was to introduce the assertion `NoFieldIsEmpty` but has been replaced with `NoFieldIsZero` and check now unexported fields as well as exported.

## Summary
Proposal to introduce an assertion that checks that no (~exported~) fields are ~empty~ zero in a struct.

## Changes
1. A function ~`NoFieldIsEmpty`~ `NoFieldIsZero` is introduced into into the `assert` package. This function fails the test and returns false if any of the fields in the inputed struct (or reference to struct) are ~empty, aligning with pre-existing definition of empty~ zero.
2. Tests for the newly introduced ~`NoFieldIsEmpty`~ `NoFieldIsZero` function were added.
3. `go generate ./...` was run.

## Motivation
I found myself repeatedly rewriting similar code in tests across different repositories in an effort to ensure that tests do not become out-of-date and no longer align with their original intention.

An example of this is writing tests that check that all fields in a struct can be stored and then loaded. Consider the test:
```go
// Tests that all fields in entity can be stored and loaded
func TestPersistence(t *testing.T) {
	entity := Entity{
		// Filled with data
	}
	
	s := NewStore()
	err := s.Store(entity)
	require.NoError(t, err)
	
	result, err := s.Load(entity.ID)
	require.NoError(t, err)
	assert.Equal(t, entity, result, "result should match the entity stored")
}
```
This test is claiming to check that all fields can be stored and loaded but it not enforcing it. If the entity was not correctly populated initially or if new fields where added to the Entity and the test was not updated then the test would not be align with its stated purpose.

In this particular case the assertion could be used as a pre-condition to ensure we always start with all fields containing data
```go
require.NoFieldIsZero(t, entity)
```
or as check at the end of test to ensure all fields where populated
```go
assert.NoFieldIsZero(t, result)
```

I have found this assertion useful for when using tests that require populated structs including:
1. Testing the storing and loading of structs into database or persistence storage.
2. Testing the population of structs e.g. writing fakers.
3. Testing the marshalling/formatting of structs and unmarshalling/parsing data to structs.

## Related issues
None.

## Additional comments
1. This form of assertion does not appear to be wide spread from what I have seen and thus maybe is of low impact - however, maybe that is just due to a dislike of reflection 😅.
2. Although I find such an assertion useful there are times when I want all bar some fields populated and it might be better to have a function with the signature
```go
func NoFieldIsZero(t TestingT, object interface{}, exclude []string, msgAndArgs ...interface{}) bool
```
3. This assertion doesn't solve the issue of nested structs are populated too (although it does help). I avoided approaching addressing this because it was unclear of how to express nested field names and handle arrays of structs. Also, having some feedback on the the simple case seemed to be a good starting point.
4. Thank you for reading & reviewing 😄 
