### PR TITLE
Promote ccoVeille to maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,6 +7,7 @@ pull requests.
   * @dolmen
   * @MovieStoreGuy
   * @brackendawson
+  * @ccoVeille
 
 ## Approvers
 
@@ -14,4 +15,3 @@ The individuals listed below are active in the project and have the ability to a
 requests.
 
   * @arjunmahishi
-  * @ccoVeille


### PR DESCRIPTION
## Summary
@ccoVeille has demonstrated continued commitment to maintain testify and I think now has at least as much familiarity with the codebase and the expected level of quality for a merge as the current maintainers had when they were appointed.

## Changes
* Move ccoVeille from approvers to maintainers in MAINTAINERS.md
* Grant @ccoVeille the "maintain" role in this repository. I will do this when this PR is merged.

## Motivation
As summarised.

## Related issues
No issue.
