### PR TITLE
assert: IsIncreasing et al can return false w/out failing

### DIFF
--- a/assert/assertion_order.go
+++ b/assert/assertion_order.go
@@ -9,7 +9,7 @@ import (
 func isOrdered(t TestingT, object interface{}, allowedComparesResults []CompareType, failMessage string, msgAndArgs ...interface{}) bool {
 	objKind := reflect.TypeOf(object).Kind()
 	if objKind != reflect.Slice && objKind != reflect.Array {
-		return false
+		return Fail(t, fmt.Sprintf("object %T is not a collection", object), msgAndArgs...)
 	}
 
 	objValue := reflect.ValueOf(object)

--- a/assert/assertion_order.go
+++ b/assert/assertion_order.go
@@ -9,7 +9,7 @@ import (
 func isOrdered(t TestingT, object interface{}, allowedComparesResults []CompareType, failMessage string, msgAndArgs ...interface{}) bool {
 	objKind := reflect.TypeOf(object).Kind()
 	if objKind != reflect.Slice && objKind != reflect.Array {
-		return Fail(t, fmt.Sprintf("object %T is not a collection", object), msgAndArgs...)
+		return Fail(t, fmt.Sprintf("object %T is not an ordered collection", object), msgAndArgs...)
 	}
 
 	objValue := reflect.ValueOf(object)

--- a/assert/assertion_order.go
+++ b/assert/assertion_order.go
@@ -50,6 +50,9 @@ func isOrdered(t TestingT, object interface{}, allowedComparesResults []CompareT
 //	assert.IsIncreasing(t, []float{1, 2})
 //	assert.IsIncreasing(t, []string{"a", "b"})
 func IsIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
 	return isOrdered(t, object, []CompareType{compareLess}, "\"%v\" is not less than \"%v\"", msgAndArgs...)
 }
 
@@ -59,6 +62,9 @@ func IsIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) boo
 //	assert.IsNonIncreasing(t, []float{2, 1})
 //	assert.IsNonIncreasing(t, []string{"b", "a"})
 func IsNonIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
 	return isOrdered(t, object, []CompareType{compareEqual, compareGreater}, "\"%v\" is not greater than or equal to \"%v\"", msgAndArgs...)
 }
 
@@ -68,6 +74,9 @@ func IsNonIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) 
 //	assert.IsDecreasing(t, []float{2, 1})
 //	assert.IsDecreasing(t, []string{"b", "a"})
 func IsDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
 	return isOrdered(t, object, []CompareType{compareGreater}, "\"%v\" is not greater than \"%v\"", msgAndArgs...)
 }
 
@@ -77,5 +86,8 @@ func IsDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) boo
 //	assert.IsNonDecreasing(t, []float{1, 2})
 //	assert.IsNonDecreasing(t, []string{"a", "b"})
 func IsNonDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
 	return isOrdered(t, object, []CompareType{compareLess, compareEqual}, "\"%v\" is not less than or equal to \"%v\"", msgAndArgs...)
 }

