### PR TITLE
suite: add support for -testify.c

### DIFF
--- a/suite/suite.go
+++ b/suite/suite.go
@@ -17,6 +17,7 @@ import (
 
 var allTestsFilter = func(_, _ string) (bool, error) { return true, nil }
 var matchMethod = flag.String("testify.m", "", "regular expression to select tests of the testify suite to run")
+var repeatItem = flag.Uint("testify.c", 1, "used to repeat each test multiple times without rerunning Setup/TearDownSuite")
 
 // Suite is a basic testing suite with methods for storing and
 // retrieving the current *testing.T context.
@@ -202,7 +203,10 @@ func Run(t *testing.T, suite TestingSuite) {
 				method.Func.Call([]reflect.Value{reflect.ValueOf(suite)})
 			},
 		}
-		tests = append(tests, test)
+
+		for i := uint(0); i < *repeatItem; i++ {
+			tests = append(tests, test)
+		}
 	}
 	if suiteSetupDone {
 		defer func() {


### PR DESCRIPTION
## Summary
Add testify's own "count" argument `-testify.c` to run tests multiple times without rerunning Setup/TeardownSuite

## Changes
I've added a new (uint) `flag` to the top of `suite/suite.go`.
And I add the same InternalTest object that is created multiple times to the `tests` slice. 


## Motivation
The first change allows tests to be repeated multiple times.  Using  go test's `-count` option results in the Setup/TeardownSuite also running multiple times. This is especially valuable when you have a SetupSuite that takes a long time.

