### PR TITLE
mock: Conditionally toggle mock Call

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -291,6 +291,15 @@ func (c *Call) Unset(options ...UnsetOption) *Call {
 	return c
 }
 
+// Toggle will conditionally enable or disable mock call via flag.
+// By default Call is toggled.
+func (c *Call) Toggle(t bool) *Call {
+	if t {
+		return c
+	}
+	return c.Unset()
+}
+
 // NotBefore indicates that the mock should only be called after the referenced
 // calls have been called as expected. The referenced calls may be from the
 // same mock instance and/or other mock instances.

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -695,6 +695,15 @@ func Test_Mock_Unset_WithUnsetDisabled_Option(t *testing.T) {
 	assert.Len(t, mockedService.ExpectedCalls, 1)
 }
 
+func Test_Mock_Toggle(t *testing.T) {
+	var mockedService = new(TestExampleImplementation)
+	mockedService.On("TheExampleMethod", 1).Toggle(true)
+	assert.Len(t, mockedService.ExpectedCalls, 1)
+
+	mockedService.On("TheExampleMethod", 1).Toggle(false)
+	assert.Len(t, mockedService.ExpectedCalls, 0)
+}
+
 func Test_Mock_Return(t *testing.T) {
 
 	// make a test impl object

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -666,6 +666,35 @@ func Test_Mock_Unset_WithFuncPanics(t *testing.T) {
 	})
 }
 
+func Test_Mock_Unset_WithUnsetToggle_Option(t *testing.T) {
+	// make a test impl object
+	var mockedService = new(TestExampleImplementation)
+	mockedService.On("TheExampleMethod", 1).
+		Unset(WithUnsetToggle(true))
+	assert.Len(t, mockedService.ExpectedCalls, 0)
+
+	mockedService.On("TestExampleMethod", 1).
+		Unset(WithUnsetToggle(false))
+	assert.Len(t, mockedService.ExpectedCalls, 1)
+}
+
+func Test_Mock_Unset_WithUnsetEnabled_Option(t *testing.T) {
+	// make a test impl object
+	var mockedService = new(TestExampleImplementation)
+	mockedService.On("TheExampleMethod", 1).
+		Unset(WithUnsetEnabled())
+
+	assert.Len(t, mockedService.ExpectedCalls, 0)
+}
+
+func Test_Mock_Unset_WithUnsetDisabled_Option(t *testing.T) {
+	// make a test impl object
+	var mockedService = new(TestExampleImplementation)
+	mockedService.On("TheExampleMethod", 1).
+		Unset(WithUnsetDisabled())
+	assert.Len(t, mockedService.ExpectedCalls, 1)
+}
+
 func Test_Mock_Return(t *testing.T) {
 
 	// make a test impl object


### PR DESCRIPTION
## Summary

Toggle on/off Unset method with an option.

## Changes

- New type `UnsetOption` was defined
- New function that return `UnsetOption` were defined: `WithUnsetToggle`, `WithUnsetEnabled`, `WithUnsetDisabled`
- `Unset` method will accept variadic list of `UnsetOptions` to be called, which makes the new change entirely backward-compatible
- By default `Unset` will be enabled, which is also backward-compatible

## Motivation

Consider the following example test scenario:

The goal is to test http server API. The test may set up a local http server, database and mocks to 3rd party services. Since the tests are calling a mocked server, it may be useful to use mock `EXPECT()` calls. Test structure:
1. Setup local server, database and mocks
2. Mock 3rd party service calls
3. Send request to local server
4. Assert response
5. Verify side effects - execute database query

As an enhancement, such tests can easily be called against deployed application, by simply replacing server and database URLs. The only catch are mocked calls, which won't be executed, since the request is sent to a remote server.

In such case, it may be possible to call `Unset()` method with `WithUnsetToggle` option, which value is set based on the current environment. For example:
```go
func Env() mock.UnsetOption {
    if os.Getenv("local") {
        return mock.WithUnsetToggle(false)
    }
    return mock.WithUnsetToggle(true)
}

// In test ...
func TestAPI(t *testing.T) {
    // setup server, database and mocks
    mock.Call3rdParty(ctx, argument).Return(nil).Unset(Env())

    response := client.Post(request)
    // assertions and database query
}
```

In the above example, if environment is "local" Unset will be disabled, meaning that all mocks will execute.
If environment is other than "local" the Unset will be enabled, meaning that mocks will not be called.

This allows to run the same suite of tests regardless of environment and setup.

### Alternative approach

> Edit: I also implemened `Toggle` method, that is way simpler and may be used in a similar way. I am looking forward to your feedback.

```go
func Env() bool {
    return os.Getenv("ENV") == "local"
}
// ...
mock.Call3rdParty(ctx, argument).Return(nil).Toggle(Env())
```

P.S. If there is an easier way to achieve similar behaviour than what I proposed, please let me know. I wasn't able to find any workaround, other than calling `Unset` in `if` block. I am also open to any suggestions and would definitely like to implement this logic somewhere in testify package, only if you think this is the right approach.

## Related issues
<!-- Put `Closes #XXXX` for each issue number this PR fixes/closes -->

None
