### PR TITLE
chore: remove redundant empty lines

### DIFF
--- a/assert/assertion_compare.go
+++ b/assert/assertion_compare.go
@@ -347,7 +347,6 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (compareResult, bool) {
 			bytesObj1, ok := obj1.([]byte)
 			if !ok {
 				bytesObj1 = obj1Value.Convert(bytesType).Interface().([]byte)
-
 			}
 			bytesObj2, ok := obj2.([]byte)
 			if !ok {

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -210,7 +210,6 @@ the problem actually occurred in calling code.*/
 // of each stack frame leading from the current test to the assert call that
 // failed.
 func CallerInfo() []string {
-
 	var pc uintptr
 	var ok bool
 	var file string
@@ -475,7 +474,6 @@ func Equal(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) 
 	}
 
 	return true
-
 }
 
 // validateEqualArgs checks whether provided arguments can be safely used in the
@@ -610,7 +608,6 @@ func EqualValues(t TestingT, expected, actual interface{}, msgAndArgs ...interfa
 	}
 
 	return true
-
 }
 
 // EqualExportedValues asserts that the types of two objects are equal and their public
@@ -665,7 +662,6 @@ func Exactly(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}
 	}
 
 	return Equal(t, expected, actual, msgAndArgs...)
-
 }
 
 // NotNil asserts that the specified object is not nil.
@@ -715,7 +711,6 @@ func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
 
 // isEmpty gets whether the specified object is considered empty or not.
 func isEmpty(object interface{}) bool {
-
 	// get nil case out of the way
 	if object == nil {
 		return true
@@ -756,7 +751,6 @@ func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
 	}
 
 	return pass
-
 }
 
 // NotEmpty asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or either
@@ -775,7 +769,6 @@ func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
 	}
 
 	return pass
-
 }
 
 // getLen tries to get the length of an object.
@@ -819,7 +812,6 @@ func True(t TestingT, value bool, msgAndArgs ...interface{}) bool {
 	}
 
 	return true
-
 }
 
 // False asserts that the specified value is false.
@@ -834,7 +826,6 @@ func False(t TestingT, value bool, msgAndArgs ...interface{}) bool {
 	}
 
 	return true
-
 }
 
 // NotEqual asserts that the specified values are NOT equal.
@@ -857,7 +848,6 @@ func NotEqual(t TestingT, expected, actual interface{}, msgAndArgs ...interface{
 	}
 
 	return true
-
 }
 
 // NotEqualValues asserts that two objects are not equal even when converted to the same type
@@ -880,7 +870,6 @@ func NotEqualValues(t TestingT, expected, actual interface{}, msgAndArgs ...inte
 // return (true, false) if element was not found.
 // return (true, true) if element was found.
 func containsElement(list interface{}, element interface{}) (ok, found bool) {
-
 	listValue := reflect.ValueOf(list)
 	listType := reflect.TypeOf(list)
 	if listType == nil {
@@ -915,7 +904,6 @@ func containsElement(list interface{}, element interface{}) (ok, found bool) {
 		}
 	}
 	return true, false
-
 }
 
 // Contains asserts that the specified string, list(array, slice...) or map contains the
@@ -938,7 +926,6 @@ func Contains(t TestingT, s, contains interface{}, msgAndArgs ...interface{}) bo
 	}
 
 	return true
-
 }
 
 // NotContains asserts that the specified string, list(array, slice...) or map does NOT contain the
@@ -961,7 +948,6 @@ func NotContains(t TestingT, s, contains interface{}, msgAndArgs ...interface{})
 	}
 
 	return true
-
 }
 
 // Subset asserts that the specified list(array, slice...) or map contains all
@@ -1667,7 +1653,6 @@ func matchRegexp(rx interface{}, str interface{}) bool {
 	default:
 		return r.MatchString(fmt.Sprint(v))
 	}
-
 }
 
 // Regexp asserts that a specified regexp matches a string.
@@ -1703,7 +1688,6 @@ func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interf
 	}
 
 	return !match
-
 }
 
 // Zero asserts that i is the zero value for its type.

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -132,7 +132,6 @@ func TestObjectsAreEqual(t *testing.T) {
 			if res != c.result {
 				t.Errorf("ObjectsAreEqual(%#v, %#v) should return %#v", c.expected, c.actual, c.result)
 			}
-
 		})
 	}
 }
@@ -208,7 +207,6 @@ type S6 struct {
 }
 
 func TestObjectsExportedFieldsAreEqual(t *testing.T) {
-
 	intValue := 1
 
 	cases := []struct {
@@ -277,7 +275,6 @@ func TestObjectsExportedFieldsAreEqual(t *testing.T) {
 			if res != c.result {
 				t.Errorf("ObjectsExportedFieldsAreEqual(%#v, %#v) should return %#v", c.expected, c.actual, c.result)
 			}
-
 		})
 	}
 }
