### PR TITLE
mock: avoid data races in Arguments.Diff

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -947,7 +947,15 @@ func (args Arguments) Diff(objects []interface{}) (string, int) {
 			actualFmt = "(Missing)"
 		} else {
 			actual = objects[i]
-			actualFmt = fmt.Sprintf("(%[1]T=%[1]v)", actual)
+			// Note: avoid %v format specifier for pointer arguments. The %v format
+			// specifier traverses the data structure, and for situations where the
+			// argument is a pointer (that may be updated concurrently) this can result
+			// in the mock code causing a data race when running go test -race.
+			if isPtr(actual) {
+				actualFmt = fmt.Sprintf("(%[1]T=%[1]p)", actual)
+			} else {
+				actualFmt = fmt.Sprintf("(%[1]T=%[1]v)", actual)
+			}
 		}
 
 		if len(args) <= i {
@@ -955,7 +963,15 @@ func (args Arguments) Diff(objects []interface{}) (string, int) {
 			expectedFmt = "(Missing)"
 		} else {
 			expected = args[i]
-			expectedFmt = fmt.Sprintf("(%[1]T=%[1]v)", expected)
+			// Note: avoid %v format specifier for pointer arguments. The %v format
+			// specifier traverses the data structure, and for situations where the
+			// argument is a pointer (that may be updated concurrently) this can result
+			// in the mock code causing a data race when running go test -race.
+			if isPtr(expected) {
+				expectedFmt = fmt.Sprintf("(%[1]T=%[1]p)", expected)
+			} else {
+				expectedFmt = fmt.Sprintf("(%[1]T=%[1]v)", expected)
+			}
 		}
 
 		if matcher, ok := expected.(argumentMatcher); ok {
@@ -1249,4 +1265,9 @@ func assertOpts(expected, actual interface{}) (expectedFmt, actualFmt string) {
 func funcName(opt interface{}) string {
 	n := runtime.FuncForPC(reflect.ValueOf(opt).Pointer()).Name()
 	return strings.TrimSuffix(path.Base(n), path.Ext(n))
+}
+
+// isPtr indicates if the supplied value is a pointer.
+func isPtr(v interface{}) bool {
+	return reflect.ValueOf(v).Kind() == reflect.Ptr
 }


### PR DESCRIPTION
Fixes a concurrency issue that would lead to testify mocks producing data races detected by go test -race. These data races would occur whenever a mock pointer argument was concurrently modified. The reason being that `Arguments.Diff` uses the `%v` format specifier to get a presentable string for the argument. This also traverses the pointed-to data structure, which would lead to the data race.

It should be noted that it is heavily inspired by https://github.com/stretchr/testify/pull/1229, but since that PR hasn't seen any updates in over a year I decided to start fresh.

## Summary
Avoids testify mocks causing data races for (concurrently accessed) pointer arguments when running `go test -race`.

## Changes
`Arguments.Diff` now uses `%p` to produce a "presentable string" for pointers rather than `%v`, since the latter traverses the pointed to data structure.

## Motivation
We need to test our code for race conditions with go test -race, and we cannot have testify be the offender of data races.


## Related issues
https://github.com/stretchr/testify/issues/1597
