### PR TITLE
mock: isolate objx-dependent code in their own source files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,7 @@ jobs:
       - run: ./.ci.gofmt.sh
       - run: ./.ci.govet.sh
       - run: go test -v -race ./...
+      - run: go test -tags testify_no_objx ./...
 
   test-old-go:
     runs-on: ubuntu-latest
@@ -40,6 +41,7 @@ jobs:
         with:
           go-version: ${{ matrix.go_version }}
       - run: go test -v -race ./...
+      - run: go test -tags testify_no_objx ./...
 
   check-actions-hashes:
     runs-on: ubuntu-latest

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -11,8 +11,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/stretchr/objx"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/internal/difflib"
 	"github.com/stretchr/testify/internal/spew"
@@ -311,7 +309,7 @@ type Mock struct {
 
 	// TestData holds any data that might be useful for testing.  Testify ignores
 	// this data completely allowing you to do whatever you like with it.
-	testData objx.Map
+	testData testData
 
 	mutex sync.Mutex
 }
@@ -322,16 +320,6 @@ type Mock struct {
 // without acquiring the mutex, which is detected by go test -race.
 func (m *Mock) String() string {
 	return fmt.Sprintf("%[1]T<%[1]p>", m)
-}
-
-// TestData holds any data that might be useful for testing.  Testify ignores
-// this data completely allowing you to do whatever you like with it.
-func (m *Mock) TestData() objx.Map {
-	if m.testData == nil {
-		m.testData = make(objx.Map)
-	}
-
-	return m.testData
 }
 
 /*

--- a/mock/mock_no_objx.go
+++ b/mock/mock_no_objx.go
@@ -1,0 +1,5 @@
+//go:build testify_no_objx || testify_no_deps
+
+package mock
+
+type testData = struct{}

--- a/mock/mock_objx.go
+++ b/mock/mock_objx.go
@@ -1,0 +1,19 @@
+// This source file isolates the uses of the objx module to ease
+// maintenance of downstream forks that remove that dependency.
+// See https://github.com/stretchr/testify/issues/1752
+
+package mock
+
+import "github.com/stretchr/objx"
+
+type testData = objx.Map
+
+// TestData holds any data that might be useful for testing.  Testify ignores
+// this data completely allowing you to do whatever you like with it.
+func (m *Mock) TestData() objx.Map {
+	if m.testData == nil {
+		m.testData = make(objx.Map)
+	}
+
+	return m.testData
+}

--- a/mock/mock_objx.go
+++ b/mock/mock_objx.go
@@ -2,6 +2,8 @@
 // maintenance of downstream forks that remove that dependency.
 // See https://github.com/stretchr/testify/issues/1752
 
+//go:build !testify_no_objx && !testify_no_deps
+
 package mock
 
 import "github.com/stretchr/objx"

--- a/mock/mock_objx_test.go
+++ b/mock/mock_objx_test.go
@@ -1,3 +1,5 @@
+//go:build !testify_no_objx && !testify_no_deps
+
 package mock
 
 import (

--- a/mock/mock_objx_test.go
+++ b/mock/mock_objx_test.go
@@ -1,0 +1,19 @@
+package mock
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Mock_TestData(t *testing.T) {
+	t.Parallel()
+
+	var mockedService = new(TestExampleImplementation)
+
+	if assert.NotNil(t, mockedService.TestData()) {
+
+		mockedService.TestData().Set("something", 123)
+		assert.Equal(t, 123, mockedService.TestData().Get("something").Data())
+	}
+}

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -164,18 +164,6 @@ func (m *MockTestingT) FailNow() {
 	Mock
 */
 
-func Test_Mock_TestData(t *testing.T) {
-	t.Parallel()
-
-	var mockedService = new(TestExampleImplementation)
-
-	if assert.NotNil(t, mockedService.TestData()) {
-
-		mockedService.TestData().Set("something", 123)
-		assert.Equal(t, 123, mockedService.TestData().Get("something").Data())
-	}
-}
-
 func Test_Mock_On(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

In order to ease maintenance of downstream forks of Testify that would remove dependency on github.com/stretchr/objx we move all uses of that module in isolated source files. A fork without that dependency could just remove those files.
See https://github.com/stretchr/testify/issues/1752#issuecomment-2921545929

The use of objx is quite contained: it is only used in Mock.TestData(). Note that we can't just remove that method or change the return value because that would be a breaking change.

## Changes

* Move `Mock.TestData()` in a new file `mock/mock_objx.go`
* Move tests of TestData in a new file `mock/mock_objx_test.go`

## Motivation

See https://github.com/stretchr/testify/issues/1752#issuecomment-2921545929

With this change it will also be possible to add a `//go:build !testify_mock_no_objx` to `mock/mock_objx.go` and `mock/mock_objx_test.go` to allow downstream users to use testify/mock without the objx dependency.

## Related issues

* #1752