### PR TITLE
.github/workflows: Run tests with stable,oldstable Go

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,12 +24,13 @@ jobs:
     strategy:
       matrix:
         go_version:
-          - "1.17"
-          - "1.18"
-          - "1.19"
-          - "1.20"
+          - stable
+          - oldstable
           - "1.21"
-          - "1.22"
+          - "1.20"
+          - "1.19"
+          - "1.18"
+          - "1.17"
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go


### PR DESCRIPTION
## Summary

The PR extends the list of Go versions with `stable, oldstable` in the `test` job.

## Motivation

This ensures `testify` always tested within the two latest Go versions.