### PR TITLE
mock: enable parallel testing on internal testsuite

### DIFF
--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -163,6 +163,7 @@ func (m *MockTestingT) FailNow() {
 */
 
 func Test_Mock_TestData(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -174,6 +175,7 @@ func Test_Mock_TestData(t *testing.T) {
 }
 
 func Test_Mock_On(t *testing.T) {
+	t.Parallel()
 
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
@@ -184,6 +186,8 @@ func Test_Mock_On(t *testing.T) {
 }
 
 func Test_Mock_Chained_On(t *testing.T) {
+	t.Parallel()
+
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
 
@@ -215,6 +219,7 @@ func Test_Mock_Chained_On(t *testing.T) {
 }
 
 func Test_Mock_On_WithArgs(t *testing.T) {
+	t.Parallel()
 
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
@@ -227,6 +232,7 @@ func Test_Mock_On_WithArgs(t *testing.T) {
 }
 
 func Test_Mock_On_WithFuncArg(t *testing.T) {
+	t.Parallel()
 
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
@@ -248,6 +254,8 @@ func Test_Mock_On_WithFuncArg(t *testing.T) {
 }
 
 func Test_Mock_On_WithIntArgMatcher(t *testing.T) {
+	t.Parallel()
+
 	var mockedService TestExampleImplementation
 
 	mockedService.On("TheExampleMethod",
@@ -271,6 +279,8 @@ func Test_Mock_On_WithIntArgMatcher(t *testing.T) {
 }
 
 func Test_Mock_On_WithArgMatcherThatPanics(t *testing.T) {
+	t.Parallel()
+
 	var mockedService TestExampleImplementation
 
 	mockedService.On("TheExampleMethod2", MatchedBy(func(_ interface{}) bool {
@@ -297,6 +307,8 @@ func Test_Mock_On_WithArgMatcherThatPanics(t *testing.T) {
 }
 
 func TestMock_WithTest(t *testing.T) {
+	t.Parallel()
+
 	var (
 		mockedService TestExampleImplementation
 		mockedTest    MockTestingT
@@ -325,6 +337,8 @@ func TestMock_WithTest(t *testing.T) {
 }
 
 func Test_Mock_On_WithPtrArgMatcher(t *testing.T) {
+	t.Parallel()
+
 	var mockedService TestExampleImplementation
 
 	mockedService.On("TheExampleMethod3",
@@ -345,6 +359,8 @@ func Test_Mock_On_WithPtrArgMatcher(t *testing.T) {
 }
 
 func Test_Mock_On_WithFuncArgMatcher(t *testing.T) {
+	t.Parallel()
+
 	var mockedService TestExampleImplementation
 
 	fixture1, fixture2 := errors.New("fixture1"), errors.New("fixture2")
@@ -369,6 +385,8 @@ func Test_Mock_On_WithFuncArgMatcher(t *testing.T) {
 }
 
 func Test_Mock_On_WithInterfaceArgMatcher(t *testing.T) {
+	t.Parallel()
+
 	var mockedService TestExampleImplementation
 
 	mockedService.On("TheExampleMethod4",
@@ -379,6 +397,8 @@ func Test_Mock_On_WithInterfaceArgMatcher(t *testing.T) {
 }
 
 func Test_Mock_On_WithChannelArgMatcher(t *testing.T) {
+	t.Parallel()
+
 	var mockedService TestExampleImplementation
 
 	mockedService.On("TheExampleMethod5",
@@ -389,6 +409,8 @@ func Test_Mock_On_WithChannelArgMatcher(t *testing.T) {
 }
 
 func Test_Mock_On_WithMapArgMatcher(t *testing.T) {
+	t.Parallel()
+
 	var mockedService TestExampleImplementation
 
 	mockedService.On("TheExampleMethod6",
@@ -399,6 +421,8 @@ func Test_Mock_On_WithMapArgMatcher(t *testing.T) {
 }
 
 func Test_Mock_On_WithSliceArgMatcher(t *testing.T) {
+	t.Parallel()
+
 	var mockedService TestExampleImplementation
 
 	mockedService.On("TheExampleMethod7",
@@ -409,6 +433,7 @@ func Test_Mock_On_WithSliceArgMatcher(t *testing.T) {
 }
 
 func Test_Mock_On_WithVariadicFunc(t *testing.T) {
+	t.Parallel()
 
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
@@ -431,6 +456,7 @@ func Test_Mock_On_WithVariadicFunc(t *testing.T) {
 }
 
 func Test_Mock_On_WithMixedVariadicFunc(t *testing.T) {
+	t.Parallel()
 
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
@@ -454,6 +480,7 @@ func Test_Mock_On_WithMixedVariadicFunc(t *testing.T) {
 }
 
 func Test_Mock_On_WithVariadicFuncWithInterface(t *testing.T) {
+	t.Parallel()
 
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
@@ -475,6 +502,7 @@ func Test_Mock_On_WithVariadicFuncWithInterface(t *testing.T) {
 }
 
 func Test_Mock_On_WithVariadicFuncWithEmptyInterfaceArray(t *testing.T) {
+	t.Parallel()
 
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
@@ -498,6 +526,8 @@ func Test_Mock_On_WithVariadicFuncWithEmptyInterfaceArray(t *testing.T) {
 }
 
 func Test_Mock_On_WithFuncPanics(t *testing.T) {
+	t.Parallel()
+
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
 
@@ -507,6 +537,7 @@ func Test_Mock_On_WithFuncPanics(t *testing.T) {
 }
 
 func Test_Mock_On_WithFuncTypeArg(t *testing.T) {
+	t.Parallel()
 
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
@@ -526,6 +557,8 @@ func Test_Mock_On_WithFuncTypeArg(t *testing.T) {
 }
 
 func Test_Mock_Unset(t *testing.T) {
+	t.Parallel()
+
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
 
@@ -554,6 +587,8 @@ func Test_Mock_Unset(t *testing.T) {
 // Since every time you call On it creates a new object
 // the last time you call Unset it will only unset the last call
 func Test_Mock_Chained_UnsetOnlyUnsetsLastCall(t *testing.T) {
+	t.Parallel()
+
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
 
@@ -588,6 +623,8 @@ func Test_Mock_Chained_UnsetOnlyUnsetsLastCall(t *testing.T) {
 }
 
 func Test_Mock_UnsetIfAlreadyUnsetFails(t *testing.T) {
+	t.Parallel()
+
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
 
@@ -607,6 +644,8 @@ func Test_Mock_UnsetIfAlreadyUnsetFails(t *testing.T) {
 }
 
 func Test_Mock_UnsetByOnMethodSpec(t *testing.T) {
+	t.Parallel()
+
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
 
@@ -628,6 +667,8 @@ func Test_Mock_UnsetByOnMethodSpec(t *testing.T) {
 }
 
 func Test_Mock_UnsetByOnMethodSpecAmongOthers(t *testing.T) {
+	t.Parallel()
+
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
 
@@ -670,6 +711,8 @@ func Test_Mock_UnsetByOnMethodSpecAmongOthers(t *testing.T) {
 }
 
 func Test_Mock_Unset_WithFuncPanics(t *testing.T) {
+	t.Parallel()
+
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
 	mock1 := mockedService.On("TheExampleMethod", 1)
@@ -681,6 +724,7 @@ func Test_Mock_Unset_WithFuncPanics(t *testing.T) {
 }
 
 func Test_Mock_Return(t *testing.T) {
+	t.Parallel()
 
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
@@ -705,6 +749,7 @@ func Test_Mock_Return(t *testing.T) {
 }
 
 func Test_Mock_Panic(t *testing.T) {
+	t.Parallel()
 
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
@@ -728,6 +773,7 @@ func Test_Mock_Panic(t *testing.T) {
 }
 
 func Test_Mock_Return_WaitUntil(t *testing.T) {
+	t.Parallel()
 
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
@@ -755,6 +801,7 @@ func Test_Mock_Return_WaitUntil(t *testing.T) {
 }
 
 func Test_Mock_Return_After(t *testing.T) {
+	t.Parallel()
 
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
@@ -781,6 +828,7 @@ func Test_Mock_Return_After(t *testing.T) {
 }
 
 func Test_Mock_Return_Run(t *testing.T) {
+	t.Parallel()
 
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
@@ -813,6 +861,8 @@ func Test_Mock_Return_Run(t *testing.T) {
 }
 
 func Test_Mock_Return_Run_Out_Of_Order(t *testing.T) {
+	t.Parallel()
+
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
 	f := func(args Arguments) {
@@ -838,6 +888,7 @@ func Test_Mock_Return_Run_Out_Of_Order(t *testing.T) {
 }
 
 func Test_Mock_Return_Once(t *testing.T) {
+	t.Parallel()
 
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
@@ -862,6 +913,7 @@ func Test_Mock_Return_Once(t *testing.T) {
 }
 
 func Test_Mock_Return_Twice(t *testing.T) {
+	t.Parallel()
 
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
@@ -887,6 +939,7 @@ func Test_Mock_Return_Twice(t *testing.T) {
 }
 
 func Test_Mock_Return_Times(t *testing.T) {
+	t.Parallel()
 
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
@@ -912,6 +965,7 @@ func Test_Mock_Return_Times(t *testing.T) {
 }
 
 func Test_Mock_Return_Nothing(t *testing.T) {
+	t.Parallel()
 
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
@@ -932,6 +986,8 @@ func Test_Mock_Return_Nothing(t *testing.T) {
 }
 
 func Test_Mock_Return_NotBefore_In_Order(t *testing.T) {
+	t.Parallel()
+
 	var mockedService = new(TestExampleImplementation)
 
 	b := mockedService.
@@ -952,6 +1008,8 @@ func Test_Mock_Return_NotBefore_In_Order(t *testing.T) {
 }
 
 func Test_Mock_Return_InOrder_Uses_NotBefore(t *testing.T) {
+	t.Parallel()
+
 	var mockedService = new(TestExampleImplementation)
 
 	InOrder(
@@ -972,6 +1030,8 @@ func Test_Mock_Return_InOrder_Uses_NotBefore(t *testing.T) {
 }
 
 func Test_Mock_Return_NotBefore_Out_Of_Order(t *testing.T) {
+	t.Parallel()
+
 	var mockedService = new(TestExampleImplementation)
 
 	b := mockedService.
@@ -1002,6 +1062,8 @@ TheExampleMethod(int,int,int)
 }
 
 func Test_Mock_Return_InOrder_Uses_NotBefore_Out_Of_Order(t *testing.T) {
+	t.Parallel()
+
 	var mockedService = new(TestExampleImplementation)
 
 	InOrder(
@@ -1031,6 +1093,8 @@ TheExampleMethod(int,int,int)
 }
 
 func Test_Mock_Return_NotBefore_Not_Enough_Times(t *testing.T) {
+	t.Parallel()
+
 	var mockedService = new(TestExampleImplementation)
 
 	b := mockedService.
@@ -1064,6 +1128,8 @@ TheExampleMethod(int,int,int)
 }
 
 func Test_Mock_Return_NotBefore_Different_Mock_In_Order(t *testing.T) {
+	t.Parallel()
+
 	var (
 		mockedService1 = new(TestExampleImplementation)
 		mockedService2 = new(TestExampleImplementation)
@@ -1087,6 +1153,8 @@ func Test_Mock_Return_NotBefore_Different_Mock_In_Order(t *testing.T) {
 }
 
 func Test_Mock_Return_NotBefore_Different_Mock_Out_Of_Order(t *testing.T) {
+	t.Parallel()
+
 	var (
 		mockedService1 = new(TestExampleImplementation)
 		mockedService2 = new(TestExampleImplementation)
@@ -1120,6 +1188,8 @@ TheExampleMethod(int,int,int)
 }
 
 func Test_Mock_Return_NotBefore_In_Order_With_Non_Dependant(t *testing.T) {
+	t.Parallel()
+
 	var mockedService = new(TestExampleImplementation)
 
 	a := mockedService.
@@ -1160,6 +1230,8 @@ func Test_Mock_Return_NotBefore_In_Order_With_Non_Dependant(t *testing.T) {
 }
 
 func Test_Mock_Return_NotBefore_Orphan_Call(t *testing.T) {
+	t.Parallel()
+
 	var mockedService = new(TestExampleImplementation)
 
 	require.PanicsWithValue(t, "not before calls must be created with Mock.On()", func() {
@@ -1171,6 +1243,7 @@ func Test_Mock_Return_NotBefore_Orphan_Call(t *testing.T) {
 }
 
 func Test_Mock_findExpectedCall(t *testing.T) {
+	t.Parallel()
 
 	m := new(Mock)
 	m.On("One", 1).Return("one")
@@ -1190,6 +1263,7 @@ func Test_Mock_findExpectedCall(t *testing.T) {
 }
 
 func Test_Mock_findExpectedCall_For_Unknown_Method(t *testing.T) {
+	t.Parallel()
 
 	m := new(Mock)
 	m.On("One", 1).Return("one")
@@ -1203,6 +1277,7 @@ func Test_Mock_findExpectedCall_For_Unknown_Method(t *testing.T) {
 }
 
 func Test_Mock_findExpectedCall_Respects_Repeatability(t *testing.T) {
+	t.Parallel()
 
 	m := new(Mock)
 	m.On("One", 1).Return("one")
@@ -1233,6 +1308,7 @@ func Test_Mock_findExpectedCall_Respects_Repeatability(t *testing.T) {
 }
 
 func Test_callString(t *testing.T) {
+	t.Parallel()
 
 	assert.Equal(t, `Method(int,bool,string)`, callString("Method", []interface{}{1, true, "something"}, false))
 	assert.Equal(t, `Method(<nil>)`, callString("Method", []interface{}{nil}, false))
@@ -1240,6 +1316,7 @@ func Test_callString(t *testing.T) {
 }
 
 func Test_Mock_Called(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1267,6 +1344,7 @@ func asyncCall(m *Mock, ch chan Arguments) {
 }
 
 func Test_Mock_Called_blocks(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1300,6 +1378,7 @@ func Test_Mock_Called_blocks(t *testing.T) {
 }
 
 func Test_Mock_Called_For_Bounded_Repeatability(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1341,6 +1420,7 @@ func Test_Mock_Called_For_Bounded_Repeatability(t *testing.T) {
 }
 
 func Test_Mock_Called_For_SetTime_Expectation(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1357,6 +1437,7 @@ func Test_Mock_Called_For_SetTime_Expectation(t *testing.T) {
 }
 
 func Test_Mock_Called_Unexpected(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1368,6 +1449,7 @@ func Test_Mock_Called_Unexpected(t *testing.T) {
 }
 
 func Test_AssertExpectationsForObjects_Helper(t *testing.T) {
+	t.Parallel()
 
 	var mockedService1 = new(TestExampleImplementation)
 	var mockedService2 = new(TestExampleImplementation)
@@ -1388,6 +1470,7 @@ func Test_AssertExpectationsForObjects_Helper(t *testing.T) {
 }
 
 func Test_AssertExpectationsForObjects_Helper_Failed(t *testing.T) {
+	t.Parallel()
 
 	var mockedService1 = new(TestExampleImplementation)
 	var mockedService2 = new(TestExampleImplementation)
@@ -1407,6 +1490,7 @@ func Test_AssertExpectationsForObjects_Helper_Failed(t *testing.T) {
 }
 
 func Test_Mock_AssertExpectations(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1424,6 +1508,7 @@ func Test_Mock_AssertExpectations(t *testing.T) {
 }
 
 func Test_Mock_AssertExpectations_Placeholder_NoArgs(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1442,6 +1527,7 @@ func Test_Mock_AssertExpectations_Placeholder_NoArgs(t *testing.T) {
 }
 
 func Test_Mock_AssertExpectations_Placeholder(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1465,6 +1551,7 @@ func Test_Mock_AssertExpectations_Placeholder(t *testing.T) {
 }
 
 func Test_Mock_AssertExpectations_With_Pointers(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1486,6 +1573,7 @@ func Test_Mock_AssertExpectations_With_Pointers(t *testing.T) {
 }
 
 func Test_Mock_AssertExpectationsCustomType(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1503,6 +1591,7 @@ func Test_Mock_AssertExpectationsCustomType(t *testing.T) {
 }
 
 func Test_Mock_AssertExpectationsFunctionalOptionsType(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1520,6 +1609,7 @@ func Test_Mock_AssertExpectationsFunctionalOptionsType(t *testing.T) {
 }
 
 func Test_Mock_AssertExpectationsFunctionalOptionsType_Empty(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1537,6 +1627,7 @@ func Test_Mock_AssertExpectationsFunctionalOptionsType_Empty(t *testing.T) {
 }
 
 func Test_Mock_AssertExpectationsFunctionalOptionsType_Indirectly(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1554,6 +1645,7 @@ func Test_Mock_AssertExpectationsFunctionalOptionsType_Indirectly(t *testing.T) 
 }
 
 func Test_Mock_AssertExpectationsFunctionalOptionsType_Diff_Func(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1568,6 +1660,7 @@ func Test_Mock_AssertExpectationsFunctionalOptionsType_Diff_Func(t *testing.T) {
 }
 
 func Test_Mock_AssertExpectationsFunctionalOptionsType_Diff_Arg(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1582,6 +1675,7 @@ func Test_Mock_AssertExpectationsFunctionalOptionsType_Diff_Arg(t *testing.T) {
 }
 
 func Test_Mock_AssertExpectations_With_Repeatability(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1603,6 +1697,7 @@ func Test_Mock_AssertExpectations_With_Repeatability(t *testing.T) {
 }
 
 func Test_Mock_AssertExpectations_Skipped_Test(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1613,6 +1708,7 @@ func Test_Mock_AssertExpectations_Skipped_Test(t *testing.T) {
 }
 
 func Test_Mock_TwoCallsWithDifferentArguments(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1632,6 +1728,7 @@ func Test_Mock_TwoCallsWithDifferentArguments(t *testing.T) {
 }
 
 func Test_Mock_AssertNumberOfCalls(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1646,6 +1743,7 @@ func Test_Mock_AssertNumberOfCalls(t *testing.T) {
 }
 
 func Test_Mock_AssertCalled(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1658,6 +1756,7 @@ func Test_Mock_AssertCalled(t *testing.T) {
 }
 
 func Test_Mock_AssertCalled_WithAnythingOfTypeArgument(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1672,6 +1771,7 @@ func Test_Mock_AssertCalled_WithAnythingOfTypeArgument(t *testing.T) {
 }
 
 func Test_Mock_AssertCalled_WithArguments(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1686,6 +1786,7 @@ func Test_Mock_AssertCalled_WithArguments(t *testing.T) {
 }
 
 func Test_Mock_AssertCalled_WithArguments_With_Repeatability(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1703,6 +1804,7 @@ func Test_Mock_AssertCalled_WithArguments_With_Repeatability(t *testing.T) {
 }
 
 func Test_Mock_AssertNotCalled(t *testing.T) {
+	t.Parallel()
 
 	var mockedService = new(TestExampleImplementation)
 
@@ -1715,6 +1817,8 @@ func Test_Mock_AssertNotCalled(t *testing.T) {
 }
 
 func Test_Mock_IsMethodCallable(t *testing.T) {
+	t.Parallel()
+
 	var mockedService = new(TestExampleImplementation)
 
 	arg := []Call{{Repeatability: 1}, {Repeatability: 2}}
@@ -1734,6 +1838,8 @@ func Test_Mock_IsMethodCallable(t *testing.T) {
 }
 
 func TestIsArgsEqual(t *testing.T) {
+	t.Parallel()
+
 	var expected = Arguments{5, 3, 4, 6, 7, 2}
 
 	// Copy elements 1 to 5
@@ -1747,6 +1853,8 @@ func TestIsArgsEqual(t *testing.T) {
 }
 
 func Test_Mock_AssertOptional(t *testing.T) {
+	t.Parallel()
+
 	// Optional called
 	var ms1 = new(TestExampleImplementation)
 	ms1.On("TheExampleMethod", 1, 2, 3).Maybe().Return(4, nil)
@@ -1775,6 +1883,7 @@ func Test_Mock_AssertOptional(t *testing.T) {
 Arguments helper methods
 */
 func Test_Arguments_Get(t *testing.T) {
+	t.Parallel()
 
 	var args = Arguments([]interface{}{"string", 123, true})
 
@@ -1785,6 +1894,7 @@ func Test_Arguments_Get(t *testing.T) {
 }
 
 func Test_Arguments_Is(t *testing.T) {
+	t.Parallel()
 
 	var args = Arguments([]interface{}{"string", 123, true})
 
@@ -1794,6 +1904,7 @@ func Test_Arguments_Is(t *testing.T) {
 }
 
 func Test_Arguments_Diff(t *testing.T) {
+	t.Parallel()
 
 	var args = Arguments([]interface{}{"Hello World", 123, true})
 	var diff string
@@ -1807,6 +1918,7 @@ func Test_Arguments_Diff(t *testing.T) {
 }
 
 func Test_Arguments_Diff_DifferentNumberOfArgs(t *testing.T) {
+	t.Parallel()
 
 	var args = Arguments([]interface{}{"string", 123, true})
 	var diff string
@@ -1819,6 +1931,7 @@ func Test_Arguments_Diff_DifferentNumberOfArgs(t *testing.T) {
 }
 
 func Test_Arguments_Diff_WithAnythingArgument(t *testing.T) {
+	t.Parallel()
 
 	var args = Arguments([]interface{}{"string", 123, true})
 	var count int
@@ -1829,6 +1942,7 @@ func Test_Arguments_Diff_WithAnythingArgument(t *testing.T) {
 }
 
 func Test_Arguments_Diff_WithAnythingArgument_InActualToo(t *testing.T) {
+	t.Parallel()
 
 	var args = Arguments([]interface{}{"string", Anything, true})
 	var count int
@@ -1839,6 +1953,7 @@ func Test_Arguments_Diff_WithAnythingArgument_InActualToo(t *testing.T) {
 }
 
 func Test_Arguments_Diff_WithAnythingOfTypeArgument(t *testing.T) {
+	t.Parallel()
 
 	var args = Arguments([]interface{}{"string", AnythingOfType("int"), true})
 	var count int
@@ -1849,6 +1964,7 @@ func Test_Arguments_Diff_WithAnythingOfTypeArgument(t *testing.T) {
 }
 
 func Test_Arguments_Diff_WithAnythingOfTypeArgument_Failing(t *testing.T) {
+	t.Parallel()
 
 	var args = Arguments([]interface{}{"string", AnythingOfType("string"), true})
 	var count int
@@ -1861,6 +1977,8 @@ func Test_Arguments_Diff_WithAnythingOfTypeArgument_Failing(t *testing.T) {
 }
 
 func Test_Arguments_Diff_WithIsTypeArgument(t *testing.T) {
+	t.Parallel()
+
 	var args = Arguments([]interface{}{"string", IsType(0), true})
 	var count int
 	_, count = args.Diff([]interface{}{"string", 123, true})
@@ -1869,6 +1987,8 @@ func Test_Arguments_Diff_WithIsTypeArgument(t *testing.T) {
 }
 
 func Test_Arguments_Diff_WithIsTypeArgument_Failing(t *testing.T) {
+	t.Parallel()
+
 	var args = Arguments([]interface{}{"string", IsType(""), true})
 	var count int
 	var diff string
@@ -1879,6 +1999,8 @@ func Test_Arguments_Diff_WithIsTypeArgument_Failing(t *testing.T) {
 }
 
 func Test_Arguments_Diff_WithArgMatcher(t *testing.T) {
+	t.Parallel()
+
 	matchFn := func(a int) bool {
 		return a == 123
 	}
@@ -1902,6 +2024,7 @@ func Test_Arguments_Diff_WithArgMatcher(t *testing.T) {
 }
 
 func Test_Arguments_Assert(t *testing.T) {
+	t.Parallel()
 
 	var args = Arguments([]interface{}{"string", 123, true})
 
@@ -1910,6 +2033,7 @@ func Test_Arguments_Assert(t *testing.T) {
 }
 
 func Test_Arguments_String_Representation(t *testing.T) {
+	t.Parallel()
 
 	var args = Arguments([]interface{}{"string", 123, true})
 	assert.Equal(t, `string,int,bool`, args.String())
@@ -1917,6 +2041,7 @@ func Test_Arguments_String_Representation(t *testing.T) {
 }
 
 func Test_Arguments_String(t *testing.T) {
+	t.Parallel()
 
 	var args = Arguments([]interface{}{"string", 123, true})
 	assert.Equal(t, "string", args.String(0))
@@ -1924,6 +2049,7 @@ func Test_Arguments_String(t *testing.T) {
 }
 
 func Test_Arguments_Error(t *testing.T) {
+	t.Parallel()
 
 	var err = errors.New("An Error")
 	var args = Arguments([]interface{}{"string", 123, true, err})
@@ -1932,6 +2058,7 @@ func Test_Arguments_Error(t *testing.T) {
 }
 
 func Test_Arguments_Error_Nil(t *testing.T) {
+	t.Parallel()
 
 	var args = Arguments([]interface{}{"string", 123, true, nil})
 	assert.Equal(t, nil, args.Error(3))
@@ -1939,6 +2066,7 @@ func Test_Arguments_Error_Nil(t *testing.T) {
 }
 
 func Test_Arguments_Int(t *testing.T) {
+	t.Parallel()
 
 	var args = Arguments([]interface{}{"string", 123, true})
 	assert.Equal(t, 123, args.Int(1))
@@ -1946,6 +2074,7 @@ func Test_Arguments_Int(t *testing.T) {
 }
 
 func Test_Arguments_Bool(t *testing.T) {
+	t.Parallel()
 
 	var args = Arguments([]interface{}{"string", 123, true})
 	assert.Equal(t, true, args.Bool(2))
@@ -1953,6 +2082,7 @@ func Test_Arguments_Bool(t *testing.T) {
 }
 
 func Test_WaitUntil_Parallel(t *testing.T) {
+	t.Parallel()
 
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
@@ -1979,6 +2109,8 @@ func Test_WaitUntil_Parallel(t *testing.T) {
 }
 
 func Test_MockMethodCalled(t *testing.T) {
+	t.Parallel()
+
 	m := new(Mock)
 	m.On("foo", "hello").Return("world")
 
@@ -1989,6 +2121,8 @@ func Test_MockMethodCalled(t *testing.T) {
 }
 
 func Test_MockMethodCalled_Panic(t *testing.T) {
+	t.Parallel()
+
 	m := new(Mock)
 	m.On("foo", "hello").Panic("world panics")
 
@@ -1998,6 +2132,8 @@ func Test_MockMethodCalled_Panic(t *testing.T) {
 
 // Test to validate fix for racy concurrent call access in MethodCalled()
 func Test_MockReturnAndCalledConcurrent(t *testing.T) {
+	t.Parallel()
+
 	iterations := 1000
 	m := &Mock{}
 	call := m.On("ConcurrencyTestMethod")
@@ -2048,6 +2184,8 @@ func (tc *tCustomLogger) Errorf(format string, args ...interface{}) {
 func (tc *tCustomLogger) FailNow() {}
 
 func TestLoggingAssertExpectations(t *testing.T) {
+	t.Parallel()
+
 	m := new(timer)
 	m.On("GetTime", 0).Return("")
 	tcl := &tCustomLogger{t, []string{}, []string{}}
@@ -2062,6 +2200,8 @@ func TestLoggingAssertExpectations(t *testing.T) {
 }
 
 func TestAfterTotalWaitTimeWhileExecution(t *testing.T) {
+	t.Parallel()
+
 	waitDuration := 1
 	total, waitMs := 5, time.Millisecond*time.Duration(waitDuration)
 	aTimer := new(timer)
@@ -2086,6 +2226,8 @@ func TestAfterTotalWaitTimeWhileExecution(t *testing.T) {
 }
 
 func TestArgumentMatcherToPrintMismatch(t *testing.T) {
+	t.Parallel()
+
 	defer func() {
 		if r := recover(); r != nil {
 			matchingExp := regexp.MustCompile(
@@ -2103,6 +2245,8 @@ func TestArgumentMatcherToPrintMismatch(t *testing.T) {
 }
 
 func TestArgumentMatcherToPrintMismatchWithReferenceType(t *testing.T) {
+	t.Parallel()
+
 	defer func() {
 		if r := recover(); r != nil {
 			matchingExp := regexp.MustCompile(
@@ -2120,6 +2264,8 @@ func TestArgumentMatcherToPrintMismatchWithReferenceType(t *testing.T) {
 }
 
 func TestClosestCallMismatchedArgumentInformationShowsTheClosest(t *testing.T) {
+	t.Parallel()
+
 	defer func() {
 		if r := recover(); r != nil {
 			matchingExp := regexp.MustCompile(unexpectedCallRegex(`TheExampleMethod(int,int,int)`, `0: 1\s+1: 1\s+2: 2`, `0: 1\s+1: 1\s+2: 1`, `Diff: 0: PASS:  \(int=1\) == \(int=1\)\s+1: PASS:  \(int=1\) == \(int=1\)\s+2: FAIL:  \(int=2\) != \(int=1\)`))
@@ -2135,6 +2281,8 @@ func TestClosestCallMismatchedArgumentInformationShowsTheClosest(t *testing.T) {
 }
 
 func TestClosestCallFavorsFirstMock(t *testing.T) {
+	t.Parallel()
+
 	defer func() {
 		if r := recover(); r != nil {
 			diffRegExp := `Difference found in argument 0:\s+--- Expected\s+\+\+\+ Actual\s+@@ -2,4 \+2,4 @@\s+\(bool\) true,\s+- \(bool\) true,\s+- \(bool\) true\s+\+ \(bool\) false,\s+\+ \(bool\) false\s+}\s+Diff: 0: FAIL:  \(\[\]bool=\[(true\s?|false\s?){3}]\) != \(\[\]bool=\[(true\s?|false\s?){3}\]\)`
@@ -2151,6 +2299,8 @@ func TestClosestCallFavorsFirstMock(t *testing.T) {
 }
 
 func TestClosestCallUsesRepeatabilityToFindClosest(t *testing.T) {
+	t.Parallel()
+
 	defer func() {
 		if r := recover(); r != nil {
 			diffRegExp := `Difference found in argument 0:\s+--- Expected\s+\+\+\+ Actual\s+@@ -1,4 \+1,4 @@\s+\(\[\]bool\) \(len=3\) {\s+- \(bool\) false,\s+- \(bool\) false,\s+\+ \(bool\) true,\s+\+ \(bool\) true,\s+\(bool\) false\s+Diff: 0: FAIL:  \(\[\]bool=\[(true\s?|false\s?){3}]\) != \(\[\]bool=\[(true\s?|false\s?){3}\]\)`
@@ -2171,6 +2321,8 @@ func TestClosestCallUsesRepeatabilityToFindClosest(t *testing.T) {
 }
 
 func TestClosestCallMismatchedArgumentValueInformation(t *testing.T) {
+	t.Parallel()
+
 	defer func() {
 		if r := recover(); r != nil {
 			matchingExp := regexp.MustCompile(unexpectedCallRegex(`GetTime(int)`, "0: 1", "0: 999", `Diff: 0: FAIL:  \(int=1\) != \(int=999\)`))
@@ -2185,26 +2337,38 @@ func TestClosestCallMismatchedArgumentValueInformation(t *testing.T) {
 }
 
 func Test_isBetterMatchThanReturnsFalseIfCandidateCallIsNil(t *testing.T) {
+	t.Parallel()
+
 	assert.False(t, matchCandidate{}.isBetterMatchThan(matchCandidate{}))
 }
 
 func Test_isBetterMatchThanReturnsTrueIfOtherCandidateCallIsNil(t *testing.T) {
+	t.Parallel()
+
 	assert.True(t, matchCandidate{call: &Call{}}.isBetterMatchThan(matchCandidate{}))
 }
 
 func Test_isBetterMatchThanReturnsFalseIfDiffCountIsGreaterThanOther(t *testing.T) {
+	t.Parallel()
+
 	assert.False(t, matchCandidate{call: &Call{}, diffCount: 2}.isBetterMatchThan(matchCandidate{call: &Call{}, diffCount: 1}))
 }
 
 func Test_isBetterMatchThanReturnsTrueIfDiffCountIsLessThanOther(t *testing.T) {
+	t.Parallel()
+
 	assert.True(t, matchCandidate{call: &Call{}, diffCount: 1}.isBetterMatchThan(matchCandidate{call: &Call{}, diffCount: 2}))
 }
 
 func Test_isBetterMatchThanReturnsTrueIfRepeatabilityIsGreaterThanOther(t *testing.T) {
+	t.Parallel()
+
 	assert.True(t, matchCandidate{call: &Call{Repeatability: 1}, diffCount: 1}.isBetterMatchThan(matchCandidate{call: &Call{Repeatability: -1}, diffCount: 1}))
 }
 
 func Test_isBetterMatchThanReturnsFalseIfRepeatabilityIsLessThanOrEqualToOther(t *testing.T) {
+	t.Parallel()
+
 	assert.False(t, matchCandidate{call: &Call{Repeatability: 1}, diffCount: 1}.isBetterMatchThan(matchCandidate{call: &Call{Repeatability: 1}, diffCount: 1}))
 }
 
@@ -2220,6 +2384,8 @@ func ConcurrencyTestMethod(m *Mock) {
 }
 
 func TestConcurrentArgumentRead(t *testing.T) {
+	t.Parallel()
+
 	methodUnderTest := func(c caller, u user) {
 		go u.Use(c)
 		c.Call()


### PR DESCRIPTION
## Summary

Add t.Parallel() to all package-level tests of the 'mock' package. Result: faster tests results.

Before:
```console
$ go test -count=10 ./mock
ok  	github.com/stretchr/testify/mock	0.631s
```
After:
```console
$ go test -count=10 ./mock
ok  	github.com/stretchr/testify/mock	0.426s
```

## Changes
* `mock` package: add `t.Parallel()` in all tests at package scope

## Motivation

Run the testsuite faster.

Hopefully also faster CI results (but CI runners are limited to [4 cores](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories), not sure )

## Related issues
#1747 enable parallel tests on `assert`, `require`