@@ -516,11 +513,9 @@ func TestEqualExportedValues(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestImplements(t *testing.T) {
-
 	mockT := new(testing.T)
 
 	if !Implements(mockT, (*AssertionTesterInterface)(nil), new(AssertionTesterConformingObject)) {
@@ -532,11 +527,9 @@ func TestImplements(t *testing.T) {
 	if Implements(mockT, (*AssertionTesterInterface)(nil), nil) {
 		t.Error("Implements method should return false: nil does not implement AssertionTesterInterface")
 	}
-
 }
 
 func TestNotImplements(t *testing.T) {
-
 	mockT := new(testing.T)
 
 	if !NotImplements(mockT, (*AssertionTesterInterface)(nil), new(AssertionTesterNonConformingObject)) {
@@ -548,11 +541,9 @@ func TestNotImplements(t *testing.T) {
 	if NotImplements(mockT, (*AssertionTesterInterface)(nil), nil) {
 		t.Error("NotImplements method should return false: nil can't be checked to be implementing AssertionTesterInterface or not")
 	}
-
 }
 
 func TestIsType(t *testing.T) {
-
 	mockT := new(testing.T)
 
 	if !IsType(mockT, new(AssertionTesterConformingObject), new(AssertionTesterConformingObject)) {
@@ -561,7 +552,6 @@ func TestIsType(t *testing.T) {
 	if IsType(mockT, new(AssertionTesterConformingObject), new(AssertionTesterNonConformingObject)) {
 		t.Error("IsType should return false: AssertionTesterConformingObject is not the same type as AssertionTesterNonConformingObject")
 	}
-
 }
 
 func TestEqual(t *testing.T) {
@@ -610,7 +600,6 @@ func ptr(i int) *int {
 }
 
 func TestSame(t *testing.T) {
-
 	mockT := new(testing.T)
 
 	if Same(mockT, ptr(1), ptr(1)) {
@@ -629,7 +618,6 @@ func TestSame(t *testing.T) {
 }
 
 func TestNotSame(t *testing.T) {
-
 	mockT := new(testing.T)
 
 	if !NotSame(mockT, ptr(1), ptr(1)) {
@@ -814,7 +802,6 @@ func TestFormatUnequalValues(t *testing.T) {
 }
 
 func TestNotNil(t *testing.T) {
-
 	mockT := new(testing.T)
 
 	if !NotNil(mockT, new(AssertionTesterConformingObject)) {
@@ -826,11 +813,9 @@ func TestNotNil(t *testing.T) {
 	if NotNil(mockT, (*struct{})(nil)) {
 		t.Error("NotNil should return false: object is (*struct{})(nil)")
 	}
-
 }
 
 func TestNil(t *testing.T) {
-
 	mockT := new(testing.T)
 
 	if !Nil(mockT, nil) {
@@ -842,11 +827,9 @@ func TestNil(t *testing.T) {
 	if Nil(mockT, new(AssertionTesterConformingObject)) {
 		t.Error("Nil should return false: object is not nil")
 	}
-
 }
 
 func TestTrue(t *testing.T) {
-
 	mockT := new(testing.T)
 
 	if !True(mockT, true) {
@@ -855,11 +838,9 @@ func TestTrue(t *testing.T) {
 	if True(mockT, false) {
 		t.Error("True should return false")
 	}
-
 }
 
 func TestFalse(t *testing.T) {
-
 	mockT := new(testing.T)
 
 	if !False(mockT, false) {
@@ -868,11 +849,9 @@ func TestFalse(t *testing.T) {
 	if False(mockT, true) {
 		t.Error("False should return false")
 	}
-
 }
 
 func TestExactly(t *testing.T) {
-
 	mockT := new(testing.T)
 
 	a := float32(1)
@@ -903,7 +882,6 @@ func TestExactly(t *testing.T) {
 }
 
 func TestNotEqual(t *testing.T) {
-
 	mockT := new(testing.T)
 
 	cases := []struct {
@@ -986,7 +964,6 @@ func TestNotEqualValues(t *testing.T) {
 }
 
 func TestContainsNotContains(t *testing.T) {
-
 	type A struct {
 		Name, Value string
 	}
@@ -1167,7 +1144,6 @@ func TestSubsetNotSubset(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run("SubSet: "+c.message, func(t *testing.T) {
-
 			mockT := new(mockTestingT)
 			res := Subset(mockT, c.list, c.subset)
 
@@ -1214,7 +1190,6 @@ func TestNotSubsetNil(t *testing.T) {
 }
 
 func Test_containsElement(t *testing.T) {
-
 	list1 := []string{"Foo", "Bar"}
 	list2 := []int{1, 2}
 	simpleMap := map[interface{}]interface{}{"Foo": "Bar"}
@@ -1445,11 +1420,9 @@ func TestCondition(t *testing.T) {
 	if Condition(mockT, func() bool { return false }, "Lie") {
 		t.Error("Condition should return false")
 	}
-
 }
 
 func TestDidPanic(t *testing.T) {
-
 	const panicMsg = "Panic!"
 
 	if funcDidPanic, msg, _ := didPanic(func() {
@@ -1468,11 +1441,9 @@ func TestDidPanic(t *testing.T) {
 	}); funcDidPanic {
 		t.Error("didPanic should return false")
 	}
-
 }
 
 func TestPanics(t *testing.T) {
-
 	mockT := new(testing.T)
 
 	if !Panics(mockT, func() {
@@ -1485,11 +1456,9 @@ func TestPanics(t *testing.T) {
 	}) {
 		t.Error("Panics should return false")
 	}
-
 }
 
 func TestPanicsWithValue(t *testing.T) {
-
 	mockT := new(testing.T)
 
 	if !PanicsWithValue(mockT, "Panic!", func() {
@@ -1517,7 +1486,6 @@ func TestPanicsWithValue(t *testing.T) {
 }
 
 func TestPanicsWithError(t *testing.T) {
-
 	mockT := new(testing.T)
 
 	if !PanicsWithError(mockT, "panic", func() {
@@ -1545,7 +1513,6 @@ func TestPanicsWithError(t *testing.T) {
 }
 
 func TestNotPanics(t *testing.T) {
-
 	mockT := new(testing.T)
 
 	if !NotPanics(mockT, func() {
@@ -1558,11 +1525,9 @@ func TestNotPanics(t *testing.T) {
 	}) {
 		t.Error("NotPanics should return false")
 	}
-
 }
 
 func TestNoError(t *testing.T) {
-
 	mockT := new(testing.T)
 
 	// start with a nil error
@@ -1593,7 +1558,6 @@ type customError struct{}
 func (*customError) Error() string { return "fail" }
 
 func TestError(t *testing.T) {
-
 	mockT := new(testing.T)
 
 	// start with a nil error
@@ -1657,7 +1621,6 @@ func TestErrorContains(t *testing.T) {
 }
 
 func Test_isEmpty(t *testing.T) {
-
 	chWithValue := make(chan struct{}, 1)
 	chWithValue <- struct{}{}
 
@@ -1684,7 +1647,6 @@ func Test_isEmpty(t *testing.T) {
 }
 
 func TestEmpty(t *testing.T) {
-
 	mockT := new(testing.T)
 	chWithValue := make(chan struct{}, 1)
 	chWithValue <- struct{}{}
@@ -1729,7 +1691,6 @@ func TestEmpty(t *testing.T) {
 }
 
 func TestNotEmpty(t *testing.T) {
-
 	mockT := new(testing.T)
 	chWithValue := make(chan struct{}, 1)
 	chWithValue <- struct{}{}
@@ -1843,7 +1804,6 @@ func TestLen(t *testing.T) {
 }
 
 func TestWithinDuration(t *testing.T) {
-
 	mockT := new(testing.T)
 	a := time.Now()
 	b := a.Add(10 * time.Second)
@@ -1862,7 +1822,6 @@ func TestWithinDuration(t *testing.T) {
 }
 
 func TestWithinRange(t *testing.T) {
-
 	mockT := new(testing.T)
 	n := time.Now()
 	s := n.Add(-time.Second)
@@ -2069,7 +2028,6 @@ func TestInEpsilon(t *testing.T) {
 	for _, tc := range cases {
 		False(t, InEpsilon(mockT, tc.a, tc.b, tc.epsilon, "Expected %V and %V to have a relative difference of %v", tc.a, tc.b, tc.epsilon))
 	}
-
 }
 
 func TestInEpsilonSlice(t *testing.T) {
@@ -3123,7 +3081,6 @@ func Test_validateEqualArgs(t *testing.T) {
 }
 
 func Test_truncatingFormat(t *testing.T) {
-
 	original := strings.Repeat("a", bufio.MaxScanTokenSize-102)
 	result := truncatingFormat(original)
 	Equal(t, fmt.Sprintf("%#v", original), result, "string should not be truncated")

--- a/assert/forward_assertions_test.go
+++ b/assert/forward_assertions_test.go
@@ -27,7 +27,6 @@ func TestIsTypeWrapper(t *testing.T) {
 	if assert.IsType(new(AssertionTesterConformingObject), new(AssertionTesterNonConformingObject)) {
 		t.Error("IsType should return false: AssertionTesterConformingObject is not the same type as AssertionTesterNonConformingObject")
 	}
-
 }
 
 func TestEqualWrapper(t *testing.T) {
@@ -67,7 +66,6 @@ func TestNotNilWrapper(t *testing.T) {
 	if assert.NotNil(nil) {
 		t.Error("NotNil should return false: object is nil")
 	}
-
 }
 
 func TestNilWrapper(t *testing.T) {
@@ -79,7 +77,6 @@ func TestNilWrapper(t *testing.T) {
 	if assert.Nil(new(AssertionTesterConformingObject)) {
 		t.Error("Nil should return false: object is not nil")
 	}
-
 }
 
 func TestTrueWrapper(t *testing.T) {
@@ -91,7 +88,6 @@ func TestTrueWrapper(t *testing.T) {
 	if assert.True(false) {
 		t.Error("True should return false")
 	}
-
 }
 
 func TestFalseWrapper(t *testing.T) {
@@ -103,7 +99,6 @@ func TestFalseWrapper(t *testing.T) {
 	if assert.False(true) {
 		t.Error("False should return false")
 	}
-
 }
 
 func TestExactlyWrapper(t *testing.T) {
@@ -130,11 +125,9 @@ func TestExactlyWrapper(t *testing.T) {
 	if assert.Exactly(a, nil) {
 		t.Error("Exactly should return false")
 	}
-
 }
 
 func TestNotEqualWrapper(t *testing.T) {
-
 	assert := New(new(testing.T))
 
 	if !assert.NotEqual("Hello World", "Hello World!") {
@@ -155,7 +148,6 @@ func TestNotEqualWrapper(t *testing.T) {
 }
 
 func TestNotEqualValuesWrapper(t *testing.T) {
-
 	assert := New(new(testing.T))
 
 	if !assert.NotEqualValues("Hello World", "Hello World!") {
@@ -179,7 +171,6 @@ func TestNotEqualValuesWrapper(t *testing.T) {
 }
 
 func TestContainsWrapper(t *testing.T) {
-
 	assert := New(new(testing.T))
 	list := []string{"Foo", "Bar"}
 
@@ -196,11 +187,9 @@ func TestContainsWrapper(t *testing.T) {
 	if assert.Contains(list, "Salut") {
 		t.Error("Contains should return false: \"[\"Foo\", \"Bar\"]\" does not contain \"Salut\"")
 	}
-
 }
 
 func TestNotContainsWrapper(t *testing.T) {
-
 	assert := New(new(testing.T))
 	list := []string{"Foo", "Bar"}
 
@@ -217,11 +206,9 @@ func TestNotContainsWrapper(t *testing.T) {
 	if assert.NotContains(list, "Foo") {
 		t.Error("NotContains should return false: \"[\"Foo\", \"Bar\"]\" contains \"Foo\"")
 	}
-
 }
 
 func TestConditionWrapper(t *testing.T) {
-
 	assert := New(new(testing.T))
 
 	if !assert.Condition(func() bool { return true }, "Truth") {
@@ -231,11 +218,9 @@ func TestConditionWrapper(t *testing.T) {
 	if assert.Condition(func() bool { return false }, "Lie") {
 		t.Error("Condition should return false")
 	}
-
 }
 
 func TestDidPanicWrapper(t *testing.T) {
-
 	if funcDidPanic, _, _ := didPanic(func() {
 		panic("Panic!")
 	}); !funcDidPanic {
@@ -246,11 +231,9 @@ func TestDidPanicWrapper(t *testing.T) {
 	}); funcDidPanic {
 		t.Error("didPanic should return false")
 	}
-
 }
 
 func TestPanicsWrapper(t *testing.T) {
-
 	assert := New(new(testing.T))
 
 	if !assert.Panics(func() {
@@ -263,11 +246,9 @@ func TestPanicsWrapper(t *testing.T) {
 	}) {
 		t.Error("Panics should return false")
 	}
-
 }
 
 func TestNotPanicsWrapper(t *testing.T) {
-
 	assert := New(new(testing.T))
 
 	if !assert.NotPanics(func() {
@@ -280,7 +261,6 @@ func TestNotPanicsWrapper(t *testing.T) {
 	}) {
 		t.Error("NotPanics should return false")
 	}
-
 }
 
 func TestNoErrorWrapper(t *testing.T) {
@@ -296,7 +276,6 @@ func TestNoErrorWrapper(t *testing.T) {
 	err = errors.New("Some error")
 
 	assert.False(mockAssert.NoError(err), "NoError with error should return False")
-
 }
 
 func TestErrorWrapper(t *testing.T) {
@@ -312,7 +291,6 @@ func TestErrorWrapper(t *testing.T) {
 	err = errors.New("Some error")
 
 	assert.True(mockAssert.Error(err), "Error with error should return True")
-
 }
 
 func TestErrorContainsWrapper(t *testing.T) {
@@ -366,7 +344,6 @@ func TestEmptyWrapper(t *testing.T) {
 	assert.False(mockAssert.Empty([]string{"something"}), "Non empty string array is not empty")
 	assert.False(mockAssert.Empty(1), "Non-zero int value is not empty")
 	assert.False(mockAssert.Empty(true), "True value is not empty")
-
 }
 
 func TestNotEmptyWrapper(t *testing.T) {
@@ -384,7 +361,6 @@ func TestNotEmptyWrapper(t *testing.T) {
 	assert.True(mockAssert.NotEmpty([]string{"something"}), "Non empty string array is not empty")
 	assert.True(mockAssert.NotEmpty(1), "Non-zero int value is not empty")
 	assert.True(mockAssert.NotEmpty(true), "True value is not empty")
-
 }
 
 func TestLenWrapper(t *testing.T) {
@@ -519,7 +495,6 @@ func TestInEpsilonWrapper(t *testing.T) {
 }
 
 func TestRegexpWrapper(t *testing.T) {
-
 	assert := New(new(testing.T))
 
 	cases := []struct {
@@ -584,7 +559,6 @@ func TestJSONEqWrapper_EqualSONString(t *testing.T) {
 	if !assert.JSONEq(`{"hello": "world", "foo": "bar"}`, `{"hello": "world", "foo": "bar"}`) {
 		t.Error("JSONEq should return true")
 	}
-
 }
 
 func TestJSONEqWrapper_EquivalentButNotEqual(t *testing.T) {
@@ -592,7 +566,6 @@ func TestJSONEqWrapper_EquivalentButNotEqual(t *testing.T) {
 	if !assert.JSONEq(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`) {
 		t.Error("JSONEq should return true")
 	}
-
 }
 
 func TestJSONEqWrapper_HashOfArraysAndHashes(t *testing.T) {
@@ -608,7 +581,6 @@ func TestJSONEqWrapper_Array(t *testing.T) {
 	if !assert.JSONEq(`["foo", {"hello": "world", "nested": "hash"}]`, `["foo", {"nested": "hash", "hello": "world"}]`) {
 		t.Error("JSONEq should return true")
 	}
-
 }
 
 func TestJSONEqWrapper_HashAndArrayNotEquivalent(t *testing.T) {
@@ -658,7 +630,6 @@ func TestYAMLEqWrapper_EqualYAMLString(t *testing.T) {
 	if !assert.YAMLEq(`{"hello": "world", "foo": "bar"}`, `{"hello": "world", "foo": "bar"}`) {
 		t.Error("YAMLEq should return true")
 	}
-
 }
 
 func TestYAMLEqWrapper_EquivalentButNotEqual(t *testing.T) {
@@ -666,7 +637,6 @@ func TestYAMLEqWrapper_EquivalentButNotEqual(t *testing.T) {
 	if !assert.YAMLEq(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`) {
 		t.Error("YAMLEq should return true")
 	}
-
 }
 
 func TestYAMLEqWrapper_HashOfArraysAndHashes(t *testing.T) {
@@ -706,7 +676,6 @@ func TestYAMLEqWrapper_Array(t *testing.T) {
 	if !assert.YAMLEq(`["foo", {"hello": "world", "nested": "hash"}]`, `["foo", {"nested": "hash", "hello": "world"}]`) {
 		t.Error("YAMLEq should return true")
 	}
-
 }
 
 func TestYAMLEqWrapper_HashAndArrayNotEquivalent(t *testing.T) {

--- a/http/test_response_writer.go
+++ b/http/test_response_writer.go
@@ -6,7 +6,6 @@ import (
 
 // Deprecated: Use [net/http/httptest] instead.
 type TestResponseWriter struct {
-
 	// StatusCode is the last int written by the call to WriteHeader(int)
 	StatusCode int
 
@@ -19,7 +18,6 @@ type TestResponseWriter struct {
 
 // Deprecated: Use [net/http/httptest] instead.
 func (rw *TestResponseWriter) Header() http.Header {
-
 	if rw.header == nil {
 		rw.header = make(http.Header)
 	}
@@ -29,7 +27,6 @@ func (rw *TestResponseWriter) Header() http.Header {
 
 // Deprecated: Use [net/http/httptest] instead.
 func (rw *TestResponseWriter) Write(bytes []byte) (int, error) {
-
 	// assume 200 success if no header has been set
 	if rw.StatusCode == 0 {
 		rw.WriteHeader(200)
@@ -40,7 +37,6 @@ func (rw *TestResponseWriter) Write(bytes []byte) (int, error) {
 
 	// return normal values
 	return 0, nil
-
 }
 
 // Deprecated: Use [net/http/httptest] instead.

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -50,6 +50,7 @@ func OpStr(s string) OptionFn {
 		o.str = s
 	}
 }
+
 func (i *TestExampleImplementation) TheExampleMethodFunctionalOptions(x string, opts ...OptionFn) error {
 	args := i.Called(x, opts)
 	return args.Error(0)
@@ -149,7 +150,6 @@ func (m *MockTestingT) FailNow() {
 */
 
 func Test_Mock_TestData(t *testing.T) {
-
 	var mockedService = new(TestExampleImplementation)
 
 	if assert.NotNil(t, mockedService.TestData()) {
@@ -160,7 +160,6 @@ func Test_Mock_TestData(t *testing.T) {
 }
 
 func Test_Mock_On(t *testing.T) {
-
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
 
@@ -395,7 +394,6 @@ func Test_Mock_On_WithSliceArgMatcher(t *testing.T) {
 }
 
 func Test_Mock_On_WithVariadicFunc(t *testing.T) {
-
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
 
@@ -413,11 +411,9 @@ func Test_Mock_On_WithVariadicFunc(t *testing.T) {
 	assert.Panics(t, func() {
 		mockedService.TheExampleMethodVariadic(1, 2)
 	})
-
 }
 
 func Test_Mock_On_WithMixedVariadicFunc(t *testing.T) {
-
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
 
@@ -436,11 +432,9 @@ func Test_Mock_On_WithMixedVariadicFunc(t *testing.T) {
 	assert.Panics(t, func() {
 		mockedService.TheExampleMethodMixedVariadic(1, 2, 3, 5)
 	})
-
 }
 
 func Test_Mock_On_WithVariadicFuncWithInterface(t *testing.T) {
-
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
 
@@ -457,11 +451,9 @@ func Test_Mock_On_WithVariadicFuncWithInterface(t *testing.T) {
 	assert.Panics(t, func() {
 		mockedService.TheExampleMethodVariadicInterface(1, 2)
 	})
-
 }
 
 func Test_Mock_On_WithVariadicFuncWithEmptyInterfaceArray(t *testing.T) {
-
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
 
@@ -480,7 +472,6 @@ func Test_Mock_On_WithVariadicFuncWithEmptyInterfaceArray(t *testing.T) {
 	assert.Panics(t, func() {
 		mockedService.TheExampleMethodVariadicInterface(1, 2)
 	})
-
 }
 
 func Test_Mock_On_WithFuncPanics(t *testing.T) {
@@ -493,7 +484,6 @@ func Test_Mock_On_WithFuncPanics(t *testing.T) {
 }
 
 func Test_Mock_On_WithFuncTypeArg(t *testing.T) {
-
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
 
@@ -667,7 +657,6 @@ func Test_Mock_Unset_WithFuncPanics(t *testing.T) {
 }
 
 func Test_Mock_Return(t *testing.T) {
-
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
 
@@ -691,7 +680,6 @@ func Test_Mock_Return(t *testing.T) {
 }
 
 func Test_Mock_Panic(t *testing.T) {
-
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
 
@@ -714,7 +702,6 @@ func Test_Mock_Panic(t *testing.T) {
 }
 
 func Test_Mock_Return_WaitUntil(t *testing.T) {
-
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
 	ch := time.After(time.Second)
@@ -741,7 +728,6 @@ func Test_Mock_Return_WaitUntil(t *testing.T) {
 }
 
 func Test_Mock_Return_After(t *testing.T) {
-
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
 
@@ -763,11 +749,9 @@ func Test_Mock_Return_After(t *testing.T) {
 	assert.Equal(t, true, call.ReturnArguments[2])
 	assert.Equal(t, 0, call.Repeatability)
 	assert.NotEqual(t, nil, call.WaitFor)
-
 }
 
 func Test_Mock_Return_Run(t *testing.T) {
-
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
 
@@ -824,7 +808,6 @@ func Test_Mock_Return_Run_Out_Of_Order(t *testing.T) {
 }
 
 func Test_Mock_Return_Once(t *testing.T) {
-
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
 
@@ -848,7 +831,6 @@ func Test_Mock_Return_Once(t *testing.T) {
 }
 
 func Test_Mock_Return_Twice(t *testing.T) {
-
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
 
@@ -873,7 +855,6 @@ func Test_Mock_Return_Twice(t *testing.T) {
 }
 
 func Test_Mock_Return_Times(t *testing.T) {
-
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
 
@@ -898,7 +879,6 @@ func Test_Mock_Return_Times(t *testing.T) {
 }
 
 func Test_Mock_Return_Nothing(t *testing.T) {
-
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
 
@@ -1157,7 +1137,6 @@ func Test_Mock_Return_NotBefore_Orphan_Call(t *testing.T) {
 }
 
 func Test_Mock_findExpectedCall(t *testing.T) {
-
 	m := new(Mock)
 	m.On("One", 1).Return("one")
 	m.On("Two", 2).Return("two")
@@ -1172,11 +1151,9 @@ func Test_Mock_findExpectedCall(t *testing.T) {
 			assert.Equal(t, "three", c.ReturnArguments[0])
 		}
 	}
-
 }
 
 func Test_Mock_findExpectedCall_For_Unknown_Method(t *testing.T) {
-
 	m := new(Mock)
 	m.On("One", 1).Return("one")
 	m.On("Two", 2).Return("two")
@@ -1185,11 +1162,9 @@ func Test_Mock_findExpectedCall_For_Unknown_Method(t *testing.T) {
 	f, _ := m.findExpectedCall("Two")
 
 	assert.Equal(t, -1, f)
-
 }
 
 func Test_Mock_findExpectedCall_Respects_Repeatability(t *testing.T) {
-
 	m := new(Mock)
 	m.On("One", 1).Return("one")
 	m.On("Two", 2).Return("two").Once()
@@ -1219,14 +1194,11 @@ func Test_Mock_findExpectedCall_Respects_Repeatability(t *testing.T) {
 }
 
 func Test_callString(t *testing.T) {
-
 	assert.Equal(t, `Method(int,bool,string)`, callString("Method", []interface{}{1, true, "something"}, false))
 	assert.Equal(t, `Method(<nil>)`, callString("Method", []interface{}{nil}, false))
-
 }
 
 func Test_Mock_Called(t *testing.T) {
-
 	var mockedService = new(TestExampleImplementation)
 
 	mockedService.On("Test_Mock_Called", 1, 2, 3).Return(5, "6", true)
@@ -1245,7 +1217,6 @@ func Test_Mock_Called(t *testing.T) {
 		assert.Equal(t, "6", returnArguments[1])
 		assert.Equal(t, true, returnArguments[2])
 	}
-
 }
 
 func asyncCall(m *Mock, ch chan Arguments) {
@@ -1253,7 +1224,6 @@ func asyncCall(m *Mock, ch chan Arguments) {
 }
 
 func Test_Mock_Called_blocks(t *testing.T) {
-
 	var mockedService = new(TestExampleImplementation)
 
 	mockedService.Mock.On("asyncCall", 1, 2, 3).Return(5, "6", true).After(20 * time.Millisecond)
@@ -1282,11 +1252,9 @@ func Test_Mock_Called_blocks(t *testing.T) {
 		assert.Equal(t, "6", returnArguments[1])
 		assert.Equal(t, true, returnArguments[2])
 	}
-
 }
 
 func Test_Mock_Called_For_Bounded_Repeatability(t *testing.T) {
-
 	var mockedService = new(TestExampleImplementation)
 
 	mockedService.
@@ -1323,11 +1291,9 @@ func Test_Mock_Called_For_Bounded_Repeatability(t *testing.T) {
 		assert.Equal(t, "hi", returnArguments2[1])
 		assert.Equal(t, false, returnArguments2[2])
 	}
-
 }
 
 func Test_Mock_Called_For_SetTime_Expectation(t *testing.T) {
-
 	var mockedService = new(TestExampleImplementation)
 
 	mockedService.On("TheExampleMethod", 1, 2, 3).Return(5, "6", true).Times(4)
@@ -1339,22 +1305,18 @@ func Test_Mock_Called_For_SetTime_Expectation(t *testing.T) {
 	assert.Panics(t, func() {
 		mockedService.TheExampleMethod(1, 2, 3)
 	})
-
 }
 
 func Test_Mock_Called_Unexpected(t *testing.T) {
-
 	var mockedService = new(TestExampleImplementation)
 
 	// make sure it panics if no expectation was made
 	assert.Panics(t, func() {
 		mockedService.Called(1, 2, 3)
 	}, "Calling unexpected method should panic")
-
 }
 
 func Test_AssertExpectationsForObjects_Helper(t *testing.T) {
-
 	var mockedService1 = new(TestExampleImplementation)
 	var mockedService2 = new(TestExampleImplementation)
 	var mockedService3 = new(TestExampleImplementation)
@@ -1370,11 +1332,9 @@ func Test_AssertExpectationsForObjects_Helper(t *testing.T) {
 
 	assert.True(t, AssertExpectationsForObjects(t, &mockedService1.Mock, &mockedService2.Mock, &mockedService3.Mock, &mockedService4.Mock))
 	assert.True(t, AssertExpectationsForObjects(t, mockedService1, mockedService2, mockedService3, mockedService4))
-
 }
 
 func Test_AssertExpectationsForObjects_Helper_Failed(t *testing.T) {
-
 	var mockedService1 = new(TestExampleImplementation)
 	var mockedService2 = new(TestExampleImplementation)
 	var mockedService3 = new(TestExampleImplementation)
@@ -1389,11 +1349,9 @@ func Test_AssertExpectationsForObjects_Helper_Failed(t *testing.T) {
 	tt := new(testing.T)
 	assert.False(t, AssertExpectationsForObjects(tt, &mockedService1.Mock, &mockedService2.Mock, &mockedService3.Mock))
 	assert.False(t, AssertExpectationsForObjects(tt, mockedService1, mockedService2, mockedService3))
-
 }
 
 func Test_Mock_AssertExpectations(t *testing.T) {
-
 	var mockedService = new(TestExampleImplementation)
 
 	mockedService.On("Test_Mock_AssertExpectations", 1, 2, 3).Return(5, 6, 7)
@@ -1406,11 +1364,9 @@ func Test_Mock_AssertExpectations(t *testing.T) {
 
 	// now assert expectations
 	assert.True(t, mockedService.AssertExpectations(tt))
-
 }
 
 func Test_Mock_AssertExpectations_Placeholder_NoArgs(t *testing.T) {
-
 	var mockedService = new(TestExampleImplementation)
 
 	mockedService.On("Test_Mock_AssertExpectations_Placeholder_NoArgs").Return(5, 6, 7).Once()
@@ -1424,11 +1380,9 @@ func Test_Mock_AssertExpectations_Placeholder_NoArgs(t *testing.T) {
 
 	// now assert expectations
 	assert.True(t, mockedService.AssertExpectations(tt))
-
 }
 
 func Test_Mock_AssertExpectations_Placeholder(t *testing.T) {
-
 	var mockedService = new(TestExampleImplementation)
 
 	mockedService.On("Test_Mock_AssertExpectations_Placeholder", 1, 2, 3).Return(5, 6, 7).Once()
@@ -1451,7 +1405,6 @@ func Test_Mock_AssertExpectations_Placeholder(t *testing.T) {
 }
 
 func Test_Mock_AssertExpectations_With_Pointers(t *testing.T) {
-
 	var mockedService = new(TestExampleImplementation)
 
 	mockedService.On("Test_Mock_AssertExpectations_With_Pointers", &struct{ Foo int }{1}).Return(1)
@@ -1468,11 +1421,9 @@ func Test_Mock_AssertExpectations_With_Pointers(t *testing.T) {
 
 	// now assert expectations
 	assert.True(t, mockedService.AssertExpectations(tt))
-
 }
 
 func Test_Mock_AssertExpectationsCustomType(t *testing.T) {
-
 	var mockedService = new(TestExampleImplementation)
 
 	mockedService.On("TheExampleMethod3", AnythingOfType("*mock.ExampleType")).Return(nil).Once()
@@ -1485,11 +1436,9 @@ func Test_Mock_AssertExpectationsCustomType(t *testing.T) {
 
 	// now assert expectations
 	assert.True(t, mockedService.AssertExpectations(tt))
-
 }
 
 func Test_Mock_AssertExpectationsFunctionalOptionsType(t *testing.T) {
-
 	var mockedService = new(TestExampleImplementation)
 
 	mockedService.On("TheExampleMethodFunctionalOptions", "test", FunctionalOptions(OpNum(1), OpStr("foo"))).Return(nil).Once()
@@ -1502,11 +1451,9 @@ func Test_Mock_AssertExpectationsFunctionalOptionsType(t *testing.T) {
 
 	// now assert expectations
 	assert.True(t, mockedService.AssertExpectations(tt))
-
 }
 
 func Test_Mock_AssertExpectationsFunctionalOptionsType_Empty(t *testing.T) {
-
 	var mockedService = new(TestExampleImplementation)
 
 	mockedService.On("TheExampleMethodFunctionalOptions", "test", FunctionalOptions()).Return(nil).Once()
@@ -1519,11 +1466,9 @@ func Test_Mock_AssertExpectationsFunctionalOptionsType_Empty(t *testing.T) {
 
 	// now assert expectations
 	assert.True(t, mockedService.AssertExpectations(tt))
-
 }
 
 func Test_Mock_AssertExpectations_With_Repeatability(t *testing.T) {
-
 	var mockedService = new(TestExampleImplementation)
 
 	mockedService.On("Test_Mock_AssertExpectations_With_Repeatability", 1, 2, 3).Return(5, 6, 7).Twice()
@@ -1540,11 +1485,9 @@ func Test_Mock_AssertExpectations_With_Repeatability(t *testing.T) {
 
 	// now assert expectations
 	assert.True(t, mockedService.AssertExpectations(tt))
-
 }
 
 func Test_Mock_AssertExpectations_Skipped_Test(t *testing.T) {
-
 	var mockedService = new(TestExampleImplementation)
 
 	mockedService.On("Test_Mock_AssertExpectations_Skipped_Test", 1, 2, 3).Return(5, 6, 7)
@@ -1554,7 +1497,6 @@ func Test_Mock_AssertExpectations_Skipped_Test(t *testing.T) {
 }
 
 func Test_Mock_TwoCallsWithDifferentArguments(t *testing.T) {
-
 	var mockedService = new(TestExampleImplementation)
 
 	mockedService.On("Test_Mock_TwoCallsWithDifferentArguments", 1, 2, 3).Return(5, 6, 7)
@@ -1569,11 +1511,9 @@ func Test_Mock_TwoCallsWithDifferentArguments(t *testing.T) {
 	assert.Equal(t, 5, args2.Int(0))
 	assert.Equal(t, 6, args2.Int(1))
 	assert.Equal(t, 7, args2.Int(2))
-
 }
 
 func Test_Mock_AssertNumberOfCalls(t *testing.T) {
-
 	var mockedService = new(TestExampleImplementation)
 
 	mockedService.On("Test_Mock_AssertNumberOfCalls", 1, 2, 3).Return(5, 6, 7)
@@ -1583,11 +1523,9 @@ func Test_Mock_AssertNumberOfCalls(t *testing.T) {
 
 	mockedService.Called(1, 2, 3)
 	assert.True(t, mockedService.AssertNumberOfCalls(t, "Test_Mock_AssertNumberOfCalls", 2))
-
 }
 
 func Test_Mock_AssertCalled(t *testing.T) {
-
 	var mockedService = new(TestExampleImplementation)
 
 	mockedService.On("Test_Mock_AssertCalled", 1, 2, 3).Return(5, 6, 7)
@@ -1595,11 +1533,9 @@ func Test_Mock_AssertCalled(t *testing.T) {
 	mockedService.Called(1, 2, 3)
 
 	assert.True(t, mockedService.AssertCalled(t, "Test_Mock_AssertCalled", 1, 2, 3))
-
 }
 
 func Test_Mock_AssertCalled_WithAnythingOfTypeArgument(t *testing.T) {
-
 	var mockedService = new(TestExampleImplementation)
 
 	mockedService.
@@ -1609,11 +1545,9 @@ func Test_Mock_AssertCalled_WithAnythingOfTypeArgument(t *testing.T) {
 	mockedService.Called(1, "two", []uint8("three"))
 
 	assert.True(t, mockedService.AssertCalled(t, "Test_Mock_AssertCalled_WithAnythingOfTypeArgument", AnythingOfType("int"), AnythingOfType("string"), AnythingOfType("[]uint8")))
-
 }
 
 func Test_Mock_AssertCalled_WithArguments(t *testing.T) {
-
 	var mockedService = new(TestExampleImplementation)
 
 	mockedService.On("Test_Mock_AssertCalled_WithArguments", 1, 2, 3).Return(5, 6, 7)
@@ -1623,11 +1557,9 @@ func Test_Mock_AssertCalled_WithArguments(t *testing.T) {
 	tt := new(testing.T)
 	assert.True(t, mockedService.AssertCalled(tt, "Test_Mock_AssertCalled_WithArguments", 1, 2, 3))
 	assert.False(t, mockedService.AssertCalled(tt, "Test_Mock_AssertCalled_WithArguments", 2, 3, 4))
-
 }
 
 func Test_Mock_AssertCalled_WithArguments_With_Repeatability(t *testing.T) {
-
 	var mockedService = new(TestExampleImplementation)
 
 	mockedService.On("Test_Mock_AssertCalled_WithArguments_With_Repeatability", 1, 2, 3).Return(5, 6, 7).Once()
@@ -1716,26 +1648,21 @@ func Test_Mock_AssertOptional(t *testing.T) {
 Arguments helper methods
 */
 func Test_Arguments_Get(t *testing.T) {
-
 	var args = Arguments([]interface{}{"string", 123, true})
 
 	assert.Equal(t, "string", args.Get(0).(string))
 	assert.Equal(t, 123, args.Get(1).(int))
 	assert.Equal(t, true, args.Get(2).(bool))
-
 }
 
 func Test_Arguments_Is(t *testing.T) {
-
 	var args = Arguments([]interface{}{"string", 123, true})
 
 	assert.True(t, args.Is("string", 123, true))
 	assert.False(t, args.Is("wrong", 456, false))
-
 }
 
 func Test_Arguments_Diff(t *testing.T) {
-
 	var args = Arguments([]interface{}{"Hello World", 123, true})
 	var diff string
 	var count int
@@ -1744,11 +1671,9 @@ func Test_Arguments_Diff(t *testing.T) {
 	assert.Equal(t, 2, count)
 	assert.Contains(t, diff, `(int=456) != (int=123)`)
 	assert.Contains(t, diff, `(string=false) != (bool=true)`)
-
 }
 
 func Test_Arguments_Diff_DifferentNumberOfArgs(t *testing.T) {
-
 	var args = Arguments([]interface{}{"string", 123, true})
 	var diff string
 	var count int
@@ -1756,41 +1681,33 @@ func Test_Arguments_Diff_DifferentNumberOfArgs(t *testing.T) {
 
 	assert.Equal(t, 3, count)
 	assert.Contains(t, diff, `(string=extra) != (Missing)`)
-
 }
 
 func Test_Arguments_Diff_WithAnythingArgument(t *testing.T) {
-
 	var args = Arguments([]interface{}{"string", 123, true})
 	var count int
 	_, count = args.Diff([]interface{}{"string", Anything, true})
 
 	assert.Equal(t, 0, count)
-
 }
 
 func Test_Arguments_Diff_WithAnythingArgument_InActualToo(t *testing.T) {
-
 	var args = Arguments([]interface{}{"string", Anything, true})
 	var count int
 	_, count = args.Diff([]interface{}{"string", 123, true})
 
 	assert.Equal(t, 0, count)
-
 }
 
 func Test_Arguments_Diff_WithAnythingOfTypeArgument(t *testing.T) {
-
 	var args = Arguments([]interface{}{"string", AnythingOfType("int"), true})
 	var count int
 	_, count = args.Diff([]interface{}{"string", 123, true})
 
 	assert.Equal(t, 0, count)
-
 }
 
 func Test_Arguments_Diff_WithAnythingOfTypeArgument_Failing(t *testing.T) {
-
 	var args = Arguments([]interface{}{"string", AnythingOfType("string"), true})
 	var count int
 	var diff string
@@ -1798,7 +1715,6 @@ func Test_Arguments_Diff_WithAnythingOfTypeArgument_Failing(t *testing.T) {
 
 	assert.Equal(t, 1, count)
 	assert.Contains(t, diff, `string != type int - (int=123)`)
-
 }
 
 func Test_Arguments_Diff_WithIsTypeArgument(t *testing.T) {
@@ -1843,58 +1759,43 @@ func Test_Arguments_Diff_WithArgMatcher(t *testing.T) {
 }
 
 func Test_Arguments_Assert(t *testing.T) {
-
 	var args = Arguments([]interface{}{"string", 123, true})
 
 	assert.True(t, args.Assert(t, "string", 123, true))
-
 }
 
 func Test_Arguments_String_Representation(t *testing.T) {
-
 	var args = Arguments([]interface{}{"string", 123, true})
 	assert.Equal(t, `string,int,bool`, args.String())
-
 }
 
 func Test_Arguments_String(t *testing.T) {
-
 	var args = Arguments([]interface{}{"string", 123, true})
 	assert.Equal(t, "string", args.String(0))
-
 }
 
 func Test_Arguments_Error(t *testing.T) {
-
 	var err = errors.New("An Error")
 	var args = Arguments([]interface{}{"string", 123, true, err})
 	assert.Equal(t, err, args.Error(3))
-
 }
 
 func Test_Arguments_Error_Nil(t *testing.T) {
-
 	var args = Arguments([]interface{}{"string", 123, true, nil})
 	assert.Equal(t, nil, args.Error(3))
-
 }
 
 func Test_Arguments_Int(t *testing.T) {
-
 	var args = Arguments([]interface{}{"string", 123, true})
 	assert.Equal(t, 123, args.Int(1))
-
 }
 
 func Test_Arguments_Bool(t *testing.T) {
-
 	var args = Arguments([]interface{}{"string", 123, true})
 	assert.Equal(t, true, args.Bool(2))
-
 }
 
 func Test_WaitUntil_Parallel(t *testing.T) {
-
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
 

--- a/require/requirements_test.go
+++ b/require/requirements_test.go
@@ -38,7 +38,6 @@ func (t *MockT) Errorf(format string, args ...interface{}) {
 }
 
 func TestImplements(t *testing.T) {
-
 	Implements(t, (*AssertionTesterInterface)(nil), new(AssertionTesterConformingObject))
 
 	mockT := new(MockT)
@@ -49,7 +48,6 @@ func TestImplements(t *testing.T) {
 }
 
 func TestIsType(t *testing.T) {
-
 	IsType(t, new(AssertionTesterConformingObject), new(AssertionTesterConformingObject))
 
 	mockT := new(MockT)
@@ -60,7 +58,6 @@ func TestIsType(t *testing.T) {
 }
 
 func TestEqual(t *testing.T) {
-
 	Equal(t, 1, 1)
 
 	mockT := new(MockT)
@@ -68,11 +65,9 @@ func TestEqual(t *testing.T) {
 	if !mockT.Failed {
 		t.Error("Check should fail")
 	}
-
 }
 
 func TestNotEqual(t *testing.T) {
-
 	NotEqual(t, 1, 2)
 	mockT := new(MockT)
 	NotEqual(mockT, 2, 2)
@@ -82,7 +77,6 @@ func TestNotEqual(t *testing.T) {
 }
 
 func TestExactly(t *testing.T) {
-
 	a := float32(1)
 	b := float32(1)
 	c := float64(1)
@@ -97,7 +91,6 @@ func TestExactly(t *testing.T) {
 }
 
 func TestNotNil(t *testing.T) {
-
 	NotNil(t, new(AssertionTesterConformingObject))
 
 	mockT := new(MockT)
@@ -108,7 +101,6 @@ func TestNotNil(t *testing.T) {
 }
 
 func TestNil(t *testing.T) {
-
 	Nil(t, nil)
 
 	mockT := new(MockT)
@@ -119,7 +111,6 @@ func TestNil(t *testing.T) {
 }
 
 func TestTrue(t *testing.T) {
-
 	True(t, true)
 
 	mockT := new(MockT)
@@ -130,7 +121,6 @@ func TestTrue(t *testing.T) {
 }
 
 func TestFalse(t *testing.T) {
-
 	False(t, false)
 
 	mockT := new(MockT)
@@ -141,7 +131,6 @@ func TestFalse(t *testing.T) {
 }
 
 func TestContains(t *testing.T) {
-
 	Contains(t, "Hello World", "Hello")
 
 	mockT := new(MockT)
@@ -152,7 +141,6 @@ func TestContains(t *testing.T) {
 }
 
 func TestNotContains(t *testing.T) {
-
 	NotContains(t, "Hello World", "Hello!")
 
 	mockT := new(MockT)
@@ -163,7 +151,6 @@ func TestNotContains(t *testing.T) {
 }
 
 func TestPanics(t *testing.T) {
-
 	Panics(t, func() {
 		panic("Panic!")
 	})
@@ -176,7 +163,6 @@ func TestPanics(t *testing.T) {
 }
 
 func TestNotPanics(t *testing.T) {
-
 	NotPanics(t, func() {})
 
 	mockT := new(MockT)
@@ -189,7 +175,6 @@ func TestNotPanics(t *testing.T) {
 }
 
 func TestNoError(t *testing.T) {
-
 	NoError(t, nil)
 
 	mockT := new(MockT)
@@ -200,7 +185,6 @@ func TestNoError(t *testing.T) {
 }
 
 func TestError(t *testing.T) {
-
 	Error(t, errors.New("some error"))
 
 	mockT := new(MockT)
@@ -211,7 +195,6 @@ func TestError(t *testing.T) {
 }
 
 func TestErrorContains(t *testing.T) {
-
 	ErrorContains(t, errors.New("some error: another error"), "some error")
 
 	mockT := new(MockT)
@@ -222,7 +205,6 @@ func TestErrorContains(t *testing.T) {
 }
 
 func TestEqualError(t *testing.T) {
-
 	EqualError(t, errors.New("some error"), "some error")
 
 	mockT := new(MockT)
@@ -233,7 +215,6 @@ func TestEqualError(t *testing.T) {
 }
 
 func TestEmpty(t *testing.T) {
-
 	Empty(t, "")
 
 	mockT := new(MockT)
@@ -244,7 +225,6 @@ func TestEmpty(t *testing.T) {
 }
 
 func TestNotEmpty(t *testing.T) {
-
 	NotEmpty(t, "x")
 
 	mockT := new(MockT)
@@ -255,7 +235,6 @@ func TestNotEmpty(t *testing.T) {
 }
 
 func TestWithinDuration(t *testing.T) {
-
 	a := time.Now()
 	b := a.Add(10 * time.Second)
 
@@ -269,7 +248,6 @@ func TestWithinDuration(t *testing.T) {
 }
 
 func TestInDelta(t *testing.T) {
-
 	InDelta(t, 1.001, 1, 0.01)
 
 	mockT := new(MockT)
@@ -280,7 +258,6 @@ func TestInDelta(t *testing.T) {
 }
 
 func TestZero(t *testing.T) {
-
 	Zero(t, "")
 
 	mockT := new(MockT)
@@ -291,7 +268,6 @@ func TestZero(t *testing.T) {
 }
 
 func TestNotZero(t *testing.T) {
-
 	NotZero(t, "x")
 
 	mockT := new(MockT)

--- a/suite/suite_test.go
+++ b/suite/suite_test.go
@@ -372,7 +372,6 @@ func TestRunSuite(t *testing.T) {
 	// called Skip()
 	assert.Equal(t, 1, suiteSkipTester.SetupSuiteRunCount)
 	assert.Equal(t, 1, suiteSkipTester.TearDownSuiteRunCount)
-
 }
 
 // This suite has no Test... methods. It's setup and teardown must be skipped.
@@ -388,7 +387,6 @@ func (s *SuiteSetupSkipTester) SetupSuite() {
 }
 
 func (s *SuiteSetupSkipTester) NonTestMethod() {
-
 }
 
 func (s *SuiteSetupSkipTester) TearDownSuite() {
@@ -486,6 +484,7 @@ func (s *CallOrderSuite) call(method string) {
 func TestSuiteCallOrder(t *testing.T) {
 	Run(t, new(CallOrderSuite))
 }
+
 func (s *CallOrderSuite) SetupSuite() {
 	s.call("SetupSuite")
 }
@@ -494,6 +493,7 @@ func (s *CallOrderSuite) TearDownSuite() {
 	s.call("TearDownSuite")
 	assert.Equal(s.T(), "SetupSuite;SetupTest;Test A;SetupSubTest;SubTest A1;TearDownSubTest;SetupSubTest;SubTest A2;TearDownSubTest;TearDownTest;SetupTest;Test B;SetupSubTest;SubTest B1;TearDownSubTest;SetupSubTest;SubTest B2;TearDownSubTest;TearDownTest;TearDownSuite", strings.Join(s.callOrder, ";"))
 }
+
 func (s *CallOrderSuite) SetupTest() {
 	s.call("SetupTest")
 }
@@ -655,6 +655,7 @@ func TestFailfastSuiteFailFastOn(t *testing.T) {
 		t.Fail()
 	}
 }
+
 func (s *FailfastSuite) SetupSuite() {
 	s.call("SetupSuite")
 }
@@ -662,6 +663,7 @@ func (s *FailfastSuite) SetupSuite() {
 func (s *FailfastSuite) TearDownSuite() {
 	s.call("TearDownSuite")
 }
+
 func (s *FailfastSuite) SetupTest() {
 	s.call("SetupTest")
 }


### PR DESCRIPTION
## Summary

The PR removes empty lines that don't add to readability.

## Changes

- Remove empty lines at the start/end of blocks.
- Add empty lines between some function declarations in the `suite/suite_test.go`.

## Motivation

Improving code readability and maintaining a consistent code style. Removing unnecessary empty lines helps to keep the codebase clean and concise, making it easier for developers to navigate and understand the code.