### PR TITLE
Lazily render mock diff output on successful match

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -942,8 +942,8 @@ func (args Arguments) Diff(objects []interface{}) (string, int) {
 
 	outputRenderers := []outputRenderer{}
 
-	for j := 0; j < maxArgCount; j++ {
-		i := j
+	for i := 0; i < maxArgCount; i++ {
+		i := i
 		var actual, expected interface{}
 		var actualFmt, expectedFmt func() string
 


### PR DESCRIPTION
## Summary
<!-- High-level, one sentence summary of what this PR accomplishes -->
- For mocks on functions that take complex types as arg, `Sprintf`-ing the `actual` value can be costly. Switch successful matches to use thunks to lazily render their output, and fully avoid rendering their output when there are no differences since we return a constant string in that case anyways

## Changes
- Switch to a string builder for accumulating output for better performance even when we *do* render
<!-- * Description of change 1 -->
<!-- * Description of change 2 -->
<!-- ... -->

## Motivation
- We heavily use mocks at DevotedHealth, and use them frequently in gRPC contexts where we're mocking RPCs that take `<Whatever>Request` structs that are costly to `%v` via `Sprintf`. `Sprintf` showed up as a tangible contributor to runtime performance when profiling some of our heavier tests. The below ~5s cpu time spent on `Sprintf` goes away completely here in one of our exemplar tests

<img width="976" alt="Screenshot 2024-06-25 at 12 16 35 PM" src="https://github.com/DevotedHealth/testify/assets/31651/37a7fe5a-e4e3-4f4d-8cad-07a101983412">

<!-- Why were the changes necessary. -->

<!-- ## Example usage (if applicable) -->

## Related issues
<!-- Put `Closes #XXXX` for each issue number this PR fixes/closes -->
