### PR TITLE
assert.Same/NotSame: improve usage of Sprintf

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -543,8 +543,9 @@ func Same(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) b
 	if !same {
 		// both are pointers but not the same type & pointing to the same address
 		return Fail(t, fmt.Sprintf("Not same: \n"+
-			"expected: %p %#v\n"+
-			"actual  : %p %#v", expected, expected, actual, actual), msgAndArgs...)
+			"expected: %p %#[1]v\n"+
+			"actual  : %p %#[2]v",
+			expected, actual), msgAndArgs...)
 	}
 
 	return true
@@ -569,8 +570,8 @@ func NotSame(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}
 
 	if same {
 		return Fail(t, fmt.Sprintf(
-			"Expected and actual point to the same object: %p %#v",
-			expected, expected), msgAndArgs...)
+			"Expected and actual point to the same object: %p %#[1]v",
+			expected), msgAndArgs...)
 	}
 	return true
 }


### PR DESCRIPTION
## Summary
Reuse variable indexes instead of duplicating them.

## Changes

Avoid using the same variable multiple times with [fmt.Sprintf](https://pkg.go.dev/fmt#hdr-Explicit_argument_indexes)

## Motivation
<!-- Why were the changes necessary. -->

> Use indexed formats like `%#[1]v` to remove parameter duplication (we should do that also in Same/NotSame code, but in a separate PR).
> _Originally posted by @dolmen in https://github.com/stretchr/testify/pull/1738#discussion_r2086147685_
            

<!-- ## Example usage (if applicable) -->

## Related issues
<!-- Put `Closes #XXXX` for each issue number this PR fixes/closes -->
