### PR TITLE
Propose Christophe Colombier (ccoVeille) as approver

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -14,3 +14,4 @@ The individuals listed below are active in the project and have the ability to a
 requests.
 
   * @arjunmahishi
+  * @ccoVeille

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,5 +6,11 @@ pull requests.
   * @boyan-soubachov
   * @dolmen
   * @MovieStoreGuy
-  * @arjunmahishi
   * @brackendawson
+
+## Approvers
+
+The individuals listed below are active in the project and have the ability to approve pull
+requests.
+
+  * @arjunmahishi


### PR DESCRIPTION
## Summary
I propose granting Christophe Colombier (@ccoVeille) approver on testify.

## Changes
* Correct the existing list of approvers.
* Add @ccoVeille as approver.

## Motivation
For the more than the last year I have seen consistent valuable contributions from @ccoVeille in issue triage, pull request reviews, and pointing me in the direction of unblocked work I can progress. I think he will make a great approver, and one day maintainer too.

## Related issues
<!-- Put `Closes #XXXX` for each issue number this PR fixes/closes -->
