### PR TITLE
chore: update docs for Unset #1621

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -208,9 +208,16 @@ func (c *Call) On(methodName string, arguments ...interface{}) *Call {
 	return c.Parent.On(methodName, arguments...)
 }
 
-// Unset removes a mock handler from being called.
+// Unset removes all mock handlers that satisfy the call instance arguments from being
+// called. Only supported on call instances with static input arguments.
 //
-//	test.On("func", mock.Anything).Unset()
+// For example, the only handler remaining after the following would be `2, 2`:
+//
+//	test.
+//	   On("func", 2, 2).Return(0).
+//	   On("func", 3, 3).Return(0).
+//	   On("func", Anything, Anything).Return(0)
+//	test.On("func", 3, 3).Unset()
 func (c *Call) Unset() *Call {
 	var unlockOnce sync.Once
 

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -211,13 +211,13 @@ func (c *Call) On(methodName string, arguments ...interface{}) *Call {
 // Unset removes all mock handlers that satisfy the call instance arguments from being
 // called. Only supported on call instances with static input arguments.
 //
-// For example, the only handler remaining after the following would be `2, 2`:
+// For example, the only handler remaining after the following would be "MyMethod(2, 2)":
 //
-//	test.
-//	   On("func", 2, 2).Return(0).
-//	   On("func", 3, 3).Return(0).
-//	   On("func", Anything, Anything).Return(0)
-//	test.On("func", 3, 3).Unset()
+//	Mock.
+//	   On("MyMethod", 2, 2).Return(0).
+//	   On("MyMethod", 3, 3).Return(0).
+//	   On("MyMethod", Anything, Anything).Return(0)
+//	Mock.On("MyMethod", 3, 3).Unset()
 func (c *Call) Unset() *Call {
 	var unlockOnce sync.Once
 


### PR DESCRIPTION
## Summary
Updates the docs to clarify how unset works.

## Changes
Doc update

## Motivation
Unset docs indicate "a" handler is removed when called when all handlers satisfying the arguments in the call unset is invoked on are removed.  This clarifies the behavior and provides a sample.  Also clarifies that Unset can only be called on static input arguments.

## Related issues
Closed #1621
