### PR TITLE
CI: fix shebang in .ci.*.sh scripts

### DIFF
--- a/.ci.gofmt.sh
+++ b/.ci.gofmt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ -n "$(gofmt -l .)" ]; then
   echo "Go code is not formatted:"

--- a/.ci.gogenerate.sh
+++ b/.ci.gogenerate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # If GOMOD is defined we are running with Go Modules enabled, either
 # automatically or via the GO111MODULE=on environment variable. Codegen only

--- a/.ci.govet.sh
+++ b/.ci.govet.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/.ci.readme.fmt.sh
+++ b/.ci.readme.fmt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Verify that the code snippets in README.md are formatted.
 # The tool https://github.com/hougesen/mdsf is used.


### PR DESCRIPTION

## Summary
Fix shebang in .ci.*.sh scripts to ease running on platforms where bash is not in /bin/bash (ex: MacOS).