### PR TITLE
Improve captureTestingT helper

### DIFF
--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -3241,10 +3241,71 @@ func (ctt *captureTestingT) checkResultAndErrMsg(t *testing.T, expectedRes, res 
 			if expectedErrMsg == content.content {
 				return
 			}
-			t.Errorf("Logged Error: %v", content.content)
+			t.Errorf("Logged Error:\n%v", escapeSpecialCharacters(content.content))
 		}
 	}
-	t.Errorf("Should log Error: %v", expectedErrMsg)
+	t.Errorf("Should log Error:\n%v", escapeSpecialCharacters(expectedErrMsg))
+}
+
+// escapeSpecialCharacters is an helper to spot differences in multiline strings
+func escapeSpecialCharacters(input string) string {
+	replacer := strings.NewReplacer(
+		"\t", "\\t",
+		"\r", "\\r",
+		"\n", "\\n\n", // newline are kept for readability
+	)
+	return replacer.Replace(input)
+}
+
+func Test_escapeSpecialCharacters(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "no special characters",
+			input:    "hello world",
+			expected: "hello world",
+		},
+
+		{
+			name:     "line ending with new lines",
+			input:    "hello world\n",
+			expected: `hello world\n` + "\n",
+		},
+
+		{
+			name: "multi-lines",
+			input: "" +
+				"hello world\n" +
+				"foo\n" +
+				"bar\n",
+			expected: `hello world\n` + "\n" +
+				`foo\n` + "\n" +
+				`bar\n` + "\n",
+		},
+		{
+			name: "complex cases",
+			input: "" +
+				"hello world\n" +
+				"\tfoo\n" +
+				"\rbar",
+			expected: "" +
+				`hello world\n` + "\n" +
+				`\tfoo\n` + "\n" +
+				`\rbar`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := escapeSpecialCharacters(test.input)
+			if actual != test.expected {
+				t.Errorf("expected %q, got %q", test.expected, actual)
+			}
+		})
+	}
 }
 
 func TestErrorIs(t *testing.T) {


### PR DESCRIPTION
## Summary
<!-- High-level, one sentence summary of what this PR accomplishes -->

A simple change to provide more explicit errors message when testing the code while refactoring asserters

## Changes
<!-- * Description of change 1 -->
<!-- * Description of change 2 -->
<!-- ... -->

This helper is used to capture the testing.TB interface, and compare
the log output with the expected output.

This is useful for testing and refactoring purposes.

This commit improves the helper by displaying:
- the captured and expected outputs on a newline.
- the special characters in the captured output, such as newlines and tabs.

Both help with readability.

Here is an example of the output before and after the change:

Before:

```
    assertions_test.go:3422: Logged Error: Should be in error chain
        expected: *assert.customError
        in chain: "EOF" (*errors.errorString)
    assertions_test.go:3422: Should log Error: Should be in error chain:
        expected: *assert.customError
        in chain: "EOF" (*errors.errorString)
```

After:

```
    assertions_test.go:3486: Logged Error:
        Should be in error chain\n
        expected: *assert.customError\n
        in chain: "EOF" (*errors.errorString)\n
    assertions_test.go:3486: Should log Error: Error:
        Should be in error chain:\n
        expected: *assert.customError\n
        in chain: "EOF" (*errors.errorString)
```

The new format helps to identify the differences:
- the missing colon after "Should be in error chain"
- the extra newline in the captured output

<!-- ## Example usage (if applicable) -->

## Motivation
<!-- Why were the changes necessary. -->

I spent 10 minutes on this change, because I lost 10 minutes in                                                                                                                      
finding the differences between the captured and expected output on a                                                                                                                     
refactoring I was doing.
                               
## Related issues
<!-- Put `Closes #XXXX` for each issue number this PR fixes/closes -->

Replaces: #1735  opened with the wrong fork