### PR TITLE
Generate better comments for require package

### DIFF
--- a/_codegen/main.go
+++ b/_codegen/main.go
@@ -107,7 +107,9 @@ func parseTemplates() (*template.Template, *template.Template, error) {
 		}
 		funcTemplate = string(f)
 	}
-	tmpl, err := template.New("function").Parse(funcTemplate)
+	tmpl, err := template.New("function").Funcs(template.FuncMap{
+		"replace": strings.ReplaceAll,
+	}).Parse(funcTemplate)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/require/require.go
+++ b/require/require.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Condition uses a Comparison to assert a complex condition.
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Condition(t TestingT, comp assert.Comparison, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -22,7 +22,7 @@ func Condition(t TestingT, comp assert.Comparison, msgAndArgs ...interface{}) {
 }
 
 // Conditionf uses a Comparison to assert a complex condition.
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Conditionf(t TestingT, comp assert.Comparison, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -40,7 +40,7 @@ func Conditionf(t TestingT, comp assert.Comparison, msg string, args ...interfac
 //	require.Contains(t, ["Hello", "World"], "World")
 //	require.Contains(t, {"Hello": "World"}, "Hello")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Contains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -58,7 +58,7 @@ func Contains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...int
 //	require.Containsf(t, ["Hello", "World"], "World", "error message %s", "formatted")
 //	require.Containsf(t, {"Hello": "World"}, "Hello", "error message %s", "formatted")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Containsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -71,7 +71,7 @@ func Containsf(t TestingT, s interface{}, contains interface{}, msg string, args
 
 // DirExists checks whether a directory exists in the given path. It also fails
 // if the path is a file rather a directory or there is an error checking whether it exists.
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func DirExists(t TestingT, path string, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -84,7 +84,7 @@ func DirExists(t TestingT, path string, msgAndArgs ...interface{}) {
 
 // DirExistsf checks whether a directory exists in the given path. It also fails
 // if the path is a file rather a directory or there is an error checking whether it exists.
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func DirExistsf(t TestingT, path string, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -100,7 +100,7 @@ func DirExistsf(t TestingT, path string, msg string, args ...interface{}) {
 // the number of appearances of each of them in both lists should match.
 //
 // require.ElementsMatch(t, [1, 3, 2, 3], [1, 3, 3, 2])
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func ElementsMatch(t TestingT, listA interface{}, listB interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -116,7 +116,7 @@ func ElementsMatch(t TestingT, listA interface{}, listB interface{}, msgAndArgs 
 // the number of appearances of each of them in both lists should match.
 //
 // require.ElementsMatchf(t, [1, 3, 2, 3], [1, 3, 3, 2], "error message %s", "formatted")
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func ElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -132,7 +132,7 @@ func ElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string
 //
 //	require.Empty(t, obj)
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -148,7 +148,7 @@ func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 //
 //	require.Emptyf(t, obj, "error message %s", "formatted")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Emptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -166,7 +166,7 @@ func Emptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses). Function equality
 // cannot be determined and will always fail.
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Equal(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -183,7 +183,7 @@ func Equal(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...i
 //	actualObj, err := SomeFunction()
 //	require.EqualError(t, err,  expectedErrorString)
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func EqualError(t TestingT, theError error, errString string, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -200,7 +200,7 @@ func EqualError(t TestingT, theError error, errString string, msgAndArgs ...inte
 //	actualObj, err := SomeFunction()
 //	require.EqualErrorf(t, err,  expectedErrorString, "error message %s", "formatted")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func EqualErrorf(t TestingT, theError error, errString string, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -222,7 +222,7 @@ func EqualErrorf(t TestingT, theError error, errString string, msg string, args 
 //	 require.EqualExportedValues(t, S{1, 2}, S{1, 3}) => true
 //	 require.EqualExportedValues(t, S{1, 2}, S{2, 3}) => false
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func EqualExportedValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -244,7 +244,7 @@ func EqualExportedValues(t TestingT, expected interface{}, actual interface{}, m
 //	 require.EqualExportedValuesf(t, S{1, 2}, S{1, 3}, "error message %s", "formatted") => true
 //	 require.EqualExportedValuesf(t, S{1, 2}, S{2, 3}, "error message %s", "formatted") => false
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func EqualExportedValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -260,7 +260,7 @@ func EqualExportedValuesf(t TestingT, expected interface{}, actual interface{}, 
 //
 //	require.EqualValues(t, uint32(123), int32(123))
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func EqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -276,7 +276,7 @@ func EqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArg
 //
 //	require.EqualValuesf(t, uint32(123), int32(123), "error message %s", "formatted")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func EqualValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -294,7 +294,7 @@ func EqualValuesf(t TestingT, expected interface{}, actual interface{}, msg stri
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses). Function equality
 // cannot be determined and will always fail.
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Equalf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -312,7 +312,7 @@ func Equalf(t TestingT, expected interface{}, actual interface{}, msg string, ar
 //		   require.Equal(t, expectedError, err)
 //	  }
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Error(t TestingT, err error, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -325,7 +325,7 @@ func Error(t TestingT, err error, msgAndArgs ...interface{}) {
 
 // ErrorAs asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
 // This is a wrapper for errors.As.
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func ErrorAs(t TestingT, err error, target interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -338,7 +338,7 @@ func ErrorAs(t TestingT, err error, target interface{}, msgAndArgs ...interface{
 
 // ErrorAsf asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
 // This is a wrapper for errors.As.
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func ErrorAsf(t TestingT, err error, target interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -355,7 +355,7 @@ func ErrorAsf(t TestingT, err error, target interface{}, msg string, args ...int
 //	actualObj, err := SomeFunction()
 //	require.ErrorContains(t, err,  expectedErrorSubString)
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func ErrorContains(t TestingT, theError error, contains string, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -372,7 +372,7 @@ func ErrorContains(t TestingT, theError error, contains string, msgAndArgs ...in
 //	actualObj, err := SomeFunction()
 //	require.ErrorContainsf(t, err,  expectedErrorSubString, "error message %s", "formatted")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func ErrorContainsf(t TestingT, theError error, contains string, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -385,7 +385,7 @@ func ErrorContainsf(t TestingT, theError error, contains string, msg string, arg
 
 // ErrorIs asserts that at least one of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func ErrorIs(t TestingT, err error, target error, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -398,7 +398,7 @@ func ErrorIs(t TestingT, err error, target error, msgAndArgs ...interface{}) {
 
 // ErrorIsf asserts that at least one of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func ErrorIsf(t TestingT, err error, target error, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -416,7 +416,7 @@ func ErrorIsf(t TestingT, err error, target error, msg string, args ...interface
 //		   require.Equal(t, expectedErrorf, err)
 //	  }
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Errorf(t TestingT, err error, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -432,7 +432,7 @@ func Errorf(t TestingT, err error, msg string, args ...interface{}) {
 //
 //	require.Eventually(t, func() bool { return true; }, time.Second, 10*time.Millisecond)
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Eventually(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -462,7 +462,7 @@ func Eventually(t TestingT, condition func() bool, waitFor time.Duration, tick t
 //		require.True(c, externalValue, "expected 'externalValue' to be true")
 //	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func EventuallyWithT(t TestingT, condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -492,7 +492,7 @@ func EventuallyWithT(t TestingT, condition func(collect *assert.CollectT), waitF
 //		require.True(c, externalValue, "expected 'externalValue' to be true")
 //	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func EventuallyWithTf(t TestingT, condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -508,7 +508,7 @@ func EventuallyWithTf(t TestingT, condition func(collect *assert.CollectT), wait
 //
 //	require.Eventuallyf(t, func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Eventuallyf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -523,7 +523,7 @@ func Eventuallyf(t TestingT, condition func() bool, waitFor time.Duration, tick 
 //
 //	require.Exactly(t, int32(123), int64(123))
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Exactly(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -538,7 +538,7 @@ func Exactly(t TestingT, expected interface{}, actual interface{}, msgAndArgs ..
 //
 //	require.Exactlyf(t, int32(123), int64(123), "error message %s", "formatted")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Exactlyf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -550,7 +550,7 @@ func Exactlyf(t TestingT, expected interface{}, actual interface{}, msg string, 
 }
 
 // Fail reports a failure through
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Fail(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -562,7 +562,7 @@ func Fail(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
 }
 
 // FailNow fails test
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func FailNow(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -574,7 +574,7 @@ func FailNow(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
 }
 
 // FailNowf fails test
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func FailNowf(t TestingT, failureMessage string, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -586,7 +586,7 @@ func FailNowf(t TestingT, failureMessage string, msg string, args ...interface{}
 }
 
 // Failf reports a failure through
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Failf(t TestingT, failureMessage string, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -601,7 +601,7 @@ func Failf(t TestingT, failureMessage string, msg string, args ...interface{}) {
 //
 //	require.False(t, myBool)
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func False(t TestingT, value bool, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -616,7 +616,7 @@ func False(t TestingT, value bool, msgAndArgs ...interface{}) {
 //
 //	require.Falsef(t, myBool, "error message %s", "formatted")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Falsef(t TestingT, value bool, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -629,7 +629,7 @@ func Falsef(t TestingT, value bool, msg string, args ...interface{}) {
 
 // FileExists checks whether a file exists in the given path. It also fails if
 // the path points to a directory or there is an error when trying to check the file.
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func FileExists(t TestingT, path string, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -642,7 +642,7 @@ func FileExists(t TestingT, path string, msgAndArgs ...interface{}) {
 
 // FileExistsf checks whether a file exists in the given path. It also fails if
 // the path points to a directory or there is an error when trying to check the file.
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func FileExistsf(t TestingT, path string, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -659,7 +659,7 @@ func FileExistsf(t TestingT, path string, msg string, args ...interface{}) {
 //	require.Greater(t, float64(2), float64(1))
 //	require.Greater(t, "b", "a")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Greater(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -677,7 +677,7 @@ func Greater(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface
 //	require.GreaterOrEqual(t, "b", "a")
 //	require.GreaterOrEqual(t, "b", "b")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func GreaterOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -695,7 +695,7 @@ func GreaterOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...in
 //	require.GreaterOrEqualf(t, "b", "a", "error message %s", "formatted")
 //	require.GreaterOrEqualf(t, "b", "b", "error message %s", "formatted")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func GreaterOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -712,7 +712,7 @@ func GreaterOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, arg
 //	require.Greaterf(t, float64(2), float64(1), "error message %s", "formatted")
 //	require.Greaterf(t, "b", "a", "error message %s", "formatted")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Greaterf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -729,7 +729,7 @@ func Greaterf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...in
 //	require.HTTPBodyContains(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
 //
 // Returns whether the assertion was successful (true) or not (false).
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func HTTPBodyContains(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -746,7 +746,7 @@ func HTTPBodyContains(t TestingT, handler http.HandlerFunc, method string, url s
 //	require.HTTPBodyContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func HTTPBodyContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -763,7 +763,7 @@ func HTTPBodyContainsf(t TestingT, handler http.HandlerFunc, method string, url 
 //	require.HTTPBodyNotContains(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
 //
 // Returns whether the assertion was successful (true) or not (false).
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func HTTPBodyNotContains(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -780,7 +780,7 @@ func HTTPBodyNotContains(t TestingT, handler http.HandlerFunc, method string, ur
 //	require.HTTPBodyNotContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func HTTPBodyNotContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -796,7 +796,7 @@ func HTTPBodyNotContainsf(t TestingT, handler http.HandlerFunc, method string, u
 //	require.HTTPError(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func HTTPError(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -812,7 +812,7 @@ func HTTPError(t TestingT, handler http.HandlerFunc, method string, url string, 
 //	require.HTTPErrorf(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func HTTPErrorf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -828,7 +828,7 @@ func HTTPErrorf(t TestingT, handler http.HandlerFunc, method string, url string,
 //	require.HTTPRedirect(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func HTTPRedirect(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -844,7 +844,7 @@ func HTTPRedirect(t TestingT, handler http.HandlerFunc, method string, url strin
 //	require.HTTPRedirectf(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func HTTPRedirectf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -860,7 +860,7 @@ func HTTPRedirectf(t TestingT, handler http.HandlerFunc, method string, url stri
 //	require.HTTPStatusCode(t, myHandler, "GET", "/notImplemented", nil, 501)
 //
 // Returns whether the assertion was successful (true) or not (false).
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func HTTPStatusCode(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -876,7 +876,7 @@ func HTTPStatusCode(t TestingT, handler http.HandlerFunc, method string, url str
 //	require.HTTPStatusCodef(t, myHandler, "GET", "/notImplemented", nil, 501, "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func HTTPStatusCodef(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -892,7 +892,7 @@ func HTTPStatusCodef(t TestingT, handler http.HandlerFunc, method string, url st
 //	require.HTTPSuccess(t, myHandler, "POST", "http://www.google.com", nil)
 //
 // Returns whether the assertion was successful (true) or not (false).
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func HTTPSuccess(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -908,7 +908,7 @@ func HTTPSuccess(t TestingT, handler http.HandlerFunc, method string, url string
 //	require.HTTPSuccessf(t, myHandler, "POST", "http://www.google.com", nil, "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func HTTPSuccessf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -923,7 +923,7 @@ func HTTPSuccessf(t TestingT, handler http.HandlerFunc, method string, url strin
 //
 //	require.Implements(t, (*MyInterface)(nil), new(MyObject))
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Implements(t TestingT, interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -938,7 +938,7 @@ func Implements(t TestingT, interfaceObject interface{}, object interface{}, msg
 //
 //	require.Implementsf(t, (*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Implementsf(t TestingT, interfaceObject interface{}, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -953,7 +953,7 @@ func Implementsf(t TestingT, interfaceObject interface{}, object interface{}, ms
 //
 //	require.InDelta(t, math.Pi, 22/7.0, 0.01)
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func InDelta(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -965,7 +965,7 @@ func InDelta(t TestingT, expected interface{}, actual interface{}, delta float64
 }
 
 // InDeltaMapValues is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func InDeltaMapValues(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -977,7 +977,7 @@ func InDeltaMapValues(t TestingT, expected interface{}, actual interface{}, delt
 }
 
 // InDeltaMapValuesf is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func InDeltaMapValuesf(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -989,7 +989,7 @@ func InDeltaMapValuesf(t TestingT, expected interface{}, actual interface{}, del
 }
 
 // InDeltaSlice is the same as InDelta, except it compares two slices.
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func InDeltaSlice(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1001,7 +1001,7 @@ func InDeltaSlice(t TestingT, expected interface{}, actual interface{}, delta fl
 }
 
 // InDeltaSlicef is the same as InDelta, except it compares two slices.
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func InDeltaSlicef(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1016,7 +1016,7 @@ func InDeltaSlicef(t TestingT, expected interface{}, actual interface{}, delta f
 //
 //	require.InDeltaf(t, math.Pi, 22/7.0, 0.01, "error message %s", "formatted")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func InDeltaf(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1028,7 +1028,7 @@ func InDeltaf(t TestingT, expected interface{}, actual interface{}, delta float6
 }
 
 // InEpsilon asserts that expected and actual have a relative error less than epsilon
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func InEpsilon(t TestingT, expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1040,7 +1040,7 @@ func InEpsilon(t TestingT, expected interface{}, actual interface{}, epsilon flo
 }
 
 // InEpsilonSlice is the same as InEpsilon, except it compares each value from two slices.
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func InEpsilonSlice(t TestingT, expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1052,7 +1052,7 @@ func InEpsilonSlice(t TestingT, expected interface{}, actual interface{}, epsilo
 }
 
 // InEpsilonSlicef is the same as InEpsilon, except it compares each value from two slices.
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func InEpsilonSlicef(t TestingT, expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1064,7 +1064,7 @@ func InEpsilonSlicef(t TestingT, expected interface{}, actual interface{}, epsil
 }
 
 // InEpsilonf asserts that expected and actual have a relative error less than epsilon
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func InEpsilonf(t TestingT, expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1081,7 +1081,7 @@ func InEpsilonf(t TestingT, expected interface{}, actual interface{}, epsilon fl
 //	require.IsDecreasing(t, []float{2, 1})
 //	require.IsDecreasing(t, []string{"b", "a"})
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func IsDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1098,7 +1098,7 @@ func IsDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 //	require.IsDecreasingf(t, []float{2, 1}, "error message %s", "formatted")
 //	require.IsDecreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func IsDecreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1115,7 +1115,7 @@ func IsDecreasingf(t TestingT, object interface{}, msg string, args ...interface
 //	require.IsIncreasing(t, []float{1, 2})
 //	require.IsIncreasing(t, []string{"a", "b"})
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func IsIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1132,7 +1132,7 @@ func IsIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 //	require.IsIncreasingf(t, []float{1, 2}, "error message %s", "formatted")
 //	require.IsIncreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func IsIncreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1149,7 +1149,7 @@ func IsIncreasingf(t TestingT, object interface{}, msg string, args ...interface
 //	require.IsNonDecreasing(t, []float{1, 2})
 //	require.IsNonDecreasing(t, []string{"a", "b"})
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func IsNonDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1166,7 +1166,7 @@ func IsNonDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) 
 //	require.IsNonDecreasingf(t, []float{1, 2}, "error message %s", "formatted")
 //	require.IsNonDecreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func IsNonDecreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1183,7 +1183,7 @@ func IsNonDecreasingf(t TestingT, object interface{}, msg string, args ...interf
 //	require.IsNonIncreasing(t, []float{2, 1})
 //	require.IsNonIncreasing(t, []string{"b", "a"})
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func IsNonIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1200,7 +1200,7 @@ func IsNonIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) 
 //	require.IsNonIncreasingf(t, []float{2, 1}, "error message %s", "formatted")
 //	require.IsNonIncreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func IsNonIncreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1212,7 +1212,7 @@ func IsNonIncreasingf(t TestingT, object interface{}, msg string, args ...interf
 }
 
 // IsType asserts that the specified objects are of the same type.
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func IsType(t TestingT, expectedType interface{}, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1224,7 +1224,7 @@ func IsType(t TestingT, expectedType interface{}, object interface{}, msgAndArgs
 }
 
 // IsTypef asserts that the specified objects are of the same type.
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func IsTypef(t TestingT, expectedType interface{}, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1239,7 +1239,7 @@ func IsTypef(t TestingT, expectedType interface{}, object interface{}, msg strin
 //
 //	require.JSONEq(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func JSONEq(t TestingT, expected string, actual string, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1254,7 +1254,7 @@ func JSONEq(t TestingT, expected string, actual string, msgAndArgs ...interface{
 //
 //	require.JSONEqf(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func JSONEqf(t TestingT, expected string, actual string, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1270,7 +1270,7 @@ func JSONEqf(t TestingT, expected string, actual string, msg string, args ...int
 //
 //	require.Len(t, mySlice, 3)
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1286,7 +1286,7 @@ func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) 
 //
 //	require.Lenf(t, mySlice, 3, "error message %s", "formatted")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Lenf(t TestingT, object interface{}, length int, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1303,7 +1303,7 @@ func Lenf(t TestingT, object interface{}, length int, msg string, args ...interf
 //	require.Less(t, float64(1), float64(2))
 //	require.Less(t, "a", "b")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1321,7 +1321,7 @@ func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{})
 //	require.LessOrEqual(t, "a", "b")
 //	require.LessOrEqual(t, "b", "b")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func LessOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1339,7 +1339,7 @@ func LessOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...inter
 //	require.LessOrEqualf(t, "a", "b", "error message %s", "formatted")
 //	require.LessOrEqualf(t, "b", "b", "error message %s", "formatted")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func LessOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1356,7 +1356,7 @@ func LessOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args .
 //	require.Lessf(t, float64(1), float64(2), "error message %s", "formatted")
 //	require.Lessf(t, "a", "b", "error message %s", "formatted")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Lessf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1372,7 +1372,7 @@ func Lessf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...inter
 //	require.Negative(t, -1)
 //	require.Negative(t, -1.23)
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Negative(t TestingT, e interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1388,7 +1388,7 @@ func Negative(t TestingT, e interface{}, msgAndArgs ...interface{}) {
 //	require.Negativef(t, -1, "error message %s", "formatted")
 //	require.Negativef(t, -1.23, "error message %s", "formatted")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Negativef(t TestingT, e interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1404,7 +1404,7 @@ func Negativef(t TestingT, e interface{}, msg string, args ...interface{}) {
 //
 //	require.Never(t, func() bool { return false; }, time.Second, 10*time.Millisecond)
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Never(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1420,7 +1420,7 @@ func Never(t TestingT, condition func() bool, waitFor time.Duration, tick time.D
 //
 //	require.Neverf(t, func() bool { return false; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Neverf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1435,7 +1435,7 @@ func Neverf(t TestingT, condition func() bool, waitFor time.Duration, tick time.
 //
 //	require.Nil(t, err)
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1450,7 +1450,7 @@ func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 //
 //	require.Nilf(t, err, "error message %s", "formatted")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Nilf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1463,7 +1463,7 @@ func Nilf(t TestingT, object interface{}, msg string, args ...interface{}) {
 
 // NoDirExists checks whether a directory does not exist in the given path.
 // It fails if the path points to an existing _directory_ only.
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NoDirExists(t TestingT, path string, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1476,7 +1476,7 @@ func NoDirExists(t TestingT, path string, msgAndArgs ...interface{}) {
 
 // NoDirExistsf checks whether a directory does not exist in the given path.
 // It fails if the path points to an existing _directory_ only.
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NoDirExistsf(t TestingT, path string, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1494,7 +1494,7 @@ func NoDirExistsf(t TestingT, path string, msg string, args ...interface{}) {
 //		   require.Equal(t, expectedObj, actualObj)
 //	  }
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NoError(t TestingT, err error, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1512,7 +1512,7 @@ func NoError(t TestingT, err error, msgAndArgs ...interface{}) {
 //		   require.Equal(t, expectedObj, actualObj)
 //	  }
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NoErrorf(t TestingT, err error, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1525,7 +1525,7 @@ func NoErrorf(t TestingT, err error, msg string, args ...interface{}) {
 
 // NoFileExists checks whether a file does not exist in a given path. It fails
 // if the path points to an existing _file_ only.
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NoFileExists(t TestingT, path string, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1538,7 +1538,7 @@ func NoFileExists(t TestingT, path string, msgAndArgs ...interface{}) {
 
 // NoFileExistsf checks whether a file does not exist in a given path. It fails
 // if the path points to an existing _file_ only.
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NoFileExistsf(t TestingT, path string, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1556,7 +1556,7 @@ func NoFileExistsf(t TestingT, path string, msg string, args ...interface{}) {
 //	require.NotContains(t, ["Hello", "World"], "Earth")
 //	require.NotContains(t, {"Hello": "World"}, "Earth")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotContains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1574,7 +1574,7 @@ func NotContains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...
 //	require.NotContainsf(t, ["Hello", "World"], "Earth", "error message %s", "formatted")
 //	require.NotContainsf(t, {"Hello": "World"}, "Earth", "error message %s", "formatted")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotContainsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1595,7 +1595,7 @@ func NotContainsf(t TestingT, s interface{}, contains interface{}, msg string, a
 // require.NotElementsMatch(t, [1, 1, 2, 3], [1, 2, 3]) -> true
 //
 // require.NotElementsMatch(t, [1, 2, 3], [1, 2, 4]) -> true
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotElementsMatch(t TestingT, listA interface{}, listB interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1616,7 +1616,7 @@ func NotElementsMatch(t TestingT, listA interface{}, listB interface{}, msgAndAr
 // require.NotElementsMatchf(t, [1, 1, 2, 3], [1, 2, 3], "error message %s", "formatted") -> true
 //
 // require.NotElementsMatchf(t, [1, 2, 3], [1, 2, 4], "error message %s", "formatted") -> true
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1634,7 +1634,7 @@ func NotElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg str
 //	  require.Equal(t, "two", obj[1])
 //	}
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1652,7 +1652,7 @@ func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 //	  require.Equal(t, "two", obj[1])
 //	}
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1669,7 +1669,7 @@ func NotEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) 
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotEqual(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1684,7 +1684,7 @@ func NotEqual(t TestingT, expected interface{}, actual interface{}, msgAndArgs .
 //
 //	require.NotEqualValues(t, obj1, obj2)
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotEqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1699,7 +1699,7 @@ func NotEqualValues(t TestingT, expected interface{}, actual interface{}, msgAnd
 //
 //	require.NotEqualValuesf(t, obj1, obj2, "error message %s", "formatted")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotEqualValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1716,7 +1716,7 @@ func NotEqualValuesf(t TestingT, expected interface{}, actual interface{}, msg s
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotEqualf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1729,7 +1729,7 @@ func NotEqualf(t TestingT, expected interface{}, actual interface{}, msg string,
 
 // NotErrorIs asserts that none of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotErrorIs(t TestingT, err error, target error, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1742,7 +1742,7 @@ func NotErrorIs(t TestingT, err error, target error, msgAndArgs ...interface{}) 
 
 // NotErrorIsf asserts that none of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotErrorIsf(t TestingT, err error, target error, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1757,7 +1757,7 @@ func NotErrorIsf(t TestingT, err error, target error, msg string, args ...interf
 //
 //	require.NotImplements(t, (*MyInterface)(nil), new(MyObject))
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotImplements(t TestingT, interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1772,7 +1772,7 @@ func NotImplements(t TestingT, interfaceObject interface{}, object interface{}, 
 //
 //	require.NotImplementsf(t, (*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotImplementsf(t TestingT, interfaceObject interface{}, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1787,7 +1787,7 @@ func NotImplementsf(t TestingT, interfaceObject interface{}, object interface{},
 //
 //	require.NotNil(t, err)
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1802,7 +1802,7 @@ func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 //
 //	require.NotNilf(t, err, "error message %s", "formatted")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotNilf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1817,7 +1817,7 @@ func NotNilf(t TestingT, object interface{}, msg string, args ...interface{}) {
 //
 //	require.NotPanics(t, func(){ RemainCalm() })
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotPanics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1832,7 +1832,7 @@ func NotPanics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 //
 //	require.NotPanicsf(t, func(){ RemainCalm() }, "error message %s", "formatted")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotPanicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1848,7 +1848,7 @@ func NotPanicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interfac
 //	require.NotRegexp(t, regexp.MustCompile("starts"), "it's starting")
 //	require.NotRegexp(t, "^start", "it's not starting")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1864,7 +1864,7 @@ func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interf
 //	require.NotRegexpf(t, regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
 //	require.NotRegexpf(t, "^start", "it's not starting", "error message %s", "formatted")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotRegexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1881,7 +1881,7 @@ func NotRegexpf(t TestingT, rx interface{}, str interface{}, msg string, args ..
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotSame(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1898,7 +1898,7 @@ func NotSame(t TestingT, expected interface{}, actual interface{}, msgAndArgs ..
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotSamef(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1916,7 +1916,7 @@ func NotSamef(t TestingT, expected interface{}, actual interface{}, msg string, 
 //	require.NotSubset(t, [1, 3, 4], [1, 2])
 //	require.NotSubset(t, {"x": 1, "y": 2}, {"z": 3})
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotSubset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1934,7 +1934,7 @@ func NotSubset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...i
 //	require.NotSubsetf(t, [1, 3, 4], [1, 2], "error message %s", "formatted")
 //	require.NotSubsetf(t, {"x": 1, "y": 2}, {"z": 3}, "error message %s", "formatted")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotSubsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1946,7 +1946,7 @@ func NotSubsetf(t TestingT, list interface{}, subset interface{}, msg string, ar
 }
 
 // NotZero asserts that i is not the zero value for its type.
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotZero(t TestingT, i interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1958,7 +1958,7 @@ func NotZero(t TestingT, i interface{}, msgAndArgs ...interface{}) {
 }
 
 // NotZerof asserts that i is not the zero value for its type.
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotZerof(t TestingT, i interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1973,7 +1973,7 @@ func NotZerof(t TestingT, i interface{}, msg string, args ...interface{}) {
 //
 //	require.Panics(t, func(){ GoCrazy() })
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Panics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1990,7 +1990,7 @@ func Panics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 //
 //	require.PanicsWithError(t, "crazy error", func(){ GoCrazy() })
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func PanicsWithError(t TestingT, errString string, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2007,7 +2007,7 @@ func PanicsWithError(t TestingT, errString string, f assert.PanicTestFunc, msgAn
 //
 //	require.PanicsWithErrorf(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func PanicsWithErrorf(t TestingT, errString string, f assert.PanicTestFunc, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2023,7 +2023,7 @@ func PanicsWithErrorf(t TestingT, errString string, f assert.PanicTestFunc, msg 
 //
 //	require.PanicsWithValue(t, "crazy error", func(){ GoCrazy() })
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func PanicsWithValue(t TestingT, expected interface{}, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2039,7 +2039,7 @@ func PanicsWithValue(t TestingT, expected interface{}, f assert.PanicTestFunc, m
 //
 //	require.PanicsWithValuef(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func PanicsWithValuef(t TestingT, expected interface{}, f assert.PanicTestFunc, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2054,7 +2054,7 @@ func PanicsWithValuef(t TestingT, expected interface{}, f assert.PanicTestFunc, 
 //
 //	require.Panicsf(t, func(){ GoCrazy() }, "error message %s", "formatted")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Panicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2070,7 +2070,7 @@ func Panicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}
 //	require.Positive(t, 1)
 //	require.Positive(t, 1.23)
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Positive(t TestingT, e interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2086,7 +2086,7 @@ func Positive(t TestingT, e interface{}, msgAndArgs ...interface{}) {
 //	require.Positivef(t, 1, "error message %s", "formatted")
 //	require.Positivef(t, 1.23, "error message %s", "formatted")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Positivef(t TestingT, e interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2102,7 +2102,7 @@ func Positivef(t TestingT, e interface{}, msg string, args ...interface{}) {
 //	require.Regexp(t, regexp.MustCompile("start"), "it's starting")
 //	require.Regexp(t, "start...$", "it's not starting")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2118,7 +2118,7 @@ func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface
 //	require.Regexpf(t, regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
 //	require.Regexpf(t, "start...$", "it's not starting", "error message %s", "formatted")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Regexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2135,7 +2135,7 @@ func Regexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...in
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Same(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2152,7 +2152,7 @@ func Same(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...in
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Samef(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2169,7 +2169,7 @@ func Samef(t TestingT, expected interface{}, actual interface{}, msg string, arg
 //	require.Subset(t, [1, 2, 3], [1, 2])
 //	require.Subset(t, {"x": 1, "y": 2}, {"x": 1})
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Subset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2186,7 +2186,7 @@ func Subset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...inte
 //	require.Subsetf(t, [1, 2, 3], [1, 2], "error message %s", "formatted")
 //	require.Subsetf(t, {"x": 1, "y": 2}, {"x": 1}, "error message %s", "formatted")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Subsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2201,7 +2201,7 @@ func Subsetf(t TestingT, list interface{}, subset interface{}, msg string, args 
 //
 //	require.True(t, myBool)
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func True(t TestingT, value bool, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2216,7 +2216,7 @@ func True(t TestingT, value bool, msgAndArgs ...interface{}) {
 //
 //	require.Truef(t, myBool, "error message %s", "formatted")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Truef(t TestingT, value bool, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2231,7 +2231,7 @@ func Truef(t TestingT, value bool, msg string, args ...interface{}) {
 //
 //	require.WithinDuration(t, time.Now(), time.Now(), 10*time.Second)
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func WithinDuration(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2246,7 +2246,7 @@ func WithinDuration(t TestingT, expected time.Time, actual time.Time, delta time
 //
 //	require.WithinDurationf(t, time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2261,7 +2261,7 @@ func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta tim
 //
 //	require.WithinRange(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second))
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func WithinRange(t TestingT, actual time.Time, start time.Time, end time.Time, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2276,7 +2276,7 @@ func WithinRange(t TestingT, actual time.Time, start time.Time, end time.Time, m
 //
 //	require.WithinRangef(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second), "error message %s", "formatted")
 //
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func WithinRangef(t TestingT, actual time.Time, start time.Time, end time.Time, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2288,7 +2288,7 @@ func WithinRangef(t TestingT, actual time.Time, start time.Time, end time.Time, 
 }
 
 // YAMLEq asserts that two YAML strings are equivalent.
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func YAMLEq(t TestingT, expected string, actual string, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2300,7 +2300,7 @@ func YAMLEq(t TestingT, expected string, actual string, msgAndArgs ...interface{
 }
 
 // YAMLEqf asserts that two YAML strings are equivalent.
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func YAMLEqf(t TestingT, expected string, actual string, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2312,7 +2312,7 @@ func YAMLEqf(t TestingT, expected string, actual string, msg string, args ...int
 }
 
 // Zero asserts that i is the zero value for its type.
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Zero(t TestingT, i interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2324,7 +2324,7 @@ func Zero(t TestingT, i interface{}, msgAndArgs ...interface{}) {
 }
 
 // Zerof asserts that i is the zero value for its type.
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Zerof(t TestingT, i interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()

--- a/require/require.go
+++ b/require/require.go
@@ -10,6 +10,7 @@ import (
 )
 
 // Condition uses a Comparison to assert a complex condition.
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func Condition(t TestingT, comp assert.Comparison, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -21,6 +22,7 @@ func Condition(t TestingT, comp assert.Comparison, msgAndArgs ...interface{}) {
 }
 
 // Conditionf uses a Comparison to assert a complex condition.
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func Conditionf(t TestingT, comp assert.Comparison, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -34,9 +36,11 @@ func Conditionf(t TestingT, comp assert.Comparison, msg string, args ...interfac
 // Contains asserts that the specified string, list(array, slice...) or map contains the
 // specified substring or element.
 //
-//	assert.Contains(t, "Hello World", "World")
-//	assert.Contains(t, ["Hello", "World"], "World")
-//	assert.Contains(t, {"Hello": "World"}, "Hello")
+//	require.Contains(t, "Hello World", "World")
+//	require.Contains(t, ["Hello", "World"], "World")
+//	require.Contains(t, {"Hello": "World"}, "Hello")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func Contains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -50,9 +54,11 @@ func Contains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...int
 // Containsf asserts that the specified string, list(array, slice...) or map contains the
 // specified substring or element.
 //
-//	assert.Containsf(t, "Hello World", "World", "error message %s", "formatted")
-//	assert.Containsf(t, ["Hello", "World"], "World", "error message %s", "formatted")
-//	assert.Containsf(t, {"Hello": "World"}, "Hello", "error message %s", "formatted")
+//	require.Containsf(t, "Hello World", "World", "error message %s", "formatted")
+//	require.Containsf(t, ["Hello", "World"], "World", "error message %s", "formatted")
+//	require.Containsf(t, {"Hello": "World"}, "Hello", "error message %s", "formatted")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func Containsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -65,6 +71,7 @@ func Containsf(t TestingT, s interface{}, contains interface{}, msg string, args
 
 // DirExists checks whether a directory exists in the given path. It also fails
 // if the path is a file rather a directory or there is an error checking whether it exists.
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func DirExists(t TestingT, path string, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -77,6 +84,7 @@ func DirExists(t TestingT, path string, msgAndArgs ...interface{}) {
 
 // DirExistsf checks whether a directory exists in the given path. It also fails
 // if the path is a file rather a directory or there is an error checking whether it exists.
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func DirExistsf(t TestingT, path string, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -91,7 +99,8 @@ func DirExistsf(t TestingT, path string, msg string, args ...interface{}) {
 // listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
 // the number of appearances of each of them in both lists should match.
 //
-// assert.ElementsMatch(t, [1, 3, 2, 3], [1, 3, 3, 2])
+// require.ElementsMatch(t, [1, 3, 2, 3], [1, 3, 3, 2])
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func ElementsMatch(t TestingT, listA interface{}, listB interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -106,7 +115,8 @@ func ElementsMatch(t TestingT, listA interface{}, listB interface{}, msgAndArgs 
 // listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
 // the number of appearances of each of them in both lists should match.
 //
-// assert.ElementsMatchf(t, [1, 3, 2, 3], [1, 3, 3, 2], "error message %s", "formatted")
+// require.ElementsMatchf(t, [1, 3, 2, 3], [1, 3, 3, 2], "error message %s", "formatted")
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func ElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -120,7 +130,9 @@ func ElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string
 // Empty asserts that the specified object is empty.  I.e. nil, "", false, 0 or either
 // a slice or a channel with len == 0.
 //
-//	assert.Empty(t, obj)
+//	require.Empty(t, obj)
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -134,7 +146,9 @@ func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 // Emptyf asserts that the specified object is empty.  I.e. nil, "", false, 0 or either
 // a slice or a channel with len == 0.
 //
-//	assert.Emptyf(t, obj, "error message %s", "formatted")
+//	require.Emptyf(t, obj, "error message %s", "formatted")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func Emptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -147,11 +161,12 @@ func Emptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
 
 // Equal asserts that two objects are equal.
 //
-//	assert.Equal(t, 123, 123)
+//	require.Equal(t, 123, 123)
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses). Function equality
 // cannot be determined and will always fail.
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func Equal(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -166,7 +181,9 @@ func Equal(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...i
 // and that it is equal to the provided error.
 //
 //	actualObj, err := SomeFunction()
-//	assert.EqualError(t, err,  expectedErrorString)
+//	require.EqualError(t, err,  expectedErrorString)
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func EqualError(t TestingT, theError error, errString string, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -181,7 +198,9 @@ func EqualError(t TestingT, theError error, errString string, msgAndArgs ...inte
 // and that it is equal to the provided error.
 //
 //	actualObj, err := SomeFunction()
-//	assert.EqualErrorf(t, err,  expectedErrorString, "error message %s", "formatted")
+//	require.EqualErrorf(t, err,  expectedErrorString, "error message %s", "formatted")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func EqualErrorf(t TestingT, theError error, errString string, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -200,8 +219,10 @@ func EqualErrorf(t TestingT, theError error, errString string, msg string, args 
 //		Exported     	int
 //		notExported   	int
 //	 }
-//	 assert.EqualExportedValues(t, S{1, 2}, S{1, 3}) => true
-//	 assert.EqualExportedValues(t, S{1, 2}, S{2, 3}) => false
+//	 require.EqualExportedValues(t, S{1, 2}, S{1, 3}) => true
+//	 require.EqualExportedValues(t, S{1, 2}, S{2, 3}) => false
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func EqualExportedValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -220,8 +241,10 @@ func EqualExportedValues(t TestingT, expected interface{}, actual interface{}, m
 //		Exported     	int
 //		notExported   	int
 //	 }
-//	 assert.EqualExportedValuesf(t, S{1, 2}, S{1, 3}, "error message %s", "formatted") => true
-//	 assert.EqualExportedValuesf(t, S{1, 2}, S{2, 3}, "error message %s", "formatted") => false
+//	 require.EqualExportedValuesf(t, S{1, 2}, S{1, 3}, "error message %s", "formatted") => true
+//	 require.EqualExportedValuesf(t, S{1, 2}, S{2, 3}, "error message %s", "formatted") => false
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func EqualExportedValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -235,7 +258,9 @@ func EqualExportedValuesf(t TestingT, expected interface{}, actual interface{}, 
 // EqualValues asserts that two objects are equal or convertible to the larger
 // type and equal.
 //
-//	assert.EqualValues(t, uint32(123), int32(123))
+//	require.EqualValues(t, uint32(123), int32(123))
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func EqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -249,7 +274,9 @@ func EqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArg
 // EqualValuesf asserts that two objects are equal or convertible to the larger
 // type and equal.
 //
-//	assert.EqualValuesf(t, uint32(123), int32(123), "error message %s", "formatted")
+//	require.EqualValuesf(t, uint32(123), int32(123), "error message %s", "formatted")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func EqualValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -262,11 +289,12 @@ func EqualValuesf(t TestingT, expected interface{}, actual interface{}, msg stri
 
 // Equalf asserts that two objects are equal.
 //
-//	assert.Equalf(t, 123, 123, "error message %s", "formatted")
+//	require.Equalf(t, 123, 123, "error message %s", "formatted")
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses). Function equality
 // cannot be determined and will always fail.
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func Equalf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -280,9 +308,11 @@ func Equalf(t TestingT, expected interface{}, actual interface{}, msg string, ar
 // Error asserts that a function returned an error (i.e. not `nil`).
 //
 //	  actualObj, err := SomeFunction()
-//	  if assert.Error(t, err) {
-//		   assert.Equal(t, expectedError, err)
+//	  if require.Error(t, err) {
+//		   require.Equal(t, expectedError, err)
 //	  }
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func Error(t TestingT, err error, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -295,6 +325,7 @@ func Error(t TestingT, err error, msgAndArgs ...interface{}) {
 
 // ErrorAs asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
 // This is a wrapper for errors.As.
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func ErrorAs(t TestingT, err error, target interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -307,6 +338,7 @@ func ErrorAs(t TestingT, err error, target interface{}, msgAndArgs ...interface{
 
 // ErrorAsf asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
 // This is a wrapper for errors.As.
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func ErrorAsf(t TestingT, err error, target interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -321,7 +353,9 @@ func ErrorAsf(t TestingT, err error, target interface{}, msg string, args ...int
 // and that the error contains the specified substring.
 //
 //	actualObj, err := SomeFunction()
-//	assert.ErrorContains(t, err,  expectedErrorSubString)
+//	require.ErrorContains(t, err,  expectedErrorSubString)
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func ErrorContains(t TestingT, theError error, contains string, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -336,7 +370,9 @@ func ErrorContains(t TestingT, theError error, contains string, msgAndArgs ...in
 // and that the error contains the specified substring.
 //
 //	actualObj, err := SomeFunction()
-//	assert.ErrorContainsf(t, err,  expectedErrorSubString, "error message %s", "formatted")
+//	require.ErrorContainsf(t, err,  expectedErrorSubString, "error message %s", "formatted")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func ErrorContainsf(t TestingT, theError error, contains string, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -349,6 +385,7 @@ func ErrorContainsf(t TestingT, theError error, contains string, msg string, arg
 
 // ErrorIs asserts that at least one of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func ErrorIs(t TestingT, err error, target error, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -361,6 +398,7 @@ func ErrorIs(t TestingT, err error, target error, msgAndArgs ...interface{}) {
 
 // ErrorIsf asserts that at least one of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func ErrorIsf(t TestingT, err error, target error, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -374,9 +412,11 @@ func ErrorIsf(t TestingT, err error, target error, msg string, args ...interface
 // Errorf asserts that a function returned an error (i.e. not `nil`).
 //
 //	  actualObj, err := SomeFunction()
-//	  if assert.Errorf(t, err, "error message %s", "formatted") {
-//		   assert.Equal(t, expectedErrorf, err)
+//	  if require.Errorf(t, err, "error message %s", "formatted") {
+//		   require.Equal(t, expectedErrorf, err)
 //	  }
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func Errorf(t TestingT, err error, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -390,7 +430,9 @@ func Errorf(t TestingT, err error, msg string, args ...interface{}) {
 // Eventually asserts that given condition will be met in waitFor time,
 // periodically checking target function each tick.
 //
-//	assert.Eventually(t, func() bool { return true; }, time.Second, 10*time.Millisecond)
+//	require.Eventually(t, func() bool { return true; }, time.Second, 10*time.Millisecond)
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func Eventually(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -415,10 +457,12 @@ func Eventually(t TestingT, condition func() bool, waitFor time.Duration, tick t
 //		time.Sleep(8*time.Second)
 //		externalValue = true
 //	}()
-//	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+//	require.EventuallyWithT(t, func(c *require.CollectT) {
 //		// add assertions as needed; any assertion failure will fail the current tick
-//		assert.True(c, externalValue, "expected 'externalValue' to be true")
+//		require.True(c, externalValue, "expected 'externalValue' to be true")
 //	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func EventuallyWithT(t TestingT, condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -443,10 +487,12 @@ func EventuallyWithT(t TestingT, condition func(collect *assert.CollectT), waitF
 //		time.Sleep(8*time.Second)
 //		externalValue = true
 //	}()
-//	assert.EventuallyWithTf(t, func(c *assert.CollectT, "error message %s", "formatted") {
+//	require.EventuallyWithTf(t, func(c *require.CollectT, "error message %s", "formatted") {
 //		// add assertions as needed; any assertion failure will fail the current tick
-//		assert.True(c, externalValue, "expected 'externalValue' to be true")
+//		require.True(c, externalValue, "expected 'externalValue' to be true")
 //	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func EventuallyWithTf(t TestingT, condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -460,7 +506,9 @@ func EventuallyWithTf(t TestingT, condition func(collect *assert.CollectT), wait
 // Eventuallyf asserts that given condition will be met in waitFor time,
 // periodically checking target function each tick.
 //
-//	assert.Eventuallyf(t, func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+//	require.Eventuallyf(t, func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func Eventuallyf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -473,7 +521,9 @@ func Eventuallyf(t TestingT, condition func() bool, waitFor time.Duration, tick 
 
 // Exactly asserts that two objects are equal in value and type.
 //
-//	assert.Exactly(t, int32(123), int64(123))
+//	require.Exactly(t, int32(123), int64(123))
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func Exactly(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -486,7 +536,9 @@ func Exactly(t TestingT, expected interface{}, actual interface{}, msgAndArgs ..
 
 // Exactlyf asserts that two objects are equal in value and type.
 //
-//	assert.Exactlyf(t, int32(123), int64(123), "error message %s", "formatted")
+//	require.Exactlyf(t, int32(123), int64(123), "error message %s", "formatted")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func Exactlyf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -498,6 +550,7 @@ func Exactlyf(t TestingT, expected interface{}, actual interface{}, msg string, 
 }
 
 // Fail reports a failure through
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func Fail(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -509,6 +562,7 @@ func Fail(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
 }
 
 // FailNow fails test
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func FailNow(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -520,6 +574,7 @@ func FailNow(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
 }
 
 // FailNowf fails test
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func FailNowf(t TestingT, failureMessage string, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -531,6 +586,7 @@ func FailNowf(t TestingT, failureMessage string, msg string, args ...interface{}
 }
 
 // Failf reports a failure through
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func Failf(t TestingT, failureMessage string, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -543,7 +599,9 @@ func Failf(t TestingT, failureMessage string, msg string, args ...interface{}) {
 
 // False asserts that the specified value is false.
 //
-//	assert.False(t, myBool)
+//	require.False(t, myBool)
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func False(t TestingT, value bool, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -556,7 +614,9 @@ func False(t TestingT, value bool, msgAndArgs ...interface{}) {
 
 // Falsef asserts that the specified value is false.
 //
-//	assert.Falsef(t, myBool, "error message %s", "formatted")
+//	require.Falsef(t, myBool, "error message %s", "formatted")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func Falsef(t TestingT, value bool, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -569,6 +629,7 @@ func Falsef(t TestingT, value bool, msg string, args ...interface{}) {
 
 // FileExists checks whether a file exists in the given path. It also fails if
 // the path points to a directory or there is an error when trying to check the file.
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func FileExists(t TestingT, path string, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -581,6 +642,7 @@ func FileExists(t TestingT, path string, msgAndArgs ...interface{}) {
 
 // FileExistsf checks whether a file exists in the given path. It also fails if
 // the path points to a directory or there is an error when trying to check the file.
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func FileExistsf(t TestingT, path string, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -593,9 +655,11 @@ func FileExistsf(t TestingT, path string, msg string, args ...interface{}) {
 
 // Greater asserts that the first element is greater than the second
 //
-//	assert.Greater(t, 2, 1)
-//	assert.Greater(t, float64(2), float64(1))
-//	assert.Greater(t, "b", "a")
+//	require.Greater(t, 2, 1)
+//	require.Greater(t, float64(2), float64(1))
+//	require.Greater(t, "b", "a")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func Greater(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -608,10 +672,12 @@ func Greater(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface
 
 // GreaterOrEqual asserts that the first element is greater than or equal to the second
 //
-//	assert.GreaterOrEqual(t, 2, 1)
-//	assert.GreaterOrEqual(t, 2, 2)
-//	assert.GreaterOrEqual(t, "b", "a")
-//	assert.GreaterOrEqual(t, "b", "b")
+//	require.GreaterOrEqual(t, 2, 1)
+//	require.GreaterOrEqual(t, 2, 2)
+//	require.GreaterOrEqual(t, "b", "a")
+//	require.GreaterOrEqual(t, "b", "b")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func GreaterOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -624,10 +690,12 @@ func GreaterOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...in
 
 // GreaterOrEqualf asserts that the first element is greater than or equal to the second
 //
-//	assert.GreaterOrEqualf(t, 2, 1, "error message %s", "formatted")
-//	assert.GreaterOrEqualf(t, 2, 2, "error message %s", "formatted")
-//	assert.GreaterOrEqualf(t, "b", "a", "error message %s", "formatted")
-//	assert.GreaterOrEqualf(t, "b", "b", "error message %s", "formatted")
+//	require.GreaterOrEqualf(t, 2, 1, "error message %s", "formatted")
+//	require.GreaterOrEqualf(t, 2, 2, "error message %s", "formatted")
+//	require.GreaterOrEqualf(t, "b", "a", "error message %s", "formatted")
+//	require.GreaterOrEqualf(t, "b", "b", "error message %s", "formatted")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func GreaterOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -640,9 +708,11 @@ func GreaterOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, arg
 
 // Greaterf asserts that the first element is greater than the second
 //
-//	assert.Greaterf(t, 2, 1, "error message %s", "formatted")
-//	assert.Greaterf(t, float64(2), float64(1), "error message %s", "formatted")
-//	assert.Greaterf(t, "b", "a", "error message %s", "formatted")
+//	require.Greaterf(t, 2, 1, "error message %s", "formatted")
+//	require.Greaterf(t, float64(2), float64(1), "error message %s", "formatted")
+//	require.Greaterf(t, "b", "a", "error message %s", "formatted")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func Greaterf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -656,9 +726,10 @@ func Greaterf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...in
 // HTTPBodyContains asserts that a specified handler returns a
 // body that contains a string.
 //
-//	assert.HTTPBodyContains(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
+//	require.HTTPBodyContains(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
 //
 // Returns whether the assertion was successful (true) or not (false).
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func HTTPBodyContains(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -672,9 +743,10 @@ func HTTPBodyContains(t TestingT, handler http.HandlerFunc, method string, url s
 // HTTPBodyContainsf asserts that a specified handler returns a
 // body that contains a string.
 //
-//	assert.HTTPBodyContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+//	require.HTTPBodyContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func HTTPBodyContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -688,9 +760,10 @@ func HTTPBodyContainsf(t TestingT, handler http.HandlerFunc, method string, url 
 // HTTPBodyNotContains asserts that a specified handler returns a
 // body that does not contain a string.
 //
-//	assert.HTTPBodyNotContains(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
+//	require.HTTPBodyNotContains(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
 //
 // Returns whether the assertion was successful (true) or not (false).
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func HTTPBodyNotContains(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -704,9 +777,10 @@ func HTTPBodyNotContains(t TestingT, handler http.HandlerFunc, method string, ur
 // HTTPBodyNotContainsf asserts that a specified handler returns a
 // body that does not contain a string.
 //
-//	assert.HTTPBodyNotContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+//	require.HTTPBodyNotContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func HTTPBodyNotContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -719,9 +793,10 @@ func HTTPBodyNotContainsf(t TestingT, handler http.HandlerFunc, method string, u
 
 // HTTPError asserts that a specified handler returns an error status code.
 //
-//	assert.HTTPError(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//	require.HTTPError(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func HTTPError(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -734,9 +809,10 @@ func HTTPError(t TestingT, handler http.HandlerFunc, method string, url string, 
 
 // HTTPErrorf asserts that a specified handler returns an error status code.
 //
-//	assert.HTTPErrorf(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//	require.HTTPErrorf(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func HTTPErrorf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -749,9 +825,10 @@ func HTTPErrorf(t TestingT, handler http.HandlerFunc, method string, url string,
 
 // HTTPRedirect asserts that a specified handler returns a redirect status code.
 //
-//	assert.HTTPRedirect(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//	require.HTTPRedirect(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func HTTPRedirect(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -764,9 +841,10 @@ func HTTPRedirect(t TestingT, handler http.HandlerFunc, method string, url strin
 
 // HTTPRedirectf asserts that a specified handler returns a redirect status code.
 //
-//	assert.HTTPRedirectf(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//	require.HTTPRedirectf(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func HTTPRedirectf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -779,9 +857,10 @@ func HTTPRedirectf(t TestingT, handler http.HandlerFunc, method string, url stri
 
 // HTTPStatusCode asserts that a specified handler returns a specified status code.
 //
-//	assert.HTTPStatusCode(t, myHandler, "GET", "/notImplemented", nil, 501)
+//	require.HTTPStatusCode(t, myHandler, "GET", "/notImplemented", nil, 501)
 //
 // Returns whether the assertion was successful (true) or not (false).
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func HTTPStatusCode(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -794,9 +873,10 @@ func HTTPStatusCode(t TestingT, handler http.HandlerFunc, method string, url str
 
 // HTTPStatusCodef asserts that a specified handler returns a specified status code.
 //
-//	assert.HTTPStatusCodef(t, myHandler, "GET", "/notImplemented", nil, 501, "error message %s", "formatted")
+//	require.HTTPStatusCodef(t, myHandler, "GET", "/notImplemented", nil, 501, "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func HTTPStatusCodef(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -809,9 +889,10 @@ func HTTPStatusCodef(t TestingT, handler http.HandlerFunc, method string, url st
 
 // HTTPSuccess asserts that a specified handler returns a success status code.
 //
-//	assert.HTTPSuccess(t, myHandler, "POST", "http://www.google.com", nil)
+//	require.HTTPSuccess(t, myHandler, "POST", "http://www.google.com", nil)
 //
 // Returns whether the assertion was successful (true) or not (false).
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func HTTPSuccess(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -824,9 +905,10 @@ func HTTPSuccess(t TestingT, handler http.HandlerFunc, method string, url string
 
 // HTTPSuccessf asserts that a specified handler returns a success status code.
 //
-//	assert.HTTPSuccessf(t, myHandler, "POST", "http://www.google.com", nil, "error message %s", "formatted")
+//	require.HTTPSuccessf(t, myHandler, "POST", "http://www.google.com", nil, "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func HTTPSuccessf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -839,7 +921,9 @@ func HTTPSuccessf(t TestingT, handler http.HandlerFunc, method string, url strin
 
 // Implements asserts that an object is implemented by the specified interface.
 //
-//	assert.Implements(t, (*MyInterface)(nil), new(MyObject))
+//	require.Implements(t, (*MyInterface)(nil), new(MyObject))
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func Implements(t TestingT, interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -852,7 +936,9 @@ func Implements(t TestingT, interfaceObject interface{}, object interface{}, msg
 
 // Implementsf asserts that an object is implemented by the specified interface.
 //
-//	assert.Implementsf(t, (*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
+//	require.Implementsf(t, (*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func Implementsf(t TestingT, interfaceObject interface{}, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -865,7 +951,9 @@ func Implementsf(t TestingT, interfaceObject interface{}, object interface{}, ms
 
 // InDelta asserts that the two numerals are within delta of each other.
 //
-//	assert.InDelta(t, math.Pi, 22/7.0, 0.01)
+//	require.InDelta(t, math.Pi, 22/7.0, 0.01)
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func InDelta(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -877,6 +965,7 @@ func InDelta(t TestingT, expected interface{}, actual interface{}, delta float64
 }
 
 // InDeltaMapValues is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func InDeltaMapValues(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -888,6 +977,7 @@ func InDeltaMapValues(t TestingT, expected interface{}, actual interface{}, delt
 }
 
 // InDeltaMapValuesf is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func InDeltaMapValuesf(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -899,6 +989,7 @@ func InDeltaMapValuesf(t TestingT, expected interface{}, actual interface{}, del
 }
 
 // InDeltaSlice is the same as InDelta, except it compares two slices.
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func InDeltaSlice(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -910,6 +1001,7 @@ func InDeltaSlice(t TestingT, expected interface{}, actual interface{}, delta fl
 }
 
 // InDeltaSlicef is the same as InDelta, except it compares two slices.
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func InDeltaSlicef(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -922,7 +1014,9 @@ func InDeltaSlicef(t TestingT, expected interface{}, actual interface{}, delta f
 
 // InDeltaf asserts that the two numerals are within delta of each other.
 //
-//	assert.InDeltaf(t, math.Pi, 22/7.0, 0.01, "error message %s", "formatted")
+//	require.InDeltaf(t, math.Pi, 22/7.0, 0.01, "error message %s", "formatted")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func InDeltaf(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -934,6 +1028,7 @@ func InDeltaf(t TestingT, expected interface{}, actual interface{}, delta float6
 }
 
 // InEpsilon asserts that expected and actual have a relative error less than epsilon
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func InEpsilon(t TestingT, expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -945,6 +1040,7 @@ func InEpsilon(t TestingT, expected interface{}, actual interface{}, epsilon flo
 }
 
 // InEpsilonSlice is the same as InEpsilon, except it compares each value from two slices.
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func InEpsilonSlice(t TestingT, expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -956,6 +1052,7 @@ func InEpsilonSlice(t TestingT, expected interface{}, actual interface{}, epsilo
 }
 
 // InEpsilonSlicef is the same as InEpsilon, except it compares each value from two slices.
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func InEpsilonSlicef(t TestingT, expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -967,6 +1064,7 @@ func InEpsilonSlicef(t TestingT, expected interface{}, actual interface{}, epsil
 }
 
 // InEpsilonf asserts that expected and actual have a relative error less than epsilon
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func InEpsilonf(t TestingT, expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -979,9 +1077,11 @@ func InEpsilonf(t TestingT, expected interface{}, actual interface{}, epsilon fl
 
 // IsDecreasing asserts that the collection is decreasing
 //
-//	assert.IsDecreasing(t, []int{2, 1, 0})
-//	assert.IsDecreasing(t, []float{2, 1})
-//	assert.IsDecreasing(t, []string{"b", "a"})
+//	require.IsDecreasing(t, []int{2, 1, 0})
+//	require.IsDecreasing(t, []float{2, 1})
+//	require.IsDecreasing(t, []string{"b", "a"})
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func IsDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -994,9 +1094,11 @@ func IsDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 
 // IsDecreasingf asserts that the collection is decreasing
 //
-//	assert.IsDecreasingf(t, []int{2, 1, 0}, "error message %s", "formatted")
-//	assert.IsDecreasingf(t, []float{2, 1}, "error message %s", "formatted")
-//	assert.IsDecreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
+//	require.IsDecreasingf(t, []int{2, 1, 0}, "error message %s", "formatted")
+//	require.IsDecreasingf(t, []float{2, 1}, "error message %s", "formatted")
+//	require.IsDecreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func IsDecreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1009,9 +1111,11 @@ func IsDecreasingf(t TestingT, object interface{}, msg string, args ...interface
 
 // IsIncreasing asserts that the collection is increasing
 //
-//	assert.IsIncreasing(t, []int{1, 2, 3})
-//	assert.IsIncreasing(t, []float{1, 2})
-//	assert.IsIncreasing(t, []string{"a", "b"})
+//	require.IsIncreasing(t, []int{1, 2, 3})
+//	require.IsIncreasing(t, []float{1, 2})
+//	require.IsIncreasing(t, []string{"a", "b"})
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func IsIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1024,9 +1128,11 @@ func IsIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 
 // IsIncreasingf asserts that the collection is increasing
 //
-//	assert.IsIncreasingf(t, []int{1, 2, 3}, "error message %s", "formatted")
-//	assert.IsIncreasingf(t, []float{1, 2}, "error message %s", "formatted")
-//	assert.IsIncreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
+//	require.IsIncreasingf(t, []int{1, 2, 3}, "error message %s", "formatted")
+//	require.IsIncreasingf(t, []float{1, 2}, "error message %s", "formatted")
+//	require.IsIncreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func IsIncreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1039,9 +1145,11 @@ func IsIncreasingf(t TestingT, object interface{}, msg string, args ...interface
 
 // IsNonDecreasing asserts that the collection is not decreasing
 //
-//	assert.IsNonDecreasing(t, []int{1, 1, 2})
-//	assert.IsNonDecreasing(t, []float{1, 2})
-//	assert.IsNonDecreasing(t, []string{"a", "b"})
+//	require.IsNonDecreasing(t, []int{1, 1, 2})
+//	require.IsNonDecreasing(t, []float{1, 2})
+//	require.IsNonDecreasing(t, []string{"a", "b"})
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func IsNonDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1054,9 +1162,11 @@ func IsNonDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) 
 
 // IsNonDecreasingf asserts that the collection is not decreasing
 //
-//	assert.IsNonDecreasingf(t, []int{1, 1, 2}, "error message %s", "formatted")
-//	assert.IsNonDecreasingf(t, []float{1, 2}, "error message %s", "formatted")
-//	assert.IsNonDecreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
+//	require.IsNonDecreasingf(t, []int{1, 1, 2}, "error message %s", "formatted")
+//	require.IsNonDecreasingf(t, []float{1, 2}, "error message %s", "formatted")
+//	require.IsNonDecreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func IsNonDecreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1069,9 +1179,11 @@ func IsNonDecreasingf(t TestingT, object interface{}, msg string, args ...interf
 
 // IsNonIncreasing asserts that the collection is not increasing
 //
-//	assert.IsNonIncreasing(t, []int{2, 1, 1})
-//	assert.IsNonIncreasing(t, []float{2, 1})
-//	assert.IsNonIncreasing(t, []string{"b", "a"})
+//	require.IsNonIncreasing(t, []int{2, 1, 1})
+//	require.IsNonIncreasing(t, []float{2, 1})
+//	require.IsNonIncreasing(t, []string{"b", "a"})
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func IsNonIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1084,9 +1196,11 @@ func IsNonIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) 
 
 // IsNonIncreasingf asserts that the collection is not increasing
 //
-//	assert.IsNonIncreasingf(t, []int{2, 1, 1}, "error message %s", "formatted")
-//	assert.IsNonIncreasingf(t, []float{2, 1}, "error message %s", "formatted")
-//	assert.IsNonIncreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
+//	require.IsNonIncreasingf(t, []int{2, 1, 1}, "error message %s", "formatted")
+//	require.IsNonIncreasingf(t, []float{2, 1}, "error message %s", "formatted")
+//	require.IsNonIncreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func IsNonIncreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1098,6 +1212,7 @@ func IsNonIncreasingf(t TestingT, object interface{}, msg string, args ...interf
 }
 
 // IsType asserts that the specified objects are of the same type.
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func IsType(t TestingT, expectedType interface{}, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1109,6 +1224,7 @@ func IsType(t TestingT, expectedType interface{}, object interface{}, msgAndArgs
 }
 
 // IsTypef asserts that the specified objects are of the same type.
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func IsTypef(t TestingT, expectedType interface{}, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1121,7 +1237,9 @@ func IsTypef(t TestingT, expectedType interface{}, object interface{}, msg strin
 
 // JSONEq asserts that two JSON strings are equivalent.
 //
-//	assert.JSONEq(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
+//	require.JSONEq(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func JSONEq(t TestingT, expected string, actual string, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1134,7 +1252,9 @@ func JSONEq(t TestingT, expected string, actual string, msgAndArgs ...interface{
 
 // JSONEqf asserts that two JSON strings are equivalent.
 //
-//	assert.JSONEqf(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
+//	require.JSONEqf(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func JSONEqf(t TestingT, expected string, actual string, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1148,7 +1268,9 @@ func JSONEqf(t TestingT, expected string, actual string, msg string, args ...int
 // Len asserts that the specified object has specific length.
 // Len also fails if the object has a type that len() not accept.
 //
-//	assert.Len(t, mySlice, 3)
+//	require.Len(t, mySlice, 3)
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1162,7 +1284,9 @@ func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) 
 // Lenf asserts that the specified object has specific length.
 // Lenf also fails if the object has a type that len() not accept.
 //
-//	assert.Lenf(t, mySlice, 3, "error message %s", "formatted")
+//	require.Lenf(t, mySlice, 3, "error message %s", "formatted")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func Lenf(t TestingT, object interface{}, length int, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1175,9 +1299,11 @@ func Lenf(t TestingT, object interface{}, length int, msg string, args ...interf
 
 // Less asserts that the first element is less than the second
 //
-//	assert.Less(t, 1, 2)
-//	assert.Less(t, float64(1), float64(2))
-//	assert.Less(t, "a", "b")
+//	require.Less(t, 1, 2)
+//	require.Less(t, float64(1), float64(2))
+//	require.Less(t, "a", "b")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1190,10 +1316,12 @@ func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{})
 
 // LessOrEqual asserts that the first element is less than or equal to the second
 //
-//	assert.LessOrEqual(t, 1, 2)
-//	assert.LessOrEqual(t, 2, 2)
-//	assert.LessOrEqual(t, "a", "b")
-//	assert.LessOrEqual(t, "b", "b")
+//	require.LessOrEqual(t, 1, 2)
+//	require.LessOrEqual(t, 2, 2)
+//	require.LessOrEqual(t, "a", "b")
+//	require.LessOrEqual(t, "b", "b")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func LessOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1206,10 +1334,12 @@ func LessOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...inter
 
 // LessOrEqualf asserts that the first element is less than or equal to the second
 //
-//	assert.LessOrEqualf(t, 1, 2, "error message %s", "formatted")
-//	assert.LessOrEqualf(t, 2, 2, "error message %s", "formatted")
-//	assert.LessOrEqualf(t, "a", "b", "error message %s", "formatted")
-//	assert.LessOrEqualf(t, "b", "b", "error message %s", "formatted")
+//	require.LessOrEqualf(t, 1, 2, "error message %s", "formatted")
+//	require.LessOrEqualf(t, 2, 2, "error message %s", "formatted")
+//	require.LessOrEqualf(t, "a", "b", "error message %s", "formatted")
+//	require.LessOrEqualf(t, "b", "b", "error message %s", "formatted")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func LessOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1222,9 +1352,11 @@ func LessOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args .
 
 // Lessf asserts that the first element is less than the second
 //
-//	assert.Lessf(t, 1, 2, "error message %s", "formatted")
-//	assert.Lessf(t, float64(1), float64(2), "error message %s", "formatted")
-//	assert.Lessf(t, "a", "b", "error message %s", "formatted")
+//	require.Lessf(t, 1, 2, "error message %s", "formatted")
+//	require.Lessf(t, float64(1), float64(2), "error message %s", "formatted")
+//	require.Lessf(t, "a", "b", "error message %s", "formatted")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func Lessf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1237,8 +1369,10 @@ func Lessf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...inter
 
 // Negative asserts that the specified element is negative
 //
-//	assert.Negative(t, -1)
-//	assert.Negative(t, -1.23)
+//	require.Negative(t, -1)
+//	require.Negative(t, -1.23)
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func Negative(t TestingT, e interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1251,8 +1385,10 @@ func Negative(t TestingT, e interface{}, msgAndArgs ...interface{}) {
 
 // Negativef asserts that the specified element is negative
 //
-//	assert.Negativef(t, -1, "error message %s", "formatted")
-//	assert.Negativef(t, -1.23, "error message %s", "formatted")
+//	require.Negativef(t, -1, "error message %s", "formatted")
+//	require.Negativef(t, -1.23, "error message %s", "formatted")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func Negativef(t TestingT, e interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1266,7 +1402,9 @@ func Negativef(t TestingT, e interface{}, msg string, args ...interface{}) {
 // Never asserts that the given condition doesn't satisfy in waitFor time,
 // periodically checking the target function each tick.
 //
-//	assert.Never(t, func() bool { return false; }, time.Second, 10*time.Millisecond)
+//	require.Never(t, func() bool { return false; }, time.Second, 10*time.Millisecond)
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func Never(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1280,7 +1418,9 @@ func Never(t TestingT, condition func() bool, waitFor time.Duration, tick time.D
 // Neverf asserts that the given condition doesn't satisfy in waitFor time,
 // periodically checking the target function each tick.
 //
-//	assert.Neverf(t, func() bool { return false; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+//	require.Neverf(t, func() bool { return false; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func Neverf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1293,7 +1433,9 @@ func Neverf(t TestingT, condition func() bool, waitFor time.Duration, tick time.
 
 // Nil asserts that the specified object is nil.
 //
-//	assert.Nil(t, err)
+//	require.Nil(t, err)
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1306,7 +1448,9 @@ func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 
 // Nilf asserts that the specified object is nil.
 //
-//	assert.Nilf(t, err, "error message %s", "formatted")
+//	require.Nilf(t, err, "error message %s", "formatted")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func Nilf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1319,6 +1463,7 @@ func Nilf(t TestingT, object interface{}, msg string, args ...interface{}) {
 
 // NoDirExists checks whether a directory does not exist in the given path.
 // It fails if the path points to an existing _directory_ only.
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func NoDirExists(t TestingT, path string, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1331,6 +1476,7 @@ func NoDirExists(t TestingT, path string, msgAndArgs ...interface{}) {
 
 // NoDirExistsf checks whether a directory does not exist in the given path.
 // It fails if the path points to an existing _directory_ only.
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func NoDirExistsf(t TestingT, path string, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1344,9 +1490,11 @@ func NoDirExistsf(t TestingT, path string, msg string, args ...interface{}) {
 // NoError asserts that a function returned no error (i.e. `nil`).
 //
 //	  actualObj, err := SomeFunction()
-//	  if assert.NoError(t, err) {
-//		   assert.Equal(t, expectedObj, actualObj)
+//	  if require.NoError(t, err) {
+//		   require.Equal(t, expectedObj, actualObj)
 //	  }
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func NoError(t TestingT, err error, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1360,9 +1508,11 @@ func NoError(t TestingT, err error, msgAndArgs ...interface{}) {
 // NoErrorf asserts that a function returned no error (i.e. `nil`).
 //
 //	  actualObj, err := SomeFunction()
-//	  if assert.NoErrorf(t, err, "error message %s", "formatted") {
-//		   assert.Equal(t, expectedObj, actualObj)
+//	  if require.NoErrorf(t, err, "error message %s", "formatted") {
+//		   require.Equal(t, expectedObj, actualObj)
 //	  }
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func NoErrorf(t TestingT, err error, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1375,6 +1525,7 @@ func NoErrorf(t TestingT, err error, msg string, args ...interface{}) {
 
 // NoFileExists checks whether a file does not exist in a given path. It fails
 // if the path points to an existing _file_ only.
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func NoFileExists(t TestingT, path string, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1387,6 +1538,7 @@ func NoFileExists(t TestingT, path string, msgAndArgs ...interface{}) {
 
 // NoFileExistsf checks whether a file does not exist in a given path. It fails
 // if the path points to an existing _file_ only.
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func NoFileExistsf(t TestingT, path string, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1400,9 +1552,11 @@ func NoFileExistsf(t TestingT, path string, msg string, args ...interface{}) {
 // NotContains asserts that the specified string, list(array, slice...) or map does NOT contain the
 // specified substring or element.
 //
-//	assert.NotContains(t, "Hello World", "Earth")
-//	assert.NotContains(t, ["Hello", "World"], "Earth")
-//	assert.NotContains(t, {"Hello": "World"}, "Earth")
+//	require.NotContains(t, "Hello World", "Earth")
+//	require.NotContains(t, ["Hello", "World"], "Earth")
+//	require.NotContains(t, {"Hello": "World"}, "Earth")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func NotContains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1416,9 +1570,11 @@ func NotContains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...
 // NotContainsf asserts that the specified string, list(array, slice...) or map does NOT contain the
 // specified substring or element.
 //
-//	assert.NotContainsf(t, "Hello World", "Earth", "error message %s", "formatted")
-//	assert.NotContainsf(t, ["Hello", "World"], "Earth", "error message %s", "formatted")
-//	assert.NotContainsf(t, {"Hello": "World"}, "Earth", "error message %s", "formatted")
+//	require.NotContainsf(t, "Hello World", "Earth", "error message %s", "formatted")
+//	require.NotContainsf(t, ["Hello", "World"], "Earth", "error message %s", "formatted")
+//	require.NotContainsf(t, {"Hello": "World"}, "Earth", "error message %s", "formatted")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func NotContainsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1434,11 +1590,12 @@ func NotContainsf(t TestingT, s interface{}, contains interface{}, msg string, a
 // the number of appearances of each of them in both lists should not match.
 // This is an inverse of ElementsMatch.
 //
-// assert.NotElementsMatch(t, [1, 1, 2, 3], [1, 1, 2, 3]) -> false
+// require.NotElementsMatch(t, [1, 1, 2, 3], [1, 1, 2, 3]) -> false
 //
-// assert.NotElementsMatch(t, [1, 1, 2, 3], [1, 2, 3]) -> true
+// require.NotElementsMatch(t, [1, 1, 2, 3], [1, 2, 3]) -> true
 //
-// assert.NotElementsMatch(t, [1, 2, 3], [1, 2, 4]) -> true
+// require.NotElementsMatch(t, [1, 2, 3], [1, 2, 4]) -> true
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func NotElementsMatch(t TestingT, listA interface{}, listB interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1454,11 +1611,12 @@ func NotElementsMatch(t TestingT, listA interface{}, listB interface{}, msgAndAr
 // the number of appearances of each of them in both lists should not match.
 // This is an inverse of ElementsMatch.
 //
-// assert.NotElementsMatchf(t, [1, 1, 2, 3], [1, 1, 2, 3], "error message %s", "formatted") -> false
+// require.NotElementsMatchf(t, [1, 1, 2, 3], [1, 1, 2, 3], "error message %s", "formatted") -> false
 //
-// assert.NotElementsMatchf(t, [1, 1, 2, 3], [1, 2, 3], "error message %s", "formatted") -> true
+// require.NotElementsMatchf(t, [1, 1, 2, 3], [1, 2, 3], "error message %s", "formatted") -> true
 //
-// assert.NotElementsMatchf(t, [1, 2, 3], [1, 2, 4], "error message %s", "formatted") -> true
+// require.NotElementsMatchf(t, [1, 2, 3], [1, 2, 4], "error message %s", "formatted") -> true
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func NotElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1472,9 +1630,11 @@ func NotElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg str
 // NotEmpty asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or either
 // a slice or a channel with len == 0.
 //
-//	if assert.NotEmpty(t, obj) {
-//	  assert.Equal(t, "two", obj[1])
+//	if require.NotEmpty(t, obj) {
+//	  require.Equal(t, "two", obj[1])
 //	}
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1488,9 +1648,11 @@ func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 // NotEmptyf asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or either
 // a slice or a channel with len == 0.
 //
-//	if assert.NotEmptyf(t, obj, "error message %s", "formatted") {
-//	  assert.Equal(t, "two", obj[1])
+//	if require.NotEmptyf(t, obj, "error message %s", "formatted") {
+//	  require.Equal(t, "two", obj[1])
 //	}
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func NotEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1503,10 +1665,11 @@ func NotEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) 
 
 // NotEqual asserts that the specified values are NOT equal.
 //
-//	assert.NotEqual(t, obj1, obj2)
+//	require.NotEqual(t, obj1, obj2)
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func NotEqual(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1519,7 +1682,9 @@ func NotEqual(t TestingT, expected interface{}, actual interface{}, msgAndArgs .
 
 // NotEqualValues asserts that two objects are not equal even when converted to the same type
 //
-//	assert.NotEqualValues(t, obj1, obj2)
+//	require.NotEqualValues(t, obj1, obj2)
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func NotEqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1532,7 +1697,9 @@ func NotEqualValues(t TestingT, expected interface{}, actual interface{}, msgAnd
 
 // NotEqualValuesf asserts that two objects are not equal even when converted to the same type
 //
-//	assert.NotEqualValuesf(t, obj1, obj2, "error message %s", "formatted")
+//	require.NotEqualValuesf(t, obj1, obj2, "error message %s", "formatted")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func NotEqualValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1545,10 +1712,11 @@ func NotEqualValuesf(t TestingT, expected interface{}, actual interface{}, msg s
 
 // NotEqualf asserts that the specified values are NOT equal.
 //
-//	assert.NotEqualf(t, obj1, obj2, "error message %s", "formatted")
+//	require.NotEqualf(t, obj1, obj2, "error message %s", "formatted")
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func NotEqualf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1561,6 +1729,7 @@ func NotEqualf(t TestingT, expected interface{}, actual interface{}, msg string,
 
 // NotErrorIs asserts that at none of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func NotErrorIs(t TestingT, err error, target error, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1573,6 +1742,7 @@ func NotErrorIs(t TestingT, err error, target error, msgAndArgs ...interface{}) 
 
 // NotErrorIsf asserts that at none of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func NotErrorIsf(t TestingT, err error, target error, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1585,7 +1755,9 @@ func NotErrorIsf(t TestingT, err error, target error, msg string, args ...interf
 
 // NotImplements asserts that an object does not implement the specified interface.
 //
-//	assert.NotImplements(t, (*MyInterface)(nil), new(MyObject))
+//	require.NotImplements(t, (*MyInterface)(nil), new(MyObject))
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func NotImplements(t TestingT, interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1598,7 +1770,9 @@ func NotImplements(t TestingT, interfaceObject interface{}, object interface{}, 
 
 // NotImplementsf asserts that an object does not implement the specified interface.
 //
-//	assert.NotImplementsf(t, (*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
+//	require.NotImplementsf(t, (*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func NotImplementsf(t TestingT, interfaceObject interface{}, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1611,7 +1785,9 @@ func NotImplementsf(t TestingT, interfaceObject interface{}, object interface{},
 
 // NotNil asserts that the specified object is not nil.
 //
-//	assert.NotNil(t, err)
+//	require.NotNil(t, err)
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1624,7 +1800,9 @@ func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 
 // NotNilf asserts that the specified object is not nil.
 //
-//	assert.NotNilf(t, err, "error message %s", "formatted")
+//	require.NotNilf(t, err, "error message %s", "formatted")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func NotNilf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1637,7 +1815,9 @@ func NotNilf(t TestingT, object interface{}, msg string, args ...interface{}) {
 
 // NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
 //
-//	assert.NotPanics(t, func(){ RemainCalm() })
+//	require.NotPanics(t, func(){ RemainCalm() })
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func NotPanics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1650,7 +1830,9 @@ func NotPanics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 
 // NotPanicsf asserts that the code inside the specified PanicTestFunc does NOT panic.
 //
-//	assert.NotPanicsf(t, func(){ RemainCalm() }, "error message %s", "formatted")
+//	require.NotPanicsf(t, func(){ RemainCalm() }, "error message %s", "formatted")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func NotPanicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1663,8 +1845,10 @@ func NotPanicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interfac
 
 // NotRegexp asserts that a specified regexp does not match a string.
 //
-//	assert.NotRegexp(t, regexp.MustCompile("starts"), "it's starting")
-//	assert.NotRegexp(t, "^start", "it's not starting")
+//	require.NotRegexp(t, regexp.MustCompile("starts"), "it's starting")
+//	require.NotRegexp(t, "^start", "it's not starting")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1677,8 +1861,10 @@ func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interf
 
 // NotRegexpf asserts that a specified regexp does not match a string.
 //
-//	assert.NotRegexpf(t, regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
-//	assert.NotRegexpf(t, "^start", "it's not starting", "error message %s", "formatted")
+//	require.NotRegexpf(t, regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
+//	require.NotRegexpf(t, "^start", "it's not starting", "error message %s", "formatted")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func NotRegexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1691,10 +1877,11 @@ func NotRegexpf(t TestingT, rx interface{}, str interface{}, msg string, args ..
 
 // NotSame asserts that two pointers do not reference the same object.
 //
-//	assert.NotSame(t, ptr1, ptr2)
+//	require.NotSame(t, ptr1, ptr2)
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func NotSame(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1707,10 +1894,11 @@ func NotSame(t TestingT, expected interface{}, actual interface{}, msgAndArgs ..
 
 // NotSamef asserts that two pointers do not reference the same object.
 //
-//	assert.NotSamef(t, ptr1, ptr2, "error message %s", "formatted")
+//	require.NotSamef(t, ptr1, ptr2, "error message %s", "formatted")
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func NotSamef(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1725,8 +1913,10 @@ func NotSamef(t TestingT, expected interface{}, actual interface{}, msg string, 
 // contain all elements given in the specified subset list(array, slice...) or
 // map.
 //
-//	assert.NotSubset(t, [1, 3, 4], [1, 2])
-//	assert.NotSubset(t, {"x": 1, "y": 2}, {"z": 3})
+//	require.NotSubset(t, [1, 3, 4], [1, 2])
+//	require.NotSubset(t, {"x": 1, "y": 2}, {"z": 3})
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func NotSubset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1741,8 +1931,10 @@ func NotSubset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...i
 // contain all elements given in the specified subset list(array, slice...) or
 // map.
 //
-//	assert.NotSubsetf(t, [1, 3, 4], [1, 2], "error message %s", "formatted")
-//	assert.NotSubsetf(t, {"x": 1, "y": 2}, {"z": 3}, "error message %s", "formatted")
+//	require.NotSubsetf(t, [1, 3, 4], [1, 2], "error message %s", "formatted")
+//	require.NotSubsetf(t, {"x": 1, "y": 2}, {"z": 3}, "error message %s", "formatted")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func NotSubsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1754,6 +1946,7 @@ func NotSubsetf(t TestingT, list interface{}, subset interface{}, msg string, ar
 }
 
 // NotZero asserts that i is not the zero value for its type.
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func NotZero(t TestingT, i interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1765,6 +1958,7 @@ func NotZero(t TestingT, i interface{}, msgAndArgs ...interface{}) {
 }
 
 // NotZerof asserts that i is not the zero value for its type.
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func NotZerof(t TestingT, i interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1777,7 +1971,9 @@ func NotZerof(t TestingT, i interface{}, msg string, args ...interface{}) {
 
 // Panics asserts that the code inside the specified PanicTestFunc panics.
 //
-//	assert.Panics(t, func(){ GoCrazy() })
+//	require.Panics(t, func(){ GoCrazy() })
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func Panics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1792,7 +1988,9 @@ func Panics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 // panics, and that the recovered panic value is an error that satisfies the
 // EqualError comparison.
 //
-//	assert.PanicsWithError(t, "crazy error", func(){ GoCrazy() })
+//	require.PanicsWithError(t, "crazy error", func(){ GoCrazy() })
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func PanicsWithError(t TestingT, errString string, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1807,7 +2005,9 @@ func PanicsWithError(t TestingT, errString string, f assert.PanicTestFunc, msgAn
 // panics, and that the recovered panic value is an error that satisfies the
 // EqualError comparison.
 //
-//	assert.PanicsWithErrorf(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+//	require.PanicsWithErrorf(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func PanicsWithErrorf(t TestingT, errString string, f assert.PanicTestFunc, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1821,7 +2021,9 @@ func PanicsWithErrorf(t TestingT, errString string, f assert.PanicTestFunc, msg 
 // PanicsWithValue asserts that the code inside the specified PanicTestFunc panics, and that
 // the recovered panic value equals the expected panic value.
 //
-//	assert.PanicsWithValue(t, "crazy error", func(){ GoCrazy() })
+//	require.PanicsWithValue(t, "crazy error", func(){ GoCrazy() })
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func PanicsWithValue(t TestingT, expected interface{}, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1835,7 +2037,9 @@ func PanicsWithValue(t TestingT, expected interface{}, f assert.PanicTestFunc, m
 // PanicsWithValuef asserts that the code inside the specified PanicTestFunc panics, and that
 // the recovered panic value equals the expected panic value.
 //
-//	assert.PanicsWithValuef(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+//	require.PanicsWithValuef(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func PanicsWithValuef(t TestingT, expected interface{}, f assert.PanicTestFunc, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1848,7 +2052,9 @@ func PanicsWithValuef(t TestingT, expected interface{}, f assert.PanicTestFunc, 
 
 // Panicsf asserts that the code inside the specified PanicTestFunc panics.
 //
-//	assert.Panicsf(t, func(){ GoCrazy() }, "error message %s", "formatted")
+//	require.Panicsf(t, func(){ GoCrazy() }, "error message %s", "formatted")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func Panicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1861,8 +2067,10 @@ func Panicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}
 
 // Positive asserts that the specified element is positive
 //
-//	assert.Positive(t, 1)
-//	assert.Positive(t, 1.23)
+//	require.Positive(t, 1)
+//	require.Positive(t, 1.23)
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func Positive(t TestingT, e interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1875,8 +2083,10 @@ func Positive(t TestingT, e interface{}, msgAndArgs ...interface{}) {
 
 // Positivef asserts that the specified element is positive
 //
-//	assert.Positivef(t, 1, "error message %s", "formatted")
-//	assert.Positivef(t, 1.23, "error message %s", "formatted")
+//	require.Positivef(t, 1, "error message %s", "formatted")
+//	require.Positivef(t, 1.23, "error message %s", "formatted")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func Positivef(t TestingT, e interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1889,8 +2099,10 @@ func Positivef(t TestingT, e interface{}, msg string, args ...interface{}) {
 
 // Regexp asserts that a specified regexp matches a string.
 //
-//	assert.Regexp(t, regexp.MustCompile("start"), "it's starting")
-//	assert.Regexp(t, "start...$", "it's not starting")
+//	require.Regexp(t, regexp.MustCompile("start"), "it's starting")
+//	require.Regexp(t, "start...$", "it's not starting")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1903,8 +2115,10 @@ func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface
 
 // Regexpf asserts that a specified regexp matches a string.
 //
-//	assert.Regexpf(t, regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
-//	assert.Regexpf(t, "start...$", "it's not starting", "error message %s", "formatted")
+//	require.Regexpf(t, regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
+//	require.Regexpf(t, "start...$", "it's not starting", "error message %s", "formatted")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func Regexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1917,10 +2131,11 @@ func Regexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...in
 
 // Same asserts that two pointers reference the same object.
 //
-//	assert.Same(t, ptr1, ptr2)
+//	require.Same(t, ptr1, ptr2)
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func Same(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1933,10 +2148,11 @@ func Same(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...in
 
 // Samef asserts that two pointers reference the same object.
 //
-//	assert.Samef(t, ptr1, ptr2, "error message %s", "formatted")
+//	require.Samef(t, ptr1, ptr2, "error message %s", "formatted")
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func Samef(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1950,8 +2166,10 @@ func Samef(t TestingT, expected interface{}, actual interface{}, msg string, arg
 // Subset asserts that the specified list(array, slice...) or map contains all
 // elements given in the specified subset list(array, slice...) or map.
 //
-//	assert.Subset(t, [1, 2, 3], [1, 2])
-//	assert.Subset(t, {"x": 1, "y": 2}, {"x": 1})
+//	require.Subset(t, [1, 2, 3], [1, 2])
+//	require.Subset(t, {"x": 1, "y": 2}, {"x": 1})
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func Subset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1965,8 +2183,10 @@ func Subset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...inte
 // Subsetf asserts that the specified list(array, slice...) or map contains all
 // elements given in the specified subset list(array, slice...) or map.
 //
-//	assert.Subsetf(t, [1, 2, 3], [1, 2], "error message %s", "formatted")
-//	assert.Subsetf(t, {"x": 1, "y": 2}, {"x": 1}, "error message %s", "formatted")
+//	require.Subsetf(t, [1, 2, 3], [1, 2], "error message %s", "formatted")
+//	require.Subsetf(t, {"x": 1, "y": 2}, {"x": 1}, "error message %s", "formatted")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func Subsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1979,7 +2199,9 @@ func Subsetf(t TestingT, list interface{}, subset interface{}, msg string, args 
 
 // True asserts that the specified value is true.
 //
-//	assert.True(t, myBool)
+//	require.True(t, myBool)
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func True(t TestingT, value bool, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1992,7 +2214,9 @@ func True(t TestingT, value bool, msgAndArgs ...interface{}) {
 
 // Truef asserts that the specified value is true.
 //
-//	assert.Truef(t, myBool, "error message %s", "formatted")
+//	require.Truef(t, myBool, "error message %s", "formatted")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func Truef(t TestingT, value bool, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2005,7 +2229,9 @@ func Truef(t TestingT, value bool, msg string, args ...interface{}) {
 
 // WithinDuration asserts that the two times are within duration delta of each other.
 //
-//	assert.WithinDuration(t, time.Now(), time.Now(), 10*time.Second)
+//	require.WithinDuration(t, time.Now(), time.Now(), 10*time.Second)
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func WithinDuration(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2018,7 +2244,9 @@ func WithinDuration(t TestingT, expected time.Time, actual time.Time, delta time
 
 // WithinDurationf asserts that the two times are within duration delta of each other.
 //
-//	assert.WithinDurationf(t, time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
+//	require.WithinDurationf(t, time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2031,7 +2259,9 @@ func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta tim
 
 // WithinRange asserts that a time is within a time range (inclusive).
 //
-//	assert.WithinRange(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second))
+//	require.WithinRange(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second))
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func WithinRange(t TestingT, actual time.Time, start time.Time, end time.Time, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2044,7 +2274,9 @@ func WithinRange(t TestingT, actual time.Time, start time.Time, end time.Time, m
 
 // WithinRangef asserts that a time is within a time range (inclusive).
 //
-//	assert.WithinRangef(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second), "error message %s", "formatted")
+//	require.WithinRangef(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second), "error message %s", "formatted")
+//
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func WithinRangef(t TestingT, actual time.Time, start time.Time, end time.Time, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2056,6 +2288,7 @@ func WithinRangef(t TestingT, actual time.Time, start time.Time, end time.Time, 
 }
 
 // YAMLEq asserts that two YAML strings are equivalent.
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func YAMLEq(t TestingT, expected string, actual string, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2067,6 +2300,7 @@ func YAMLEq(t TestingT, expected string, actual string, msgAndArgs ...interface{
 }
 
 // YAMLEqf asserts that two YAML strings are equivalent.
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func YAMLEqf(t TestingT, expected string, actual string, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2078,6 +2312,7 @@ func YAMLEqf(t TestingT, expected string, actual string, msg string, args ...int
 }
 
 // Zero asserts that i is the zero value for its type.
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func Zero(t TestingT, i interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2089,6 +2324,7 @@ func Zero(t TestingT, i interface{}, msgAndArgs ...interface{}) {
 }
 
 // Zerof asserts that i is the zero value for its type.
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func Zerof(t TestingT, i interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()

--- a/require/require.go
+++ b/require/require.go
@@ -10,7 +10,6 @@ import (
 )
 
 // Condition uses a Comparison to assert a complex condition.
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Condition(t TestingT, comp assert.Comparison, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -22,7 +21,6 @@ func Condition(t TestingT, comp assert.Comparison, msgAndArgs ...interface{}) {
 }
 
 // Conditionf uses a Comparison to assert a complex condition.
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Conditionf(t TestingT, comp assert.Comparison, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -39,8 +37,6 @@ func Conditionf(t TestingT, comp assert.Comparison, msg string, args ...interfac
 //	require.Contains(t, "Hello World", "World")
 //	require.Contains(t, ["Hello", "World"], "World")
 //	require.Contains(t, {"Hello": "World"}, "Hello")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Contains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -57,8 +53,6 @@ func Contains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...int
 //	require.Containsf(t, "Hello World", "World", "error message %s", "formatted")
 //	require.Containsf(t, ["Hello", "World"], "World", "error message %s", "formatted")
 //	require.Containsf(t, {"Hello": "World"}, "Hello", "error message %s", "formatted")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Containsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -71,7 +65,6 @@ func Containsf(t TestingT, s interface{}, contains interface{}, msg string, args
 
 // DirExists checks whether a directory exists in the given path. It also fails
 // if the path is a file rather a directory or there is an error checking whether it exists.
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func DirExists(t TestingT, path string, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -84,7 +77,6 @@ func DirExists(t TestingT, path string, msgAndArgs ...interface{}) {
 
 // DirExistsf checks whether a directory exists in the given path. It also fails
 // if the path is a file rather a directory or there is an error checking whether it exists.
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func DirExistsf(t TestingT, path string, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -100,7 +92,6 @@ func DirExistsf(t TestingT, path string, msg string, args ...interface{}) {
 // the number of appearances of each of them in both lists should match.
 //
 // require.ElementsMatch(t, [1, 3, 2, 3], [1, 3, 3, 2])
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func ElementsMatch(t TestingT, listA interface{}, listB interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -116,7 +107,6 @@ func ElementsMatch(t TestingT, listA interface{}, listB interface{}, msgAndArgs 
 // the number of appearances of each of them in both lists should match.
 //
 // require.ElementsMatchf(t, [1, 3, 2, 3], [1, 3, 3, 2], "error message %s", "formatted")
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func ElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -131,8 +121,6 @@ func ElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string
 // a slice or a channel with len == 0.
 //
 //	require.Empty(t, obj)
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -147,8 +135,6 @@ func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 // a slice or a channel with len == 0.
 //
 //	require.Emptyf(t, obj, "error message %s", "formatted")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Emptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -166,7 +152,6 @@ func Emptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses). Function equality
 // cannot be determined and will always fail.
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Equal(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -182,8 +167,6 @@ func Equal(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...i
 //
 //	actualObj, err := SomeFunction()
 //	require.EqualError(t, err,  expectedErrorString)
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func EqualError(t TestingT, theError error, errString string, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -199,8 +182,6 @@ func EqualError(t TestingT, theError error, errString string, msgAndArgs ...inte
 //
 //	actualObj, err := SomeFunction()
 //	require.EqualErrorf(t, err,  expectedErrorString, "error message %s", "formatted")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func EqualErrorf(t TestingT, theError error, errString string, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -221,8 +202,6 @@ func EqualErrorf(t TestingT, theError error, errString string, msg string, args 
 //	 }
 //	 require.EqualExportedValues(t, S{1, 2}, S{1, 3}) => true
 //	 require.EqualExportedValues(t, S{1, 2}, S{2, 3}) => false
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func EqualExportedValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -243,8 +222,6 @@ func EqualExportedValues(t TestingT, expected interface{}, actual interface{}, m
 //	 }
 //	 require.EqualExportedValuesf(t, S{1, 2}, S{1, 3}, "error message %s", "formatted") => true
 //	 require.EqualExportedValuesf(t, S{1, 2}, S{2, 3}, "error message %s", "formatted") => false
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func EqualExportedValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -259,8 +236,6 @@ func EqualExportedValuesf(t TestingT, expected interface{}, actual interface{}, 
 // type and equal.
 //
 //	require.EqualValues(t, uint32(123), int32(123))
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func EqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -275,8 +250,6 @@ func EqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArg
 // type and equal.
 //
 //	require.EqualValuesf(t, uint32(123), int32(123), "error message %s", "formatted")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func EqualValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -294,7 +267,6 @@ func EqualValuesf(t TestingT, expected interface{}, actual interface{}, msg stri
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses). Function equality
 // cannot be determined and will always fail.
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Equalf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -311,8 +283,6 @@ func Equalf(t TestingT, expected interface{}, actual interface{}, msg string, ar
 //	  if require.Error(t, err) {
 //		   require.Equal(t, expectedError, err)
 //	  }
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Error(t TestingT, err error, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -325,7 +295,6 @@ func Error(t TestingT, err error, msgAndArgs ...interface{}) {
 
 // ErrorAs asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
 // This is a wrapper for errors.As.
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func ErrorAs(t TestingT, err error, target interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -338,7 +307,6 @@ func ErrorAs(t TestingT, err error, target interface{}, msgAndArgs ...interface{
 
 // ErrorAsf asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
 // This is a wrapper for errors.As.
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func ErrorAsf(t TestingT, err error, target interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -354,8 +322,6 @@ func ErrorAsf(t TestingT, err error, target interface{}, msg string, args ...int
 //
 //	actualObj, err := SomeFunction()
 //	require.ErrorContains(t, err,  expectedErrorSubString)
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func ErrorContains(t TestingT, theError error, contains string, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -371,8 +337,6 @@ func ErrorContains(t TestingT, theError error, contains string, msgAndArgs ...in
 //
 //	actualObj, err := SomeFunction()
 //	require.ErrorContainsf(t, err,  expectedErrorSubString, "error message %s", "formatted")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func ErrorContainsf(t TestingT, theError error, contains string, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -385,7 +349,6 @@ func ErrorContainsf(t TestingT, theError error, contains string, msg string, arg
 
 // ErrorIs asserts that at least one of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func ErrorIs(t TestingT, err error, target error, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -398,7 +361,6 @@ func ErrorIs(t TestingT, err error, target error, msgAndArgs ...interface{}) {
 
 // ErrorIsf asserts that at least one of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func ErrorIsf(t TestingT, err error, target error, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -415,8 +377,6 @@ func ErrorIsf(t TestingT, err error, target error, msg string, args ...interface
 //	  if require.Errorf(t, err, "error message %s", "formatted") {
 //		   require.Equal(t, expectedErrorf, err)
 //	  }
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Errorf(t TestingT, err error, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -431,8 +391,6 @@ func Errorf(t TestingT, err error, msg string, args ...interface{}) {
 // periodically checking target function each tick.
 //
 //	require.Eventually(t, func() bool { return true; }, time.Second, 10*time.Millisecond)
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Eventually(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -461,8 +419,6 @@ func Eventually(t TestingT, condition func() bool, waitFor time.Duration, tick t
 //		// add assertions as needed; any assertion failure will fail the current tick
 //		require.True(c, externalValue, "expected 'externalValue' to be true")
 //	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func EventuallyWithT(t TestingT, condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -491,8 +447,6 @@ func EventuallyWithT(t TestingT, condition func(collect *assert.CollectT), waitF
 //		// add assertions as needed; any assertion failure will fail the current tick
 //		require.True(c, externalValue, "expected 'externalValue' to be true")
 //	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func EventuallyWithTf(t TestingT, condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -507,8 +461,6 @@ func EventuallyWithTf(t TestingT, condition func(collect *assert.CollectT), wait
 // periodically checking target function each tick.
 //
 //	require.Eventuallyf(t, func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Eventuallyf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -522,8 +474,6 @@ func Eventuallyf(t TestingT, condition func() bool, waitFor time.Duration, tick 
 // Exactly asserts that two objects are equal in value and type.
 //
 //	require.Exactly(t, int32(123), int64(123))
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Exactly(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -537,8 +487,6 @@ func Exactly(t TestingT, expected interface{}, actual interface{}, msgAndArgs ..
 // Exactlyf asserts that two objects are equal in value and type.
 //
 //	require.Exactlyf(t, int32(123), int64(123), "error message %s", "formatted")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Exactlyf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -550,7 +498,6 @@ func Exactlyf(t TestingT, expected interface{}, actual interface{}, msg string, 
 }
 
 // Fail reports a failure through
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Fail(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -562,7 +509,6 @@ func Fail(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
 }
 
 // FailNow fails test
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func FailNow(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -574,7 +520,6 @@ func FailNow(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
 }
 
 // FailNowf fails test
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func FailNowf(t TestingT, failureMessage string, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -586,7 +531,6 @@ func FailNowf(t TestingT, failureMessage string, msg string, args ...interface{}
 }
 
 // Failf reports a failure through
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Failf(t TestingT, failureMessage string, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -600,8 +544,6 @@ func Failf(t TestingT, failureMessage string, msg string, args ...interface{}) {
 // False asserts that the specified value is false.
 //
 //	require.False(t, myBool)
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func False(t TestingT, value bool, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -615,8 +557,6 @@ func False(t TestingT, value bool, msgAndArgs ...interface{}) {
 // Falsef asserts that the specified value is false.
 //
 //	require.Falsef(t, myBool, "error message %s", "formatted")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Falsef(t TestingT, value bool, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -629,7 +569,6 @@ func Falsef(t TestingT, value bool, msg string, args ...interface{}) {
 
 // FileExists checks whether a file exists in the given path. It also fails if
 // the path points to a directory or there is an error when trying to check the file.
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func FileExists(t TestingT, path string, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -642,7 +581,6 @@ func FileExists(t TestingT, path string, msgAndArgs ...interface{}) {
 
 // FileExistsf checks whether a file exists in the given path. It also fails if
 // the path points to a directory or there is an error when trying to check the file.
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func FileExistsf(t TestingT, path string, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -658,8 +596,6 @@ func FileExistsf(t TestingT, path string, msg string, args ...interface{}) {
 //	require.Greater(t, 2, 1)
 //	require.Greater(t, float64(2), float64(1))
 //	require.Greater(t, "b", "a")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Greater(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -676,8 +612,6 @@ func Greater(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface
 //	require.GreaterOrEqual(t, 2, 2)
 //	require.GreaterOrEqual(t, "b", "a")
 //	require.GreaterOrEqual(t, "b", "b")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func GreaterOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -694,8 +628,6 @@ func GreaterOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...in
 //	require.GreaterOrEqualf(t, 2, 2, "error message %s", "formatted")
 //	require.GreaterOrEqualf(t, "b", "a", "error message %s", "formatted")
 //	require.GreaterOrEqualf(t, "b", "b", "error message %s", "formatted")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func GreaterOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -711,8 +643,6 @@ func GreaterOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, arg
 //	require.Greaterf(t, 2, 1, "error message %s", "formatted")
 //	require.Greaterf(t, float64(2), float64(1), "error message %s", "formatted")
 //	require.Greaterf(t, "b", "a", "error message %s", "formatted")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Greaterf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -729,7 +659,6 @@ func Greaterf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...in
 //	require.HTTPBodyContains(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
 //
 // Returns whether the assertion was successful (true) or not (false).
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func HTTPBodyContains(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -746,7 +675,6 @@ func HTTPBodyContains(t TestingT, handler http.HandlerFunc, method string, url s
 //	require.HTTPBodyContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func HTTPBodyContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -763,7 +691,6 @@ func HTTPBodyContainsf(t TestingT, handler http.HandlerFunc, method string, url 
 //	require.HTTPBodyNotContains(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
 //
 // Returns whether the assertion was successful (true) or not (false).
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func HTTPBodyNotContains(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -780,7 +707,6 @@ func HTTPBodyNotContains(t TestingT, handler http.HandlerFunc, method string, ur
 //	require.HTTPBodyNotContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func HTTPBodyNotContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -796,7 +722,6 @@ func HTTPBodyNotContainsf(t TestingT, handler http.HandlerFunc, method string, u
 //	require.HTTPError(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func HTTPError(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -812,7 +737,6 @@ func HTTPError(t TestingT, handler http.HandlerFunc, method string, url string, 
 //	require.HTTPErrorf(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func HTTPErrorf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -828,7 +752,6 @@ func HTTPErrorf(t TestingT, handler http.HandlerFunc, method string, url string,
 //	require.HTTPRedirect(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func HTTPRedirect(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -844,7 +767,6 @@ func HTTPRedirect(t TestingT, handler http.HandlerFunc, method string, url strin
 //	require.HTTPRedirectf(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func HTTPRedirectf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -860,7 +782,6 @@ func HTTPRedirectf(t TestingT, handler http.HandlerFunc, method string, url stri
 //	require.HTTPStatusCode(t, myHandler, "GET", "/notImplemented", nil, 501)
 //
 // Returns whether the assertion was successful (true) or not (false).
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func HTTPStatusCode(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -876,7 +797,6 @@ func HTTPStatusCode(t TestingT, handler http.HandlerFunc, method string, url str
 //	require.HTTPStatusCodef(t, myHandler, "GET", "/notImplemented", nil, 501, "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func HTTPStatusCodef(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -892,7 +812,6 @@ func HTTPStatusCodef(t TestingT, handler http.HandlerFunc, method string, url st
 //	require.HTTPSuccess(t, myHandler, "POST", "http://www.google.com", nil)
 //
 // Returns whether the assertion was successful (true) or not (false).
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func HTTPSuccess(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -908,7 +827,6 @@ func HTTPSuccess(t TestingT, handler http.HandlerFunc, method string, url string
 //	require.HTTPSuccessf(t, myHandler, "POST", "http://www.google.com", nil, "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func HTTPSuccessf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -922,8 +840,6 @@ func HTTPSuccessf(t TestingT, handler http.HandlerFunc, method string, url strin
 // Implements asserts that an object is implemented by the specified interface.
 //
 //	require.Implements(t, (*MyInterface)(nil), new(MyObject))
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Implements(t TestingT, interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -937,8 +853,6 @@ func Implements(t TestingT, interfaceObject interface{}, object interface{}, msg
 // Implementsf asserts that an object is implemented by the specified interface.
 //
 //	require.Implementsf(t, (*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Implementsf(t TestingT, interfaceObject interface{}, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -952,8 +866,6 @@ func Implementsf(t TestingT, interfaceObject interface{}, object interface{}, ms
 // InDelta asserts that the two numerals are within delta of each other.
 //
 //	require.InDelta(t, math.Pi, 22/7.0, 0.01)
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func InDelta(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -965,7 +877,6 @@ func InDelta(t TestingT, expected interface{}, actual interface{}, delta float64
 }
 
 // InDeltaMapValues is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func InDeltaMapValues(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -977,7 +888,6 @@ func InDeltaMapValues(t TestingT, expected interface{}, actual interface{}, delt
 }
 
 // InDeltaMapValuesf is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func InDeltaMapValuesf(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -989,7 +899,6 @@ func InDeltaMapValuesf(t TestingT, expected interface{}, actual interface{}, del
 }
 
 // InDeltaSlice is the same as InDelta, except it compares two slices.
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func InDeltaSlice(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1001,7 +910,6 @@ func InDeltaSlice(t TestingT, expected interface{}, actual interface{}, delta fl
 }
 
 // InDeltaSlicef is the same as InDelta, except it compares two slices.
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func InDeltaSlicef(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1015,8 +923,6 @@ func InDeltaSlicef(t TestingT, expected interface{}, actual interface{}, delta f
 // InDeltaf asserts that the two numerals are within delta of each other.
 //
 //	require.InDeltaf(t, math.Pi, 22/7.0, 0.01, "error message %s", "formatted")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func InDeltaf(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1028,7 +934,6 @@ func InDeltaf(t TestingT, expected interface{}, actual interface{}, delta float6
 }
 
 // InEpsilon asserts that expected and actual have a relative error less than epsilon
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func InEpsilon(t TestingT, expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1040,7 +945,6 @@ func InEpsilon(t TestingT, expected interface{}, actual interface{}, epsilon flo
 }
 
 // InEpsilonSlice is the same as InEpsilon, except it compares each value from two slices.
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func InEpsilonSlice(t TestingT, expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1052,7 +956,6 @@ func InEpsilonSlice(t TestingT, expected interface{}, actual interface{}, epsilo
 }
 
 // InEpsilonSlicef is the same as InEpsilon, except it compares each value from two slices.
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func InEpsilonSlicef(t TestingT, expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1064,7 +967,6 @@ func InEpsilonSlicef(t TestingT, expected interface{}, actual interface{}, epsil
 }
 
 // InEpsilonf asserts that expected and actual have a relative error less than epsilon
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func InEpsilonf(t TestingT, expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1080,8 +982,6 @@ func InEpsilonf(t TestingT, expected interface{}, actual interface{}, epsilon fl
 //	require.IsDecreasing(t, []int{2, 1, 0})
 //	require.IsDecreasing(t, []float{2, 1})
 //	require.IsDecreasing(t, []string{"b", "a"})
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func IsDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1097,8 +997,6 @@ func IsDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 //	require.IsDecreasingf(t, []int{2, 1, 0}, "error message %s", "formatted")
 //	require.IsDecreasingf(t, []float{2, 1}, "error message %s", "formatted")
 //	require.IsDecreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func IsDecreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1114,8 +1012,6 @@ func IsDecreasingf(t TestingT, object interface{}, msg string, args ...interface
 //	require.IsIncreasing(t, []int{1, 2, 3})
 //	require.IsIncreasing(t, []float{1, 2})
 //	require.IsIncreasing(t, []string{"a", "b"})
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func IsIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1131,8 +1027,6 @@ func IsIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 //	require.IsIncreasingf(t, []int{1, 2, 3}, "error message %s", "formatted")
 //	require.IsIncreasingf(t, []float{1, 2}, "error message %s", "formatted")
 //	require.IsIncreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func IsIncreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1148,8 +1042,6 @@ func IsIncreasingf(t TestingT, object interface{}, msg string, args ...interface
 //	require.IsNonDecreasing(t, []int{1, 1, 2})
 //	require.IsNonDecreasing(t, []float{1, 2})
 //	require.IsNonDecreasing(t, []string{"a", "b"})
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func IsNonDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1165,8 +1057,6 @@ func IsNonDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) 
 //	require.IsNonDecreasingf(t, []int{1, 1, 2}, "error message %s", "formatted")
 //	require.IsNonDecreasingf(t, []float{1, 2}, "error message %s", "formatted")
 //	require.IsNonDecreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func IsNonDecreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1182,8 +1072,6 @@ func IsNonDecreasingf(t TestingT, object interface{}, msg string, args ...interf
 //	require.IsNonIncreasing(t, []int{2, 1, 1})
 //	require.IsNonIncreasing(t, []float{2, 1})
 //	require.IsNonIncreasing(t, []string{"b", "a"})
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func IsNonIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1199,8 +1087,6 @@ func IsNonIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) 
 //	require.IsNonIncreasingf(t, []int{2, 1, 1}, "error message %s", "formatted")
 //	require.IsNonIncreasingf(t, []float{2, 1}, "error message %s", "formatted")
 //	require.IsNonIncreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func IsNonIncreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1212,7 +1098,6 @@ func IsNonIncreasingf(t TestingT, object interface{}, msg string, args ...interf
 }
 
 // IsType asserts that the specified objects are of the same type.
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func IsType(t TestingT, expectedType interface{}, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1224,7 +1109,6 @@ func IsType(t TestingT, expectedType interface{}, object interface{}, msgAndArgs
 }
 
 // IsTypef asserts that the specified objects are of the same type.
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func IsTypef(t TestingT, expectedType interface{}, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1238,8 +1122,6 @@ func IsTypef(t TestingT, expectedType interface{}, object interface{}, msg strin
 // JSONEq asserts that two JSON strings are equivalent.
 //
 //	require.JSONEq(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func JSONEq(t TestingT, expected string, actual string, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1253,8 +1135,6 @@ func JSONEq(t TestingT, expected string, actual string, msgAndArgs ...interface{
 // JSONEqf asserts that two JSON strings are equivalent.
 //
 //	require.JSONEqf(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func JSONEqf(t TestingT, expected string, actual string, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1269,8 +1149,6 @@ func JSONEqf(t TestingT, expected string, actual string, msg string, args ...int
 // Len also fails if the object has a type that len() not accept.
 //
 //	require.Len(t, mySlice, 3)
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1285,8 +1163,6 @@ func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) 
 // Lenf also fails if the object has a type that len() not accept.
 //
 //	require.Lenf(t, mySlice, 3, "error message %s", "formatted")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Lenf(t TestingT, object interface{}, length int, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1302,8 +1178,6 @@ func Lenf(t TestingT, object interface{}, length int, msg string, args ...interf
 //	require.Less(t, 1, 2)
 //	require.Less(t, float64(1), float64(2))
 //	require.Less(t, "a", "b")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1320,8 +1194,6 @@ func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{})
 //	require.LessOrEqual(t, 2, 2)
 //	require.LessOrEqual(t, "a", "b")
 //	require.LessOrEqual(t, "b", "b")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func LessOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1338,8 +1210,6 @@ func LessOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...inter
 //	require.LessOrEqualf(t, 2, 2, "error message %s", "formatted")
 //	require.LessOrEqualf(t, "a", "b", "error message %s", "formatted")
 //	require.LessOrEqualf(t, "b", "b", "error message %s", "formatted")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func LessOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1355,8 +1225,6 @@ func LessOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args .
 //	require.Lessf(t, 1, 2, "error message %s", "formatted")
 //	require.Lessf(t, float64(1), float64(2), "error message %s", "formatted")
 //	require.Lessf(t, "a", "b", "error message %s", "formatted")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Lessf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1371,8 +1239,6 @@ func Lessf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...inter
 //
 //	require.Negative(t, -1)
 //	require.Negative(t, -1.23)
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Negative(t TestingT, e interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1387,8 +1253,6 @@ func Negative(t TestingT, e interface{}, msgAndArgs ...interface{}) {
 //
 //	require.Negativef(t, -1, "error message %s", "formatted")
 //	require.Negativef(t, -1.23, "error message %s", "formatted")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Negativef(t TestingT, e interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1403,8 +1267,6 @@ func Negativef(t TestingT, e interface{}, msg string, args ...interface{}) {
 // periodically checking the target function each tick.
 //
 //	require.Never(t, func() bool { return false; }, time.Second, 10*time.Millisecond)
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Never(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1419,8 +1281,6 @@ func Never(t TestingT, condition func() bool, waitFor time.Duration, tick time.D
 // periodically checking the target function each tick.
 //
 //	require.Neverf(t, func() bool { return false; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Neverf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1434,8 +1294,6 @@ func Neverf(t TestingT, condition func() bool, waitFor time.Duration, tick time.
 // Nil asserts that the specified object is nil.
 //
 //	require.Nil(t, err)
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1449,8 +1307,6 @@ func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 // Nilf asserts that the specified object is nil.
 //
 //	require.Nilf(t, err, "error message %s", "formatted")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Nilf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1463,7 +1319,6 @@ func Nilf(t TestingT, object interface{}, msg string, args ...interface{}) {
 
 // NoDirExists checks whether a directory does not exist in the given path.
 // It fails if the path points to an existing _directory_ only.
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NoDirExists(t TestingT, path string, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1476,7 +1331,6 @@ func NoDirExists(t TestingT, path string, msgAndArgs ...interface{}) {
 
 // NoDirExistsf checks whether a directory does not exist in the given path.
 // It fails if the path points to an existing _directory_ only.
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NoDirExistsf(t TestingT, path string, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1493,8 +1347,6 @@ func NoDirExistsf(t TestingT, path string, msg string, args ...interface{}) {
 //	  if require.NoError(t, err) {
 //		   require.Equal(t, expectedObj, actualObj)
 //	  }
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NoError(t TestingT, err error, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1511,8 +1363,6 @@ func NoError(t TestingT, err error, msgAndArgs ...interface{}) {
 //	  if require.NoErrorf(t, err, "error message %s", "formatted") {
 //		   require.Equal(t, expectedObj, actualObj)
 //	  }
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NoErrorf(t TestingT, err error, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1525,7 +1375,6 @@ func NoErrorf(t TestingT, err error, msg string, args ...interface{}) {
 
 // NoFileExists checks whether a file does not exist in a given path. It fails
 // if the path points to an existing _file_ only.
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NoFileExists(t TestingT, path string, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1538,7 +1387,6 @@ func NoFileExists(t TestingT, path string, msgAndArgs ...interface{}) {
 
 // NoFileExistsf checks whether a file does not exist in a given path. It fails
 // if the path points to an existing _file_ only.
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NoFileExistsf(t TestingT, path string, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1555,8 +1403,6 @@ func NoFileExistsf(t TestingT, path string, msg string, args ...interface{}) {
 //	require.NotContains(t, "Hello World", "Earth")
 //	require.NotContains(t, ["Hello", "World"], "Earth")
 //	require.NotContains(t, {"Hello": "World"}, "Earth")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotContains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1573,8 +1419,6 @@ func NotContains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...
 //	require.NotContainsf(t, "Hello World", "Earth", "error message %s", "formatted")
 //	require.NotContainsf(t, ["Hello", "World"], "Earth", "error message %s", "formatted")
 //	require.NotContainsf(t, {"Hello": "World"}, "Earth", "error message %s", "formatted")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotContainsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1595,7 +1439,6 @@ func NotContainsf(t TestingT, s interface{}, contains interface{}, msg string, a
 // require.NotElementsMatch(t, [1, 1, 2, 3], [1, 2, 3]) -> true
 //
 // require.NotElementsMatch(t, [1, 2, 3], [1, 2, 4]) -> true
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotElementsMatch(t TestingT, listA interface{}, listB interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1616,7 +1459,6 @@ func NotElementsMatch(t TestingT, listA interface{}, listB interface{}, msgAndAr
 // require.NotElementsMatchf(t, [1, 1, 2, 3], [1, 2, 3], "error message %s", "formatted") -> true
 //
 // require.NotElementsMatchf(t, [1, 2, 3], [1, 2, 4], "error message %s", "formatted") -> true
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1633,8 +1475,6 @@ func NotElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg str
 //	if require.NotEmpty(t, obj) {
 //	  require.Equal(t, "two", obj[1])
 //	}
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1651,8 +1491,6 @@ func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 //	if require.NotEmptyf(t, obj, "error message %s", "formatted") {
 //	  require.Equal(t, "two", obj[1])
 //	}
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1669,7 +1507,6 @@ func NotEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) 
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotEqual(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1683,8 +1520,6 @@ func NotEqual(t TestingT, expected interface{}, actual interface{}, msgAndArgs .
 // NotEqualValues asserts that two objects are not equal even when converted to the same type
 //
 //	require.NotEqualValues(t, obj1, obj2)
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotEqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1698,8 +1533,6 @@ func NotEqualValues(t TestingT, expected interface{}, actual interface{}, msgAnd
 // NotEqualValuesf asserts that two objects are not equal even when converted to the same type
 //
 //	require.NotEqualValuesf(t, obj1, obj2, "error message %s", "formatted")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotEqualValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1716,7 +1549,6 @@ func NotEqualValuesf(t TestingT, expected interface{}, actual interface{}, msg s
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotEqualf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1729,7 +1561,6 @@ func NotEqualf(t TestingT, expected interface{}, actual interface{}, msg string,
 
 // NotErrorIs asserts that none of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotErrorIs(t TestingT, err error, target error, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1742,7 +1573,6 @@ func NotErrorIs(t TestingT, err error, target error, msgAndArgs ...interface{}) 
 
 // NotErrorIsf asserts that none of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotErrorIsf(t TestingT, err error, target error, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1756,8 +1586,6 @@ func NotErrorIsf(t TestingT, err error, target error, msg string, args ...interf
 // NotImplements asserts that an object does not implement the specified interface.
 //
 //	require.NotImplements(t, (*MyInterface)(nil), new(MyObject))
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotImplements(t TestingT, interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1771,8 +1599,6 @@ func NotImplements(t TestingT, interfaceObject interface{}, object interface{}, 
 // NotImplementsf asserts that an object does not implement the specified interface.
 //
 //	require.NotImplementsf(t, (*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotImplementsf(t TestingT, interfaceObject interface{}, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1786,8 +1612,6 @@ func NotImplementsf(t TestingT, interfaceObject interface{}, object interface{},
 // NotNil asserts that the specified object is not nil.
 //
 //	require.NotNil(t, err)
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1801,8 +1625,6 @@ func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 // NotNilf asserts that the specified object is not nil.
 //
 //	require.NotNilf(t, err, "error message %s", "formatted")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotNilf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1816,8 +1638,6 @@ func NotNilf(t TestingT, object interface{}, msg string, args ...interface{}) {
 // NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
 //
 //	require.NotPanics(t, func(){ RemainCalm() })
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotPanics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1831,8 +1651,6 @@ func NotPanics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 // NotPanicsf asserts that the code inside the specified PanicTestFunc does NOT panic.
 //
 //	require.NotPanicsf(t, func(){ RemainCalm() }, "error message %s", "formatted")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotPanicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1847,8 +1665,6 @@ func NotPanicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interfac
 //
 //	require.NotRegexp(t, regexp.MustCompile("starts"), "it's starting")
 //	require.NotRegexp(t, "^start", "it's not starting")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1863,8 +1679,6 @@ func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interf
 //
 //	require.NotRegexpf(t, regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
 //	require.NotRegexpf(t, "^start", "it's not starting", "error message %s", "formatted")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotRegexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1881,7 +1695,6 @@ func NotRegexpf(t TestingT, rx interface{}, str interface{}, msg string, args ..
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotSame(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1898,7 +1711,6 @@ func NotSame(t TestingT, expected interface{}, actual interface{}, msgAndArgs ..
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotSamef(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1915,8 +1727,6 @@ func NotSamef(t TestingT, expected interface{}, actual interface{}, msg string, 
 //
 //	require.NotSubset(t, [1, 3, 4], [1, 2])
 //	require.NotSubset(t, {"x": 1, "y": 2}, {"z": 3})
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotSubset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1933,8 +1743,6 @@ func NotSubset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...i
 //
 //	require.NotSubsetf(t, [1, 3, 4], [1, 2], "error message %s", "formatted")
 //	require.NotSubsetf(t, {"x": 1, "y": 2}, {"z": 3}, "error message %s", "formatted")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotSubsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1946,7 +1754,6 @@ func NotSubsetf(t TestingT, list interface{}, subset interface{}, msg string, ar
 }
 
 // NotZero asserts that i is not the zero value for its type.
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotZero(t TestingT, i interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1958,7 +1765,6 @@ func NotZero(t TestingT, i interface{}, msgAndArgs ...interface{}) {
 }
 
 // NotZerof asserts that i is not the zero value for its type.
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func NotZerof(t TestingT, i interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1972,8 +1778,6 @@ func NotZerof(t TestingT, i interface{}, msg string, args ...interface{}) {
 // Panics asserts that the code inside the specified PanicTestFunc panics.
 //
 //	require.Panics(t, func(){ GoCrazy() })
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Panics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1989,8 +1793,6 @@ func Panics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 // EqualError comparison.
 //
 //	require.PanicsWithError(t, "crazy error", func(){ GoCrazy() })
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func PanicsWithError(t TestingT, errString string, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2006,8 +1808,6 @@ func PanicsWithError(t TestingT, errString string, f assert.PanicTestFunc, msgAn
 // EqualError comparison.
 //
 //	require.PanicsWithErrorf(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func PanicsWithErrorf(t TestingT, errString string, f assert.PanicTestFunc, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2022,8 +1822,6 @@ func PanicsWithErrorf(t TestingT, errString string, f assert.PanicTestFunc, msg 
 // the recovered panic value equals the expected panic value.
 //
 //	require.PanicsWithValue(t, "crazy error", func(){ GoCrazy() })
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func PanicsWithValue(t TestingT, expected interface{}, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2038,8 +1836,6 @@ func PanicsWithValue(t TestingT, expected interface{}, f assert.PanicTestFunc, m
 // the recovered panic value equals the expected panic value.
 //
 //	require.PanicsWithValuef(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func PanicsWithValuef(t TestingT, expected interface{}, f assert.PanicTestFunc, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2053,8 +1849,6 @@ func PanicsWithValuef(t TestingT, expected interface{}, f assert.PanicTestFunc, 
 // Panicsf asserts that the code inside the specified PanicTestFunc panics.
 //
 //	require.Panicsf(t, func(){ GoCrazy() }, "error message %s", "formatted")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Panicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2069,8 +1863,6 @@ func Panicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}
 //
 //	require.Positive(t, 1)
 //	require.Positive(t, 1.23)
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Positive(t TestingT, e interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2085,8 +1877,6 @@ func Positive(t TestingT, e interface{}, msgAndArgs ...interface{}) {
 //
 //	require.Positivef(t, 1, "error message %s", "formatted")
 //	require.Positivef(t, 1.23, "error message %s", "formatted")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Positivef(t TestingT, e interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2101,8 +1891,6 @@ func Positivef(t TestingT, e interface{}, msg string, args ...interface{}) {
 //
 //	require.Regexp(t, regexp.MustCompile("start"), "it's starting")
 //	require.Regexp(t, "start...$", "it's not starting")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2117,8 +1905,6 @@ func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface
 //
 //	require.Regexpf(t, regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
 //	require.Regexpf(t, "start...$", "it's not starting", "error message %s", "formatted")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Regexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2135,7 +1921,6 @@ func Regexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...in
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Same(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2152,7 +1937,6 @@ func Same(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...in
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Samef(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2168,8 +1952,6 @@ func Samef(t TestingT, expected interface{}, actual interface{}, msg string, arg
 //
 //	require.Subset(t, [1, 2, 3], [1, 2])
 //	require.Subset(t, {"x": 1, "y": 2}, {"x": 1})
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Subset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2185,8 +1967,6 @@ func Subset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...inte
 //
 //	require.Subsetf(t, [1, 2, 3], [1, 2], "error message %s", "formatted")
 //	require.Subsetf(t, {"x": 1, "y": 2}, {"x": 1}, "error message %s", "formatted")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Subsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2200,8 +1980,6 @@ func Subsetf(t TestingT, list interface{}, subset interface{}, msg string, args 
 // True asserts that the specified value is true.
 //
 //	require.True(t, myBool)
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func True(t TestingT, value bool, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2215,8 +1993,6 @@ func True(t TestingT, value bool, msgAndArgs ...interface{}) {
 // Truef asserts that the specified value is true.
 //
 //	require.Truef(t, myBool, "error message %s", "formatted")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Truef(t TestingT, value bool, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2230,8 +2006,6 @@ func Truef(t TestingT, value bool, msg string, args ...interface{}) {
 // WithinDuration asserts that the two times are within duration delta of each other.
 //
 //	require.WithinDuration(t, time.Now(), time.Now(), 10*time.Second)
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func WithinDuration(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2245,8 +2019,6 @@ func WithinDuration(t TestingT, expected time.Time, actual time.Time, delta time
 // WithinDurationf asserts that the two times are within duration delta of each other.
 //
 //	require.WithinDurationf(t, time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2260,8 +2032,6 @@ func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta tim
 // WithinRange asserts that a time is within a time range (inclusive).
 //
 //	require.WithinRange(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second))
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func WithinRange(t TestingT, actual time.Time, start time.Time, end time.Time, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2275,8 +2045,6 @@ func WithinRange(t TestingT, actual time.Time, start time.Time, end time.Time, m
 // WithinRangef asserts that a time is within a time range (inclusive).
 //
 //	require.WithinRangef(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second), "error message %s", "formatted")
-//
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func WithinRangef(t TestingT, actual time.Time, start time.Time, end time.Time, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2288,7 +2056,6 @@ func WithinRangef(t TestingT, actual time.Time, start time.Time, end time.Time, 
 }
 
 // YAMLEq asserts that two YAML strings are equivalent.
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func YAMLEq(t TestingT, expected string, actual string, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2300,7 +2067,6 @@ func YAMLEq(t TestingT, expected string, actual string, msgAndArgs ...interface{
 }
 
 // YAMLEqf asserts that two YAML strings are equivalent.
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func YAMLEqf(t TestingT, expected string, actual string, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2312,7 +2078,6 @@ func YAMLEqf(t TestingT, expected string, actual string, msg string, args ...int
 }
 
 // Zero asserts that i is the zero value for its type.
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Zero(t TestingT, i interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2324,7 +2089,6 @@ func Zero(t TestingT, i interface{}, msgAndArgs ...interface{}) {
 }
 
 // Zerof asserts that i is the zero value for its type.
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func Zerof(t TestingT, i interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()

--- a/require/require.go.tmpl
+++ b/require/require.go.tmpl
@@ -1,4 +1,5 @@
-{{.Comment}}
+{{ replace .Comment "assert." "require."}}
+// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
 func {{.DocInfo.Name}}(t TestingT, {{.Params}}) {
 	if h, ok := t.(tHelper); ok { h.Helper() }
 	if assert.{{.DocInfo.Name}}(t, {{.ForwardedParams}}) { return }

--- a/require/require.go.tmpl
+++ b/require/require.go.tmpl
@@ -1,5 +1,5 @@
 {{ replace .Comment "assert." "require."}}
-// Instead of returning a boolean result this function calls `t.FailNow()` on failure.
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func {{.DocInfo.Name}}(t TestingT, {{.Params}}) {
 	if h, ok := t.(tHelper); ok { h.Helper() }
 	if assert.{{.DocInfo.Name}}(t, {{.ForwardedParams}}) { return }

--- a/require/require.go.tmpl
+++ b/require/require.go.tmpl
@@ -1,5 +1,4 @@
 {{ replace .Comment "assert." "require."}}
-// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func {{.DocInfo.Name}}(t TestingT, {{.Params}}) {
 	if h, ok := t.(tHelper); ok { h.Helper() }
 	if assert.{{.DocInfo.Name}}(t, {{.ForwardedParams}}) { return }


### PR DESCRIPTION
## Summary

The comments for the require package were just copied over from the assert package when generating the functions. This could lead to confusion because
1. The code-examples were showing examples using the assert package instead of the require package
2. The function-documentation was not mentioning that the functions were calling `t.FailNow()` which is some critical information when using this package.


## Changes
1. Added a "replace" function to the template
2. require.go.tmpl now replaces the package name accordingly
3. require.go.tmpl now adds another line to the function-docs explaining the difference to the assert-function

## Motivation
When new developers are coming in they most likely did not go through the github-documentation for every package used in the application. But what they do is read the function-docs when they go through code to understand what it is doing.
In case of test-cases using both `require` and `assert` it gets confusing because the function docs for the `require` package are referencing the `assert` package and don't really document the actual function.
