### PR TITLE
mock.AnythingOfType fix panic when matching nil type

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -808,7 +808,8 @@ type AnythingOfTypeArgument = anythingOfTypeArgument
 type anythingOfTypeArgument string
 
 // AnythingOfType returns a special value containing the
-// name of the type to check for. The type name will be matched against the type name returned by [reflect.Type.String].
+// name of the type to check for. The type name will be matched against the type
+// name returned by [reflect.Type.String], or against "<nil>" for nil type .
 //
 // Used in Diff and Assert.
 //
@@ -1007,10 +1008,16 @@ func (args Arguments) Diff(objects []interface{}) (string, int) {
 			switch expected := expected.(type) {
 			case anythingOfTypeArgument:
 				// type checking
-				if reflect.TypeOf(actual).Name() != string(expected) && reflect.TypeOf(actual).String() != string(expected) {
+				actualTypeName := "<nil>"
+				actualTypeString := "<nil>"
+				if actual != nil {
+					actualTypeName = reflect.TypeOf(actual).Name()
+					actualTypeString = reflect.TypeOf(actual).String()
+				}
+				if actualTypeName != string(expected) && actualTypeString != string(expected) {
 					// not match
 					differences++
-					output = fmt.Sprintf("%s\t%d: FAIL:  type %s != type %s - %s\n", output, i, expected, reflect.TypeOf(actual).Name(), actualFmt)
+					output = fmt.Sprintf("%s\t%d: FAIL:  type %s != type %s - %s\n", output, i, expected, actualTypeName, actualFmt)
 				}
 			case *IsTypeArgument:
 				actualT := reflect.TypeOf(actual)


### PR DESCRIPTION
Fix a panic in the AnythingOfType matcher when matching nil type.

It's reported that IsType had the same panic but a refactor between then and now appears to have fixed this.

## Summary
<!-- High-level, one sentence summary of what this PR accomplishes -->

## Changes
* Handle the nil type case before calling reflect.Type.String.
* Because (<nil>=<nil>) looks confusing, change the failure message value format to the more idiomatic (%T)(%v).
* In order to better test the failure message, change the mockTestingT to capture the messages passed to it.

## Motivation
AnythingOfType would panic if the actual arg value was of type nil. 

## Related issues
* Closes #1209
* Supersedes #1219
