### PR TITLE
chore: improve tests for True and False asserters.

### DIFF
--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -852,10 +852,12 @@ func TestTrue(t *testing.T) {
 	if !True(mockT, true) {
 		t.Error("True should return true")
 	}
-	if True(mockT, false) {
-		t.Error("True should return false")
-	}
 
+	testedValue := false
+	mockCT := new(captureTestingT)
+	res := True(mockCT, testedValue)
+	expectedResult := false // we expect a failure
+	mockCT.checkResultAndErrMsg(t, expectedResult, res, "Should be true\n")
 }
 
 func TestFalse(t *testing.T) {
@@ -865,10 +867,12 @@ func TestFalse(t *testing.T) {
 	if !False(mockT, false) {
 		t.Error("False should return true")
 	}
-	if False(mockT, true) {
-		t.Error("False should return false")
-	}
 
+	testedValue := true
+	mockCT := new(captureTestingT)
+	res := False(mockCT, testedValue)
+	expectedResult := false // we expect a failure
+	mockCT.checkResultAndErrMsg(t, expectedResult, res, "Should be false\n")
 }
 
 func TestExactly(t *testing.T) {
@@ -2585,7 +2589,7 @@ Diff:
 @@ -1,2 +1,2 @@
 -(time.Time) 2020-09-24 00:00:00 +0000 UTC
 +(time.Time) 2020-09-25 00:00:00 +0000 UTC
- 
+
 `
 
 	actual = diff(


### PR DESCRIPTION
## Summary
We are now testing the failure messages for the assert package.

## Changes

Only the tests are updated, code is unchanged.

Using captureTestingT helper helps us to check:
- the result of the asserter 
- the error message reported by the asserter

Previously the tests were checking only the result of the asserter, but not the error message.

## Motivation

It allows us to make sure the error message reported are OK.

Here I'm limiting the scope to show how it could help us.

<!-- Why were the changes necessary. -->

<!-- ## Example usage (if applicable) -->

## Related issues

This is a proof of concept PR that follows up #1737 that was closed because:
- it was not using a fork
- there were a lot of changes to review.

- #1737
