### PR TITLE
Add opt-in parallel test methods.

### DIFF
--- a/suite/interfaces.go
+++ b/suite/interfaces.go
@@ -22,6 +22,12 @@ type SetupTestSuite interface {
 	SetupTest()
 }
 
+// SetupParallelTestSuite has a SetupTest method, which will run before each
+// parallel test in the suite.
+type SetupParallelTestSuite interface {
+	SetupTest(*testing.T)
+}
+
 // TearDownAllSuite has a TearDownSuite method, which will run after
 // all the tests in the suite have been run.
 type TearDownAllSuite interface {
@@ -34,16 +40,34 @@ type TearDownTestSuite interface {
 	TearDownTest()
 }
 
+// TearDownParallelTestSuite has a TearDownTest method, which will run after
+// each parallel test in the suite.
+type TearDownParallelTestSuite interface {
+	TearDownTest(*testing.T)
+}
+
 // BeforeTest has a function to be executed right before the test
 // starts and receives the suite and test names as input
 type BeforeTest interface {
 	BeforeTest(suiteName, testName string)
 }
 
+// BeforeParallelTest has a function to be executed right before the parallel
+// test starts and receives the suite and test names as input
+type BeforeParallelTest interface {
+	BeforeTest(t *testing.T, suiteName, testName string)
+}
+
 // AfterTest has a function to be executed right after the test
 // finishes and receives the suite and test names as input
 type AfterTest interface {
 	AfterTest(suiteName, testName string)
+}
+
+// AfterParallelTest has a function to be executed right after the parallel
+// test finishes and receives the suite and test names as input
+type AfterParallelTest interface {
+	AfterTest(t *testing.T, suiteName, testName string)
 }
 
 // WithStats implements HandleStats, a function that will be executed

--- a/suite/interfaces.go
+++ b/suite/interfaces.go
@@ -18,6 +18,8 @@ type SetupAllSuite interface {
 
 // SetupTestSuite has a SetupTest method, which will run before each
 // test in the suite.
+//
+// See SetupParallelTestSuite instead if you want to write parallel tests.
 type SetupTestSuite interface {
 	SetupTest()
 }
@@ -36,6 +38,8 @@ type TearDownAllSuite interface {
 
 // TearDownTestSuite has a TearDownTest method, which will run after
 // each test in the suite.
+//
+// See TearDownParallelTestSuite instead if you want to write parallel tests.
 type TearDownTestSuite interface {
 	TearDownTest()
 }
@@ -48,6 +52,8 @@ type TearDownParallelTestSuite interface {
 
 // BeforeTest has a function to be executed right before the test
 // starts and receives the suite and test names as input
+//
+// See BeforeParallelTest instead if you want to write parallel tests.
 type BeforeTest interface {
 	BeforeTest(suiteName, testName string)
 }
@@ -60,6 +66,8 @@ type BeforeParallelTest interface {
 
 // AfterTest has a function to be executed right after the test
 // finishes and receives the suite and test names as input
+//
+// See AfterParallelTest instead if you want to write parallel tests.
 type AfterTest interface {
 	AfterTest(suiteName, testName string)
 }

--- a/suite/suite.go
+++ b/suite/suite.go
@@ -195,12 +195,21 @@ func Run(t *testing.T, suite TestingSuite) {
 					}
 
 					if afterTestSuite, ok := suite.(AfterTest); ok {
+						if isParallel {
+							t.Errorf("%T implementations cannot contain parallel tests (e.g., %#q). See %T instead.", AfterTest(nil), method.Name, AfterParallelTest(nil))
+							t.FailNow()
+						}
 						afterTestSuite.AfterTest(suiteName, method.Name)
 					} else if afterTestSuite, ok := suite.(AfterParallelTest); ok {
 						afterTestSuite.AfterTest(t, suiteName, method.Name)
 					}
 
 					if tearDownTestSuite, ok := suite.(TearDownTestSuite); ok {
+						if isParallel {
+							t.Errorf("%T implementations cannot contain parallel tests (e.g., %#q). See %T instead.", TearDownTestSuite(nil), method.Name, TearDownParallelTestSuite(nil))
+							t.FailNow()
+						}
+
 						tearDownTestSuite.TearDownTest()
 					} else if tearDownTestSuite, ok := suite.(TearDownParallelTestSuite); ok {
 						tearDownTestSuite.TearDownTest(t)
@@ -214,11 +223,22 @@ func Run(t *testing.T, suite TestingSuite) {
 				}()
 
 				if setupTestSuite, ok := suite.(SetupTestSuite); ok {
+					if isParallel {
+						t.Errorf("%T implementations cannot contain parallel tests (e.g., %#q). See %T instead.", SetupTestSuite(nil), method.Name, SetupParallelTestSuite(nil))
+						t.FailNow()
+					}
+
 					setupTestSuite.SetupTest()
 				} else if setupTestSuite, ok := suite.(SetupParallelTestSuite); ok {
 					setupTestSuite.SetupTest(t)
 				}
+
 				if beforeTestSuite, ok := suite.(BeforeTest); ok {
+					if isParallel {
+						t.Errorf("%T implementations cannot contain parallel tests (e.g., %#q). See %T instead.", BeforeTest(nil), method.Name, BeforeParallelTest(nil))
+						t.FailNow()
+					}
+
 					beforeTestSuite.BeforeTest(methodFinder.Elem().Name(), method.Name)
 				} else if beforeTestSuite, ok := suite.(BeforeParallelTest); ok {
 					beforeTestSuite.BeforeTest(t, methodFinder.Elem().Name(), method.Name)

--- a/suite/suite_parallel_test.go
+++ b/suite/suite_parallel_test.go
@@ -15,13 +15,12 @@ import (
 
 type parallelSuiteData struct {
 	calls          []string
-	callsIndex     map[string]int
 	parallelSuiteT map[string]*testing.T
 }
 
 type parallelSuite struct {
 	suite.Suite
-	mutex *sync.Mutex
+	mutex sync.Mutex
 	data  *parallelSuiteData
 }
 
@@ -30,16 +29,14 @@ func (s *parallelSuite) recordCall(method string) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 	s.data.calls = append(s.data.calls, method)
-	s.data.callsIndex[method] = len(s.data.calls) - 1
 }
 
 func TestSuiteParallel(t *testing.T) {
 	data := parallelSuiteData{
 		calls:          []string{},
-		callsIndex:     make(map[string]int, 8),
-		parallelSuiteT: make(map[string]*testing.T, 2),
+		parallelSuiteT: map[string]*testing.T{},
 	}
-	s := &parallelSuite{mutex: &sync.Mutex{}, data: &data}
+	s := &parallelSuite{data: &data}
 	suite.Run(t, s)
 }
 

--- a/suite/suite_parallel_test.go
+++ b/suite/suite_parallel_test.go
@@ -1,0 +1,115 @@
+package suite_test
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type parallelSuiteData struct {
+	calls          []string
+	callsIndex     map[string]int
+	parallelSuiteT map[string]*testing.T
+}
+
+type parallelSuite struct {
+	suite.Suite
+	mutex *sync.Mutex
+	data  *parallelSuiteData
+}
+
+func (s *parallelSuite) recordCall(method string) {
+	time.Sleep(time.Duration(rand.Intn(300)) * time.Millisecond)
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	s.data.calls = append(s.data.calls, method)
+	s.data.callsIndex[method] = len(s.data.calls) - 1
+}
+
+func TestSuiteParallel(t *testing.T) {
+	data := parallelSuiteData{
+		calls:          []string{},
+		callsIndex:     make(map[string]int, 8),
+		parallelSuiteT: make(map[string]*testing.T, 2),
+	}
+	s := &parallelSuite{mutex: &sync.Mutex{}, data: &data}
+	suite.Run(t, s)
+}
+
+func (s *parallelSuite) SetupSuite() {
+	s.recordCall("SetupSuite")
+}
+
+func (s *parallelSuite) TearDownSuite() {
+	t := s.T()
+
+	s.recordCall("TearDownSuite")
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	testACalls := []string{}
+	testBCalls := []string{}
+	for _, call := range s.data.calls {
+		if strings.Contains(call, "Test_A") {
+			testACalls = append(testACalls, call)
+		} else if strings.Contains(call, "Test_B") {
+			testBCalls = append(testBCalls, call)
+		}
+	}
+	assert.Equal(
+		t,
+		[]string{
+			fmt.Sprintf("BeforeTest %s/parallel/ParallelTest_A ParallelTest_A", t.Name()),
+			"Test_A",
+			fmt.Sprintf("AfterTest %s/parallel/ParallelTest_A ParallelTest_A", t.Name()),
+		},
+		testACalls,
+	)
+	assert.Equal(
+		t,
+		[]string{
+			fmt.Sprintf("BeforeTest %s/parallel/ParallelTest_B ParallelTest_B", t.Name()),
+			"Test_B",
+			fmt.Sprintf("AfterTest %s/parallel/ParallelTest_B ParallelTest_B", t.Name()),
+		},
+		testBCalls,
+	)
+
+	require.NotEmpty(t, s.data.calls)
+
+	assert.Equal(t, "SetupSuite", s.data.calls[0])
+	assert.Equal(t, "TearDownSuite", s.data.calls[len(s.data.calls)-1])
+
+	assert.NotEqual(t, s, s.data.parallelSuiteT["Test_A"])
+	assert.NotEqual(t, s, s.data.parallelSuiteT["Test_B"])
+	assert.NotEqual(t, s.data.parallelSuiteT["Test_A"], s.data.parallelSuiteT["Test_B"])
+}
+
+func (s *parallelSuite) BeforeTest(t *testing.T, _, testName string) {
+	s.recordCall(fmt.Sprintf("BeforeTest %s %s", t.Name(), testName))
+}
+
+func (s *parallelSuite) AfterTest(t *testing.T, _, testName string) {
+	s.recordCall(fmt.Sprintf("AfterTest %s %s", t.Name(), testName))
+}
+
+func (s *parallelSuite) ParallelTest_A(t *testing.T) {
+	s.recordCall("Test_A")
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	s.data.parallelSuiteT["Test_A"] = t
+}
+
+func (s *parallelSuite) ParallelTest_B(t *testing.T) {
+	s.recordCall("Test_B")
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	s.data.parallelSuiteT["Test_B"] = t
+}


### PR DESCRIPTION
## Summary
Add “ParallelTest” methods that run in parallel.

## Changes
- Add `SetupParallelTestSuite`, `TearDownParalleltestSuite`, `BeforeParallelTest`, & `AfterParallelTest` interfaces that allow the relevant suite methods to accept a `*testing.T`.
- Teach Suite to recognize `ParallelTest*` methods and, if present, execute them after the other methods in a `parallel` subtest.

## Motivation
Issue #187 has vexed testify users for almost a decade. The library is too widely used for breaking changes such as PR #1109. This changeset proposes an alternative solution that preserves backward compatibility while allowing users to opt-in to the new functionality.

<!-- ## Example usage (if applicable) -->
See the new `suite_parallel_test.go` file (derived from PR #1109’s tests).

## Related issues
Closes #187.
