### PR TITLE
feat: add support for go-cmp argument matching

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ go 1.17
 
 require (
 	github.com/davecgh/go-spew v1.1.1
+	github.com/google/go-cmp v0.6.0
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/stretchr/objx v0.5.2 // To avoid a cycle the version of testify used by objx should be excluded below
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=


### PR DESCRIPTION
## Summary

Added support for Google's `go-cmp` library in the mock package for customizable deep comparisons during test assertions: 

- Updated `go.mod` to include `go-cmp` dependency
- Introduced `goCmpArgument` type in `mock/mock.go` to encapsulate comparison values and options
- Implemented `GoCmp()` helper function to create comparison arguments
- Use `cmp.Diff()` for precise comparison output
- Allow customization via `cmp.Options`

## Changes

Adds new assertion behavior (not a bug fix):
- Introduces `GoCmp()` as an alternative to `mock.MatchedBy()`
- Enables field-level comparison customization via `cmp.Option`
- Adds diff output formatting in error messages

## Motivation

Support more precise comparisons than `reflect.DeepEqual` (e.g., ignoring specific fields)

## Example usage

```go
// Basic usage with a map
mock.On("Method", mock.GoCmp(map[string]bool{"test": true}))

// With options for unexported fields
mock.On("Method", mock.GoCmp(&ExampleType{ran: false}, cmp.AllowUnexported(ExampleType{})))
```


## Related issues

Might relate to some issues looking for a better way to match arguments: 

- https://github.com/stretchr/testify/issues/1695
- https://github.com/stretchr/testify/issues/1234
- https://github.com/stretchr/testify/issues/1002
- https://github.com/stretchr/testify/issues/817