### PR TITLE
Replace Never & Eventually functions with synchronous versions

### DIFF
--- a/require/require.go
+++ b/require/require.go
@@ -31,6 +31,60 @@ func Conditionf(t TestingT, comp assert.Comparison, msg string, args ...interfac
 	t.FailNow()
 }
 
+// Consistently asserts that a given condition will always be met until
+// waitFor time plus the time taken for the last call to condition to return has
+// elapsed. The condition is considered met when the condition function does not
+// report failures on the CollectT passed to it. The supplied CollectT collects
+// all errors from one tick (if there are any) and if the condition is ever not
+// met, then the collected errors are copied to t. It is safe to use assertions
+// from the require package in the condition function, these will immediately
+// cease execution of the condition function, but not of the test. The condition
+// function is called synchronously immediately and then every tick duration
+// after that. Consistently will adjust the time interval or drop ticks to make
+// up for slow condition functions.
+//
+//	assert.Consistently(t, func(c *assert.CollectT) {
+//		i, err := shouldError()
+//		require.Error(c, err)
+//		require.Equal(c, 7, i)
+//	}, 10*time.Second, 1*time.Second, "shouldError() did not return 7 and an error")
+func Consistently(t TestingT, condition func(*assert.CollectT), waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Consistently(t, condition, waitFor, tick, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Consistentlyf asserts that a given condition will always be met until
+// waitFor time plus the time taken for the last call to condition to return has
+// elapsed. The condition is considered met when the condition function does not
+// report failures on the CollectT passed to it. The supplied CollectT collects
+// all errors from one tick (if there are any) and if the condition is ever not
+// met, then the collected errors are copied to t. It is safe to use assertions
+// from the require package in the condition function, these will immediately
+// cease execution of the condition function, but not of the test. The condition
+// function is called synchronously immediately and then every tick duration
+// after that. Consistentlyf will adjust the time interval or drop ticks to make
+// up for slow condition functions.
+//
+//	assert.Consistentlyf(t, func(c *assert.CollectT, "error message %s", "formatted") {
+//		i, err := shouldError()
+//		require.Error(c, err)
+//		require.Equal(c, 7, i)
+//	}, 10*time.Second, 1*time.Second, "shouldError() did not return 7 and an error")
+func Consistentlyf(t TestingT, condition func(*assert.CollectT), waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Consistentlyf(t, condition, waitFor, tick, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
 // Contains asserts that the specified string, list(array, slice...) or map contains the
 // specified substring or element.
 //
@@ -391,11 +445,73 @@ func Errorf(t TestingT, err error, msg string, args ...interface{}) {
 // periodically checking target function each tick.
 //
 //	assert.Eventually(t, func() bool { return true; }, time.Second, 10*time.Millisecond)
+//
+// Deprecated: For some values of waitFor and tick; Eventually may fail having
+// never called condition. Eventually may leak goroutines. Use [EventuallySync]
+// instead.
 func Eventually(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
 	if assert.Eventually(t, condition, waitFor, tick, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// EventuallySync asserts that a given condition will be met before waitFor time
+// plus the time taken for the last call to condition to return. The condition
+// is considered met when the condition function does not report failures on the
+// CollectT passed to it. The supplied CollectT collects all errors from one
+// tick (if there are any) and if the condition is not met before EventuallySync
+// returns, then the collected errors of the last tick are copied to t. The
+// condition function is called synchronously immediately and then every tick
+// duration after that. EventuallySync will adjust the time interval or drop
+// ticks to make up for slow condition functions.
+//
+//	externalValue := false
+//	go func() {
+//		time.Sleep(8*time.Second)
+//		externalValue = true
+//	}()
+//	assert.EventuallySync(t, func(c *assert.CollectT) {
+//		// add assertions as needed; any assertion failure will fail the current tick
+//		assert.True(c, externalValue, "expected 'externalValue' to be true")
+//	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
+func EventuallySync(t TestingT, condition func(*assert.CollectT), waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.EventuallySync(t, condition, waitFor, tick, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// EventuallySyncf asserts that a given condition will be met before waitFor time
+// plus the time taken for the last call to condition to return. The condition
+// is considered met when the condition function does not report failures on the
+// CollectT passed to it. The supplied CollectT collects all errors from one
+// tick (if there are any) and if the condition is not met before EventuallySyncf
+// returns, then the collected errors of the last tick are copied to t. The
+// condition function is called synchronously immediately and then every tick
+// duration after that. EventuallySyncf will adjust the time interval or drop
+// ticks to make up for slow condition functions.
+//
+//	externalValue := false
+//	go func() {
+//		time.Sleep(8*time.Second)
+//		externalValue = true
+//	}()
+//	assert.EventuallySyncf(t, func(c *assert.CollectT, "error message %s", "formatted") {
+//		// add assertions as needed; any assertion failure will fail the current tick
+//		assert.True(c, externalValue, "expected 'externalValue' to be true")
+//	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
+func EventuallySyncf(t TestingT, condition func(*assert.CollectT), waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.EventuallySyncf(t, condition, waitFor, tick, msg, args...) {
 		return
 	}
 	t.FailNow()
@@ -419,6 +535,10 @@ func Eventually(t TestingT, condition func() bool, waitFor time.Duration, tick t
 //		// add assertions as needed; any assertion failure will fail the current tick
 //		assert.True(c, externalValue, "expected 'externalValue' to be true")
 //	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
+//
+// Deprecated: For some values of waitFor and tick; EventuallyWithT may fail
+// having never called condition. EventuallyWithT may leak goroutines. Use
+// [EventuallySync] instead.
 func EventuallyWithT(t TestingT, condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -447,6 +567,10 @@ func EventuallyWithT(t TestingT, condition func(collect *assert.CollectT), waitF
 //		// add assertions as needed; any assertion failure will fail the current tick
 //		assert.True(c, externalValue, "expected 'externalValue' to be true")
 //	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
+//
+// Deprecated: For some values of waitFor and tick; EventuallyWithTf may fail
+// having never called condition. EventuallyWithTf may leak goroutines. Use
+// [EventuallySync] instead.
 func EventuallyWithTf(t TestingT, condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -461,6 +585,10 @@ func EventuallyWithTf(t TestingT, condition func(collect *assert.CollectT), wait
 // periodically checking target function each tick.
 //
 //	assert.Eventuallyf(t, func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+//
+// Deprecated: For some values of waitFor and tick; Eventuallyf may fail having
+// never called condition. Eventuallyf may leak goroutines. Use [EventuallyfSync]
+// instead.
 func Eventuallyf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1267,6 +1395,10 @@ func Negativef(t TestingT, e interface{}, msg string, args ...interface{}) {
 // periodically checking the target function each tick.
 //
 //	assert.Never(t, func() bool { return false; }, time.Second, 10*time.Millisecond)
+//
+// Deprecated: For some values of waitFor and tick; Never may pass without
+// calling condition. Never may leak goroutines. Use [Consistently] and invert
+// the logic of condition instead.
 func Never(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1281,6 +1413,10 @@ func Never(t TestingT, condition func() bool, waitFor time.Duration, tick time.D
 // periodically checking the target function each tick.
 //
 //	assert.Neverf(t, func() bool { return false; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+//
+// Deprecated: For some values of waitFor and tick; Neverf may pass without
+// calling condition. Neverf may leak goroutines. Use [Consistently] and invert
+// the logic of condition instead.
 func Neverf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()

--- a/require/require_forward.go
+++ b/require/require_forward.go
@@ -25,6 +25,54 @@ func (a *Assertions) Conditionf(comp assert.Comparison, msg string, args ...inte
 	Conditionf(a.t, comp, msg, args...)
 }
 
+// Consistently asserts that a given condition will always be met until
+// waitFor time plus the time taken for the last call to condition to return has
+// elapsed. The condition is considered met when the condition function does not
+// report failures on the CollectT passed to it. The supplied CollectT collects
+// all errors from one tick (if there are any) and if the condition is ever not
+// met, then the collected errors are copied to t. It is safe to use assertions
+// from the require package in the condition function, these will immediately
+// cease execution of the condition function, but not of the test. The condition
+// function is called synchronously immediately and then every tick duration
+// after that. Consistently will adjust the time interval or drop ticks to make
+// up for slow condition functions.
+//
+//	a.Consistently(func(c *assert.CollectT) {
+//		i, err := shouldError()
+//		require.Error(c, err)
+//		require.Equal(c, 7, i)
+//	}, 10*time.Second, 1*time.Second, "shouldError() did not return 7 and an error")
+func (a *Assertions) Consistently(condition func(*assert.CollectT), waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Consistently(a.t, condition, waitFor, tick, msgAndArgs...)
+}
+
+// Consistentlyf asserts that a given condition will always be met until
+// waitFor time plus the time taken for the last call to condition to return has
+// elapsed. The condition is considered met when the condition function does not
+// report failures on the CollectT passed to it. The supplied CollectT collects
+// all errors from one tick (if there are any) and if the condition is ever not
+// met, then the collected errors are copied to t. It is safe to use assertions
+// from the require package in the condition function, these will immediately
+// cease execution of the condition function, but not of the test. The condition
+// function is called synchronously immediately and then every tick duration
+// after that. Consistentlyf will adjust the time interval or drop ticks to make
+// up for slow condition functions.
+//
+//	a.Consistentlyf(func(c *assert.CollectT, "error message %s", "formatted") {
+//		i, err := shouldError()
+//		require.Error(c, err)
+//		require.Equal(c, 7, i)
+//	}, 10*time.Second, 1*time.Second, "shouldError() did not return 7 and an error")
+func (a *Assertions) Consistentlyf(condition func(*assert.CollectT), waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Consistentlyf(a.t, condition, waitFor, tick, msg, args...)
+}
+
 // Contains asserts that the specified string, list(array, slice...) or map contains the
 // specified substring or element.
 //
@@ -313,11 +361,67 @@ func (a *Assertions) Errorf(err error, msg string, args ...interface{}) {
 // periodically checking target function each tick.
 //
 //	a.Eventually(func() bool { return true; }, time.Second, 10*time.Millisecond)
+//
+// Deprecated: For some values of waitFor and tick; Eventually may fail having
+// never called condition. Eventually may leak goroutines. Use [EventuallySync]
+// instead.
 func (a *Assertions) Eventually(condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
 	Eventually(a.t, condition, waitFor, tick, msgAndArgs...)
+}
+
+// EventuallySync asserts that a given condition will be met before waitFor time
+// plus the time taken for the last call to condition to return. The condition
+// is considered met when the condition function does not report failures on the
+// CollectT passed to it. The supplied CollectT collects all errors from one
+// tick (if there are any) and if the condition is not met before EventuallySync
+// returns, then the collected errors of the last tick are copied to t. The
+// condition function is called synchronously immediately and then every tick
+// duration after that. EventuallySync will adjust the time interval or drop
+// ticks to make up for slow condition functions.
+//
+//	externalValue := false
+//	go func() {
+//		time.Sleep(8*time.Second)
+//		externalValue = true
+//	}()
+//	a.EventuallySync(func(c *assert.CollectT) {
+//		// add assertions as needed; any assertion failure will fail the current tick
+//		assert.True(c, externalValue, "expected 'externalValue' to be true")
+//	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
+func (a *Assertions) EventuallySync(condition func(*assert.CollectT), waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	EventuallySync(a.t, condition, waitFor, tick, msgAndArgs...)
+}
+
+// EventuallySyncf asserts that a given condition will be met before waitFor time
+// plus the time taken for the last call to condition to return. The condition
+// is considered met when the condition function does not report failures on the
+// CollectT passed to it. The supplied CollectT collects all errors from one
+// tick (if there are any) and if the condition is not met before EventuallySyncf
+// returns, then the collected errors of the last tick are copied to t. The
+// condition function is called synchronously immediately and then every tick
+// duration after that. EventuallySyncf will adjust the time interval or drop
+// ticks to make up for slow condition functions.
+//
+//	externalValue := false
+//	go func() {
+//		time.Sleep(8*time.Second)
+//		externalValue = true
+//	}()
+//	a.EventuallySyncf(func(c *assert.CollectT, "error message %s", "formatted") {
+//		// add assertions as needed; any assertion failure will fail the current tick
+//		assert.True(c, externalValue, "expected 'externalValue' to be true")
+//	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
+func (a *Assertions) EventuallySyncf(condition func(*assert.CollectT), waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	EventuallySyncf(a.t, condition, waitFor, tick, msg, args...)
 }
 
 // EventuallyWithT asserts that given condition will be met in waitFor time,
@@ -338,6 +442,10 @@ func (a *Assertions) Eventually(condition func() bool, waitFor time.Duration, ti
 //		// add assertions as needed; any assertion failure will fail the current tick
 //		assert.True(c, externalValue, "expected 'externalValue' to be true")
 //	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
+//
+// Deprecated: For some values of waitFor and tick; EventuallyWithT may fail
+// having never called condition. EventuallyWithT may leak goroutines. Use
+// [EventuallySync] instead.
 func (a *Assertions) EventuallyWithT(condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -363,6 +471,10 @@ func (a *Assertions) EventuallyWithT(condition func(collect *assert.CollectT), w
 //		// add assertions as needed; any assertion failure will fail the current tick
 //		assert.True(c, externalValue, "expected 'externalValue' to be true")
 //	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
+//
+// Deprecated: For some values of waitFor and tick; EventuallyWithTf may fail
+// having never called condition. EventuallyWithTf may leak goroutines. Use
+// [EventuallySync] instead.
 func (a *Assertions) EventuallyWithTf(condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -374,6 +486,10 @@ func (a *Assertions) EventuallyWithTf(condition func(collect *assert.CollectT), 
 // periodically checking target function each tick.
 //
 //	a.Eventuallyf(func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+//
+// Deprecated: For some values of waitFor and tick; Eventuallyf may fail having
+// never called condition. Eventuallyf may leak goroutines. Use [EventuallyfSync]
+// instead.
 func (a *Assertions) Eventuallyf(condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1003,6 +1119,10 @@ func (a *Assertions) Negativef(e interface{}, msg string, args ...interface{}) {
 // periodically checking the target function each tick.
 //
 //	a.Never(func() bool { return false; }, time.Second, 10*time.Millisecond)
+//
+// Deprecated: For some values of waitFor and tick; Never may pass without
+// calling condition. Never may leak goroutines. Use [Consistently] and invert
+// the logic of condition instead.
 func (a *Assertions) Never(condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1014,6 +1134,10 @@ func (a *Assertions) Never(condition func() bool, waitFor time.Duration, tick ti
 // periodically checking the target function each tick.
 //
 //	a.Neverf(func() bool { return false; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+//
+// Deprecated: For some values of waitFor and tick; Neverf may pass without
+// calling condition. Neverf may leak goroutines. Use [Consistently] and invert
+// the logic of condition instead.
 func (a *Assertions) Neverf(condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()


### PR DESCRIPTION
## Summary
`Eventually`, `EventuallyWithT`, and `Never` have serious defects which require changes to their behaviour to rectify:
* They can leak goroutines.
* The can return a verdict without ever testing the condition!!!
* They always wait tick before testing the condition.

Making them syncronous fixes every known problem with these functions.

## Changes
* Create a synchronous version of `EventuallyWithT` called `EventuallySync`. Making the call to `condition` syncrhonous means we no longer have to decide what to do (or what not to do) when an asynchronous call to the user's condition function doesn't return before the end of the test. This solves the goroutine leak (#1611) but also forces the definition of a new function as there could be many badly written tests which would now deadlock if this was implimented in the existing functions. This also means evaluation of the test result happens between calls to the `condition` function, making the assertion easier to use for the user and solving #1654.
* Create a synchronous version of `Never` for the same reasons. Implementing it as `Consistently` allows it to use `CollectT` too and delivers #1087.
* Always run `condition` immediately. This solves the timing race (#1652) where the select statement could be reached for the first time with both tick and waitFor channels ready, where the function would randomly return a verdict without actually testing the condition. This also delivers a popular request: #1424
* Mark `Eventually` and `EventuallyWithT` as deprecated with warnings about their faults and suggest the use of `EventuallySync` instead.
* Mark `Never` as deprecated with warnings about its faults and suggest the use of `Consistently` instead.
* Make the flaking Eventually tests less likelt to fail or fail more quickly.

## Motivation
* Eventually/Never/etc.. can leak goroutines.
* Eventually/Never/etc.. can show either test result without testing anything.
* Eventually/Never/etc.. make our tests flake.
* People want Eventually/Never/etc.. to be faster.
* People want a Consistently assertion.

## Related issues
* Closes #1087
* Closes #1424
* Closes #1611
* Closes #1652
* Closes #1654

