### PR TITLE
Format assertions files with gofumpt

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -212,7 +212,6 @@ the problem actually occurred in calling code.*/
 // of each stack frame leading from the current test to the assert call that
 // failed.
 func CallerInfo() []string {
-
 	var pc uintptr
 	var file string
 	var line int
@@ -493,7 +492,6 @@ func Equal(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) 
 	}
 
 	return true
-
 }
 
 // validateEqualArgs checks whether provided arguments can be safely used in the
@@ -548,7 +546,7 @@ func NotSame(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}
 
 	same, ok := samePointers(expected, actual)
 	if !ok {
-		//fails when the arguments are not pointers
+		// fails when the arguments are not pointers
 		return !(Fail(t, "Both arguments must be pointers", msgAndArgs...))
 	}
 
@@ -567,7 +565,7 @@ func NotSame(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}
 func samePointers(first, second interface{}) (same bool, ok bool) {
 	firstPtr, secondPtr := reflect.ValueOf(first), reflect.ValueOf(second)
 	if firstPtr.Kind() != reflect.Ptr || secondPtr.Kind() != reflect.Ptr {
-		return false, false //not both are pointers
+		return false, false // not both are pointers
 	}
 
 	firstType, secondType := reflect.TypeOf(first), reflect.TypeOf(second)
@@ -628,7 +626,6 @@ func EqualValues(t TestingT, expected, actual interface{}, msgAndArgs ...interfa
 	}
 
 	return true
-
 }
 
 // EqualExportedValues asserts that the types of two objects are equal and their public
@@ -683,7 +680,6 @@ func Exactly(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}
 	}
 
 	return Equal(t, expected, actual, msgAndArgs...)
-
 }
 
 // NotNil asserts that the specified object is not nil.
@@ -733,7 +729,6 @@ func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
 
 // isEmpty gets whether the specified object is considered empty or not.
 func isEmpty(object interface{}) bool {
-
 	// get nil case out of the way
 	if object == nil {
 		return true
@@ -774,7 +769,6 @@ func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
 	}
 
 	return pass
-
 }
 
 // NotEmpty asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or either
@@ -793,7 +787,6 @@ func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
 	}
 
 	return pass
-
 }
 
 // getLen tries to get the length of an object.
@@ -837,7 +830,6 @@ func True(t TestingT, value bool, msgAndArgs ...interface{}) bool {
 	}
 
 	return true
-
 }
 
 // False asserts that the specified value is false.
@@ -852,7 +844,6 @@ func False(t TestingT, value bool, msgAndArgs ...interface{}) bool {
 	}
 
 	return true
-
 }
 
 // NotEqual asserts that the specified values are NOT equal.
@@ -875,7 +866,6 @@ func NotEqual(t TestingT, expected, actual interface{}, msgAndArgs ...interface{
 	}
 
 	return true
-
 }
 
 // NotEqualValues asserts that two objects are not equal even when converted to the same type
@@ -898,7 +888,6 @@ func NotEqualValues(t TestingT, expected, actual interface{}, msgAndArgs ...inte
 // return (true, false) if element was not found.
 // return (true, true) if element was found.
 func containsElement(list interface{}, element interface{}) (ok, found bool) {
-
 	listValue := reflect.ValueOf(list)
 	listType := reflect.TypeOf(list)
 	if listType == nil {
@@ -933,7 +922,6 @@ func containsElement(list interface{}, element interface{}) (ok, found bool) {
 		}
 	}
 	return true, false
-
 }
 
 // Contains asserts that the specified string, list(array, slice...) or map contains the
@@ -956,7 +944,6 @@ func Contains(t TestingT, s, contains interface{}, msgAndArgs ...interface{}) bo
 	}
 
 	return true
-
 }
 
 // NotContains asserts that the specified string, list(array, slice...) or map does NOT contain the
@@ -979,7 +966,6 @@ func NotContains(t TestingT, s, contains interface{}, msgAndArgs ...interface{})
 	}
 
 	return true
-
 }
 
 // Subset asserts that the list (array, slice, or map) contains all elements
