### PR TITLE
add type to error message of assert.Same

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -544,8 +544,8 @@ func Same(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) b
 	if !same {
 		// both are pointers but not the same type & pointing to the same address
 		return Fail(t, fmt.Sprintf("Not same: \n"+
-			"expected: %p %#[1]v\n"+
-			"actual  : %p %#[2]v",
+			"expected: %#[1]v (%[1]T)(%[1]p)\n"+
+			"actual  : %#[2]v (%[2]T)(%[2]p)",
 			expected, actual), msgAndArgs...)
 	}
 

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -635,7 +635,7 @@ func ptr(i int) *int {
 func TestSame(t *testing.T) {
 	t.Parallel()
 
-	mockT := new(testing.T)
+	mockT := new(mockTestingT)
 
 	if Same(mockT, ptr(1), ptr(1)) {
 		t.Error("Same should return false")
@@ -650,6 +650,22 @@ func TestSame(t *testing.T) {
 	if !Same(mockT, p, p) {
 		t.Error("Same should return true")
 	}
+
+	t.Run("same object, different type", func(t *testing.T) {
+		type s struct {
+			i int
+		}
+		type sPtr *s
+		ps := &s{1}
+		dps := sPtr(ps)
+		if Same(mockT, dps, ps) {
+			t.Error("Same should return false")
+		}
+		expPat :=
+			`expected: &assert.s\{i:1\} \(assert.sPtr\)\((0x[a-f0-9]+)\)\s*\n` +
+				`\s+actual  : &assert.s\{i:1\} \(\*assert.s\)\((0x[a-f0-9]+)\)`
+		Regexp(t, regexp.MustCompile(expPat), mockT.errorString())
+	})
 }
 
 func TestNotSame(t *testing.T) {


### PR DESCRIPTION
## Summary

This PR adds a type names of testing values to a fail message of assert.Same().

This PR recreates the content of #1056. The original PR was closed due to merge conflicts.

## Changes

Adds type names of testing values to a fail message of assert.Same(), which might be necessary to identify the cause of failing.

## Motivation

Currently, when `assert.Same()` fails, it outputs a message with pointer values and its go-syntax representation of `actual`/`expected` values.

`assert.Same()` would fail when types of two values are different. The following test code would fail:

~~~go
type Member struct {
	Name string
	Age  int
}

type MemberPtr *Member

func TestMember(t *testing.T) {
	m := &Member{"Niko", 18}
	p := MemberPtr(m)

	assert.Same(t, m, p)
}
~~~

However, it seems no difference between `actual` and `expected` in its fail message, because they point to the same object. It would be hard to know why the test fails from this message.

~~~
=== RUN   TestMember
    my_test.go:20:
        	Error Trace:	/tmp/mytest/my_test.go:20
        	Error:      	Not same:
        	            	expected: 0x14000112438 &mytest.Member{Name:"Niko", Age:18}
        	            	actual  : 0x14000112438 &mytest.Member{Name:"Niko", Age:18}
        	Test:       	TestMember
--- FAIL: TestMember (0.00s)
FAIL
exit status 1
FAIL	mytest	0.230s
~~~

This PR adds type names of two values. The output would be like this:

~~~
=== RUN   TestMember
    my_test.go:20:
        	Error Trace:	/tmp/mytest/my_test.go:20
        	Error:      	Not same:
        	            	expected: &mytest.Member{Name:"Niko", Age:18} (*mytest.Member)(0x14000192438)
        	            	actual  : &mytest.Member{Name:"Niko", Age:18} (mytest.MemberPtr)(0x14000192438)
        	Test:       	TestMember
--- FAIL: TestMember (0.00s)
FAIL
exit status 1
FAIL	mytest	0.253s
~~~

## Related issues

