### PR TITLE
fix(require): correct invalid examples in doc comments #issue-1776

### DIFF
--- a/require/require.go
+++ b/require/require.go
@@ -1388,9 +1388,8 @@ func NoDirExistsf(t TestingT, path string, msg string, args ...interface{}) {
 // NoError asserts that a function returned no error (i.e. `nil`).
 //
 //	  actualObj, err := SomeFunction()
-//	  if require.NoError(t, err) {
-//		   require.Equal(t, expectedObj, actualObj)
-//	  }
+//	  require.NoError(t, err)
+//	  require.Equal(t, expectedObj, actualObj)
 func NoError(t TestingT, err error, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1404,9 +1403,8 @@ func NoError(t TestingT, err error, msgAndArgs ...interface{}) {
 // NoErrorf asserts that a function returned no error (i.e. `nil`).
 //
 //	  actualObj, err := SomeFunction()
-//	  if require.NoErrorf(t, err, "error message %s", "formatted") {
-//		   require.Equal(t, expectedObj, actualObj)
-//	  }
+//	  require.NoErrorf(t, err, "error message %s", "formatted")
+//	  require.Equal(t, expectedObj, actualObj)
 func NoErrorf(t TestingT, err error, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()


### PR DESCRIPTION
## Summary
Correct invalid examples in require package doc comments.
require does not return a boolean value; its responsibility is to fail immediately.

## Changes
- Updated doc comments where examples incorrectly used require inside an if condition.
```go
// NoError asserts that a function returned no error (i.e. `nil`).
//
//	  actualObj, err := SomeFunction()
//	  require.NoError(t, err)
//	  require.Equal(t, expectedObj, actualObj)
func NoError(t TestingT, err error, msgAndArgs ...interface{})
```

## Motivation
Unlike assert, require functions do not return a boolean value.
The previous examples suggested patterns such as if require.NoError(t, err) { ... }, which are invalid.
This PR corrects the documentation to properly reflect the intended usage of require.

## Related issues

Closes #1776
