### PR TITLE
Document suite's lack of support for t.Parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,8 @@ You can use the [mockery tool](https://vektra.github.io/mockery/latest/) to auto
 
 [`suite`](https://pkg.go.dev/github.com/stretchr/testify/suite "API documentation") package
 -----------------------------------------------------------------------------------------
+> [!WARNING]
+> The suite package does not support parallel tests. See [#934](https://github.com/stretchr/testify/issues/934).
 
 The `suite` package provides functionality that you might be used to from more common object-oriented languages.  With it, you can build a testing suite as a struct, build setup/teardown methods and testing methods on your struct, and run them with 'go test' as per normal.
 

--- a/suite/doc.go
+++ b/suite/doc.go
@@ -5,6 +5,8 @@
 // or individual tests (depending on which interface(s) you
 // implement).
 //
+// The suite package does not support parallel tests. See [issue 934].
+//
 // A testing suite is usually built by first extending the built-in
 // suite functionality from suite.Suite in testify.  Alternatively,
 // you could reproduce that logic on your own if you wanted (you
@@ -63,4 +65,6 @@
 //	func TestExampleTestSuite(t *testing.T) {
 //	    suite.Run(t, new(ExampleTestSuite))
 //	}
+//
+// [issue 934]: https://github.com/stretchr/testify/issues/934
 package suite


### PR DESCRIPTION
## Summary
Document that at this time suite cannot support Parallel tests

## Changes
Document this in README.md and suite's godoc.

## Motivation
Suite will always be broken when using parallel tests in testify v1. The only clean fix is a breaking change described in #1109 

## Related issues
Related to
* #934 
* #187 
