### PR TITLE
fix: grammar in godoc

### DIFF
--- a/assert/assertion_format.go
+++ b/assert/assertion_format.go
@@ -621,7 +621,7 @@ func NotEqualValuesf(t TestingT, expected interface{}, actual interface{}, msg s
 	return NotEqualValues(t, expected, actual, append([]interface{}{msg}, args...)...)
 }
 
-// NotErrorIsf asserts that at none of the errors in err's chain matches target.
+// NotErrorIsf asserts that none of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
 func NotErrorIsf(t TestingT, err error, target error, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {

--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -1234,7 +1234,7 @@ func (a *Assertions) NotEqualf(expected interface{}, actual interface{}, msg str
 	return NotEqualf(a.t, expected, actual, msg, args...)
 }
 
-// NotErrorIs asserts that at none of the errors in err's chain matches target.
+// NotErrorIs asserts that none of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
 func (a *Assertions) NotErrorIs(err error, target error, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
@@ -1243,7 +1243,7 @@ func (a *Assertions) NotErrorIs(err error, target error, msgAndArgs ...interface
 	return NotErrorIs(a.t, err, target, msgAndArgs...)
 }
 
-// NotErrorIsf asserts that at none of the errors in err's chain matches target.
+// NotErrorIsf asserts that none of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
 func (a *Assertions) NotErrorIsf(err error, target error, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -2094,7 +2094,7 @@ func ErrorIs(t TestingT, err, target error, msgAndArgs ...interface{}) bool {
 	), msgAndArgs...)
 }
 
-// NotErrorIs asserts that at none of the errors in err's chain matches target.
+// NotErrorIs asserts that none of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
 func NotErrorIs(t TestingT, err, target error, msgAndArgs ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {

--- a/require/require.go
+++ b/require/require.go
@@ -1559,7 +1559,7 @@ func NotEqualf(t TestingT, expected interface{}, actual interface{}, msg string,
 	t.FailNow()
 }
 
-// NotErrorIs asserts that at none of the errors in err's chain matches target.
+// NotErrorIs asserts that none of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
 func NotErrorIs(t TestingT, err error, target error, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
@@ -1571,7 +1571,7 @@ func NotErrorIs(t TestingT, err error, target error, msgAndArgs ...interface{}) 
 	t.FailNow()
 }
 
-// NotErrorIsf asserts that at none of the errors in err's chain matches target.
+// NotErrorIsf asserts that none of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
 func NotErrorIsf(t TestingT, err error, target error, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {

--- a/require/require_forward.go
+++ b/require/require_forward.go
@@ -1235,7 +1235,7 @@ func (a *Assertions) NotEqualf(expected interface{}, actual interface{}, msg str
 	NotEqualf(a.t, expected, actual, msg, args...)
 }
 
-// NotErrorIs asserts that at none of the errors in err's chain matches target.
+// NotErrorIs asserts that none of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
 func (a *Assertions) NotErrorIs(err error, target error, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
@@ -1244,7 +1244,7 @@ func (a *Assertions) NotErrorIs(err error, target error, msgAndArgs ...interface
 	NotErrorIs(a.t, err, target, msgAndArgs...)
 }
 
-// NotErrorIsf asserts that at none of the errors in err's chain matches target.
+// NotErrorIsf asserts that none of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
 func (a *Assertions) NotErrorIsf(err error, target error, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {


### PR DESCRIPTION
## Summary
Grammar fixes in doc: _asserts that at none_ -> _asserts that none_

```console
$ grep 'that at none' */*.go
assert/assertion_format.go:// NotErrorIsf asserts that at none of the errors in err's chain matches target.
assert/assertion_forward.go:// NotErrorIs asserts that at none of the errors in err's chain matches target.
assert/assertion_forward.go:// NotErrorIsf asserts that at none of the errors in err's chain matches target.
assert/assertions.go:// NotErrorIs asserts that at none of the errors in err's chain matches target.
require/require.go:// NotErrorIs asserts that at none of the errors in err's chain matches target.
require/require.go:// NotErrorIsf asserts that at none of the errors in err's chain matches target.
require/require_forward.go:// NotErrorIs asserts that at none of the errors in err's chain matches target.
require/require_forward.go:// NotErrorIsf asserts that at none of the errors in err's chain matches target.
```

