### PR TITLE
Diff only after checking repeatability

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -379,14 +379,14 @@ func (m *Mock) findExpectedCall(method string, arguments ...interface{}) (int, *
 	var expectedCall *Call
 
 	for i, call := range m.ExpectedCalls {
-		if call.Method == method {
-			_, diffCount := call.Arguments.Diff(arguments)
-			if diffCount == 0 {
-				expectedCall = call
-				if call.Repeatability > -1 {
-					return i, call
-				}
-			}
+		if call.Method != method {
+			continue
+		}
+		if call.Repeatability <= -1 {
+			continue
+		}
+		if _, diffCount := call.Arguments.Diff(arguments); diffCount == 0 {
+			return i, call
 		}
 	}
 


### PR DESCRIPTION
## Summary
Optimisation of `findExpectedCall`

## Motivation
That's quite a long story about how I got here. We are migrating Nuclio from Go version 1.21 to 1.23, and apparently, something has changed there in between. This [test](https://github.com/nuclio/nuclio/blob/d27fafd873035a78650b24ea392c08b661a6b34f/pkg/dashboard/test/server_test.go#L1131-L1237) stopped working, failing on a mock call. So, I decided to dig into how testify works and noticed that if you have more than one call of the same function in `ExpectedCalls`, the Diff function will still run against it, even if the function has already been called once and its Repeatability is `-1`. And it would be fine if only we didn't have `suite.Require().Equal` as part of `mock.MatchedBy` function, which failed on the 1st iteration here without even reaching the required iteration in `ExpectedCalls`. 

UPD:I  noticed that the tests fail in cases where this function returns a call without considering Repeatability. While this behavior is tied to the implementation details, it can take quite a bit of time to figure out the root cause of these failures, which isn't ideal from a UX perspective. This PR is more of a suggestion rather than a change request, so feel free to close it if you believe it’s unnecessary.