### PR TITLE
Update minimum required go version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ To update Testify to the latest version, use `go get -u github.com/stretchr/test
 Supported go versions
 ==================
 
-We currently support the most recent major Go versions from 1.19 onward.
+We currently support the most recent major Go versions from 1.17 onward.
 
 ------
 


### PR DESCRIPTION
## Summary

Update the minimum required go version in readme. Since the go.mod and the ci says the minimum version should be 1.17.

## Changes

No other changes, just update the readme.

## Motivation

Update and clarify the minimum required go version, so 1.17 and 1.18 go version users will have a try.

## Related issues

None