### PR TITLE
Dolmen/suite faster method filtering

### DIFF
--- a/suite/suite.go
+++ b/suite/suite.go
@@ -140,16 +140,24 @@ func Run(t *testing.T, suite TestingSuite) {
 	methodFinder := reflect.TypeOf(suite)
 	suiteName := methodFinder.Elem().Name()
 
-	for i := 0; i < methodFinder.NumMethod(); i++ {
-		method := methodFinder.Method(i)
-
-		ok, err := methodFilter(method.Name)
+	var matchMethodRE *regexp.Regexp
+	if *matchMethod != "" {
+		var err error
+		matchMethodRE, err = regexp.Compile(*matchMethod)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "testify: invalid regexp for -m: %s\n", err)
 			os.Exit(1)
 		}
+	}
 
-		if !ok {
+	for i := 0; i < methodFinder.NumMethod(); i++ {
+		method := methodFinder.Method(i)
+
+		if !strings.HasPrefix(method.Name, "Test") {
+			continue
+		}
+		// Apply -testify.m filter
+		if matchMethodRE != nil && !matchMethodRE.MatchString(method.Name) {
 			continue
 		}
 
@@ -223,15 +231,6 @@ func Run(t *testing.T, suite TestingSuite) {
 	}
 
 	runTests(t, tests)
-}
-
-// Filtering method according to set regular expression
-// specified command-line argument -m
-func methodFilter(name string) (bool, error) {
-	if !strings.HasPrefix(name, "Test") {
-		return false, nil
-	}
-	return regexp.MatchString(*matchMethod, name)
 }
 
 func runTests(t *testing.T, tests []test) {

--- a/suite/suite.go
+++ b/suite/suite.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"regexp"
 	"runtime/debug"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -227,7 +228,7 @@ func Run(t *testing.T, suite TestingSuite) {
 // Filtering method according to set regular expression
 // specified command-line argument -m
 func methodFilter(name string) (bool, error) {
-	if ok, _ := regexp.MatchString("^Test", name); !ok {
+	if !strings.HasPrefix(name, "Test") {
 		return false, nil
 	}
 	return regexp.MatchString(*matchMethod, name)


### PR DESCRIPTION
## Summary

In package `suite`, speed-up the filtering of methods (`-testify.m` flag) by compiling the regexp just once instead of when checking each method.

## Changes
* faster filtering of suite methods which are tests by using `strings.HasPrefix` instead of a `^Test` regexp compiled for every checked method
* faster filtering when `-testify.m` is given: compile the regexp once

## Motivation

Runtime speed!

## Related issues

N/A