### PR TITLE
Improve ErrorIs message when error is nil but an error was expected

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -2101,7 +2101,7 @@ func ErrorIs(t TestingT, err, target error, msgAndArgs ...interface{}) bool {
 	if target != nil {
 		expectedText = target.Error()
 		if err == nil {
-			return Fail(t, fmt.Sprintf("Expected error %q but got nil.", expectedText), msgAndArgs...)
+			return Fail(t, fmt.Sprintf("Expected error with %q in chain but got nil.", expectedText), msgAndArgs...)
 		}
 	}
 

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -2100,6 +2100,9 @@ func ErrorIs(t TestingT, err, target error, msgAndArgs ...interface{}) bool {
 	var expectedText string
 	if target != nil {
 		expectedText = target.Error()
+		if err == nil {
+			return Fail(t, fmt.Sprintf("Expected error %q but got nil.", expectedText), msgAndArgs...)
+		}
 	}
 
 	chain := buildErrorChainString(err)

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -3237,9 +3237,9 @@ func TestErrorIs(t *testing.T) {
 				"in chain: \"EOF\"\n",
 		},
 		{
-			err:    nil,
-			target: io.EOF,
-			result: false,
+			err:          nil,
+			target:       io.EOF,
+			result:       false,
 			resultErrMsg: "Expected error \"EOF\" but got nil.\n",
 		},
 		{

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -3240,10 +3240,7 @@ func TestErrorIs(t *testing.T) {
 			err:    nil,
 			target: io.EOF,
 			result: false,
-			resultErrMsg: "" +
-				"Target error should be in err chain:\n" +
-				"expected: \"EOF\"\n" +
-				"in chain: \n",
+			resultErrMsg: "Expected error \"EOF\" but got nil.\n",
 		},
 		{
 			err:    io.EOF,

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -3240,7 +3240,7 @@ func TestErrorIs(t *testing.T) {
 			err:          nil,
 			target:       io.EOF,
 			result:       false,
-			resultErrMsg: "Expected error \"EOF\" but got nil.\n",
+			resultErrMsg: "Expected error with \"EOF\" in chain but got nil.\n",
 		},
 		{
 			err:    io.EOF,


### PR DESCRIPTION
## Summary
This improves the UX of users of `ErrorIs()` in case the value `nil` is passed for `err` while an error was expected.

## Changes
- added check if `err == nil && target != nil` -> return a special error-string 
- updated relevant test case

## Motivation
The error message when an error is expected but `err` is `nil` (a common occurence in the world of testing) could be more helpful, e.g.:
```
(before)
some_test.go:20:
                Error Trace:    /[...]/some_test.go:20
                Error:          Target error should be in err chain:
                                expected: "sample error message"
                                in chain:
```
vs
```
(after)
some_test.go:20:
                Error Trace:    /[...]/some_test.go:20
                Error:          Expected error with "sample error message" in chain but got nil.
```

