### PR TITLE
Improve ErrorAs failure message when error is nil

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -2202,11 +2202,17 @@ func ErrorAs(t TestingT, err error, target interface{}, msgAndArgs ...interface{
 		return true
 	}
 
+	expectedText := reflect.ValueOf(target).Elem().Type().String()
+	if err == nil {
+		return Fail(t, fmt.Sprintf("An error is expected but got nil.\n"+
+			"expected: %s", expectedText), msgAndArgs...)
+	}
+
 	chain := buildErrorChainString(err, true)
 
 	return Fail(t, fmt.Sprintf("Should be in error chain:\n"+
 		"expected: %s\n"+
-		"in chain: %s", reflect.ValueOf(target).Elem().Type(), chain,
+		"in chain: %s", expectedText, chain,
 	), msgAndArgs...)
 }
 

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -3402,9 +3402,8 @@ func TestErrorAs(t *testing.T) {
 			err:    nil,
 			result: false,
 			resultErrMsg: "" +
-				"Should be in error chain:\n" +
-				"expected: *assert.customError\n" +
-				"in chain: \n",
+				"An error is expected but got nil.\n" +
+				`expected: *assert.customError` + "\n",
 		},
 		{
 			err:    fmt.Errorf("abc: %w", errors.New("def")),


### PR DESCRIPTION
## Summary

The following changes were made to improve the error messages

## Changes

Improve ErrorAs failure message when error is nil

Before:

```
    Should be in error chain:
    expected: *assert.customError
    in chain:
```

After:

```
    An error is expected but got nil.
    expected: *assert.customError
```

The message `An error is expected but got nil.` is the one already reported by `assert.Error`

## Motivation

This follows the changes that were made with #1681

- #1681

## Related issues

Closes #1733

- #1733
