### PR TITLE
fix: compare functional option names for indirect calls

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -1204,31 +1204,16 @@ type tHelper interface {
 func assertOpts(expected, actual interface{}) (expectedFmt, actualFmt string) {
 	expectedOpts := reflect.ValueOf(expected)
 	actualOpts := reflect.ValueOf(actual)
-	var expectedNames []string
-	for i := 0; i < expectedOpts.Len(); i++ {
-		expectedNames = append(expectedNames, funcName(expectedOpts.Index(i).Interface()))
-	}
-	var actualNames []string
-	for i := 0; i < actualOpts.Len(); i++ {
-		actualNames = append(actualNames, funcName(actualOpts.Index(i).Interface()))
-	}
-	if !assert.ObjectsAreEqual(expectedNames, actualNames) {
-		expectedFmt = fmt.Sprintf("%v", expectedNames)
-		actualFmt = fmt.Sprintf("%v", actualNames)
+
+	if expectedOpts.Len() != actualOpts.Len() {
+		expectedFmt = fmt.Sprintf("%v", expectedOpts)
+		actualFmt = fmt.Sprintf("%v", actualOpts)
 		return
 	}
 
 	for i := 0; i < expectedOpts.Len(); i++ {
 		expectedOpt := expectedOpts.Index(i).Interface()
 		actualOpt := actualOpts.Index(i).Interface()
-
-		expectedFunc := expectedNames[i]
-		actualFunc := actualNames[i]
-		if expectedFunc != actualFunc {
-			expectedFmt = expectedFunc
-			actualFmt = actualFunc
-			return
-		}
 
 		ot := reflect.TypeOf(expectedOpt)
 		var expectedValues []reflect.Value
@@ -1248,8 +1233,8 @@ func assertOpts(expected, actual interface{}) (expectedFmt, actualFmt string) {
 
 		for i := 0; i < ot.NumIn(); i++ {
 			if !assert.ObjectsAreEqual(expectedValues[i].Interface(), actualValues[i].Interface()) {
-				expectedFmt = fmt.Sprintf("%s %+v", expectedNames[i], expectedValues[i].Interface())
-				actualFmt = fmt.Sprintf("%s %+v", expectedNames[i], actualValues[i].Interface())
+				expectedFmt = fmt.Sprintf("%s %+v", funcName(expectedOpts.Index(i).Interface()), expectedValues[i].Interface())
+				actualFmt = fmt.Sprintf("%s %+v", funcName(actualOpts.Index(i).Interface()), actualValues[i].Interface())
 				return
 			}
 		}

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -1227,16 +1227,14 @@ func assertOpts(expected, actual interface{}) (expectedFmt, actualFmt string) {
 	}
 
 	for i := 0; i < expectedOpts.Len(); i++ {
+		expectedOpt := expectedOpts.Index(i).Interface()
+		actualOpt := actualOpts.Index(i).Interface()
+
 		if !isFuncSame(expectedFuncs[i], actualFuncs[i]) {
 			expectedFmt = expectedNames[i]
 			actualFmt = actualNames[i]
 			return
 		}
-	}
-
-	for i := 0; i < expectedOpts.Len(); i++ {
-		expectedOpt := expectedOpts.Index(i).Interface()
-		actualOpt := actualOpts.Index(i).Interface()
 
 		ot := reflect.TypeOf(expectedOpt)
 		var expectedValues []reflect.Value

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -1205,12 +1205,6 @@ func assertOpts(expected, actual interface{}) (expectedFmt, actualFmt string) {
 	expectedOpts := reflect.ValueOf(expected)
 	actualOpts := reflect.ValueOf(actual)
 
-	if expectedOpts.Len() != actualOpts.Len() {
-		expectedFmt = fmt.Sprintf("%v", expectedOpts)
-		actualFmt = fmt.Sprintf("%v", actualOpts)
-		return
-	}
-
 	var expectedNames []string
 	for i := 0; i < expectedOpts.Len(); i++ {
 		expectedNames = append(expectedNames, funcName(expectedOpts.Index(i).Interface()))
@@ -1228,6 +1222,14 @@ func assertOpts(expected, actual interface{}) (expectedFmt, actualFmt string) {
 	for i := 0; i < expectedOpts.Len(); i++ {
 		expectedOpt := expectedOpts.Index(i).Interface()
 		actualOpt := actualOpts.Index(i).Interface()
+
+		expectedFunc := expectedNames[i]
+		actualFunc := actualNames[i]
+		if expectedFunc != actualFunc {
+			expectedFmt = expectedFunc
+			actualFmt = actualFunc
+			return
+		}
 
 		ot := reflect.TypeOf(expectedOpt)
 		var expectedValues []reflect.Value

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -1260,5 +1260,12 @@ func assertOpts(expected, actual interface{}) (expectedFmt, actualFmt string) {
 
 func funcName(opt interface{}) string {
 	n := runtime.FuncForPC(reflect.ValueOf(opt).Pointer()).Name()
-	return strings.TrimSuffix(path.Base(n), path.Ext(n))
+	trimmed := strings.TrimSuffix(path.Base(n), path.Ext(n))
+	splitted := strings.Split(trimmed, ".")
+
+	if len(splitted) == 0 {
+		return trimmed
+	}
+
+	return splitted[len(splitted)-1]
 }

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -1227,14 +1227,14 @@ func assertOpts(expected, actual interface{}) (expectedFmt, actualFmt string) {
 	}
 
 	for i := 0; i < expectedOpts.Len(); i++ {
-		expectedOpt := expectedOpts.Index(i).Interface()
-		actualOpt := actualOpts.Index(i).Interface()
-
 		if !isFuncSame(expectedFuncs[i], actualFuncs[i]) {
 			expectedFmt = expectedNames[i]
 			actualFmt = actualNames[i]
 			return
 		}
+
+		expectedOpt := expectedOpts.Index(i).Interface()
+		actualOpt := actualOpts.Index(i).Interface()
 
 		ot := reflect.TypeOf(expectedOpt)
 		var expectedValues []reflect.Value

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -1211,6 +1211,20 @@ func assertOpts(expected, actual interface{}) (expectedFmt, actualFmt string) {
 		return
 	}
 
+	var expectedNames []string
+	for i := 0; i < expectedOpts.Len(); i++ {
+		expectedNames = append(expectedNames, funcName(expectedOpts.Index(i).Interface()))
+	}
+	var actualNames []string
+	for i := 0; i < actualOpts.Len(); i++ {
+		actualNames = append(actualNames, funcName(actualOpts.Index(i).Interface()))
+	}
+	if !assert.ObjectsAreEqual(expectedNames, actualNames) {
+		expectedFmt = fmt.Sprintf("%v", expectedNames)
+		actualFmt = fmt.Sprintf("%v", actualNames)
+		return
+	}
+
 	for i := 0; i < expectedOpts.Len(); i++ {
 		expectedOpt := expectedOpts.Index(i).Interface()
 		actualOpt := actualOpts.Index(i).Interface()
@@ -1232,9 +1246,9 @@ func assertOpts(expected, actual interface{}) (expectedFmt, actualFmt string) {
 		reflect.ValueOf(actualOpt).Call(actualValues)
 
 		for i := 0; i < ot.NumIn(); i++ {
-			if !assert.ObjectsAreEqual(expectedValues[i].Interface(), actualValues[i].Interface()) {
-				expectedFmt = fmt.Sprintf("%s %+v", funcName(expectedOpts.Index(i).Interface()), expectedValues[i].Interface())
-				actualFmt = fmt.Sprintf("%s %+v", funcName(actualOpts.Index(i).Interface()), actualValues[i].Interface())
+			if expectedArg, actualArg := expectedValues[i].Interface(), actualValues[i].Interface(); !assert.ObjectsAreEqual(expectedArg, actualArg) {
+				expectedFmt = fmt.Sprintf("%s(%T) -> %#v", expectedNames[i], expectedArg, expectedArg)
+				actualFmt = fmt.Sprintf("%s(%T) -> %#v", expectedNames[i], actualArg, actualArg)
 				return
 			}
 		}

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -1516,23 +1516,6 @@ func Test_Mock_AssertExpectationsFunctionalOptionsType(t *testing.T) {
 
 }
 
-func Test_Mock_AssertExpectationsFunctionalOptionsType_Indirectly(t *testing.T) {
-
-	var mockedService = new(TestExampleImplementation)
-
-	mockedService.On("TheExampleMethodFunctionalOptions", "test", FunctionalOptions(OpNum(1), OpStr("foo"))).Return(nil).Once()
-
-	tt := new(testing.T)
-	assert.False(t, mockedService.AssertExpectations(tt))
-
-	// make the call now
-	TheExampleMethodFunctionalOptionsIndirect(mockedService)
-
-	// now assert expectations
-	assert.True(t, mockedService.AssertExpectations(tt))
-
-}
-
 func Test_Mock_AssertExpectationsFunctionalOptionsType_Empty(t *testing.T) {
 
 	var mockedService = new(TestExampleImplementation)
@@ -1544,6 +1527,23 @@ func Test_Mock_AssertExpectationsFunctionalOptionsType_Empty(t *testing.T) {
 
 	// make the call now
 	mockedService.TheExampleMethodFunctionalOptions("test")
+
+	// now assert expectations
+	assert.True(t, mockedService.AssertExpectations(tt))
+
+}
+
+func Test_Mock_AssertExpectationsFunctionalOptionsType_Indirectly(t *testing.T) {
+
+	var mockedService = new(TestExampleImplementation)
+
+	mockedService.On("TheExampleMethodFunctionalOptions", "test", FunctionalOptions(OpNum(1), OpStr("foo"))).Return(nil).Once()
+
+	tt := new(testing.T)
+	assert.False(t, mockedService.AssertExpectations(tt))
+
+	// make the call now
+	TheExampleMethodFunctionalOptionsIndirect(mockedService)
 
 	// now assert expectations
 	assert.True(t, mockedService.AssertExpectations(tt))

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -50,6 +50,13 @@ func OpStr(s string) OptionFn {
 		o.str = s
 	}
 }
+
+func OpBytes(b []byte) OptionFn {
+	return func(m *options) {
+		m.str = string(b)
+	}
+}
+
 func (i *TestExampleImplementation) TheExampleMethodFunctionalOptions(x string, opts ...OptionFn) error {
 	args := i.Called(x, opts)
 	return args.Error(0)
@@ -1509,7 +1516,7 @@ func Test_Mock_AssertExpectationsFunctionalOptionsType(t *testing.T) {
 
 }
 
-func Test_Mock_AssertExpectationsFunctionalOptionsTypeIndirectly(t *testing.T) {
+func Test_Mock_AssertExpectationsFunctionalOptionsType_Indirectly(t *testing.T) {
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1543,17 +1550,31 @@ func Test_Mock_AssertExpectationsFunctionalOptionsType_Empty(t *testing.T) {
 
 }
 
-func Test_Mock_AssertExpectationsFunctionalOptionsType_Diff(t *testing.T) {
+func Test_Mock_AssertExpectationsFunctionalOptionsType_Diff_Name(t *testing.T) {
 
 	var mockedService = new(TestExampleImplementation)
 
-	mockedService.On("TheExampleMethodFunctionalOptions", "test", FunctionalOptions(OpNum(1))).Return(nil).Once()
+	mockedService.On("TheExampleMethodFunctionalOptions", "test", FunctionalOptions(OpStr("this"))).Return(nil).Once()
 
 	tt := new(testing.T)
 	assert.False(t, mockedService.AssertExpectations(tt))
 
 	assert.Panics(t, func() {
-		mockedService.TheExampleMethodFunctionalOptions("test", OpStr("1"))
+		mockedService.TheExampleMethodFunctionalOptions("test", OpBytes([]byte("this")))
+	})
+}
+
+func Test_Mock_AssertExpectationsFunctionalOptionsType_Diff_Arg(t *testing.T) {
+
+	var mockedService = new(TestExampleImplementation)
+
+	mockedService.On("TheExampleMethodFunctionalOptions", "test", FunctionalOptions(OpStr("this"))).Return(nil).Once()
+
+	tt := new(testing.T)
+	assert.False(t, mockedService.AssertExpectations(tt))
+
+	assert.Panics(t, func() {
+		mockedService.TheExampleMethodFunctionalOptions("test", OpStr("that"))
 	})
 }
 

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -1550,7 +1550,7 @@ func Test_Mock_AssertExpectationsFunctionalOptionsType_Indirectly(t *testing.T) 
 
 }
 
-func Test_Mock_AssertExpectationsFunctionalOptionsType_Diff_Name(t *testing.T) {
+func Test_Mock_AssertExpectationsFunctionalOptionsType_Diff_Func(t *testing.T) {
 
 	var mockedService = new(TestExampleImplementation)
 

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -55,6 +55,10 @@ func (i *TestExampleImplementation) TheExampleMethodFunctionalOptions(x string, 
 	return args.Error(0)
 }
 
+func TheExampleMethodFunctionalOptionsIndirect(i *TestExampleImplementation) {
+	i.TheExampleMethodFunctionalOptions("test", OpNum(1), OpStr("foo"))
+}
+
 //go:noinline
 func (i *TestExampleImplementation) TheExampleMethod2(yesorno bool) {
 	i.Called(yesorno)
@@ -1505,6 +1509,23 @@ func Test_Mock_AssertExpectationsFunctionalOptionsType(t *testing.T) {
 
 }
 
+func Test_Mock_AssertExpectationsFunctionalOptionsTypeIndirectly(t *testing.T) {
+
+	var mockedService = new(TestExampleImplementation)
+
+	mockedService.On("TheExampleMethodFunctionalOptions", "test", FunctionalOptions(OpNum(1), OpStr("foo"))).Return(nil).Once()
+
+	tt := new(testing.T)
+	assert.False(t, mockedService.AssertExpectations(tt))
+
+	// make the call now
+	TheExampleMethodFunctionalOptionsIndirect(mockedService)
+
+	// now assert expectations
+	assert.True(t, mockedService.AssertExpectations(tt))
+
+}
+
 func Test_Mock_AssertExpectationsFunctionalOptionsType_Empty(t *testing.T) {
 
 	var mockedService = new(TestExampleImplementation)
@@ -1520,6 +1541,20 @@ func Test_Mock_AssertExpectationsFunctionalOptionsType_Empty(t *testing.T) {
 	// now assert expectations
 	assert.True(t, mockedService.AssertExpectations(tt))
 
+}
+
+func Test_Mock_AssertExpectationsFunctionalOptionsType_Diff(t *testing.T) {
+
+	var mockedService = new(TestExampleImplementation)
+
+	mockedService.On("TheExampleMethodFunctionalOptions", "test", FunctionalOptions(OpNum(1))).Return(nil).Once()
+
+	tt := new(testing.T)
+	assert.False(t, mockedService.AssertExpectations(tt))
+
+	assert.Panics(t, func() {
+		mockedService.TheExampleMethodFunctionalOptions("test", OpStr("1"))
+	})
 }
 
 func Test_Mock_AssertExpectations_With_Repeatability(t *testing.T) {


### PR DESCRIPTION
## Summary
Closes Functional Options testing broken for indirect calls #1380. The fix is consists of not comparing the the function names, as it is already asserted when comparing `expectedValues` and `actualValues`

## Changes
* Adds test `Test_Mock_AssertExpectationsFunctionalOptionsTypeIndirectly` which would fail without the fix
* Adds test `Test_Mock_AssertExpectationsFunctionalOptionsType_Diff` to examine behavior of slightly different functional options in expected vs actual.
* Changes the `funcName` implementation to only compare the relevant last part, if applicable. This aids in reading the diff that is produced when the function names don't. match (for go1.20 or higher)

## Motivation
The choice was made to omit the comparison of function names completely, instead of comparing only the relevant last part. The reason is that go1.19 and lower don't give enough any meaningful comparable part in the function name. Nevertheless the most relevant part of the function name is included in the diff result. Without it, the diff yielded in `Test_Mock_AssertExpectationsFunctionalOptionsType_Diff` would have resulted in (go1.20):
```
mock.Test_Mock_AssertExpectationsFunctionalOptionsType_Diff.OpNum &{num:0 str:1} != mock.Test_Mock_AssertExpectationsFunctionalOptionsType_Diff.OpNum &{num:1 str:}
```
The current implementation instead yields a diff:
```
OpStr &{num:0 str:1} != OpNum &{num:1 str:}
```

Though there could be added benefit in displaying the full location of the function, I can revert that part if desired.

## Related issues
Closes #1380
