### PR TITLE
Record Return Arguments of a Call

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -80,12 +80,12 @@ type Call struct {
 	requires []*Call
 }
 
-func newCall(parent *Mock, methodName string, callerInfo []string, methodArguments ...interface{}) *Call {
+func newCall(parent *Mock, methodName string, callerInfo []string, methodArguments Arguments, returnArguments Arguments) *Call {
 	return &Call{
 		Parent:          parent,
 		Method:          methodName,
 		Arguments:       methodArguments,
-		ReturnArguments: make([]interface{}, 0),
+		ReturnArguments: returnArguments,
 		callerInfo:      callerInfo,
 		Repeatability:   0,
 		WaitFor:         nil,
@@ -351,7 +351,8 @@ func (m *Mock) On(methodName string, arguments ...interface{}) *Call {
 
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
-	c := newCall(m, methodName, assert.CallerInfo(), arguments...)
+
+	c := newCall(m, methodName, assert.CallerInfo(), arguments, make([]interface{}, 0))
 	m.ExpectedCalls = append(m.ExpectedCalls, c)
 	return c
 }
@@ -529,7 +530,7 @@ func (m *Mock) MethodCalled(methodName string, arguments ...interface{}) Argumen
 	call.totalCalls++
 
 	// add the call
-	m.Calls = append(m.Calls, *newCall(m, methodName, assert.CallerInfo(), arguments...))
+	m.Calls = append(m.Calls, *newCall(m, methodName, assert.CallerInfo(), arguments, call.ReturnArguments))
 	m.mutex.Unlock()
 
 	// block if specified


### PR DESCRIPTION
## Summary
I had a situation where I did not have full visibility into what was returned by one of my mocked functions.  In this light, it is helpful to have the recorded arguments in the `mock.Calls` field.  I was surprised to find that for the recorded `Call`s `ReturnArguments` is left empty and is only used for `ExpectedCalls`.  This PR now properly records the ReturnArguments for a `Call`.