### PR TITLE
assert.EqualValues: improve test coverage to 100%

### DIFF
--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -978,15 +978,15 @@ func TestNotEqual(t *testing.T) {
 	}
 }
 
-func TestNotEqualValues(t *testing.T) {
+func TestEqualValuesAndNotEqualValues(t *testing.T) {
 	t.Parallel()
 
 	mockT := new(testing.T)
 
 	cases := []struct {
-		expected interface{}
-		actual   interface{}
-		result   bool
+		expected       interface{}
+		actual         interface{}
+		notEqualResult bool // result for NotEqualValues
 	}{
 		// cases that are expected not to match
 		{"Hello World", "Hello World!", true},
@@ -1013,11 +1013,22 @@ func TestNotEqualValues(t *testing.T) {
 	}
 
 	for _, c := range cases {
+		// Test NotEqualValues
 		t.Run(fmt.Sprintf("NotEqualValues(%#v, %#v)", c.expected, c.actual), func(t *testing.T) {
 			res := NotEqualValues(mockT, c.expected, c.actual)
 
-			if res != c.result {
-				t.Errorf("NotEqualValues(%#v, %#v) should return %#v", c.expected, c.actual, c.result)
+			if res != c.notEqualResult {
+				t.Errorf("NotEqualValues(%#v, %#v) should return %#v", c.expected, c.actual, c.notEqualResult)
+			}
+		})
+
+		// Test EqualValues (inverse of NotEqualValues)
+		t.Run(fmt.Sprintf("EqualValues(%#v, %#v)", c.expected, c.actual), func(t *testing.T) {
+			expectedEqualResult := !c.notEqualResult // EqualValues should return opposite of NotEqualValues
+			res := EqualValues(mockT, c.expected, c.actual)
+
+			if res != expectedEqualResult {
+				t.Errorf("EqualValues(%#v, %#v) should return %#v", c.expected, c.actual, expectedEqualResult)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

This change ensures both success and failure paths are tested for `EqualValues`, covering the error formatting and failure reporting code that was previously untested.

Coverage improvement:
- EqualValues: 57.1% → 100.0%
- Overall package: 68.4% → 68.5%

Note: this change has been made with the help of the [sketch.dev](https://sketch.dev) coding agent.

## Changes
Extend `TestNotEqualValues` to also test `EqualValues` by leveraging the fact that they are inverse functions. The same test cases are used to verify that `EqualValues` returns the opposite result of `NotEqualValues`.

The test function was renamed to `TestEqualValuesAndNotEqualValues` to reflect its dual purpose while maintaining all existing test logic.

## Motivation
* Increase test coverage
* Test [sketch.dev](https://sketch.dev)
