### PR TITLE
comments for the require package

### DIFF
--- a/_codegen/main.go
+++ b/_codegen/main.go
@@ -107,7 +107,9 @@ func parseTemplates() (*template.Template, *template.Template, error) {
 		}
 		funcTemplate = string(f)
 	}
-	tmpl, err := template.New("function").Parse(funcTemplate)
+	tmpl, err := template.New("function").Funcs(template.FuncMap{
+		"replace": strings.ReplaceAll,
+	}).Parse(funcTemplate)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/require/require.go
+++ b/require/require.go
@@ -1,4 +1,5 @@
 // Code generated with github.com/stretchr/testify/_codegen; DO NOT EDIT.
+// stops test execution when a test fails. All assertion functions call t.FailNow().
 
 package require
 
@@ -34,9 +35,9 @@ func Conditionf(t TestingT, comp assert.Comparison, msg string, args ...interfac
 // Contains asserts that the specified string, list(array, slice...) or map contains the
 // specified substring or element.
 //
-//	assert.Contains(t, "Hello World", "World")
-//	assert.Contains(t, ["Hello", "World"], "World")
-//	assert.Contains(t, {"Hello": "World"}, "Hello")
+//	require.Contains(t, "Hello World", "World")
+//	require.Contains(t, ["Hello", "World"], "World")
+//	require.Contains(t, {"Hello": "World"}, "Hello")
 func Contains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -50,9 +51,9 @@ func Contains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...int
 // Containsf asserts that the specified string, list(array, slice...) or map contains the
 // specified substring or element.
 //
-//	assert.Containsf(t, "Hello World", "World", "error message %s", "formatted")
-//	assert.Containsf(t, ["Hello", "World"], "World", "error message %s", "formatted")
-//	assert.Containsf(t, {"Hello": "World"}, "Hello", "error message %s", "formatted")
+//	require.Containsf(t, "Hello World", "World", "error message %s", "formatted")
+//	require.Containsf(t, ["Hello", "World"], "World", "error message %s", "formatted")
+//	require.Containsf(t, {"Hello": "World"}, "Hello", "error message %s", "formatted")
 func Containsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -91,7 +92,7 @@ func DirExistsf(t TestingT, path string, msg string, args ...interface{}) {
 // listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
 // the number of appearances of each of them in both lists should match.
 //
-// assert.ElementsMatch(t, [1, 3, 2, 3], [1, 3, 3, 2])
+// require.ElementsMatch(t, [1, 3, 2, 3], [1, 3, 3, 2])
 func ElementsMatch(t TestingT, listA interface{}, listB interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -106,7 +107,7 @@ func ElementsMatch(t TestingT, listA interface{}, listB interface{}, msgAndArgs 
 // listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
 // the number of appearances of each of them in both lists should match.
 //
-// assert.ElementsMatchf(t, [1, 3, 2, 3], [1, 3, 3, 2], "error message %s", "formatted")
+// require.ElementsMatchf(t, [1, 3, 2, 3], [1, 3, 3, 2], "error message %s", "formatted")
 func ElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -120,7 +121,7 @@ func ElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string
 // Empty asserts that the specified object is empty.  I.e. nil, "", false, 0 or either
 // a slice or a channel with len == 0.
 //
-//	assert.Empty(t, obj)
+//	require.Empty(t, obj)
 func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -134,7 +135,7 @@ func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 // Emptyf asserts that the specified object is empty.  I.e. nil, "", false, 0 or either
 // a slice or a channel with len == 0.
 //
-//	assert.Emptyf(t, obj, "error message %s", "formatted")
+//	require.Emptyf(t, obj, "error message %s", "formatted")
 func Emptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -147,7 +148,7 @@ func Emptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
 
 // Equal asserts that two objects are equal.
 //
-//	assert.Equal(t, 123, 123)
+//	require.Equal(t, 123, 123)
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses). Function equality
@@ -166,7 +167,7 @@ func Equal(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...i
 // and that it is equal to the provided error.
 //
 //	actualObj, err := SomeFunction()
-//	assert.EqualError(t, err,  expectedErrorString)
+//	require.EqualError(t, err,  expectedErrorString)
 func EqualError(t TestingT, theError error, errString string, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -181,7 +182,7 @@ func EqualError(t TestingT, theError error, errString string, msgAndArgs ...inte
 // and that it is equal to the provided error.
 //
 //	actualObj, err := SomeFunction()
-//	assert.EqualErrorf(t, err,  expectedErrorString, "error message %s", "formatted")
+//	require.EqualErrorf(t, err,  expectedErrorString, "error message %s", "formatted")
 func EqualErrorf(t TestingT, theError error, errString string, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -200,8 +201,8 @@ func EqualErrorf(t TestingT, theError error, errString string, msg string, args 
 //		Exported     	int
 //		notExported   	int
 //	 }
-//	 assert.EqualExportedValues(t, S{1, 2}, S{1, 3}) => true
-//	 assert.EqualExportedValues(t, S{1, 2}, S{2, 3}) => false
+//	 require.EqualExportedValues(t, S{1, 2}, S{1, 3}) => true
+//	 require.EqualExportedValues(t, S{1, 2}, S{2, 3}) => false
 func EqualExportedValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -220,8 +221,8 @@ func EqualExportedValues(t TestingT, expected interface{}, actual interface{}, m
 //		Exported     	int
 //		notExported   	int
 //	 }
-//	 assert.EqualExportedValuesf(t, S{1, 2}, S{1, 3}, "error message %s", "formatted") => true
-//	 assert.EqualExportedValuesf(t, S{1, 2}, S{2, 3}, "error message %s", "formatted") => false
+//	 require.EqualExportedValuesf(t, S{1, 2}, S{1, 3}, "error message %s", "formatted") => true
+//	 require.EqualExportedValuesf(t, S{1, 2}, S{2, 3}, "error message %s", "formatted") => false
 func EqualExportedValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -235,7 +236,7 @@ func EqualExportedValuesf(t TestingT, expected interface{}, actual interface{}, 
 // EqualValues asserts that two objects are equal or convertible to the larger
 // type and equal.
 //
-//	assert.EqualValues(t, uint32(123), int32(123))
+//	 require.EqualValues(t, uint32(123), int32(123))
 func EqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -249,7 +250,7 @@ func EqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArg
 // EqualValuesf asserts that two objects are equal or convertible to the larger
 // type and equal.
 //
-//	assert.EqualValuesf(t, uint32(123), int32(123), "error message %s", "formatted")
+//	 require.EqualValuesf(t, uint32(123), int32(123), "error message %s", "formatted")
 func EqualValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -262,7 +263,7 @@ func EqualValuesf(t TestingT, expected interface{}, actual interface{}, msg stri
 
 // Equalf asserts that two objects are equal.
 //
-//	assert.Equalf(t, 123, 123, "error message %s", "formatted")
+//	 require.Equalf(t, 123, 123, "error message %s", "formatted")
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses). Function equality
@@ -280,8 +281,8 @@ func Equalf(t TestingT, expected interface{}, actual interface{}, msg string, ar
 // Error asserts that a function returned an error (i.e. not `nil`).
 //
 //	  actualObj, err := SomeFunction()
-//	  if assert.Error(t, err) {
-//		   assert.Equal(t, expectedError, err)
+//	  if require.Error(t, err) {
+//		   require.Equal(t, expectedError, err)
 //	  }
 func Error(t TestingT, err error, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
@@ -321,7 +322,7 @@ func ErrorAsf(t TestingT, err error, target interface{}, msg string, args ...int
 // and that the error contains the specified substring.
 //
 //	actualObj, err := SomeFunction()
-//	assert.ErrorContains(t, err,  expectedErrorSubString)
+//	 require.ErrorContains(t, err,  expectedErrorSubString)
 func ErrorContains(t TestingT, theError error, contains string, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -336,7 +337,7 @@ func ErrorContains(t TestingT, theError error, contains string, msgAndArgs ...in
 // and that the error contains the specified substring.
 //
 //	actualObj, err := SomeFunction()
-//	assert.ErrorContainsf(t, err,  expectedErrorSubString, "error message %s", "formatted")
+//	 require.ErrorContainsf(t, err,  expectedErrorSubString, "error message %s", "formatted")
 func ErrorContainsf(t TestingT, theError error, contains string, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -374,8 +375,8 @@ func ErrorIsf(t TestingT, err error, target error, msg string, args ...interface
 // Errorf asserts that a function returned an error (i.e. not `nil`).
 //
 //	  actualObj, err := SomeFunction()
-//	  if assert.Errorf(t, err, "error message %s", "formatted") {
-//		   assert.Equal(t, expectedErrorf, err)
+//	  if require.Errorf(t, err, "error message %s", "formatted") {
+//		   require.Equal(t, expectedErrorf, err)
 //	  }
 func Errorf(t TestingT, err error, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
@@ -390,7 +391,7 @@ func Errorf(t TestingT, err error, msg string, args ...interface{}) {
 // Eventually asserts that given condition will be met in waitFor time,
 // periodically checking target function each tick.
 //
-//	assert.Eventually(t, func() bool { return true; }, time.Second, 10*time.Millisecond)
+//	 require.Eventually(t, func() bool { return true; }, time.Second, 10*time.Millisecond)
 func Eventually(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -415,9 +416,9 @@ func Eventually(t TestingT, condition func() bool, waitFor time.Duration, tick t
 //		time.Sleep(8*time.Second)
 //		externalValue = true
 //	}()
-//	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+//	 require.EventuallyWithT(t, func(c *require.CollectT) {
 //		// add assertions as needed; any assertion failure will fail the current tick
-//		assert.True(c, externalValue, "expected 'externalValue' to be true")
+//		require.True(c, externalValue, "expected 'externalValue' to be true")
 //	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
 func EventuallyWithT(t TestingT, condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
@@ -443,9 +444,9 @@ func EventuallyWithT(t TestingT, condition func(collect *assert.CollectT), waitF
 //		time.Sleep(8*time.Second)
 //		externalValue = true
 //	}()
-//	assert.EventuallyWithTf(t, func(c *assert.CollectT, "error message %s", "formatted") {
+//	 require.EventuallyWithTf(t, func(c *require.CollectT, "error message %s", "formatted") {
 //		// add assertions as needed; any assertion failure will fail the current tick
-//		assert.True(c, externalValue, "expected 'externalValue' to be true")
+//		require.True(c, externalValue, "expected 'externalValue' to be true")
 //	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
 func EventuallyWithTf(t TestingT, condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
@@ -460,7 +461,7 @@ func EventuallyWithTf(t TestingT, condition func(collect *assert.CollectT), wait
 // Eventuallyf asserts that given condition will be met in waitFor time,
 // periodically checking target function each tick.
 //
-//	assert.Eventuallyf(t, func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+//	 require.Eventuallyf(t, func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
 func Eventuallyf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -473,7 +474,7 @@ func Eventuallyf(t TestingT, condition func() bool, waitFor time.Duration, tick 
 
 // Exactly asserts that two objects are equal in value and type.
 //
-//	assert.Exactly(t, int32(123), int64(123))
+//	 require.Exactly(t, int32(123), int64(123))
 func Exactly(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -486,7 +487,7 @@ func Exactly(t TestingT, expected interface{}, actual interface{}, msgAndArgs ..
 
 // Exactlyf asserts that two objects are equal in value and type.
 //
-//	assert.Exactlyf(t, int32(123), int64(123), "error message %s", "formatted")
+//	 require.Exactlyf(t, int32(123), int64(123), "error message %s", "formatted")
 func Exactlyf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -543,7 +544,7 @@ func Failf(t TestingT, failureMessage string, msg string, args ...interface{}) {
 
 // False asserts that the specified value is false.
 //
-//	assert.False(t, myBool)
+//	 require.False(t, myBool)
 func False(t TestingT, value bool, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -556,7 +557,7 @@ func False(t TestingT, value bool, msgAndArgs ...interface{}) {
 
 // Falsef asserts that the specified value is false.
 //
-//	assert.Falsef(t, myBool, "error message %s", "formatted")
+//	 require.Falsef(t, myBool, "error message %s", "formatted")
 func Falsef(t TestingT, value bool, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -593,9 +594,9 @@ func FileExistsf(t TestingT, path string, msg string, args ...interface{}) {
 
 // Greater asserts that the first element is greater than the second
 //
-//	assert.Greater(t, 2, 1)
-//	assert.Greater(t, float64(2), float64(1))
-//	assert.Greater(t, "b", "a")
+//	 require.Greater(t, 2, 1)
+//	 require.Greater(t, float64(2), float64(1))
+//	 require.Greater(t, "b", "a")
 func Greater(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -608,10 +609,10 @@ func Greater(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface
 
 // GreaterOrEqual asserts that the first element is greater than or equal to the second
 //
-//	assert.GreaterOrEqual(t, 2, 1)
-//	assert.GreaterOrEqual(t, 2, 2)
-//	assert.GreaterOrEqual(t, "b", "a")
-//	assert.GreaterOrEqual(t, "b", "b")
+//	 require.GreaterOrEqual(t, 2, 1)
+//	 require.GreaterOrEqual(t, 2, 2)
+//	 require.GreaterOrEqual(t, "b", "a")
+//	 require.GreaterOrEqual(t, "b", "b")
 func GreaterOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -624,10 +625,10 @@ func GreaterOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...in
 
 // GreaterOrEqualf asserts that the first element is greater than or equal to the second
 //
-//	assert.GreaterOrEqualf(t, 2, 1, "error message %s", "formatted")
-//	assert.GreaterOrEqualf(t, 2, 2, "error message %s", "formatted")
-//	assert.GreaterOrEqualf(t, "b", "a", "error message %s", "formatted")
-//	assert.GreaterOrEqualf(t, "b", "b", "error message %s", "formatted")
+//	 require.GreaterOrEqualf(t, 2, 1, "error message %s", "formatted")
+//	 require.GreaterOrEqualf(t, 2, 2, "error message %s", "formatted")
+//	 require.GreaterOrEqualf(t, "b", "a", "error message %s", "formatted")
+//	 require.GreaterOrEqualf(t, "b", "b", "error message %s", "formatted")
 func GreaterOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -640,9 +641,9 @@ func GreaterOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, arg
 
 // Greaterf asserts that the first element is greater than the second
 //
-//	assert.Greaterf(t, 2, 1, "error message %s", "formatted")
-//	assert.Greaterf(t, float64(2), float64(1), "error message %s", "formatted")
-//	assert.Greaterf(t, "b", "a", "error message %s", "formatted")
+//	 require.Greaterf(t, 2, 1, "error message %s", "formatted")
+//	 require.Greaterf(t, float64(2), float64(1), "error message %s", "formatted")
+//	 require.Greaterf(t, "b", "a", "error message %s", "formatted")
 func Greaterf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -656,7 +657,7 @@ func Greaterf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...in
 // HTTPBodyContains asserts that a specified handler returns a
 // body that contains a string.
 //
-//	assert.HTTPBodyContains(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
+//	 require.HTTPBodyContains(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPBodyContains(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
@@ -672,7 +673,7 @@ func HTTPBodyContains(t TestingT, handler http.HandlerFunc, method string, url s
 // HTTPBodyContainsf asserts that a specified handler returns a
 // body that contains a string.
 //
-//	assert.HTTPBodyContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+//	 require.HTTPBodyContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPBodyContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
@@ -688,7 +689,7 @@ func HTTPBodyContainsf(t TestingT, handler http.HandlerFunc, method string, url 
 // HTTPBodyNotContains asserts that a specified handler returns a
 // body that does not contain a string.
 //
-//	assert.HTTPBodyNotContains(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
+//	 require.HTTPBodyNotContains(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPBodyNotContains(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
@@ -704,7 +705,7 @@ func HTTPBodyNotContains(t TestingT, handler http.HandlerFunc, method string, ur
 // HTTPBodyNotContainsf asserts that a specified handler returns a
 // body that does not contain a string.
 //
-//	assert.HTTPBodyNotContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+//	 require.HTTPBodyNotContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPBodyNotContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
@@ -719,7 +720,7 @@ func HTTPBodyNotContainsf(t TestingT, handler http.HandlerFunc, method string, u
 
 // HTTPError asserts that a specified handler returns an error status code.
 //
-//	assert.HTTPError(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//	 require.HTTPError(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPError(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
@@ -734,7 +735,7 @@ func HTTPError(t TestingT, handler http.HandlerFunc, method string, url string, 
 
 // HTTPErrorf asserts that a specified handler returns an error status code.
 //
-//	assert.HTTPErrorf(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//	 require.HTTPErrorf(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPErrorf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
@@ -749,7 +750,7 @@ func HTTPErrorf(t TestingT, handler http.HandlerFunc, method string, url string,
 
 // HTTPRedirect asserts that a specified handler returns a redirect status code.
 //
-//	assert.HTTPRedirect(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//	 require.HTTPRedirect(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPRedirect(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
@@ -764,7 +765,7 @@ func HTTPRedirect(t TestingT, handler http.HandlerFunc, method string, url strin
 
 // HTTPRedirectf asserts that a specified handler returns a redirect status code.
 //
-//	assert.HTTPRedirectf(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//	 require.HTTPRedirectf(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPRedirectf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
@@ -779,7 +780,7 @@ func HTTPRedirectf(t TestingT, handler http.HandlerFunc, method string, url stri
 
 // HTTPStatusCode asserts that a specified handler returns a specified status code.
 //
-//	assert.HTTPStatusCode(t, myHandler, "GET", "/notImplemented", nil, 501)
+//	 require.HTTPStatusCode(t, myHandler, "GET", "/notImplemented", nil, 501)
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPStatusCode(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msgAndArgs ...interface{}) {
@@ -794,7 +795,7 @@ func HTTPStatusCode(t TestingT, handler http.HandlerFunc, method string, url str
 
 // HTTPStatusCodef asserts that a specified handler returns a specified status code.
 //
-//	assert.HTTPStatusCodef(t, myHandler, "GET", "/notImplemented", nil, 501, "error message %s", "formatted")
+//	 require.HTTPStatusCodef(t, myHandler, "GET", "/notImplemented", nil, 501, "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPStatusCodef(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msg string, args ...interface{}) {
@@ -809,7 +810,7 @@ func HTTPStatusCodef(t TestingT, handler http.HandlerFunc, method string, url st
 
 // HTTPSuccess asserts that a specified handler returns a success status code.
 //
-//	assert.HTTPSuccess(t, myHandler, "POST", "http://www.google.com", nil)
+//	 require.HTTPSuccess(t, myHandler, "POST", "http://www.google.com", nil)
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPSuccess(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
@@ -824,7 +825,7 @@ func HTTPSuccess(t TestingT, handler http.HandlerFunc, method string, url string
 
 // HTTPSuccessf asserts that a specified handler returns a success status code.
 //
-//	assert.HTTPSuccessf(t, myHandler, "POST", "http://www.google.com", nil, "error message %s", "formatted")
+//	 require.HTTPSuccessf(t, myHandler, "POST", "http://www.google.com", nil, "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPSuccessf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
@@ -839,7 +840,7 @@ func HTTPSuccessf(t TestingT, handler http.HandlerFunc, method string, url strin
 
 // Implements asserts that an object is implemented by the specified interface.
 //
-//	assert.Implements(t, (*MyInterface)(nil), new(MyObject))
+//	 require.Implements(t, (*MyInterface)(nil), new(MyObject))
 func Implements(t TestingT, interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -852,7 +853,7 @@ func Implements(t TestingT, interfaceObject interface{}, object interface{}, msg
 
 // Implementsf asserts that an object is implemented by the specified interface.
 //
-//	assert.Implementsf(t, (*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
+//	 require.Implementsf(t, (*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
 func Implementsf(t TestingT, interfaceObject interface{}, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -865,7 +866,7 @@ func Implementsf(t TestingT, interfaceObject interface{}, object interface{}, ms
 
 // InDelta asserts that the two numerals are within delta of each other.
 //
-//	assert.InDelta(t, math.Pi, 22/7.0, 0.01)
+//	 require.InDelta(t, math.Pi, 22/7.0, 0.01)
 func InDelta(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -922,7 +923,7 @@ func InDeltaSlicef(t TestingT, expected interface{}, actual interface{}, delta f
 
 // InDeltaf asserts that the two numerals are within delta of each other.
 //
-//	assert.InDeltaf(t, math.Pi, 22/7.0, 0.01, "error message %s", "formatted")
+//	 require.InDeltaf(t, math.Pi, 22/7.0, 0.01, "error message %s", "formatted")
 func InDeltaf(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -979,9 +980,9 @@ func InEpsilonf(t TestingT, expected interface{}, actual interface{}, epsilon fl
 
 // IsDecreasing asserts that the collection is decreasing
 //
-//	assert.IsDecreasing(t, []int{2, 1, 0})
-//	assert.IsDecreasing(t, []float{2, 1})
-//	assert.IsDecreasing(t, []string{"b", "a"})
+//	 require.IsDecreasing(t, []int{2, 1, 0})
+//	 require.IsDecreasing(t, []float{2, 1})
+//	 require.IsDecreasing(t, []string{"b", "a"})
 func IsDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -994,9 +995,9 @@ func IsDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 
 // IsDecreasingf asserts that the collection is decreasing
 //
-//	assert.IsDecreasingf(t, []int{2, 1, 0}, "error message %s", "formatted")
-//	assert.IsDecreasingf(t, []float{2, 1}, "error message %s", "formatted")
-//	assert.IsDecreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
+//	 require.IsDecreasingf(t, []int{2, 1, 0}, "error message %s", "formatted")
+//	 require.IsDecreasingf(t, []float{2, 1}, "error message %s", "formatted")
+//	 require.IsDecreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
 func IsDecreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1009,9 +1010,9 @@ func IsDecreasingf(t TestingT, object interface{}, msg string, args ...interface
 
 // IsIncreasing asserts that the collection is increasing
 //
-//	assert.IsIncreasing(t, []int{1, 2, 3})
-//	assert.IsIncreasing(t, []float{1, 2})
-//	assert.IsIncreasing(t, []string{"a", "b"})
+//	 require.IsIncreasing(t, []int{1, 2, 3})
+//	 require.IsIncreasing(t, []float{1, 2})
+//	 require.IsIncreasing(t, []string{"a", "b"})
 func IsIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1024,9 +1025,9 @@ func IsIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 
 // IsIncreasingf asserts that the collection is increasing
 //
-//	assert.IsIncreasingf(t, []int{1, 2, 3}, "error message %s", "formatted")
-//	assert.IsIncreasingf(t, []float{1, 2}, "error message %s", "formatted")
-//	assert.IsIncreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
+//	 require.IsIncreasingf(t, []int{1, 2, 3}, "error message %s", "formatted")
+//	 require.IsIncreasingf(t, []float{1, 2}, "error message %s", "formatted")
+//	 require.IsIncreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
 func IsIncreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1039,9 +1040,9 @@ func IsIncreasingf(t TestingT, object interface{}, msg string, args ...interface
 
 // IsNonDecreasing asserts that the collection is not decreasing
 //
-//	assert.IsNonDecreasing(t, []int{1, 1, 2})
-//	assert.IsNonDecreasing(t, []float{1, 2})
-//	assert.IsNonDecreasing(t, []string{"a", "b"})
+//	 require.IsNonDecreasing(t, []int{1, 1, 2})
+//	 require.IsNonDecreasing(t, []float{1, 2})
+//	 require.IsNonDecreasing(t, []string{"a", "b"})
 func IsNonDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1054,9 +1055,9 @@ func IsNonDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) 
 
 // IsNonDecreasingf asserts that the collection is not decreasing
 //
-//	assert.IsNonDecreasingf(t, []int{1, 1, 2}, "error message %s", "formatted")
-//	assert.IsNonDecreasingf(t, []float{1, 2}, "error message %s", "formatted")
-//	assert.IsNonDecreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
+//	 require.IsNonDecreasingf(t, []int{1, 1, 2}, "error message %s", "formatted")
+//	 require.IsNonDecreasingf(t, []float{1, 2}, "error message %s", "formatted")
+//	 require.IsNonDecreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
 func IsNonDecreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1069,9 +1070,9 @@ func IsNonDecreasingf(t TestingT, object interface{}, msg string, args ...interf
 
 // IsNonIncreasing asserts that the collection is not increasing
 //
-//	assert.IsNonIncreasing(t, []int{2, 1, 1})
-//	assert.IsNonIncreasing(t, []float{2, 1})
-//	assert.IsNonIncreasing(t, []string{"b", "a"})
+//	 require.IsNonIncreasing(t, []int{2, 1, 1})
+//	 require.IsNonIncreasing(t, []float{2, 1})
+//	 require.IsNonIncreasing(t, []string{"b", "a"})
 func IsNonIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1084,9 +1085,9 @@ func IsNonIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) 
 
 // IsNonIncreasingf asserts that the collection is not increasing
 //
-//	assert.IsNonIncreasingf(t, []int{2, 1, 1}, "error message %s", "formatted")
-//	assert.IsNonIncreasingf(t, []float{2, 1}, "error message %s", "formatted")
-//	assert.IsNonIncreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
+//	 require.IsNonIncreasingf(t, []int{2, 1, 1}, "error message %s", "formatted")
+//	 require.IsNonIncreasingf(t, []float{2, 1}, "error message %s", "formatted")
+//	 require.IsNonIncreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
 func IsNonIncreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1121,7 +1122,7 @@ func IsTypef(t TestingT, expectedType interface{}, object interface{}, msg strin
 
 // JSONEq asserts that two JSON strings are equivalent.
 //
-//	assert.JSONEq(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
+//	 require.JSONEq(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
 func JSONEq(t TestingT, expected string, actual string, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1134,7 +1135,7 @@ func JSONEq(t TestingT, expected string, actual string, msgAndArgs ...interface{
 
 // JSONEqf asserts that two JSON strings are equivalent.
 //
-//	assert.JSONEqf(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
+//	 require.JSONEqf(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
 func JSONEqf(t TestingT, expected string, actual string, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1148,7 +1149,7 @@ func JSONEqf(t TestingT, expected string, actual string, msg string, args ...int
 // Len asserts that the specified object has specific length.
 // Len also fails if the object has a type that len() not accept.
 //
-//	assert.Len(t, mySlice, 3)
+//	 require.Len(t, mySlice, 3)
 func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1162,7 +1163,7 @@ func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) 
 // Lenf asserts that the specified object has specific length.
 // Lenf also fails if the object has a type that len() not accept.
 //
-//	assert.Lenf(t, mySlice, 3, "error message %s", "formatted")
+//	 require.Lenf(t, mySlice, 3, "error message %s", "formatted")
 func Lenf(t TestingT, object interface{}, length int, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1175,9 +1176,9 @@ func Lenf(t TestingT, object interface{}, length int, msg string, args ...interf
 
 // Less asserts that the first element is less than the second
 //
-//	assert.Less(t, 1, 2)
-//	assert.Less(t, float64(1), float64(2))
-//	assert.Less(t, "a", "b")
+//	 require.Less(t, 1, 2)
+//	 require.Less(t, float64(1), float64(2))
+//	 require.Less(t, "a", "b")
 func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1190,10 +1191,10 @@ func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{})
 
 // LessOrEqual asserts that the first element is less than or equal to the second
 //
-//	assert.LessOrEqual(t, 1, 2)
-//	assert.LessOrEqual(t, 2, 2)
-//	assert.LessOrEqual(t, "a", "b")
-//	assert.LessOrEqual(t, "b", "b")
+//	 require.LessOrEqual(t, 1, 2)
+//	 require.LessOrEqual(t, 2, 2)
+//	 require.LessOrEqual(t, "a", "b")
+//	 require.LessOrEqual(t, "b", "b")
 func LessOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1206,10 +1207,10 @@ func LessOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...inter
 
 // LessOrEqualf asserts that the first element is less than or equal to the second
 //
-//	assert.LessOrEqualf(t, 1, 2, "error message %s", "formatted")
-//	assert.LessOrEqualf(t, 2, 2, "error message %s", "formatted")
-//	assert.LessOrEqualf(t, "a", "b", "error message %s", "formatted")
-//	assert.LessOrEqualf(t, "b", "b", "error message %s", "formatted")
+//	 require.LessOrEqualf(t, 1, 2, "error message %s", "formatted")
+//	 require.LessOrEqualf(t, 2, 2, "error message %s", "formatted")
+//	 require.LessOrEqualf(t, "a", "b", "error message %s", "formatted")
+//	 require.LessOrEqualf(t, "b", "b", "error message %s", "formatted")
 func LessOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1222,9 +1223,9 @@ func LessOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args .
 
 // Lessf asserts that the first element is less than the second
 //
-//	assert.Lessf(t, 1, 2, "error message %s", "formatted")
-//	assert.Lessf(t, float64(1), float64(2), "error message %s", "formatted")
-//	assert.Lessf(t, "a", "b", "error message %s", "formatted")
+//	 require.Lessf(t, 1, 2, "error message %s", "formatted")
+//	 require.Lessf(t, float64(1), float64(2), "error message %s", "formatted")
+//	 require.Lessf(t, "a", "b", "error message %s", "formatted")
 func Lessf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1237,8 +1238,8 @@ func Lessf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...inter
 
 // Negative asserts that the specified element is negative
 //
-//	assert.Negative(t, -1)
-//	assert.Negative(t, -1.23)
+//	 require.Negative(t, -1)
+//	 require.Negative(t, -1.23)
 func Negative(t TestingT, e interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1251,8 +1252,8 @@ func Negative(t TestingT, e interface{}, msgAndArgs ...interface{}) {
 
 // Negativef asserts that the specified element is negative
 //
-//	assert.Negativef(t, -1, "error message %s", "formatted")
-//	assert.Negativef(t, -1.23, "error message %s", "formatted")
+//	 require.Negativef(t, -1, "error message %s", "formatted")
+//	 require.Negativef(t, -1.23, "error message %s", "formatted")
 func Negativef(t TestingT, e interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1266,7 +1267,7 @@ func Negativef(t TestingT, e interface{}, msg string, args ...interface{}) {
 // Never asserts that the given condition doesn't satisfy in waitFor time,
 // periodically checking the target function each tick.
 //
-//	assert.Never(t, func() bool { return false; }, time.Second, 10*time.Millisecond)
+//	 require.Never(t, func() bool { return false; }, time.Second, 10*time.Millisecond)
 func Never(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1280,7 +1281,7 @@ func Never(t TestingT, condition func() bool, waitFor time.Duration, tick time.D
 // Neverf asserts that the given condition doesn't satisfy in waitFor time,
 // periodically checking the target function each tick.
 //
-//	assert.Neverf(t, func() bool { return false; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+//	 require.Neverf(t, func() bool { return false; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
 func Neverf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1293,7 +1294,7 @@ func Neverf(t TestingT, condition func() bool, waitFor time.Duration, tick time.
 
 // Nil asserts that the specified object is nil.
 //
-//	assert.Nil(t, err)
+//	 require.Nil(t, err)
 func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1306,7 +1307,7 @@ func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 
 // Nilf asserts that the specified object is nil.
 //
-//	assert.Nilf(t, err, "error message %s", "formatted")
+//	 require.Nilf(t, err, "error message %s", "formatted")
 func Nilf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1344,8 +1345,8 @@ func NoDirExistsf(t TestingT, path string, msg string, args ...interface{}) {
 // NoError asserts that a function returned no error (i.e. `nil`).
 //
 //	  actualObj, err := SomeFunction()
-//	  if assert.NoError(t, err) {
-//		   assert.Equal(t, expectedObj, actualObj)
+//	  if require.NoError(t, err) {
+//		   require.Equal(t, expectedObj, actualObj)
 //	  }
 func NoError(t TestingT, err error, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
@@ -1400,9 +1401,9 @@ func NoFileExistsf(t TestingT, path string, msg string, args ...interface{}) {
 // NotContains asserts that the specified string, list(array, slice...) or map does NOT contain the
 // specified substring or element.
 //
-//	assert.NotContains(t, "Hello World", "Earth")
-//	assert.NotContains(t, ["Hello", "World"], "Earth")
-//	assert.NotContains(t, {"Hello": "World"}, "Earth")
+//	 require.NotContains(t, "Hello World", "Earth")
+//	 require.NotContains(t, ["Hello", "World"], "Earth")
+//	 require.NotContains(t, {"Hello": "World"}, "Earth")
 func NotContains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1416,9 +1417,9 @@ func NotContains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...
 // NotContainsf asserts that the specified string, list(array, slice...) or map does NOT contain the
 // specified substring or element.
 //
-//	assert.NotContainsf(t, "Hello World", "Earth", "error message %s", "formatted")
-//	assert.NotContainsf(t, ["Hello", "World"], "Earth", "error message %s", "formatted")
-//	assert.NotContainsf(t, {"Hello": "World"}, "Earth", "error message %s", "formatted")
+//	 require.NotContainsf(t, "Hello World", "Earth", "error message %s", "formatted")
+//	 require.NotContainsf(t, ["Hello", "World"], "Earth", "error message %s", "formatted")
+//	 require.NotContainsf(t, {"Hello": "World"}, "Earth", "error message %s", "formatted")
 func NotContainsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1503,7 +1504,7 @@ func NotEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) 
 
 // NotEqual asserts that the specified values are NOT equal.
 //
-//	assert.NotEqual(t, obj1, obj2)
+//	 require.NotEqual(t, obj1, obj2)
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
@@ -1519,7 +1520,7 @@ func NotEqual(t TestingT, expected interface{}, actual interface{}, msgAndArgs .
 
 // NotEqualValues asserts that two objects are not equal even when converted to the same type
 //
-//	assert.NotEqualValues(t, obj1, obj2)
+//	 require.NotEqualValues(t, obj1, obj2)
 func NotEqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1532,7 +1533,7 @@ func NotEqualValues(t TestingT, expected interface{}, actual interface{}, msgAnd
 
 // NotEqualValuesf asserts that two objects are not equal even when converted to the same type
 //
-//	assert.NotEqualValuesf(t, obj1, obj2, "error message %s", "formatted")
+//	 require.NotEqualValuesf(t, obj1, obj2, "error message %s", "formatted")
 func NotEqualValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1545,7 +1546,7 @@ func NotEqualValuesf(t TestingT, expected interface{}, actual interface{}, msg s
 
 // NotEqualf asserts that the specified values are NOT equal.
 //
-//	assert.NotEqualf(t, obj1, obj2, "error message %s", "formatted")
+//	 require.NotEqualf(t, obj1, obj2, "error message %s", "formatted")
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
@@ -1609,7 +1610,7 @@ func NotErrorIsf(t TestingT, err error, target error, msg string, args ...interf
 
 // NotImplements asserts that an object does not implement the specified interface.
 //
-//	assert.NotImplements(t, (*MyInterface)(nil), new(MyObject))
+//	 require.NotImplements(t, (*MyInterface)(nil), new(MyObject))
 func NotImplements(t TestingT, interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1622,7 +1623,7 @@ func NotImplements(t TestingT, interfaceObject interface{}, object interface{}, 
 
 // NotImplementsf asserts that an object does not implement the specified interface.
 //
-//	assert.NotImplementsf(t, (*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
+//	 require.NotImplementsf(t, (*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
 func NotImplementsf(t TestingT, interfaceObject interface{}, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1635,7 +1636,7 @@ func NotImplementsf(t TestingT, interfaceObject interface{}, object interface{},
 
 // NotNil asserts that the specified object is not nil.
 //
-//	assert.NotNil(t, err)
+//	 require.NotNil(t, err)
 func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1648,7 +1649,7 @@ func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 
 // NotNilf asserts that the specified object is not nil.
 //
-//	assert.NotNilf(t, err, "error message %s", "formatted")
+//	 require.NotNilf(t, err, "error message %s", "formatted")
 func NotNilf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1661,7 +1662,7 @@ func NotNilf(t TestingT, object interface{}, msg string, args ...interface{}) {
 
 // NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
 //
-//	assert.NotPanics(t, func(){ RemainCalm() })
+//	 require.NotPanics(t, func(){ RemainCalm() })
 func NotPanics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1674,7 +1675,7 @@ func NotPanics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 
 // NotPanicsf asserts that the code inside the specified PanicTestFunc does NOT panic.
 //
-//	assert.NotPanicsf(t, func(){ RemainCalm() }, "error message %s", "formatted")
+//	 require.NotPanicsf(t, func(){ RemainCalm() }, "error message %s", "formatted")
 func NotPanicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1687,8 +1688,8 @@ func NotPanicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interfac
 
 // NotRegexp asserts that a specified regexp does not match a string.
 //
-//	assert.NotRegexp(t, regexp.MustCompile("starts"), "it's starting")
-//	assert.NotRegexp(t, "^start", "it's not starting")
+//	 require.NotRegexp(t, regexp.MustCompile("starts"), "it's starting")
+//	 require.NotRegexp(t, "^start", "it's not starting")
 func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1701,8 +1702,8 @@ func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interf
 
 // NotRegexpf asserts that a specified regexp does not match a string.
 //
-//	assert.NotRegexpf(t, regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
-//	assert.NotRegexpf(t, "^start", "it's not starting", "error message %s", "formatted")
+//	 require.NotRegexpf(t, regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
+//	 require.NotRegexpf(t, "^start", "it's not starting", "error message %s", "formatted")
 func NotRegexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1715,7 +1716,7 @@ func NotRegexpf(t TestingT, rx interface{}, str interface{}, msg string, args ..
 
 // NotSame asserts that two pointers do not reference the same object.
 //
-//	assert.NotSame(t, ptr1, ptr2)
+//	 require.NotSame(t, ptr1, ptr2)
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
@@ -1731,7 +1732,7 @@ func NotSame(t TestingT, expected interface{}, actual interface{}, msgAndArgs ..
 
 // NotSamef asserts that two pointers do not reference the same object.
 //
-//	assert.NotSamef(t, ptr1, ptr2, "error message %s", "formatted")
+//	 require.NotSamef(t, ptr1, ptr2, "error message %s", "formatted")
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
@@ -1749,8 +1750,8 @@ func NotSamef(t TestingT, expected interface{}, actual interface{}, msg string, 
 // contain all elements given in the specified subset list(array, slice...) or
 // map.
 //
-//	assert.NotSubset(t, [1, 3, 4], [1, 2])
-//	assert.NotSubset(t, {"x": 1, "y": 2}, {"z": 3})
+//	 require.NotSubset(t, [1, 3, 4], [1, 2])
+//	 require.NotSubset(t, {"x": 1, "y": 2}, {"z": 3})
 func NotSubset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1765,8 +1766,8 @@ func NotSubset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...i
 // contain all elements given in the specified subset list(array, slice...) or
 // map.
 //
-//	assert.NotSubsetf(t, [1, 3, 4], [1, 2], "error message %s", "formatted")
-//	assert.NotSubsetf(t, {"x": 1, "y": 2}, {"z": 3}, "error message %s", "formatted")
+//	 require.NotSubsetf(t, [1, 3, 4], [1, 2], "error message %s", "formatted")
+//	 require.NotSubsetf(t, {"x": 1, "y": 2}, {"z": 3}, "error message %s", "formatted")
 func NotSubsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1801,7 +1802,7 @@ func NotZerof(t TestingT, i interface{}, msg string, args ...interface{}) {
 
 // Panics asserts that the code inside the specified PanicTestFunc panics.
 //
-//	assert.Panics(t, func(){ GoCrazy() })
+//	 require.Panics(t, func(){ GoCrazy() })
 func Panics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1816,7 +1817,7 @@ func Panics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 // panics, and that the recovered panic value is an error that satisfies the
 // EqualError comparison.
 //
-//	assert.PanicsWithError(t, "crazy error", func(){ GoCrazy() })
+//	 require.PanicsWithError(t, "crazy error", func(){ GoCrazy() })
 func PanicsWithError(t TestingT, errString string, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1831,7 +1832,7 @@ func PanicsWithError(t TestingT, errString string, f assert.PanicTestFunc, msgAn
 // panics, and that the recovered panic value is an error that satisfies the
 // EqualError comparison.
 //
-//	assert.PanicsWithErrorf(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+//	 require.PanicsWithErrorf(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
 func PanicsWithErrorf(t TestingT, errString string, f assert.PanicTestFunc, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1845,7 +1846,7 @@ func PanicsWithErrorf(t TestingT, errString string, f assert.PanicTestFunc, msg 
 // PanicsWithValue asserts that the code inside the specified PanicTestFunc panics, and that
 // the recovered panic value equals the expected panic value.
 //
-//	assert.PanicsWithValue(t, "crazy error", func(){ GoCrazy() })
+//	 require.PanicsWithValue(t, "crazy error", func(){ GoCrazy() })
 func PanicsWithValue(t TestingT, expected interface{}, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1859,7 +1860,7 @@ func PanicsWithValue(t TestingT, expected interface{}, f assert.PanicTestFunc, m
 // PanicsWithValuef asserts that the code inside the specified PanicTestFunc panics, and that
 // the recovered panic value equals the expected panic value.
 //
-//	assert.PanicsWithValuef(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+//	 require.PanicsWithValuef(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
 func PanicsWithValuef(t TestingT, expected interface{}, f assert.PanicTestFunc, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1872,7 +1873,7 @@ func PanicsWithValuef(t TestingT, expected interface{}, f assert.PanicTestFunc, 
 
 // Panicsf asserts that the code inside the specified PanicTestFunc panics.
 //
-//	assert.Panicsf(t, func(){ GoCrazy() }, "error message %s", "formatted")
+//	 require.Panicsf(t, func(){ GoCrazy() }, "error message %s", "formatted")
 func Panicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1885,8 +1886,8 @@ func Panicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}
 
 // Positive asserts that the specified element is positive
 //
-//	assert.Positive(t, 1)
-//	assert.Positive(t, 1.23)
+//	 require.Positive(t, 1)
+//	 require.Positive(t, 1.23)
 func Positive(t TestingT, e interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1899,8 +1900,8 @@ func Positive(t TestingT, e interface{}, msgAndArgs ...interface{}) {
 
 // Positivef asserts that the specified element is positive
 //
-//	assert.Positivef(t, 1, "error message %s", "formatted")
-//	assert.Positivef(t, 1.23, "error message %s", "formatted")
+//	 require.Positivef(t, 1, "error message %s", "formatted")
+//	 require.Positivef(t, 1.23, "error message %s", "formatted")
 func Positivef(t TestingT, e interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1913,8 +1914,8 @@ func Positivef(t TestingT, e interface{}, msg string, args ...interface{}) {
 
 // Regexp asserts that a specified regexp matches a string.
 //
-//	assert.Regexp(t, regexp.MustCompile("start"), "it's starting")
-//	assert.Regexp(t, "start...$", "it's not starting")
+//	 require.Regexp(t, regexp.MustCompile("start"), "it's starting")
+//	 require.Regexp(t, "start...$", "it's not starting")
 func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1927,8 +1928,8 @@ func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface
 
 // Regexpf asserts that a specified regexp matches a string.
 //
-//	assert.Regexpf(t, regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
-//	assert.Regexpf(t, "start...$", "it's not starting", "error message %s", "formatted")
+//	 require.Regexpf(t, regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
+//	 require.Regexpf(t, "start...$", "it's not starting", "error message %s", "formatted")
 func Regexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1941,7 +1942,7 @@ func Regexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...in
 
 // Same asserts that two pointers reference the same object.
 //
-//	assert.Same(t, ptr1, ptr2)
+//	 require.Same(t, ptr1, ptr2)
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
@@ -1957,7 +1958,7 @@ func Same(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...in
 
 // Samef asserts that two pointers reference the same object.
 //
-//	assert.Samef(t, ptr1, ptr2, "error message %s", "formatted")
+//	 require.Samef(t, ptr1, ptr2, "error message %s", "formatted")
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
@@ -1974,8 +1975,8 @@ func Samef(t TestingT, expected interface{}, actual interface{}, msg string, arg
 // Subset asserts that the specified list(array, slice...) or map contains all
 // elements given in the specified subset list(array, slice...) or map.
 //
-//	assert.Subset(t, [1, 2, 3], [1, 2])
-//	assert.Subset(t, {"x": 1, "y": 2}, {"x": 1})
+//	 require.Subset(t, [1, 2, 3], [1, 2])
+//	 require.Subset(t, {"x": 1, "y": 2}, {"x": 1})
 func Subset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1989,8 +1990,8 @@ func Subset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...inte
 // Subsetf asserts that the specified list(array, slice...) or map contains all
 // elements given in the specified subset list(array, slice...) or map.
 //
-//	assert.Subsetf(t, [1, 2, 3], [1, 2], "error message %s", "formatted")
-//	assert.Subsetf(t, {"x": 1, "y": 2}, {"x": 1}, "error message %s", "formatted")
+//	 require.Subsetf(t, [1, 2, 3], [1, 2], "error message %s", "formatted")
+//	 require.Subsetf(t, {"x": 1, "y": 2}, {"x": 1}, "error message %s", "formatted")
 func Subsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2003,7 +2004,7 @@ func Subsetf(t TestingT, list interface{}, subset interface{}, msg string, args 
 
 // True asserts that the specified value is true.
 //
-//	assert.True(t, myBool)
+//	 require.True(t, myBool)
 func True(t TestingT, value bool, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2016,7 +2017,7 @@ func True(t TestingT, value bool, msgAndArgs ...interface{}) {
 
 // Truef asserts that the specified value is true.
 //
-//	assert.Truef(t, myBool, "error message %s", "formatted")
+//	 require.Truef(t, myBool, "error message %s", "formatted")
 func Truef(t TestingT, value bool, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2029,7 +2030,7 @@ func Truef(t TestingT, value bool, msg string, args ...interface{}) {
 
 // WithinDuration asserts that the two times are within duration delta of each other.
 //
-//	assert.WithinDuration(t, time.Now(), time.Now(), 10*time.Second)
+//	 require.WithinDuration(t, time.Now(), time.Now(), 10*time.Second)
 func WithinDuration(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2042,7 +2043,7 @@ func WithinDuration(t TestingT, expected time.Time, actual time.Time, delta time
 
 // WithinDurationf asserts that the two times are within duration delta of each other.
 //
-//	assert.WithinDurationf(t, time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
+//	 require.WithinDurationf(t, time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
 func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2055,7 +2056,7 @@ func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta tim
 
 // WithinRange asserts that a time is within a time range (inclusive).
 //
-//	assert.WithinRange(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second))
+//	 require.WithinRange(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second))
 func WithinRange(t TestingT, actual time.Time, start time.Time, end time.Time, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2068,7 +2069,7 @@ func WithinRange(t TestingT, actual time.Time, start time.Time, end time.Time, m
 
 // WithinRangef asserts that a time is within a time range (inclusive).
 //
-//	assert.WithinRangef(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second), "error message %s", "formatted")
+//	 require.WithinRangef(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second), "error message %s", "formatted")
 func WithinRangef(t TestingT, actual time.Time, start time.Time, end time.Time, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()

--- a/require/require.go
+++ b/require/require.go
@@ -2043,7 +2043,7 @@ func WithinDuration(t TestingT, expected time.Time, actual time.Time, delta time
 
 // WithinDurationf asserts that the two times are within duration delta of each other.
 //
-//	 require.WithinDurationf(t, time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
+//	 require.WithinDurationf(t, time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted") 
 func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()

--- a/require/require.go.tmpl
+++ b/require/require.go.tmpl
@@ -1,4 +1,5 @@
-{{.Comment}}
+{{ replace .Comment "assert." "require."}}
+// Failure of this check is fatal ([testing.T.FailNow] is called on failure).
 func {{.DocInfo.Name}}(t TestingT, {{.Params}}) {
 	if h, ok := t.(tHelper); ok { h.Helper() }
 	if assert.{{.DocInfo.Name}}(t, {{.ForwardedParams}}) { return }


### PR DESCRIPTION
## Summary
What was asked and done in #1610 , with the review comments addressed.

## Changes
Added a "replace" function to the template
require.go.tmpl now replaces the package name accordingly
require.go.tmpl now adds another line to the function-docs explaining the difference to the assert-function

## Motivation
In case of test-cases using both require and assert it gets confusing because the function docs for the require package are referencing the assert package and don't really document the actual function.
## Related issues
#1610 - Generate better comments for require package