### PR TITLE
assert: faster and simpler isEmpty using reflect.Value.IsZero

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -752,8 +752,11 @@ func isEmpty(object interface{}) bool {
 		return true
 	}
 
-	objValue := reflect.ValueOf(object)
+	return isEmptyValue(reflect.ValueOf(object))
+}
 
+// isEmptyValue gets whether the specified reflect.Value is considered empty or not.
+func isEmptyValue(objValue reflect.Value) bool {
 	switch objValue.Kind() {
 	// collection types are empty when they have no element
 	case reflect.Chan, reflect.Map, reflect.Slice:
@@ -763,13 +766,12 @@ func isEmpty(object interface{}) bool {
 		if objValue.IsNil() {
 			return true
 		}
-		deref := objValue.Elem().Interface()
-		return isEmpty(deref)
+		return isEmptyValue(objValue.Elem())
 	// for all other types, compare against the zero value
 	// array types are empty when they match their zero-initialized state
 	default:
 		zero := reflect.Zero(objValue.Type())
-		return reflect.DeepEqual(object, zero.Interface())
+		return reflect.DeepEqual(objValue.Interface(), zero.Interface())
 	}
 }
 

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -757,22 +757,20 @@ func isEmpty(object interface{}) bool {
 
 // isEmptyValue gets whether the specified reflect.Value is considered empty or not.
 func isEmptyValue(objValue reflect.Value) bool {
+	if objValue.IsZero() {
+		return true
+	}
+	// Special cases of non-zero values that we consider empty
 	switch objValue.Kind() {
 	// collection types are empty when they have no element
+	// Note: array types are empty when they match their zero-initialized state.
 	case reflect.Chan, reflect.Map, reflect.Slice:
 		return objValue.Len() == 0
-	// pointers are empty if nil or if the value they point to is empty
+	// non-nil pointers are empty if the value they point to is empty
 	case reflect.Ptr:
-		if objValue.IsNil() {
-			return true
-		}
 		return isEmptyValue(objValue.Elem())
-	// for all other types, compare against the zero value
-	// array types are empty when they match their zero-initialized state
-	default:
-		zero := reflect.Zero(objValue.Type())
-		return reflect.DeepEqual(objValue.Interface(), zero.Interface())
 	}
+	return false
 }
 
 // Empty asserts that the given value is "empty".

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -1843,6 +1843,19 @@ func Test_isEmpty(t *testing.T) {
 	}{a: 42, B: 0}))
 }
 
+func Benchmark_isEmpty(b *testing.B) {
+	b.ReportAllocs()
+
+	v := new(int)
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		isEmpty("")
+		isEmpty(42)
+		isEmpty(v)
+	}
+}
+
 func TestEmpty(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Refactor `isEmpty` which is the backend of `assert.Empty` and `assert.NotEmpty`.

## Changes
* `add Benchmark_isEmpty` that shows that some cases of `isEmpty` allocate memory
* split `isEmpty` into `isEmpty` and `isEmptyValue` for more efficient recursion when checking pointer values
* simplify `isEmptyValue` by using `reflect.Value.IsZero` (available since Go 1.13, so after the initial implementation of `assert.IsEmpty`).

## Motivation

* simpler implementation
* faster:
   * check for zero value using `reflect.Value.IsZero` which doesn't allocate memory.

## Related issues