### PR TITLE
CI: test also with Go 1.24, 1.25

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,8 @@ jobs:
           - "1.21"
           - "1.22"
           - "1.23"
+          - "1.24"
+          - "1.25"
     steps:
       - uses: actions/checkout@v5
       - name: Setup Go


### PR DESCRIPTION
## Summary
test also with Go 1.24, 1.25

## Changes

- test with Go 1.24
- test with Go 1.25

## Motivation

should testing  with available versions of Go.

## Related issues

- copy of https://github.com/stretchr/testify/pull/1783
