### PR TITLE
.github/workflows: Run tests for Go 1.22

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,7 @@ jobs:
           - "1.19"
           - "1.20"
           - "1.21"
+          - "1.22"
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go


### PR DESCRIPTION
## Summary
Run tests for Go 1.22.

## Changes
Add Go 1.22 to test matrix.

## Motivation
Make sure the current and future code stays functional on latest released Go version.

## Related issues
N/a
