### PR TITLE
suite: fix panic if a WithStats suite skips a test early

### DIFF
--- a/suite/stats.go
+++ b/suite/stats.go
@@ -31,8 +31,14 @@ func (s SuiteInformation) start(testName string) {
 }
 
 func (s SuiteInformation) end(testName string, passed bool) {
-	s.TestStats[testName].End = time.Now()
-	s.TestStats[testName].Passed = passed
+	testStats, started := s.TestStats[testName]
+
+	if !started {
+		return
+	}
+
+	testStats.End = time.Now()
+	testStats.Passed = passed
 }
 
 func (s SuiteInformation) Passed() bool {

--- a/suite/suite.go
+++ b/suite/suite.go
@@ -166,15 +166,12 @@ func Run(t *testing.T, suite TestingSuite) {
 				parentT := suite.T()
 				suite.SetT(t)
 				defer recoverAndFailOnPanic(t)
-
-				var startedStats bool
-
 				defer func() {
 					t.Helper()
 
 					r := recover()
 
-					if startedStats {
+					if stats != nil {
 						passed := !t.Failed() && r == nil
 						stats.end(method.Name, passed)
 					}
@@ -194,14 +191,12 @@ func Run(t *testing.T, suite TestingSuite) {
 				if setupTestSuite, ok := suite.(SetupTestSuite); ok {
 					setupTestSuite.SetupTest()
 				}
-
 				if beforeTestSuite, ok := suite.(BeforeTest); ok {
 					beforeTestSuite.BeforeTest(methodFinder.Elem().Name(), method.Name)
 				}
 
 				if stats != nil {
 					stats.start(method.Name)
-					startedStats = true
 				}
 
 				method.Func.Call([]reflect.Value{reflect.ValueOf(suite)})

--- a/suite/suite.go
+++ b/suite/suite.go
@@ -166,12 +166,15 @@ func Run(t *testing.T, suite TestingSuite) {
 				parentT := suite.T()
 				suite.SetT(t)
 				defer recoverAndFailOnPanic(t)
+
+				var startedStats bool
+
 				defer func() {
 					t.Helper()
 
 					r := recover()
 
-					if stats != nil {
+					if startedStats {
 						passed := !t.Failed() && r == nil
 						stats.end(method.Name, passed)
 					}
@@ -191,12 +194,14 @@ func Run(t *testing.T, suite TestingSuite) {
 				if setupTestSuite, ok := suite.(SetupTestSuite); ok {
 					setupTestSuite.SetupTest()
 				}
+
 				if beforeTestSuite, ok := suite.(BeforeTest); ok {
 					beforeTestSuite.BeforeTest(methodFinder.Elem().Name(), method.Name)
 				}
 
 				if stats != nil {
 					stats.start(method.Name)
+					startedStats = true
 				}
 
 				method.Func.Call([]reflect.Value{reflect.ValueOf(suite)})

--- a/suite/suite_stats_and_skip_test.go
+++ b/suite/suite_stats_and_skip_test.go
@@ -1,0 +1,29 @@
+package suite
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mySuite struct {
+	Suite
+}
+
+func (s *mySuite) SetupTest() {
+	s.T().Skip("Just because!")
+}
+func (s *mySuite) HandleStats(_ string, _ *SuiteInformation) {}
+
+func (s *mySuite) TestSomething() {
+	panic("Should not get here.")
+}
+
+func TestSuiteWithStatsAndSkip(t *testing.T) {
+	assert.NotPanics(
+		t,
+		func() {
+			Run(t, &mySuite{})
+		},
+	)
+}


### PR DESCRIPTION
## Summary
This fixes issue #1722.

## Changes
Prevent stats.end() if stats.start() never ran.

## Motivation
Allow skipping a test in a setup/before hook. See issue #1722 for an example.

## Related issues
Closes #1722