### PR TITLE
assert: remove deprecated build constraints

### DIFF
--- a/assert/yaml/yaml_custom.go
+++ b/assert/yaml/yaml_custom.go
@@ -1,5 +1,4 @@
 //go:build testify_yaml_custom && !testify_yaml_fail && !testify_yaml_default
-// +build testify_yaml_custom,!testify_yaml_fail,!testify_yaml_default
 
 // Package yaml is an implementation of YAML functions that calls a pluggable implementation.
 //

--- a/assert/yaml/yaml_default.go
+++ b/assert/yaml/yaml_default.go
@@ -1,5 +1,4 @@
 //go:build !testify_yaml_fail && !testify_yaml_custom
-// +build !testify_yaml_fail,!testify_yaml_custom
 
 // Package yaml is just an indirection to handle YAML deserialization.
 //

--- a/assert/yaml/yaml_fail.go
+++ b/assert/yaml/yaml_fail.go
@@ -1,5 +1,4 @@
 //go:build testify_yaml_fail && !testify_yaml_custom && !testify_yaml_default
-// +build testify_yaml_fail,!testify_yaml_custom,!testify_yaml_default
 
 // Package yaml is an implementation of YAML functions that always fail.
 //


### PR DESCRIPTION
## Summary

This PR removes outdated build constraints.

## Changes

Remove unnecessary `// +build` comments from files in the `assert/yaml` package.

## Motivation

To cleanup the code.

The ["Build constraints"](https://pkg.go.dev/cmd/go#hdr-Build_constraints) says:

> Go versions 1.16 and earlier used a different syntax for build constraints, with a "// +build" prefix. The gofmt command will add an equivalent //go:build constraint when encountering the older syntax.

It's a safe change because the minimum supported version by `testify` is Go 1.17.