--- a/assert/assertion_order_test.go
+++ b/assert/assertion_order_test.go
@@ -44,7 +44,7 @@ func TestIsIncreasing(t *testing.T) {
 		{collection: []uint64{2, 1}, msg: `"2" is not less than "1"`},
 		{collection: []float32{2.34, 1.23}, msg: `"2.34" is not less than "1.23"`},
 		{collection: []float64{2.34, 1.23}, msg: `"2.34" is not less than "1.23"`},
-		{collection: struct{}{}, msg: `object struct {} is not a collection`},
+		{collection: struct{}{}, msg: `object struct {} is not an ordered collection`},
 	} {
 		t.Run(fmt.Sprintf("%#v", currCase.collection), func(t *testing.T) {
 			out := &outputT{buf: bytes.NewBuffer(nil)}
@@ -92,7 +92,7 @@ func TestIsNonIncreasing(t *testing.T) {
 		{collection: []uint64{1, 2}, msg: `"1" is not greater than or equal to "2"`},
 		{collection: []float32{1.23, 2.34}, msg: `"1.23" is not greater than or equal to "2.34"`},
 		{collection: []float64{1.23, 2.34}, msg: `"1.23" is not greater than or equal to "2.34"`},
-		{collection: struct{}{}, msg: `object struct {} is not a collection`},
+		{collection: struct{}{}, msg: `object struct {} is not an ordered collection`},
 	} {
 		t.Run(fmt.Sprintf("%#v", currCase.collection), func(t *testing.T) {
 			out := &outputT{buf: bytes.NewBuffer(nil)}
@@ -140,7 +140,7 @@ func TestIsDecreasing(t *testing.T) {
 		{collection: []uint64{1, 2}, msg: `"1" is not greater than "2"`},
 		{collection: []float32{1.23, 2.34}, msg: `"1.23" is not greater than "2.34"`},
 		{collection: []float64{1.23, 2.34}, msg: `"1.23" is not greater than "2.34"`},
-		{collection: struct{}{}, msg: `object struct {} is not a collection`},
+		{collection: struct{}{}, msg: `object struct {} is not an ordered collection`},
 	} {
 		t.Run(fmt.Sprintf("%#v", currCase.collection), func(t *testing.T) {
 			out := &outputT{buf: bytes.NewBuffer(nil)}
@@ -188,7 +188,7 @@ func TestIsNonDecreasing(t *testing.T) {
 		{collection: []uint64{2, 1}, msg: `"2" is not less than or equal to "1"`},
 		{collection: []float32{2.34, 1.23}, msg: `"2.34" is not less than or equal to "1.23"`},
 		{collection: []float64{2.34, 1.23}, msg: `"2.34" is not less than or equal to "1.23"`},
-		{collection: struct{}{}, msg: `object struct {} is not a collection`},
+		{collection: struct{}{}, msg: `object struct {} is not an ordered collection`},
 	} {
 		t.Run(fmt.Sprintf("%#v", currCase.collection), func(t *testing.T) {
 			out := &outputT{buf: bytes.NewBuffer(nil)}

--- a/assert/assertion_order_test.go
+++ b/assert/assertion_order_test.go
@@ -2,6 +2,7 @@ package assert
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 )
 
@@ -43,10 +44,13 @@ func TestIsIncreasing(t *testing.T) {
 		{collection: []uint64{2, 1}, msg: `"2" is not less than "1"`},
 		{collection: []float32{2.34, 1.23}, msg: `"2.34" is not less than "1.23"`},
 		{collection: []float64{2.34, 1.23}, msg: `"2.34" is not less than "1.23"`},
+		{collection: struct{}{}, msg: `object struct {} is not a collection`},
 	} {
-		out := &outputT{buf: bytes.NewBuffer(nil)}
-		False(t, IsIncreasing(out, currCase.collection))
-		Contains(t, out.buf.String(), currCase.msg)
+		t.Run(fmt.Sprintf("%#v", currCase.collection), func(t *testing.T) {
+			out := &outputT{buf: bytes.NewBuffer(nil)}
+			False(t, IsIncreasing(out, currCase.collection))
+			Contains(t, out.buf.String(), currCase.msg)
+		})
 	}
 }
 
@@ -88,10 +92,13 @@ func TestIsNonIncreasing(t *testing.T) {
 		{collection: []uint64{1, 2}, msg: `"1" is not greater than or equal to "2"`},
 		{collection: []float32{1.23, 2.34}, msg: `"1.23" is not greater than or equal to "2.34"`},
 		{collection: []float64{1.23, 2.34}, msg: `"1.23" is not greater than or equal to "2.34"`},
+		{collection: struct{}{}, msg: `object struct {} is not a collection`},
 	} {
-		out := &outputT{buf: bytes.NewBuffer(nil)}
-		False(t, IsNonIncreasing(out, currCase.collection))
-		Contains(t, out.buf.String(), currCase.msg)
+		t.Run(fmt.Sprintf("%#v", currCase.collection), func(t *testing.T) {
+			out := &outputT{buf: bytes.NewBuffer(nil)}
+			False(t, IsNonIncreasing(out, currCase.collection))
+			Contains(t, out.buf.String(), currCase.msg)
+		})
 	}
 }
 
@@ -133,10 +140,13 @@ func TestIsDecreasing(t *testing.T) {
 		{collection: []uint64{1, 2}, msg: `"1" is not greater than "2"`},
 		{collection: []float32{1.23, 2.34}, msg: `"1.23" is not greater than "2.34"`},
 		{collection: []float64{1.23, 2.34}, msg: `"1.23" is not greater than "2.34"`},
+		{collection: struct{}{}, msg: `object struct {} is not a collection`},
 	} {
-		out := &outputT{buf: bytes.NewBuffer(nil)}
-		False(t, IsDecreasing(out, currCase.collection))
-		Contains(t, out.buf.String(), currCase.msg)
+		t.Run(fmt.Sprintf("%#v", currCase.collection), func(t *testing.T) {
+			out := &outputT{buf: bytes.NewBuffer(nil)}
+			False(t, IsDecreasing(out, currCase.collection))
+			Contains(t, out.buf.String(), currCase.msg)
+		})
 	}
 }
 
@@ -178,10 +188,13 @@ func TestIsNonDecreasing(t *testing.T) {
 		{collection: []uint64{2, 1}, msg: `"2" is not less than or equal to "1"`},
 		{collection: []float32{2.34, 1.23}, msg: `"2.34" is not less than or equal to "1.23"`},
 		{collection: []float64{2.34, 1.23}, msg: `"2.34" is not less than or equal to "1.23"`},
+		{collection: struct{}{}, msg: `object struct {} is not a collection`},
 	} {
-		out := &outputT{buf: bytes.NewBuffer(nil)}
-		False(t, IsNonDecreasing(out, currCase.collection))
-		Contains(t, out.buf.String(), currCase.msg)
+		t.Run(fmt.Sprintf("%#v", currCase.collection), func(t *testing.T) {
+			out := &outputT{buf: bytes.NewBuffer(nil)}
+			False(t, IsNonDecreasing(out, currCase.collection))
+			Contains(t, out.buf.String(), currCase.msg)
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
If you passed a non-collection to IsIncreasing or any of its compatriots then the assertion would return false without failing the test.

## Changes
* Make `isOrdered()` return `Fail()` rather than `false` in validation so that the test will fail.
* Test the above.

## Motivation
The following invalid usage would previously pass:
```go
var nonList int
assert.IsIncreasing(t, nonList)
```

## Related issues
Closes #1419