### PR TITLE
mock: fix doc comment for NotBefore

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -256,7 +256,7 @@ func (c *Call) Unset() *Call {
 // calls have been called as expected. The referenced calls may be from the
 // same mock instance and/or other mock instances.
 //
-//	Mock.On("Do").Return(nil).Notbefore(
+//	Mock.On("Do").Return(nil).NotBefore(
 //	    Mock.On("Init").Return(nil)
 //	)
 func (c *Call) NotBefore(calls ...*Call) *Call {


### PR DESCRIPTION
## Summary

Correct typo in the documentation comment for the `mock.NotBefore`.

## Changes
<!-- * Description of change 1 -->
<!-- * Description of change 2 -->
<!-- ... -->

## Motivation

To improve documentation.

## Related

The same changes are in the unmerged PR #1278 which needs rebasing.
