### PR TITLE
assert.CallerInfo: micro cleanup

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -24,8 +24,6 @@ import (
 	"github.com/stretchr/testify/assert/yaml"
 )
 
-const stackFrameBufferSize = 10
-
 //go:generate sh -c "cd ../_codegen && go build && cd - && ../_codegen/_codegen -output-package=assert -template=assertion_format.go.tmpl"
 
 // TestingT is an interface wrapper around *testing.T
@@ -217,8 +215,10 @@ func CallerInfo() []string {
 	var line int
 	var name string
 
-	callers := []string{}
+	const stackFrameBufferSize = 10
 	pcs := make([]uintptr, stackFrameBufferSize)
+
+	callers := []string{}
 	offset := 1
 
 	for {
@@ -273,13 +273,14 @@ func CallerInfo() []string {
 				isTest(name, "Example") {
 				break
 			}
+
 			if !more {
 				break
 			}
 		}
-		// We know we already have less than a buffer's worth of frames
-		offset += stackFrameBufferSize
 
+		// Next batch
+		offset += cap(pcs)
 	}
 
 	return callers


### PR DESCRIPTION
## Summary

Move the stackFrameBufferSize const which was in package scope but used only by CallerInfo, into CallerInfo body.

## Changes

* Move the `stackFrameBufferSize` const into `CallerInfo` body
* Small refactor use of stack frame handling to remove one reference to that const

## Motivation

Cleanup: the `stackFrameBufferSize` constant doesn't pollute the package scope anymore.

That constant wasn't even defined near the `CallerInfo` body, but at the top of the file, which made it harder to lookup.
