### PR TITLE
Fix: a data race condition after a timeout on an `assert.Eventually` call.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ _testmain.go
 
 .DS_Store
 
+.idea
+
 # Output of "go test -c"
 /assert/assert.test
 /require/require.test

--- a/require/requirements_test.go
+++ b/require/requirements_test.go
@@ -788,3 +788,22 @@ func TestEventuallyWithTTrue(t *testing.T) {
 	False(t, mockT.Failed, "Check should pass")
 	Equal(t, 2, counter, "Condition is expected to be called 2 times")
 }
+
+func TestEventuallyTimeout(t *testing.T) {
+	t.Parallel()
+
+	mockT := new(MockT)
+
+	counter := 0
+	condition := func() bool {
+		counter += 1
+		// this is here to check for data race conditions.
+		time.Sleep(20 * time.Millisecond)
+		return false
+	}
+	//Done to check for data race
+	counter += 1
+	Eventually(mockT, condition, 100*time.Millisecond, 20*time.Millisecond)
+	True(t, mockT.Failed, "check should fail")
+	Greater(t, counter, 2, "we should have more than one iteration")
+}


### PR DESCRIPTION
## Summary
Fixes a data race when using assert.Eventually so the variables can be safely used after a timeout

This was found in my test code when the eventually timed out and I was using something set in the closure. It required the `--race`  `go test` parameter set.


## Changes
added a wait group to wait for the end of the go routine call in assert.Eventually

