### PR TITLE
Assertion for minimum number of method/function invocations

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -648,6 +648,22 @@ func (m *Mock) AssertNumberOfCalls(t TestingT, methodName string, expectedCalls 
 	return assert.Equal(t, expectedCalls, actualCalls, fmt.Sprintf("Expected number of calls (%d) does not match the actual number of calls (%d).", expectedCalls, actualCalls))
 }
 
+// AssertMinNumberOfCalls asserts that the method was called at-least expectedMinCalls times.
+func (m *Mock) AssertMinNumberOfCalls(t TestingT, methodName string, expectedMinCalls int) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	var actualCalls int
+	for _, call := range m.calls() {
+		if call.Method == methodName {
+			actualCalls++
+		}
+	}
+	return assert.LessOrEqual(t, expectedMinCalls, actualCalls, fmt.Sprintf("Actual number of calls (%d) does not satisfy the minimum expected number of calls (%d).", actualCalls, expectedMinCalls))
+}
+
 // AssertCalled asserts that the method was called.
 // It can produce a false result when an argument is a pointer type and the underlying value changed after calling the mocked method.
 func (m *Mock) AssertCalled(t TestingT, methodName string, arguments ...interface{}) bool {

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -1536,6 +1536,22 @@ func Test_Mock_AssertNumberOfCalls(t *testing.T) {
 
 }
 
+func Test_Mock_AssertMinNumberOfCalls(t *testing.T) {
+
+	var mockedService = new(TestExampleImplementation)
+
+	mockedService.On("Test_Mock_AssertMinNumberOfCalls", 1, 2, 3).Return(5, 6, 7)
+
+	mockedService.Called(1, 2, 3)
+	assert.True(t, mockedService.AssertNumberOfCalls(t, "Test_Mock_AssertMinNumberOfCalls", 1))
+	assert.True(t, mockedService.AssertMinNumberOfCalls(t, "Test_Mock_AssertMinNumberOfCalls", 1))
+
+	mockedService.Called(1, 2, 3)
+	assert.True(t, mockedService.AssertNumberOfCalls(t, "Test_Mock_AssertMinNumberOfCalls", 2))
+	assert.True(t, mockedService.AssertMinNumberOfCalls(t, "Test_Mock_AssertMinNumberOfCalls", 1))
+	assert.True(t, mockedService.AssertMinNumberOfCalls(t, "Test_Mock_AssertMinNumberOfCalls", 2))
+}
+
 func Test_Mock_AssertCalled(t *testing.T) {
 
 	var mockedService = new(TestExampleImplementation)


### PR DESCRIPTION

## Summary
Method for asserting minimum number of invocations made to a method.

## Changes
Added assertion method named `AssertMinNumberOfCalls` which takes expected minimum number of calls along with the method name for assertion. Assertion fails if specified minimum number of invocations are not made to the method.

## Motivation
There are cases where exact number of invocations of a method cannot be predetermined accurately. Eg, number of network calls made by a retry logic which is governed by time out and time delay. Number of calls made in such cases will depend on time of previous call and time out of governing context. Hence ability to ensure a minimum threshold is required

## Example usage
```
mockClient.AssertMinNumberOfCalls(t, "ModifyRule", 6)
```
