### PR TITLE
Document consequences of calling t.FailNow()

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -331,7 +331,8 @@ func (m *Mock) TestData() objx.Map {
 	Setting expectations
 */
 
-// Test sets the test struct variable of the mock object
+// Test sets the [TestingT] on which errors will be reported, otherwise errors
+// will cause a panic.
 // Test should not be called on an object that is going to be used in a
 // goroutine other than the one running the test function.
 func (m *Mock) Test(t TestingT) {

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -332,6 +332,8 @@ func (m *Mock) TestData() objx.Map {
 */
 
 // Test sets the test struct variable of the mock object
+// Test should not be called on an object that is going to be used in a
+// goroutine other than the one running the test function.
 func (m *Mock) Test(t TestingT) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()

--- a/require/doc.go
+++ b/require/doc.go
@@ -23,6 +23,8 @@
 //
 // The `require` package have same global functions as in the `assert` package,
 // but instead of returning a boolean result they call `t.FailNow()`.
+// A consequence of this is that it must be called from the goroutine running
+// the test function, not from other goroutines created during the test.
 //
 // Every assertion function also takes an optional string message as the final argument,
 // allowing custom error messages to be appended to the message the assertion method outputs.


### PR DESCRIPTION
## Summary

These comments are adapted from `t.FailNow()`'s own documentation.

## Changes

I added warnings on high-level APIs likely to be used by end users, and leading to `t.FailNow()` being called.

## Motivation

Such additional documentation can spare users headache in situations where ignoring the warnings would lead to test suites hanging forever

## Related issues

Closes #1701