@@ -1704,7 +1690,6 @@ func matchRegexp(rx interface{}, str interface{}) bool {
 	default:
 		return r.MatchString(fmt.Sprint(v))
 	}
-
 }
 
 // Regexp asserts that a specified regexp matches a string.
@@ -1740,7 +1725,6 @@ func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interf
 	}
 
 	return !match
-
 }
 
 // Zero asserts that i is the zero value for its type.

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -91,15 +91,13 @@ type AssertionTesterInterface interface {
 }
 
 // AssertionTesterConformingObject is an object that conforms to the AssertionTesterInterface interface
-type AssertionTesterConformingObject struct {
-}
+type AssertionTesterConformingObject struct{}
 
 func (a *AssertionTesterConformingObject) TestMethod() {
 }
 
 // AssertionTesterNonConformingObject is an object that does not conform to the AssertionTesterInterface interface
-type AssertionTesterNonConformingObject struct {
-}
+type AssertionTesterNonConformingObject struct{}
 
 func TestObjectsAreEqual(t *testing.T) {
 	cases := []struct {
@@ -132,7 +130,6 @@ func TestObjectsAreEqual(t *testing.T) {
 			if res != c.result {
 				t.Errorf("ObjectsAreEqual(%#v, %#v) should return %#v", c.expected, c.actual, c.result)
 			}
-
 		})
 	}
 }
@@ -208,7 +205,6 @@ type S6 struct {
 }
 
 func TestObjectsExportedFieldsAreEqual(t *testing.T) {
-
 	intValue := 1
 
 	cases := []struct {
@@ -277,7 +273,6 @@ func TestObjectsExportedFieldsAreEqual(t *testing.T) {
 			if res != c.result {
 				t.Errorf("ObjectsExportedFieldsAreEqual(%#v, %#v) should return %#v", c.expected, c.actual, c.result)
 			}
-
 		})
 	}
 }
