### PR TITLE
NotSame should fail if args are not pointers #1661

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -542,10 +542,10 @@ func NotSame(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}
 	return true
 }
 
-// samePointers checks if two generic interface objects are pointers to
-// the same object. It returns two values: a boolean indicating if they
-// point to the same object, and another boolean indicating whether both
-// inputs are valid pointers of the same type.
+// samePointers checks if two generic interface objects are pointers of the same
+// type pointing to the same object. It returns two values: same indicating if
+// they are the same type and point to the same object, and ok indicating that
+// both inputs are pointers.
 func samePointers(first, second interface{}) (same bool, ok bool) {
 	firstPtr, secondPtr := reflect.ValueOf(first), reflect.ValueOf(second)
 	if firstPtr.Kind() != reflect.Ptr || secondPtr.Kind() != reflect.Ptr {

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -527,7 +527,10 @@ func NotSame(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	if same, ok := samePointers(expected, actual); ok {
+
+	same, ok := samePointers(expected, actual)
+
+	if ok {
 		//if ok is true, then both arguments are pointers
 		if same {
 			return Fail(t, fmt.Sprintf(

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -542,8 +542,10 @@ func NotSame(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}
 	//we return !Fail because Fail return false, but we need to return true if the arguments are not pointers(by default)
 }
 
-// samePointers compares two generic interface objects and returns whether
-// they point to the same object
+// samePointers checks if two generic interface objects are pointers to
+// the same object. It returns two values: a boolean indicating if they
+// point to the same object, and another boolean indicating whether both
+// inputs are valid pointers of the same type.
 func samePointers(first, second interface{}) (same bool, ok bool) {
 	firstPtr, secondPtr := reflect.ValueOf(first), reflect.ValueOf(second)
 	if firstPtr.Kind() != reflect.Ptr || secondPtr.Kind() != reflect.Ptr {

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -507,8 +507,8 @@ func Same(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) b
 		return Fail(t, "Both arguments must be pointers", msgAndArgs...)
 	}
 
-	//both are pointers but pointing to different addresses
 	if !same {
+		// both are pointers but not the same type & pointing to the same address
 		return Fail(t, fmt.Sprintf("Not same: \n"+
 			"expected: %p %#v\n"+
 			"actual  : %p %#v", expected, expected, actual, actual), msgAndArgs...)

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -529,20 +529,17 @@ func NotSame(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}
 	}
 
 	same, ok := samePointers(expected, actual)
-
-	if ok {
-		//if ok is true, then both arguments are pointers
-		if same {
-			return Fail(t, fmt.Sprintf(
-				"Expected and actual point to the same object: %p %#v",
-				expected, expected), msgAndArgs...) //because Fail return false, but we need to
-		}
-		return true
+	if !ok {
+		//fails when the arguments are not pointers
+		return !(Fail(t, "Both arguments must be pointers", msgAndArgs...))
 	}
 
-	//fails when the arguments are not pointers
-	return !(Fail(t, "Both arguments must be pointers", msgAndArgs...))
-	//we return !Fail because Fail return false, but we need to return true if the arguments are not pointers(by default)
+	if same {
+		return Fail(t, fmt.Sprintf(
+			"Expected and actual point to the same object: %p %#v",
+			expected, expected), msgAndArgs...)
+	}
+	return true
 }
 
 // samePointers checks if two generic interface objects are pointers to

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -532,19 +532,19 @@ func NotSame(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}
 
 // samePointers compares two generic interface objects and returns whether
 // they point to the same object
-func samePointers(first, second interface{}) bool {
+func samePointers(first, second interface{}) (same bool, ok bool) {
 	firstPtr, secondPtr := reflect.ValueOf(first), reflect.ValueOf(second)
 	if firstPtr.Kind() != reflect.Ptr || secondPtr.Kind() != reflect.Ptr {
-		return false
+		return false, false //not both are pointers
 	}
 
 	firstType, secondType := reflect.TypeOf(first), reflect.TypeOf(second)
 	if firstType != secondType {
-		return false
+		return false, true // both are pointers, but of different types
 	}
 
 	// compare pointer addresses
-	return first == second
+	return first == second, true
 }
 
 // formatUnequalValues takes two values of arbitrary types and returns string

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -605,44 +605,47 @@ func Test_samePointers(t *testing.T) {
 		second interface{}
 	}
 	tests := []struct {
-		name      string
-		args      args
-		assertion BoolAssertionFunc
+		name string
+		args args
+		same BoolAssertionFunc
+		ok   BoolAssertionFunc
 	}{
 		{
-			name:      "1 != 2",
-			args:      args{first: 1, second: 2},
-			assertion: False,
+			name: "1 != 2",
+			args: args{first: 1, second: 2},
+			same: False,
+			ok:   False,
 		},
 		{
-			name:      "1 != 1 (not same ptr)",
-			args:      args{first: 1, second: 1},
-			assertion: False,
+			name: "1 != 1 (not same ptr)",
+			args: args{first: 1, second: 1},
+			same: False,
+			ok:   False,
 		},
 		{
-			name:      "ptr(1) == ptr(1)",
-			args:      args{first: p, second: p},
-			assertion: True,
+			name: "ptr(1) == ptr(1)",
+			args: args{first: p, second: p},
+			same: True,
+			ok:   True,
 		},
 		{
-			name:      "int(1) != float32(1)",
-			args:      args{first: int(1), second: float32(1)},
-			assertion: False,
+			name: "int(1) != float32(1)",
+			args: args{first: int(1), second: float32(1)},
+			same: False,
+			ok:   False,
 		},
 		{
-			name:      "array != slice",
-			args:      args{first: [2]int{1, 2}, second: []int{1, 2}},
-			assertion: False,
+			name: "array != slice",
+			args: args{first: [2]int{1, 2}, second: []int{1, 2}},
+			same: False,
+			ok:   False,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			same, ok := samePointers(tt.args.first, tt.args.second)
-			if !ok {
-				tt.assertion(t, false) // both arguments must be pointers
-				return
-			}
-			tt.assertion(t, same)
+			tt.same(t, same)
+			tt.ok(t, ok)
 		})
 	}
 }

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -640,6 +640,18 @@ func Test_samePointers(t *testing.T) {
 			same: False,
 			ok:   False,
 		},
+		{
+			name: "non-pointer vs pointer (1 != ptr(2))",
+			args: args{first: 1, second: p},
+			same: False,
+			ok:   False,
+		},
+		{
+			name: "pointer vs non-pointer (ptr(2) != 1)",
+			args: args{first: p, second: 1},
+			same: False,
+			ok:   False,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -637,7 +637,12 @@ func Test_samePointers(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.assertion(t, samePointers(tt.args.first, tt.args.second))
+			same, ok := samePointers(tt.args.first, tt.args.second)
+			if !ok {
+				tt.assertion(t, false) // both arguments must be pointers
+				return
+			}
+			tt.assertion(t, same)
 		})
 	}
 }


### PR DESCRIPTION
## Summary
Reduces the confusion assosciated with NotSame that previously would check nothing if any of the values is not a pointer. The changes made were tested using TestSame, TestNotSame, and Test_samePointers tests, and the changes did clear the tests.

## Changes
1. Modified samePointers to return another bool value(ok) that would determine if the 2 values are of pointer type or not, while the returned "same" bool value would determine if the 2 pointers are same.
2. Modified assert.NotSame to call Fail() if the 2 values are either i)pointers pointing to the same address or ii)either/both of the values are not pointers.
3.  Modified assert.Same to call Fail() if the 2 values are either i)pointers not pointing to the same address or ii)either/both of the values are not pointers.
4. Modified Test_samePointers to handle the new behavior of samePointers by checking both if the inputs are pointers (ok) and if they point to the same object (same).

## Motivation
Ensure NotSame accurately verifies pointer sameness by handling non-pointer inputs explicitly, improving clarity and reducing potential misuse.

## Related issues
Closes #1661
