### PR TITLE
CI: make GitHub workflow permissions explicit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,10 @@
 name: All builds
 on: [push, pull_request]
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,9 @@
 name: Create release from new tag
 
+# setting default permissions to "none"
+# because permissions are set at the job level
+permissions: {}
+
 # this flow will be run only when new tags are pushed that match our pattern
 on:
   push:


### PR DESCRIPTION
## Summary
<!-- High-level, one sentence summary of what this PR accomplishes -->
make GitHub workflow permissions explicit

## Changes
<!-- * Description of change 1 -->
<!-- * Description of change 2 -->
<!-- ... -->
Add a top-level `permissions` field in each GitHub workflow file.

Note that this should not lead to any changes in the permissions workflows currently have because the permissions written mirror the default permissions or are overwritten by job-level permissions

## Motivation
<!-- Why were the changes necessary. -->
It makes workflow permissions easier to read and understand, and it makes some scanner happy like [OSSF Scorecard](https://scorecard.dev/): https://deps.dev/project/github/stretchr%2Ftestify

<!-- ## Example usage (if applicable) -->

## Related issues
<!-- Put `Closes #XXXX` for each issue number this PR fixes/closes -->
None.
