### PR TITLE
mock: update callString to format context.Context as pointer

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -1,6 +1,7 @@
 package mock
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"path"
@@ -446,6 +447,11 @@ func callString(method string, arguments Arguments, includeArgumentValues bool) 
 	if includeArgumentValues {
 		var argVals []string
 		for argIndex, arg := range arguments {
+			if ctx, ok := arg.(context.Context); ok {
+				// avoid data race from formating context directly
+				argVals = append(argVals, fmt.Sprintf("%d: %p", argIndex, ctx))
+				continue
+			}
 			if _, ok := arg.(*FunctionalOptionsArgument); ok {
 				argVals = append(argVals, fmt.Sprintf("%d: %s", argIndex, arg))
 				continue


### PR DESCRIPTION
## Summary
This PR updates `func callString` in `package mock` to format `context.Context` arguments as their pointer value, in order to avoid a race.

## Changes
- changed `func callString` to format `context.Context` args as their pointer value
- added subtest `Test_callString/context` to validate

## Motivation
This is an example race detected from the new test `Test_callString/context`, before including the fix:
<details><summary>Data Race</summary>

```
==================
WARNING: DATA RACE
Write at 0x00c000016470 by goroutine 10:
  sync/atomic.AddInt32()
      /home/jordan/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/runtime/race_amd64.s:281 +0xb
  sync/atomic.AddInt32()
      <autogenerated>:1 +0x14
  context.(*cancelCtx).cancel()
      /home/jordan/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/context/context.go:561 +0x2e7
  context.WithCancel.func1()
      /home/jordan/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/context/context.go:237 +0x52
  github.com/stretchr/testify/mock.Test_callString.func1.2()
      /home/jordan/testify/mock/mock_test.go:1248 +0x99

Previous read at 0x00c000016470 by goroutine 9:
  reflect.Value.Int()
      /home/jordan/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/reflect/value.go:1458 +0x544
  fmt.(*pp).printValue()
      /home/jordan/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/fmt/print.go:792 +0x4a0
  fmt.(*pp).printValue()
      /home/jordan/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/fmt/print.go:853 +0x1d1e
  fmt.(*pp).printValue()
      /home/jordan/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/fmt/print.go:853 +0x1d1e
  fmt.(*pp).printValue()
      /home/jordan/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/fmt/print.go:921 +0x130a
  fmt.(*pp).printArg()
      /home/jordan/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/fmt/print.go:759 +0xb84
  fmt.(*pp).doPrintf()
      /home/jordan/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/fmt/print.go:1074 +0x5cf
  fmt.Sprintf()
      /home/jordan/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/fmt/print.go:239 +0x5c
  github.com/stretchr/testify/mock.callString()
      /home/jordan/testify/mock/mock.go:453 +0x4ae
  github.com/stretchr/testify/mock.Test_callString.func1()
      /home/jordan/testify/mock/mock_test.go:1253 +0x217
  testing.tRunner()
      /home/jordan/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/testing/testing.go:1690 +0x226
  testing.(*T).Run.gowrap1()
      /home/jordan/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/testing/testing.go:1743 +0x44

Goroutine 10 (running) created at:
  github.com/stretchr/testify/mock.Test_callString.func1()
      /home/jordan/testify/mock/mock_test.go:1245 +0x19c
  testing.tRunner()
      /home/jordan/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/testing/testing.go:1690 +0x226
  testing.(*T).Run.gowrap1()
      /home/jordan/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/testing/testing.go:1743 +0x44

Goroutine 9 (running) created at:
  testing.(*T).Run()
      /home/jordan/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/testing/testing.go:1743 +0x825
  github.com/stretchr/testify/mock.Test_callString()
      /home/jordan/testify/mock/mock_test.go:1238 +0x195
  testing.tRunner()
      /home/jordan/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/testing/testing.go:1690 +0x226
  testing.(*T).Run.gowrap1()
      /home/jordan/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.4.linux-amd64/src/testing/testing.go:1743 +0x44
==================

```
</details>
