### PR TITLE
chore(deps): replace gopkg.in/yaml.v3 with github.com/goccy/go-yaml

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -20,7 +20,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/pmezard/go-difflib/difflib"
 
-	// Wrapper around gopkg.in/yaml.v3
+	// Wrapper around github.com/goccy/go-yaml
 	"github.com/stretchr/testify/assert/yaml"
 )
 

--- a/assert/yaml/yaml_custom.go
+++ b/assert/yaml/yaml_custom.go
@@ -7,7 +7,7 @@
 //	go test -tags testify_yaml_custom
 //
 // This implementation can be used at build time to replace the default implementation
-// to avoid linking with [gopkg.in/yaml.v3].
+// to avoid linking with [github.com/goccy/go-yaml].
 //
 // In your test package:
 //

--- a/assert/yaml/yaml_default.go
+++ b/assert/yaml/yaml_default.go
@@ -6,7 +6,7 @@
 // indirection with an alternative implementation of this package that uses
 // another implementation of YAML deserialization. This allows to not either not
 // use YAML deserialization at all, or to use another implementation than
-// [gopkg.in/yaml.v3] (for example for license compatibility reasons, see [PR #1120]).
+// [github.com/goccy/go-yaml] (for example for license compatibility reasons, see [PR #1120]).
 //
 // Alternative implementations are selected using build tags:
 //
@@ -28,9 +28,9 @@
 // [PR #1120]: https://github.com/stretchr/testify/pull/1120
 package yaml
 
-import goyaml "gopkg.in/yaml.v3"
+import goyaml "github.com/goccy/go-yaml"
 
-// Unmarshal is just a wrapper of [gopkg.in/yaml.v3.Unmarshal].
+// Unmarshal is just a wrapper of [github.com/goccy/go-yaml.Unmarshal].
 func Unmarshal(in []byte, out interface{}) error {
 	return goyaml.Unmarshal(in, out)
 }

--- a/assert/yaml/yaml_fail.go
+++ b/assert/yaml/yaml_fail.go
@@ -3,7 +3,7 @@
 // Package yaml is an implementation of YAML functions that always fail.
 //
 // This implementation can be used at build time to replace the default implementation
-// to avoid linking with [gopkg.in/yaml.v3]:
+// to avoid linking with [github.com/goccy/go-yaml]:
 //
 //	go test -tags testify_yaml_fail
 package yaml

--- a/go.mod
+++ b/go.mod
@@ -2,13 +2,15 @@ module github.com/stretchr/testify
 
 // This should match the minimum supported version that is tested in
 // .github/workflows/main.yml
-go 1.17
+go 1.21.0
+
+toolchain go1.23.10
 
 require (
 	github.com/davecgh/go-spew v1.1.1
+	github.com/goccy/go-yaml v1.18.0
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/stretchr/objx v0.5.2 // To avoid a cycle the version of testify used by objx should be excluded below
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 // Break dependency cycle with objx.

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,8 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/goccy/go-yaml v1.18.0 h1:8W7wMFS12Pcas7KU+VVkaiCng+kG8QiFeFwzFb+rwuw=
+github.com/goccy/go-yaml v1.18.0/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
-gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
## Summary
`gopkg.in/yaml.v3 ` is not maintained let's use maintained alternative.

## Changes
Basically search and replace and run `go mod tidy`

## Motivation
The current lib is archived and not maintained. The alternative will be to use k8s fork but it's heavier (in terms of dependencies).

## Related issues
- https://github.com/kubernetes-sigs/yaml
