### PR TITLE
suite: add support for user-defined test filtering

### DIFF
--- a/suite/suite.go
+++ b/suite/suite.go
@@ -119,6 +119,12 @@ func (suite *Suite) Run(name string, subtest func()) bool {
 // Run takes a testing suite and runs all of the tests attached
 // to it.
 func Run(t *testing.T, suite TestingSuite) {
+	RunWithSkip(t, suite, func(_, _ string) bool { return false })
+}
+
+// RunWithSkip takes a testing suite and a skip function allowing
+// for extra filtering on tests to be run
+func RunWithSkip(t *testing.T, suite TestingSuite, skip func(string, string) bool) {
 	defer recoverAndFailOnPanic(t)
 
 	suite.SetT(t)
@@ -148,16 +154,8 @@ func Run(t *testing.T, suite TestingSuite) {
 			continue
 		}
 
-		if !suiteSetupDone {
-			if stats != nil {
-				stats.Start = time.Now()
-			}
-
-			if setupAllSuite, ok := suite.(SetupAllSuite); ok {
-				setupAllSuite.SetupSuite()
-			}
-
-			suiteSetupDone = true
+		if skip(suiteName, method.Name) {
+			continue
 		}
 
 		test := testing.InternalTest{
@@ -204,6 +202,19 @@ func Run(t *testing.T, suite TestingSuite) {
 		}
 		tests = append(tests, test)
 	}
+
+	if len(tests) > 0 {
+		if stats != nil {
+			stats.Start = time.Now()
+		}
+
+		if setupAllSuite, ok := suite.(SetupAllSuite); ok {
+			setupAllSuite.SetupSuite()
+		}
+
+		suiteSetupDone = true
+	}
+
 	if suiteSetupDone {
 		defer func() {
 			if tearDownAllSuite, ok := suite.(TearDownAllSuite); ok {

--- a/suite/suite_test.go
+++ b/suite/suite_test.go
@@ -746,3 +746,169 @@ func TestUnInitializedSuites(t *testing.T) {
 		})
 	})
 }
+
+var register = map[string]bool{"SuiteTesterTestTwo": true}
+
+func skip(suiteName, testName string) bool {
+	return register[suiteName+testName]
+}
+
+// TestRunSuiteWithSkip will be run by the 'go test' command, so within it, we
+// can run our suite using the Run(*testing.T, TestingSuite) function.
+func TestRunSuiteWithSkip(t *testing.T) {
+	suiteTester := new(SuiteTester)
+	RunWithSkip(t, suiteTester, skip)
+
+	// Normally, the test would end here.  The following are simply
+	// some assertions to ensure that the Run function is working as
+	// intended - they are not part of the example.
+
+	// The suite was only run once, so the SetupSuite and TearDownSuite
+	// methods should have each been run only once.
+	assert.Equal(t, 1, suiteTester.SetupSuiteRunCount)
+	assert.Equal(t, 1, suiteTester.TearDownSuiteRunCount)
+
+	assert.Len(t, suiteTester.SuiteNameAfter, 3)
+	assert.Len(t, suiteTester.SuiteNameBefore, 3)
+	assert.Len(t, suiteTester.TestNameAfter, 3)
+	assert.Len(t, suiteTester.TestNameBefore, 3)
+
+	assert.Contains(t, suiteTester.TestNameAfter, "TestOne")
+	assert.NotContains(t, suiteTester.TestNameAfter, "TestTwo")
+	assert.Contains(t, suiteTester.TestNameAfter, "TestSkip")
+	assert.Contains(t, suiteTester.TestNameAfter, "TestSubtest")
+
+	assert.Contains(t, suiteTester.TestNameBefore, "TestOne")
+	assert.NotContains(t, suiteTester.TestNameBefore, "TestTwo")
+	assert.Contains(t, suiteTester.TestNameBefore, "TestSkip")
+	assert.Contains(t, suiteTester.TestNameBefore, "TestSubtest")
+
+	assert.Contains(t, suiteTester.SetupSubTestNames, "TestRunSuiteWithSkip/TestSubtest/first")
+	assert.Contains(t, suiteTester.SetupSubTestNames, "TestRunSuiteWithSkip/TestSubtest/second")
+
+	assert.Contains(t, suiteTester.TearDownSubTestNames, "TestRunSuiteWithSkip/TestSubtest/first")
+	assert.Contains(t, suiteTester.TearDownSubTestNames, "TestRunSuiteWithSkip/TestSubtest/second")
+
+	for _, suiteName := range suiteTester.SuiteNameAfter {
+		assert.Equal(t, "SuiteTester", suiteName)
+	}
+
+	for _, suiteName := range suiteTester.SuiteNameBefore {
+		assert.Equal(t, "SuiteTester", suiteName)
+	}
+
+	for _, when := range suiteTester.TimeAfter {
+		assert.False(t, when.IsZero())
+	}
+
+	for _, when := range suiteTester.TimeBefore {
+		assert.False(t, when.IsZero())
+	}
+
+	// There are four test methods (TestOne, TestTwo, TestSkip, and TestSubtest), so
+	// the SetupTest and TearDownTest methods (which should be run once for
+	// each test) should have been run four times.
+	assert.Equal(t, 3, suiteTester.SetupTestRunCount)
+	assert.Equal(t, 3, suiteTester.TearDownTestRunCount)
+
+	// Each test should have been run once.
+	assert.Equal(t, 1, suiteTester.TestOneRunCount)
+	assert.Equal(t, 0, suiteTester.TestTwoRunCount)
+	assert.Equal(t, 1, suiteTester.TestSubtestRunCount)
+
+	assert.Equal(t, 2, suiteTester.TearDownSubTestRunCount)
+	assert.Equal(t, 2, suiteTester.SetupSubTestRunCount)
+
+	// Methods that don't match the test method identifier shouldn't
+	// have been run at all.
+	assert.Equal(t, 0, suiteTester.NonTestMethodRunCount)
+
+	suiteSkipTester := new(SuiteSkipTester)
+	Run(t, suiteSkipTester)
+
+	// The suite was only run once, so the SetupSuite and TearDownSuite
+	// methods should have each been run only once, even though SetupSuite
+	// called Skip()
+	assert.Equal(t, 1, suiteSkipTester.SetupSuiteRunCount)
+	assert.Equal(t, 1, suiteSkipTester.TearDownSuiteRunCount)
+
+}
+
+// TestRunSuiteWithSkip will be run by the 'go test' command, so within it, we
+// can run our suite using the Run(*testing.T, TestingSuite) function.
+func TestRunSuiteWithSkipAll(t *testing.T) {
+	suiteTester := new(SuiteTester)
+	RunWithSkip(t, suiteTester, func(_, _ string) bool { return true })
+
+	// Normally, the test would end here.  The following are simply
+	// some assertions to ensure that the Run function is working as
+	// intended - they are not part of the example.
+
+	// The suite was only run once, so the SetupSuite and TearDownSuite
+	// methods should have each been run only once.
+	assert.Equal(t, 0, suiteTester.SetupSuiteRunCount)
+	assert.Equal(t, 0, suiteTester.TearDownSuiteRunCount)
+
+	assert.Len(t, suiteTester.SuiteNameAfter, 0)
+	assert.Len(t, suiteTester.SuiteNameBefore, 0)
+	assert.Len(t, suiteTester.TestNameAfter, 0)
+	assert.Len(t, suiteTester.TestNameBefore, 0)
+
+	assert.NotContains(t, suiteTester.TestNameAfter, "TestOne")
+	assert.NotContains(t, suiteTester.TestNameAfter, "TestTwo")
+	assert.NotContains(t, suiteTester.TestNameAfter, "TestSkip")
+	assert.NotContains(t, suiteTester.TestNameAfter, "TestSubtest")
+
+	assert.NotContains(t, suiteTester.TestNameBefore, "TestOne")
+	assert.NotContains(t, suiteTester.TestNameBefore, "TestTwo")
+	assert.NotContains(t, suiteTester.TestNameBefore, "TestSkip")
+	assert.NotContains(t, suiteTester.TestNameBefore, "TestSubtest")
+
+	assert.NotContains(t, suiteTester.SetupSubTestNames, "TestRunSuiteWithSkipAll/TestSubtest/first")
+	assert.NotContains(t, suiteTester.SetupSubTestNames, "TestRunSuiteWithSkipAll/TestSubtest/second")
+
+	assert.NotContains(t, suiteTester.TearDownSubTestNames, "TestRunSuiteWithSkipAll/TestSubtest/first")
+	assert.NotContains(t, suiteTester.TearDownSubTestNames, "TestRunSuiteWithSkipAll/TestSubtest/second")
+
+	for _, suiteName := range suiteTester.SuiteNameAfter {
+		assert.Equal(t, "SuiteTester", suiteName)
+	}
+
+	for _, suiteName := range suiteTester.SuiteNameBefore {
+		assert.Equal(t, "SuiteTester", suiteName)
+	}
+
+	for _, when := range suiteTester.TimeAfter {
+		assert.False(t, when.IsZero())
+	}
+
+	for _, when := range suiteTester.TimeBefore {
+		assert.False(t, when.IsZero())
+	}
+
+	// There are four test methods (TestOne, TestTwo, TestSkip, and TestSubtest), so
+	// the SetupTest and TearDownTest methods (which should be run once for
+	// each test) should have been run four times.
+	assert.Equal(t, 0, suiteTester.SetupTestRunCount)
+	assert.Equal(t, 0, suiteTester.TearDownTestRunCount)
+
+	// Each test should have been run once.
+	assert.Equal(t, 0, suiteTester.TestOneRunCount)
+	assert.Equal(t, 0, suiteTester.TestTwoRunCount)
+	assert.Equal(t, 0, suiteTester.TestSubtestRunCount)
+
+	assert.Equal(t, 0, suiteTester.TearDownSubTestRunCount)
+	assert.Equal(t, 0, suiteTester.SetupSubTestRunCount)
+
+	// Methods that don't match the test method identifier shouldn't
+	// have been run at all.
+	assert.Equal(t, 0, suiteTester.NonTestMethodRunCount)
+
+	suiteSkipTester := new(SuiteSkipTester)
+	Run(t, suiteSkipTester)
+
+	// All tests were skipped via skip function, so Setup/TearDownSuite should not run
+	assert.Equal(t, 0, suiteSkipTester.SetupSuiteRunCount)
+	assert.Equal(t, 0, suiteSkipTester.TearDownSuiteRunCount)
+
+}


### PR DESCRIPTION
## Summary
Adds support for users to provide extra filtering on which tests to run.

## Changes 
A new Exported function was needed in the suite package to support this. 
```
func RunWithSkip(t *testing.T, suite TestingSuite, skip func(string, string) bool)
```
This function is the same as the existing Run function with an extra call to the skip function passed by the user.
I now let the `Run` function call this one. 

Another change was to move the running of the SetupSuite to outside the iteration of the (test) methods.
This is to avoid it running unnecessarily when you try to run a specific test that is filtered out but others aren't.
e.g: \
`go test MySuite/MyTest `
Let say `MyTest` is skipped by the skip function. The iteration over  `methodFinder.NumMethod()` will still go over the other tests of the suite which are possibly not skipped and will run the SetupSuite. However, because you only specified MyTest, they won't run either. Now the SetupSuite (and Teardown) is executed unnecessarily. 

##  Motivation
The main motivation of this change is to allow for test registration. This allows tests to be skipped, as defined by the user, without repeatedly running the Setup/TeardownTest repeatedly for skipped tests.







