### PR TITLE
assert: refactor Test*FileExists and Test*DirExists tests to enable parallel testing

### DIFF
--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -2626,7 +2626,7 @@ func getTempSymlinkPath(t *testing.T, file string) string {
 	tempDir := t.TempDir()
 	link := filepath.Join(tempDir, file+"_symlink")
 	if err := os.Symlink(file, link); err != nil {
-		t.Fatal("could not create temp symlink, err:", err)
+		t.Fatalf("could not create temp symlink %q pointing to %q: %v", link, file, err)
 	}
 	return link
 }


### PR DESCRIPTION
## Summary

Refactor `TestFileExists`, `TestNoFileExists`, `TestDirExists` and `TestNoDirExists` to be able to run in parallel: we now use a temporary directory handled by `go test` to create temporary files.

Much infrastructure logic is moved to the helper `getTempSymlinkPath` for improved readability of each test suite. 

## Changes
* use [`testing.T.TempDir`](https://pkg.go.dev/testing#T.TempDir) (available since go1.15) as the storage location for files created temporarly for testing. This directory is handled by `go test`, so this allows us to remove cleanup code.
* as there is no more race condition, we enable parallel testing on `Test*Exists`.

## Motivation

* cleanup: improved readability of the Test*Exists code
* enable parallel testing on all `assert` tests for faster dev loop

## Related issues
* #1747 where parallel testing was initially enabled