### PR TITLE
Extend assert.Same to support pointer-like objects

### DIFF
--- a/assert/assertion_format.go
+++ b/assert/assertion_format.go
@@ -702,7 +702,8 @@ func NotRegexpf(t TestingT, rx interface{}, str interface{}, msg string, args ..
 //
 //	assert.NotSamef(t, ptr1, ptr2, "error message %s", "formatted")
 //
-// Both arguments must be pointer variables. Pointer variable sameness is
+// Both arguments must be pointer variables or something directly coercible
+// to a pointer such as a map or channel. Pointer variable sameness is
 // determined based on the equality of both type and value.
 func NotSamef(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
@@ -794,7 +795,8 @@ func Regexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...in
 //
 //	assert.Samef(t, ptr1, ptr2, "error message %s", "formatted")
 //
-// Both arguments must be pointer variables. Pointer variable sameness is
+// Both arguments must be pointer variables or something directly coercible
+// to a pointer such as a map or channel. Pointer variable sameness is
 // determined based on the equality of both type and value.
 func Samef(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {

--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -1392,7 +1392,8 @@ func (a *Assertions) NotRegexpf(rx interface{}, str interface{}, msg string, arg
 //
 //	a.NotSame(ptr1, ptr2)
 //
-// Both arguments must be pointer variables. Pointer variable sameness is
+// Both arguments must be pointer variables or something directly coercible
+// to a pointer such as a map or channel. Pointer variable sameness is
 // determined based on the equality of both type and value.
 func (a *Assertions) NotSame(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
@@ -1405,7 +1406,8 @@ func (a *Assertions) NotSame(expected interface{}, actual interface{}, msgAndArg
 //
 //	a.NotSamef(ptr1, ptr2, "error message %s", "formatted")
 //
-// Both arguments must be pointer variables. Pointer variable sameness is
+// Both arguments must be pointer variables or something directly coercible
+// to a pointer such as a map or channel. Pointer variable sameness is
 // determined based on the equality of both type and value.
 func (a *Assertions) NotSamef(expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
@@ -1576,7 +1578,8 @@ func (a *Assertions) Regexpf(rx interface{}, str interface{}, msg string, args .
 //
 //	a.Same(ptr1, ptr2)
 //
-// Both arguments must be pointer variables. Pointer variable sameness is
+// Both arguments must be pointer variables or something directly coercible
+// to a pointer such as a map or channel. Pointer variable sameness is
 // determined based on the equality of both type and value.
 func (a *Assertions) Same(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
@@ -1589,7 +1592,8 @@ func (a *Assertions) Same(expected interface{}, actual interface{}, msgAndArgs .
 //
 //	a.Samef(ptr1, ptr2, "error message %s", "formatted")
 //
-// Both arguments must be pointer variables. Pointer variable sameness is
+// Both arguments must be pointer variables or something directly coercible
+// to a pointer such as a map or channel. Pointer variable sameness is
 // determined based on the equality of both type and value.
 func (a *Assertions) Samef(expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {

--- a/require/require.go
+++ b/require/require.go
@@ -1759,7 +1759,8 @@ func NotRegexpf(t TestingT, rx interface{}, str interface{}, msg string, args ..
 //
 //	require.NotSame(t, ptr1, ptr2)
 //
-// Both arguments must be pointer variables. Pointer variable sameness is
+// Both arguments must be pointer variables or something directly coercible
+// to a pointer such as a map or channel. Pointer variable sameness is
 // determined based on the equality of both type and value.
 func NotSame(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
@@ -1775,7 +1776,8 @@ func NotSame(t TestingT, expected interface{}, actual interface{}, msgAndArgs ..
 //
 //	require.NotSamef(t, ptr1, ptr2, "error message %s", "formatted")
 //
-// Both arguments must be pointer variables. Pointer variable sameness is
+// Both arguments must be pointer variables or something directly coercible
+// to a pointer such as a map or channel. Pointer variable sameness is
 // determined based on the equality of both type and value.
 func NotSamef(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
@@ -1991,7 +1993,8 @@ func Regexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...in
 //
 //	require.Same(t, ptr1, ptr2)
 //
-// Both arguments must be pointer variables. Pointer variable sameness is
+// Both arguments must be pointer variables or something directly coercible
+// to a pointer such as a map or channel. Pointer variable sameness is
 // determined based on the equality of both type and value.
 func Same(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
@@ -2007,7 +2010,8 @@ func Same(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...in
 //
 //	require.Samef(t, ptr1, ptr2, "error message %s", "formatted")
 //
-// Both arguments must be pointer variables. Pointer variable sameness is
+// Both arguments must be pointer variables or something directly coercible
+// to a pointer such as a map or channel. Pointer variable sameness is
 // determined based on the equality of both type and value.
 func Samef(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {

--- a/require/require_forward.go
+++ b/require/require_forward.go
@@ -1393,7 +1393,8 @@ func (a *Assertions) NotRegexpf(rx interface{}, str interface{}, msg string, arg
 //
 //	a.NotSame(ptr1, ptr2)
 //
-// Both arguments must be pointer variables. Pointer variable sameness is
+// Both arguments must be pointer variables or something directly coercible
+// to a pointer such as a map or channel. Pointer variable sameness is
 // determined based on the equality of both type and value.
 func (a *Assertions) NotSame(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
@@ -1406,7 +1407,8 @@ func (a *Assertions) NotSame(expected interface{}, actual interface{}, msgAndArg
 //
 //	a.NotSamef(ptr1, ptr2, "error message %s", "formatted")
 //
-// Both arguments must be pointer variables. Pointer variable sameness is
+// Both arguments must be pointer variables or something directly coercible
+// to a pointer such as a map or channel. Pointer variable sameness is
 // determined based on the equality of both type and value.
 func (a *Assertions) NotSamef(expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
@@ -1577,7 +1579,8 @@ func (a *Assertions) Regexpf(rx interface{}, str interface{}, msg string, args .
 //
 //	a.Same(ptr1, ptr2)
 //
-// Both arguments must be pointer variables. Pointer variable sameness is
+// Both arguments must be pointer variables or something directly coercible
+// to a pointer such as a map or channel. Pointer variable sameness is
 // determined based on the equality of both type and value.
 func (a *Assertions) Same(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
@@ -1590,7 +1593,8 @@ func (a *Assertions) Same(expected interface{}, actual interface{}, msgAndArgs .
 //
 //	a.Samef(ptr1, ptr2, "error message %s", "formatted")
 //
-// Both arguments must be pointer variables. Pointer variable sameness is
+// Both arguments must be pointer variables or something directly coercible
+// to a pointer such as a map or channel. Pointer variable sameness is
 // determined based on the equality of both type and value.
 func (a *Assertions) Samef(expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {


### PR DESCRIPTION
## Summary
Modify assert.Same and assert.NotSame to support comparing maps and channels by pointer equality.

## Changes
1. Rename `samePointers` to `sameReferences` and generalize it so it will try comparing objects that are represented using a single pointer/reference, as opposed to comparing only literal pointers. We maintain the invariant that the two args must have the same Kind and Type.
2. Rename `Test_samePointers` to `Test_sameReferences`
3. Add test cases to `Test_sameReferences`, `TestSame`, and `TestNotSame`.

## Motivation
Today, assert.Same and assert.NotSame support comparing only literal pointers. This PR generalizes both functions so they also support comparing maps and channels by type and pointer equality.

Why these two types? Because the [Go language reference][0] states:

> - A pointer value is a reference to the variable holding the pointer base type value. 
> - A map or channel value is a reference to the implementation-specific data structure of the map or channel.

That is, all three types are represented by a single reference to some underlying value.

Given this, my belief is it would minimize surprise for users if we handle all three cases in the same way in Same/NotSame: we compare the objects by pointer equality, regardless if the underlying value is a user-defined object vs some implementation-specific data structure.

By this logic, I decided against modifying Same/NotSame to support comparing things like slices, which are not represented via a single reference.

  [0]: https://go.dev/ref/spec#Representation_of_values

## Related issues
There is a related discussion https://github.com/stretchr/testify/discussions/1732, where (iiuc) the claim was made that we should not support Same/NotSame for maps because we cannot compare map keys and values for sameness in all cases.

However, I found this a somewhat surprising argument: if Same is given a pointer to some user-defined struct, it currently does not attempt to introspect and compare the contents of that struct. So, I don't see why it's necessary or expected to do the same for maps.

Hence, this PR.
