### PR TITLE
assert: fix typos in comments

### DIFF
--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -1327,7 +1327,7 @@ func TestNotElementsMatch(t *testing.T) {
 		actual   interface{}
 		result   bool
 	}{
-		// not mathing
+		// not matching
 		{[]int{1}, []int{}, true},
 		{[]int{}, []int{2}, true},
 		{[]int{1}, []int{2}, true},

--- a/assert/yaml/yaml_custom.go
+++ b/assert/yaml/yaml_custom.go
@@ -15,7 +15,7 @@
 //		import assertYaml "github.com/stretchr/testify/assert/yaml"
 //
 //		func init() {
-//			assertYaml.Unmarshall = func (in []byte, out interface{}) error {
+//			assertYaml.Unmarshal = func (in []byte, out interface{}) error {
 //				// ...
 //	     			return nil
 //			}

--- a/assert/yaml/yaml_default.go
+++ b/assert/yaml/yaml_default.go
@@ -5,7 +5,7 @@
 //
 // This package is just an indirection that allows the builder to override the
 // indirection with an alternative implementation of this package that uses
-// another implemantation of YAML deserialization. This allows to not either not
+// another implementation of YAML deserialization. This allows to not either not
 // use YAML deserialization at all, or to use another implementation than
 // [gopkg.in/yaml.v3] (for example for license compatibility reasons, see [PR #1120]).
 //


### PR DESCRIPTION
## Summary

Correct spelling mistakes in comments.

## Changes

- Fix typos only in Go comments in the `assert` directory.

## Motivation

To improve documentation.