### PR TITLE
Use the right method to get the expected error type

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -2202,17 +2202,17 @@ func ErrorAs(t TestingT, err error, target interface{}, msgAndArgs ...interface{
 		return true
 	}
 
-	expectedText := reflect.ValueOf(target).Elem().Type().String()
+	expectedType := reflect.TypeOf(target).Elem().String()
 	if err == nil {
 		return Fail(t, fmt.Sprintf("An error is expected but got nil.\n"+
-			"expected: %s", expectedText), msgAndArgs...)
+			"expected: %s", expectedType), msgAndArgs...)
 	}
 
 	chain := buildErrorChainString(err, true)
 
 	return Fail(t, fmt.Sprintf("Should be in error chain:\n"+
 		"expected: %s\n"+
-		"in chain: %s", expectedText, chain,
+		"in chain: %s", expectedType, chain,
 	), msgAndArgs...)
 }
 
@@ -2230,7 +2230,7 @@ func NotErrorAs(t TestingT, err error, target interface{}, msgAndArgs ...interfa
 
 	return Fail(t, fmt.Sprintf("Target error should not be in err chain:\n"+
 		"found: %s\n"+
-		"in chain: %s", reflect.ValueOf(target).Elem().Type(), chain,
+		"in chain: %s", reflect.TypeOf(target).Elem().String(), chain,
 	), msgAndArgs...)
 }
 


### PR DESCRIPTION
## Summary

The type can be requested directly without getting the value.

## Changes

Use the right method to get the expected error type.

## Motivation
<!-- Why were the changes necessary. -->

>Use `reflect.TypeOf(target).Elem().String()`

The following feedback was provided after the [previous PR](https://github.com/stretchr/testify/pull/1734) was merged.

_Originally posted by @dolmen in https://github.com/stretchr/testify/pull/1734#discussion_r2086158023_

<!-- ## Example usage (if applicable) -->

## Related issues

Related to:

- #1734
