### PR TITLE
assert.Contains: fix failure for byte slices

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -927,6 +927,26 @@ func containsElement(list interface{}, element interface{}) (ok, found bool) {
 		return true, false
 	}
 
+	if listKind == reflect.Slice {
+		elementValue := reflect.ValueOf(element)
+		if listType.Elem().Kind() == reflect.Uint8 {
+			if elementType, ok := element.(string); ok {
+				return true, bytes.Contains(listValue.Bytes(), []byte(elementType))
+			}
+			if elementType, ok := element.([]byte); ok {
+				return true, bytes.Contains(listValue.Bytes(), elementType)
+			}
+		}
+
+		if elementValue.Kind() == reflect.Slice {
+			for i := 0; i <= listValue.Len()-elementValue.Len(); i++ {
+				if ObjectsAreEqual(listValue.Slice(i, i+elementValue.Len()).Interface(), element) {
+					return true, true
+				}
+			}
+			return true, false
+		}
+	}
 	for i := 0; i < listValue.Len(); i++ {
 		if ObjectsAreEqual(listValue.Index(i).Interface(), element) {
 			return true, true

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -1217,6 +1217,7 @@ func Test_containsElement(t *testing.T) {
 
 	list1 := []string{"Foo", "Bar"}
 	list2 := []int{1, 2}
+	list3 := []byte(`Hello World Hello`)
 	simpleMap := map[interface{}]interface{}{"Foo": "Bar"}
 
 	ok, found := containsElement("Hello World", "World")
@@ -1248,6 +1249,14 @@ func Test_containsElement(t *testing.T) {
 	False(t, found)
 
 	ok, found = containsElement(list2, "1")
+	True(t, ok)
+	False(t, found)
+
+	ok, found = containsElement(list3, []byte(`World`))
+	True(t, ok)
+	True(t, found)
+
+	ok, found = containsElement(list3, []byte(`Foo`))
 	True(t, ok)
 	False(t, found)
 


### PR DESCRIPTION
## Summary
Fixes assertion failure when using assert.Contains on byte slices.

## Changes
1. Updated assertion logic to properly handle []byte.
2. Ensured assert.Contains correctly detects byte slice containment.
3. Added test cases to verify the fix.

## Motivation
The previous implementation caused false negatives when checking for byte slice containment with assert.Contains. This fix ensures proper handling and improves test reliability.

## Related issues
issue #1720