### PR TITLE
assert.JSONEq: shortcut if same strings

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1853,6 +1853,11 @@ func JSONEq(t TestingT, expected string, actual string, msgAndArgs ...interface{
 		return Fail(t, fmt.Sprintf("Expected value ('%s') is not valid json.\nJSON parsing error: '%s'", expected, err.Error()), msgAndArgs...)
 	}
 
+	// Shortcut if same bytes
+	if actual == expected {
+		return true
+	}
+
 	if err := json.Unmarshal([]byte(actual), &actualJSONAsInterface); err != nil {
 		return Fail(t, fmt.Sprintf("Input ('%s') needs to be valid json.\nJSON parsing error: '%s'", actual, err.Error()), msgAndArgs...)
 	}


### PR DESCRIPTION
## Summary

Shortcut in `assert.JSONEq` once we have validated that 'expected' is valid JSON, and 'actual' is the exact same string.

## Changes
* add shortcut in `JSONEq`

## Motivation

Faster check for the very common case where the test succeeds because the strings are equal.

## Related issues
<!-- Put `Closes #XXXX` for each issue number this PR fixes/closes -->
#1755 same, but for YAMLEq