### PR TITLE
mock: in order mock calls

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -274,6 +274,13 @@ func (c *Call) NotBefore(calls ...*Call) *Call {
 }
 
 // InOrder defines the order in which the calls should be made
+//
+//	For example:
+//
+//	InOrder(
+//		Mock.On("init").Return(nil),
+//		Mock.On("Do").Return(nil),
+//	)
 func InOrder(calls ...*Call) {
 	for i := 1; i < len(calls); i++ {
 		calls[i].NotBefore(calls[i-1])

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -273,6 +273,13 @@ func (c *Call) NotBefore(calls ...*Call) *Call {
 	return c
 }
 
+// InOrder defines the order in which the calls should be made
+func InOrder(calls ...*Call) {
+	for i := 1; i < len(calls); i++ {
+		calls[i].NotBefore(calls[i-1])
+	}
+}
+
 // Mock is the workhorse used to track activity on another object.
 // For an example of its usage, refer to the "Example Usage" section at the top
 // of this document.

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -940,19 +940,15 @@ func Test_Mock_Return_NotBefore_In_Order(t *testing.T) {
 func Test_Mock_Return_InOrder_Uses_NotBefore(t *testing.T) {
 	var mockedService = new(TestExampleImplementation)
 
-	b := mockedService.
-		On("TheExampleMethod", 1, 2, 3).
-		Return(4, nil)
-	c := mockedService.
-		On("TheExampleMethod2", true).
-		Return()
-
 	InOrder(
-		b,
-		c,
+		mockedService.
+			On("TheExampleMethod", 1, 2, 3).
+			Return(4, nil),
+		mockedService.
+			On("TheExampleMethod2", true).
+			Return(),
 	)
 
-	require.Equal(t, []*Call{b, c}, mockedService.ExpectedCalls)
 	require.NotPanics(t, func() {
 		mockedService.TheExampleMethod(1, 2, 3)
 	})
@@ -994,19 +990,14 @@ TheExampleMethod(int,int,int)
 func Test_Mock_Return_InOrder_Uses_NotBefore_Out_Of_Order(t *testing.T) {
 	var mockedService = new(TestExampleImplementation)
 
-	b := mockedService.
-		On("TheExampleMethod", 1, 2, 3).
-		Return(4, nil).Twice()
-	c := mockedService.
-		On("TheExampleMethod2", true).
-		Return()
-
 	InOrder(
-		b,
-		c,
+		mockedService.
+			On("TheExampleMethod", 1, 2, 3).
+			Return(4, nil).Twice(),
+		mockedService.
+			On("TheExampleMethod2", true).
+			Return(),
 	)
-
-	require.Equal(t, []*Call{b, c}, mockedService.ExpectedCalls)
 
 	expectedPanicString := `mock: Unexpected Method Call
 -----------------------------


### PR DESCRIPTION
## Summary
<!-- High-level, one sentence summary of what this PR accomplishes -->

Add helper method to declare the order of the mock calls.

## Changes
<!-- * Description of change 1 -->
<!-- * Description of change 2 -->
<!-- ... -->

* add `InOrder(calls ...*Call)` helper method to declare the order of mock calls by calling `NotBefore()`


## Motivation
<!-- Why were the changes necessary. -->

This is probably the only feature I miss from `gomock.InOrder()`, it is more intuitive and cleaner to declare the order of the mock calls. Probably most cases can be satisfied with this method.

<!-- ## Example usage (if applicable) -->
```
InOrder(
	mockedService1.On("TheExampleMethod", 1, 2, 3).Return(4, nil),
	mockedService2.On("TheExampleMethod2", true).Return(),
	mockedService3.On("TheExampleMethod3", "abc", 3).Return(false, nil),
)

```
## Related issues
Closes #1639 
