### PR TITLE
.github/workflows: Run tests for Go 1.23

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,7 @@ jobs:
           - "1.20"
           - "1.21"
           - "1.22"
+          - "1.23"
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go


### PR DESCRIPTION
## Summary

The PR adds the latest Go version to the list of Go versions in the GitHub Actions workflow.

## Motivation

The library should be tested against the newest Go version.