### PR TITLE
suite.Run: refactor handling of stats for improved readability

### DIFF
--- a/suite/stats.go
+++ b/suite/stats.go
@@ -16,26 +16,30 @@ type TestInformation struct {
 }
 
 func newSuiteInformation() *SuiteInformation {
-	testStats := make(map[string]*TestInformation)
-
 	return &SuiteInformation{
-		TestStats: testStats,
+		TestStats: make(map[string]*TestInformation),
 	}
 }
 
-func (s SuiteInformation) start(testName string) {
+func (s *SuiteInformation) start(testName string) {
+	if s == nil {
+		return
+	}
 	s.TestStats[testName] = &TestInformation{
 		TestName: testName,
 		Start:    time.Now(),
 	}
 }
 
-func (s SuiteInformation) end(testName string, passed bool) {
+func (s *SuiteInformation) end(testName string, passed bool) {
+	if s == nil {
+		return
+	}
 	s.TestStats[testName].End = time.Now()
 	s.TestStats[testName].Passed = passed
 }
 
-func (s SuiteInformation) Passed() bool {
+func (s *SuiteInformation) Passed() bool {
 	for _, stats := range s.TestStats {
 		if !stats.Passed {
 			return false

--- a/suite/suite.go
+++ b/suite/suite.go
@@ -161,10 +161,7 @@ func Run(t *testing.T, suite TestingSuite) {
 
 					r := recover()
 
-					if stats != nil {
-						passed := !t.Failed() && r == nil
-						stats.end(method.Name, passed)
-					}
+					stats.end(method.Name, !t.Failed() && r == nil)
 
 					if afterTestSuite, ok := suite.(AfterTest); ok {
 						afterTestSuite.AfterTest(suiteName, method.Name)
@@ -185,9 +182,7 @@ func Run(t *testing.T, suite TestingSuite) {
 					beforeTestSuite.BeforeTest(methodFinder.Elem().Name(), method.Name)
 				}
 
-				if stats != nil {
-					stats.start(method.Name)
-				}
+				stats.start(method.Name)
 
 				method.Func.Call([]reflect.Value{reflect.ValueOf(suite)})
 			},


### PR DESCRIPTION
## Summary
Refactor handling of stats in [`suite.Run`](https://pkg.go.dev/github.com/stretchr/testify/suite#Run) with the goal of reducing indented blocks to improve readability.

## Changes

The [`SuiteInformation`](https://pkg.go.dev/github.com/stretchr/testify/suite#SuiteInformation) methods now handle being called with a nil receiver to work as no-op. This allows to call them from [`suite.Run`](https://pkg.go.dev/github.com/stretchr/testify/suite#Run) without nil checks blocks, so with improved readability thanks to the removal of indented blocks.

## Motivation
Improve readability of [`suite.Run`](https://pkg.go.dev/github.com/stretchr/testify/suite#Run).

## Related issues
N/A