@@ -328,11 +323,15 @@ func TestCopyExportedFields(t *testing.T) {
 			}},
 		},
 		{
-			input: S4{[]*Nested{
-				{1, 2}},
+			input: S4{
+				[]*Nested{
+					{1, 2},
+				},
 			},
-			expected: S4{[]*Nested{
-				{1, nil}},
+			expected: S4{
+				[]*Nested{
+					{1, nil},
+				},
 			},
 		},
 		{
@@ -516,11 +515,9 @@ func TestEqualExportedValues(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestImplements(t *testing.T) {
-
 	mockT := new(testing.T)
 
 	if !Implements(mockT, (*AssertionTesterInterface)(nil), new(AssertionTesterConformingObject)) {
@@ -532,11 +529,9 @@ func TestImplements(t *testing.T) {
 	if Implements(mockT, (*AssertionTesterInterface)(nil), nil) {
 		t.Error("Implements method should return false: nil does not implement AssertionTesterInterface")
 	}
-
 }
 
 func TestNotImplements(t *testing.T) {
-
 	mockT := new(testing.T)
 
 	if !NotImplements(mockT, (*AssertionTesterInterface)(nil), new(AssertionTesterNonConformingObject)) {
@@ -548,11 +543,9 @@ func TestNotImplements(t *testing.T) {
 	if NotImplements(mockT, (*AssertionTesterInterface)(nil), nil) {
 		t.Error("NotImplements method should return false: nil can't be checked to be implementing AssertionTesterInterface or not")
 	}
-
 }
 
 func TestIsType(t *testing.T) {
-
 	mockT := new(testing.T)
 
 	if !IsType(mockT, new(AssertionTesterConformingObject), new(AssertionTesterConformingObject)) {
@@ -561,7 +554,6 @@ func TestIsType(t *testing.T) {
 	if IsType(mockT, new(AssertionTesterConformingObject), new(AssertionTesterNonConformingObject)) {
 		t.Error("IsType should return false: AssertionTesterConformingObject is not the same type as AssertionTesterNonConformingObject")
 	}
-
 }
 
 func TestEqual(t *testing.T) {
@@ -610,7 +602,6 @@ func ptr(i int) *int {
 }
 
 func TestSame(t *testing.T) {
-
 	mockT := new(testing.T)
 
 	if Same(mockT, ptr(1), ptr(1)) {
@@ -629,7 +620,6 @@ func TestSame(t *testing.T) {
 }
 
 func TestNotSame(t *testing.T) {
-
 	mockT := new(testing.T)
 
 	if !NotSame(mockT, ptr(1), ptr(1)) {
@@ -814,7 +804,6 @@ func TestFormatUnequalValues(t *testing.T) {
 }
 
 func TestNotNil(t *testing.T) {
-
 	mockT := new(testing.T)
 
 	if !NotNil(mockT, new(AssertionTesterConformingObject)) {
@@ -826,11 +815,9 @@ func TestNotNil(t *testing.T) {
 	if NotNil(mockT, (*struct{})(nil)) {
 		t.Error("NotNil should return false: object is (*struct{})(nil)")
 	}
-
 }
 
 func TestNil(t *testing.T) {
-
 	mockT := new(testing.T)
 
 	if !Nil(mockT, nil) {
@@ -842,11 +829,9 @@ func TestNil(t *testing.T) {
 	if Nil(mockT, new(AssertionTesterConformingObject)) {
 		t.Error("Nil should return false: object is not nil")
 	}
-
 }
 
 func TestTrue(t *testing.T) {
-
 	mockT := new(testing.T)
 
 	if !True(mockT, true) {
@@ -855,11 +840,9 @@ func TestTrue(t *testing.T) {
 	if True(mockT, false) {
 		t.Error("True should return false")
 	}
-
 }
 
 func TestFalse(t *testing.T) {
-
 	mockT := new(testing.T)
 
 	if !False(mockT, false) {
@@ -868,11 +851,9 @@ func TestFalse(t *testing.T) {
 	if False(mockT, true) {
 		t.Error("False should return false")
 	}
-
 }
 
 func TestExactly(t *testing.T) {
-
 	mockT := new(testing.T)
 
 	a := float32(1)
@@ -903,7 +884,6 @@ func TestExactly(t *testing.T) {
 }
 
 func TestNotEqual(t *testing.T) {
-
 	mockT := new(testing.T)
 
 	cases := []struct {
@@ -986,7 +966,6 @@ func TestNotEqualValues(t *testing.T) {
 }
 
 func TestContainsNotContains(t *testing.T) {
-
 	type A struct {
 		Name, Value string
 	}
@@ -1169,7 +1148,6 @@ func TestSubsetNotSubset(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run("SubSet: "+c.message, func(t *testing.T) {
-
 			mockT := new(mockTestingT)
 			res := Subset(mockT, c.list, c.subset)
 
@@ -1216,7 +1194,6 @@ func TestNotSubsetNil(t *testing.T) {
 }
 
 func Test_containsElement(t *testing.T) {
-
 	list1 := []string{"Foo", "Bar"}
 	list2 := []int{1, 2}
 	simpleMap := map[interface{}]interface{}{"Foo": "Bar"}
@@ -1447,11 +1424,9 @@ func TestCondition(t *testing.T) {
 	if Condition(mockT, func() bool { return false }, "Lie") {
 		t.Error("Condition should return false")
 	}
-
 }
 
 func TestDidPanic(t *testing.T) {
-
 	const panicMsg = "Panic!"
 
 	if funcDidPanic, msg, _ := didPanic(func() {
@@ -1470,11 +1445,9 @@ func TestDidPanic(t *testing.T) {
 	}); funcDidPanic {
 		t.Error("didPanic should return false")
 	}
-
 }
 
 func TestPanics(t *testing.T) {
-
 	mockT := new(testing.T)
 
 	if !Panics(mockT, func() {
@@ -1487,11 +1460,9 @@ func TestPanics(t *testing.T) {
 	}) {
 		t.Error("Panics should return false")
 	}
-
 }
 
 func TestPanicsWithValue(t *testing.T) {
-
 	mockT := new(testing.T)
 
 	if !PanicsWithValue(mockT, "Panic!", func() {
@@ -1519,7 +1490,6 @@ func TestPanicsWithValue(t *testing.T) {
 }
 
 func TestPanicsWithError(t *testing.T) {
-
 	mockT := new(testing.T)
 
 	if !PanicsWithError(mockT, "panic", func() {
@@ -1547,7 +1517,6 @@ func TestPanicsWithError(t *testing.T) {
 }
 
 func TestNotPanics(t *testing.T) {
-
 	mockT := new(testing.T)
 
 	if !NotPanics(mockT, func() {
@@ -1560,11 +1529,9 @@ func TestNotPanics(t *testing.T) {
 	}) {
 		t.Error("NotPanics should return false")
 	}
-
 }
 
 func TestNoError(t *testing.T) {
-
 	mockT := new(testing.T)
 
 	// start with a nil error
@@ -1595,7 +1562,6 @@ type customError struct{}
 func (*customError) Error() string { return "fail" }
 
 func TestError(t *testing.T) {
-
 	mockT := new(testing.T)
 
 	// start with a nil error
@@ -1659,7 +1625,6 @@ func TestErrorContains(t *testing.T) {
 }
 
 func Test_isEmpty(t *testing.T) {
-
 	chWithValue := make(chan struct{}, 1)
 	chWithValue <- struct{}{}
 
@@ -1686,7 +1651,6 @@ func Test_isEmpty(t *testing.T) {
 }
 
 func TestEmpty(t *testing.T) {
-
 	mockT := new(testing.T)
 	chWithValue := make(chan struct{}, 1)
 	chWithValue <- struct{}{}
@@ -1731,7 +1695,6 @@ func TestEmpty(t *testing.T) {
 }
 
 func TestNotEmpty(t *testing.T) {
-
 	mockT := new(testing.T)
 	chWithValue := make(chan struct{}, 1)
 	chWithValue <- struct{}{}
@@ -1845,7 +1808,6 @@ func TestLen(t *testing.T) {
 }
 
 func TestWithinDuration(t *testing.T) {
-
 	mockT := new(testing.T)
 	a := time.Now()
 	b := a.Add(10 * time.Second)
@@ -1864,7 +1826,6 @@ func TestWithinDuration(t *testing.T) {
 }
 
 func TestWithinRange(t *testing.T) {
-
 	mockT := new(testing.T)
 	n := time.Now()
 	s := n.Add(-time.Second)
@@ -2071,7 +2032,6 @@ func TestInEpsilon(t *testing.T) {
 	for _, tc := range cases {
 		False(t, InEpsilon(mockT, tc.a, tc.b, tc.epsilon, "Expected %V and %V to have a relative difference of %v", tc.a, tc.b, tc.epsilon))
 	}
-
 }
 
 func TestInEpsilonSlice(t *testing.T) {
@@ -2673,8 +2633,7 @@ func TestFailNowWithPlainTestingT(t *testing.T) {
 	}, "should panic since mockT is missing FailNow()")
 }
 
-type mockFailNowTestingT struct {
-}
+type mockFailNowTestingT struct{}
 
 func (m *mockFailNowTestingT) Errorf(format string, args ...interface{}) {}
 
@@ -2689,7 +2648,7 @@ func TestFailNowWithFullTestingT(t *testing.T) {
 }
 
 func TestBytesEqual(t *testing.T) {
-	var cases = []struct {
+	cases := []struct {
 		a, b []byte
 	}{
 		{make([]byte, 2), make([]byte, 2)},
@@ -3154,7 +3113,6 @@ func Test_validateEqualArgs(t *testing.T) {
 }
 
 func Test_truncatingFormat(t *testing.T) {
-
 	original := strings.Repeat("a", bufio.MaxScanTokenSize-102)
 	result := truncatingFormat(original)
 	Equal(t, fmt.Sprintf("%#v", original), result, "string should not be truncated")


### PR DESCRIPTION
## Summary

Format assertions files with gofumpt

## Changes

None, except formatting.

## Motivation
<!-- Why were the changes necessary. -->
- Having a cleaner code base
- Be able to use gofumpt locally
<!-- ## Example usage (if applicable) -->

Replaces #1736 created with the wrong fork.

- #1736