### PR TITLE
suite.Passed: add one more status test report

### DIFF
--- a/suite/stats_test.go
+++ b/suite/stats_test.go
@@ -27,3 +27,15 @@ func TestPassedReturnsFalseWhenSomeTestFails(t *testing.T) {
 
 	assert.False(t, sinfo.Passed())
 }
+
+func TestPassedReturnsFalseWhenAllTestsFail(t *testing.T) {
+	sinfo := newSuiteInformation()
+	sinfo.TestStats = map[string]*TestInformation{
+		"Test1": {TestName: "Test1", Passed: false},
+		"Test2": {TestName: "Test2", Passed: false},
+		"Test3": {TestName: "Test3", Passed: false},
+	}
+
+	assert.False(t, sinfo.Passed())
+}
+

--- a/suite/stats_test.go
+++ b/suite/stats_test.go
@@ -38,4 +38,3 @@ func TestPassedReturnsFalseWhenAllTestsFail(t *testing.T) {
 
 	assert.False(t, sinfo.Passed())
 }
-


### PR DESCRIPTION
## Summary
This test case verifies that the Passed method returns false when all tests in the suite fail

## Changes
Added a test case to check the scenario where all tests fail.

## Motivation
This test is important to ensure that the Passed method correctly identifies the overall failure state of a test suite when none of the individual tests pass.

 ## Example usage 
This test can be used as a part of the test suite to validate the behavior of the Passed method under failure conditions.

## Related issues
None
