### PR TITLE
assert.YAMLEq: shortcut if same strings

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1876,6 +1876,11 @@ func YAMLEq(t TestingT, expected string, actual string, msgAndArgs ...interface{
 		return Fail(t, fmt.Sprintf("Expected value ('%s') is not valid yaml.\nYAML parsing error: '%s'", expected, err.Error()), msgAndArgs...)
 	}
 
+	// Shortcut if same bytes
+	if actual == expected {
+		return true
+	}
+
 	if err := yaml.Unmarshal([]byte(actual), &actualYAMLAsInterface); err != nil {
 		return Fail(t, fmt.Sprintf("Input ('%s') needs to be valid yaml.\nYAML error: '%s'", actual, err.Error()), msgAndArgs...)
 	}


### PR DESCRIPTION
## Summary

Shortcut in `assert.YAMLEq` once we have validated that 'expected' is valid JSON, and 'actual' is the exact same string.

## Changes
* add shortcut in `YAMLEq`

## Motivation

Faster check for the very common case where the test succeeds because the strings are equal.

## Related issues
<!-- Put `Closes #XXXX` for each issue number this PR fixes/closes -->
#1754 same, but for JSONEq