### PR TITLE
suite: validate method signatures and continue execution for valid tests

### DIFF
--- a/suite/suite.go
+++ b/suite/suite.go
@@ -164,7 +164,7 @@ func Run(t *testing.T, suite TestingSuite) {
 				name: method.Name,
 				run: func(t *testing.T) {
 					t.Errorf(
-						"testify: suite method %q has invalid signature: expected no inputs or return values (has %d inputs, %d outputs)",
+						"testify: suite method %q has invalid signature: expected no input or output parameters, method has %d input parameters and %d output parameters",
 						method.Name, method.Type.NumIn()-1, method.Type.NumOut(),
 					)
 				},

--- a/suite/suite.go
+++ b/suite/suite.go
@@ -149,7 +149,19 @@ func Run(t *testing.T, suite TestingSuite) {
 		if !ok {
 			continue
 		}
-
+		// Check method signature
+		if method.Type.NumIn() > 1 || method.Type.NumOut() > 0 {
+			tests = append(tests, test{
+				name: method.Name,
+				run: func(t *testing.T) {
+					t.Errorf(
+						"testify: suite method %q has invalid signature: expected no inputs or return values (has %d inputs, %d outputs)",
+						method.Name, method.Type.NumIn()-1, method.Type.NumOut(),
+					)
+				},
+			})
+			continue
+		}
 		test := test{
 			name: method.Name,
 			run: func(t *testing.T) {


### PR DESCRIPTION
## Summary
This PR improves method signature validation in Testify's suite execution by ensuring that invalid methods are logged, and valid methods continue to execute.

## Changes
* Added validation of method signatures (checking for arguments and return values) at an earlier stage, after method filtering.
* Replaced `t.Fatalf` with `t.Errorf` to report invalid method signatures while allowing the test suite to continue executing valid methods.
* Introduced additional test cases to cover both valid and invalid method signatures.

## Motivation
* To ensure that invalid method signatures in the suite are reported without stopping execution, allowing valid methods to run and improving overall test suite behavior.

## Related issues
* Closes #1508