### PR TITLE
Increase timeouts in Test_Mock_Called_blocks to reduce flakiness in CI

### DIFF
--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -1256,7 +1256,7 @@ func Test_Mock_Called_blocks(t *testing.T) {
 
 	var mockedService = new(TestExampleImplementation)
 
-	mockedService.Mock.On("asyncCall", 1, 2, 3).Return(5, "6", true).After(2 * time.Millisecond)
+	mockedService.Mock.On("asyncCall", 1, 2, 3).Return(5, "6", true).After(20 * time.Millisecond)
 
 	ch := make(chan Arguments)
 
@@ -1265,7 +1265,7 @@ func Test_Mock_Called_blocks(t *testing.T) {
 	select {
 	case <-ch:
 		t.Fatal("should have waited")
-	case <-time.After(1 * time.Millisecond):
+	case <-time.After(10 * time.Millisecond):
 	}
 
 	returnArguments := <-ch


### PR DESCRIPTION
## Summary
Increased timeouts in the `Test_Mock_Called_blocks` test to improve stability and reduce flakiness in CI environments.

## Changes
* Modified the timeout in the `select` block from `1ms` to `10ms` to allow more time before checking for the channel.
* Adjusted the `After` clause in the mocked service's `asyncCall` from `2ms` to `20ms` to ensure sufficient time for the asynchronous operation to complete.

## Motivation
The changes were necessary to address intermittent test failures caused by tight timing constraints in low-powered CI environments. By increasing the timeouts, we aim to enhance the reliability of our tests, ensuring they pass consistently across different execution environments.

## Related issues
Closes #1666