### PR TITLE
CI: test also with Go 1.23

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,7 @@ jobs:
           - "1.20"
           - "1.21"
           - "1.22"
+          - "1.23"
     steps:
       - uses: actions/checkout@v5
       - name: Setup Go


### PR DESCRIPTION

## Summary
Now that Go 1.25.0 is released, Go 1.23 must be explicitely mentioned for testing as it was previously "oldstable".

## Changes
* add go1.23 in CI matrix 
