### PR TITLE
fix: fix IsMethodCallable

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -714,28 +714,16 @@ func (m *Mock) AssertNotCalled(t TestingT, methodName string, arguments ...inter
 
 // IsMethodCallable checking that the method can be called
 // If the method was called more than `Repeatability` return false
-func (m *Mock) IsMethodCallable(t TestingT, methodName string, arguments ...interface{}) bool {
-	if h, ok := t.(tHelper); ok {
-		h.Helper()
-	}
+func (m *Mock) IsMethodCallable(methodName string, arguments ...interface{}) bool {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
-
-	for _, v := range m.ExpectedCalls {
-		if v.Method != methodName {
-			continue
-		}
-		if len(arguments) != len(v.Arguments) {
-			continue
-		}
-		if v.Repeatability < v.totalCalls {
-			continue
-		}
-		if isArgsEqual(v.Arguments, arguments) {
-			return true
-		}
+	index, _ := m.findExpectedCall(methodName, arguments...)
+	if index != -1 {
+		return true
 	}
-	return false
+
+	// return false if call was not expected
+	return m.methodWasCalled(methodName, arguments)
 }
 
 // isArgsEqual compares arguments

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -1712,22 +1712,15 @@ func Test_Mock_AssertNotCalled(t *testing.T) {
 }
 
 func Test_Mock_IsMethodCallable(t *testing.T) {
-	var mockedService = new(TestExampleImplementation)
+	mock := new(TestExampleImplementation)
 
-	arg := []Call{{Repeatability: 1}, {Repeatability: 2}}
-	arg2 := []Call{{Repeatability: 1}, {Repeatability: 1}}
-	arg3 := []Call{{Repeatability: 1}, {Repeatability: 1}}
+	// Case 1: Method is expected and has remaining repeatability
+	mock.Mock.ExpectedCalls = append(mock.Mock.ExpectedCalls, &Call{Method: "TestMethod", Repeatability: 1})
+	assert.True(t, mock.IsMethodCallable("TestMethod"), "TestArg")
 
-	mockedService.On("Test_Mock_IsMethodCallable", arg2).Return(true).Twice()
-
-	assert.False(t, mockedService.IsMethodCallable(t, "Test_Mock_IsMethodCallable", arg))
-	assert.True(t, mockedService.IsMethodCallable(t, "Test_Mock_IsMethodCallable", arg2))
-	assert.True(t, mockedService.IsMethodCallable(t, "Test_Mock_IsMethodCallable", arg3))
-
-	mockedService.MethodCalled("Test_Mock_IsMethodCallable", arg2)
-	mockedService.MethodCalled("Test_Mock_IsMethodCallable", arg2)
-
-	assert.False(t, mockedService.IsMethodCallable(t, "Test_Mock_IsMethodCallable", arg2))
+	// Case 2: Method is expected but has no repeatability left
+	mock.Mock.ExpectedCalls[0].Repeatability = -1
+	assert.False(t, mock.IsMethodCallable("TestMethod"), "TestArg")
 }
 
 func TestIsArgsEqual(t *testing.T) {


### PR DESCRIPTION
fixes method IsMethodCallable and respective unit test

## Summary
<!-- High-level, one sentence summary of what this PR accomplishes -->
fixes the method IsMethodCallable and respective unit test

## Changes
calling findExpectedCall to check if the call is expected, if Yes return true, otherwise return true and falsefor the cases if the provided method was called and not called respectively.
fix respective unit test

## Motivation
implementation of IsMethodCallable is not correct also the unit test is not written correctly

<!-- ## Example usage (if applicable) -->

## Related issues
Closes https://github.com/stretchr/testify/issues/1712
