### PR TITLE
assert: add Kind and NotKind

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -502,6 +502,21 @@ func Kind(t TestingT, expectedKind reflect.Kind, object interface{}, msgAndArgs 
 	return Fail(t, fmt.Sprintf("Object expected to be of kind %v, but was %v", expectedKind, objectKind), msgAndArgs...)
 }
 
+// NotKind asserts that the given object's kind does not match the unexpected kind.
+//
+//	assert.NotKind(t, reflect.Int, "Hello World")
+func NotKind(t TestingT, unexpectedKind reflect.Kind, object interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	objectKind := reflect.TypeOf(object).Kind()
+	if objectKind != unexpectedKind {
+		return true
+	}
+	return Fail(t, fmt.Sprintf("Object expected NOT to be of kind %v, but was %v", unexpectedKind, objectKind), msgAndArgs...)
+}
+
 // Equal asserts that two objects are equal.
 //
 //	assert.Equal(t, 123, 123)

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -2313,3 +2313,15 @@ func buildErrorChainString(err error, withType bool) string {
 	}
 	return chain
 }
+
+// Kind check if the given object is of the given type
+func Kind(t TestingT, expected reflect.Kind, object interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	if reflect.TypeOf(object).Kind() == expected {
+		return true
+	}
+	return false
+}

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -487,6 +487,21 @@ func IsNotType(t TestingT, theType, object interface{}, msgAndArgs ...interface{
 	return Fail(t, fmt.Sprintf("Object type expected to be different than %T", theType), msgAndArgs...)
 }
 
+// Kind asserts that the given object's kind matches the expected kind.
+//
+//	assert.Kind(t, reflect.String, "Hello World")
+func Kind(t TestingT, expectedKind reflect.Kind, object interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	objectKind := reflect.TypeOf(object).Kind()
+	if objectKind == expectedKind {
+		return true
+	}
+	return Fail(t, fmt.Sprintf("Object expected to be of kind %v, but was %v", expectedKind, objectKind), msgAndArgs...)
+}
+
 // Equal asserts that two objects are equal.
 //
 //	assert.Equal(t, 123, 123)
@@ -2312,16 +2327,4 @@ func buildErrorChainString(err error, withType bool) string {
 		}
 	}
 	return chain
-}
-
-// Kind check if the given object is of the given type
-func Kind(t TestingT, expected reflect.Kind, object interface{}) bool {
-	if h, ok := t.(tHelper); ok {
-		h.Helper()
-	}
-
-	if reflect.TypeOf(object).Kind() == expected {
-		return true
-	}
-	return false
 }

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -608,10 +608,14 @@ func TestEqual(t *testing.T) {
 		{uint64(123), uint64(123), true, ""},
 		{myType("1"), myType("1"), true, ""},
 		{&struct{}{}, &struct{}{}, true, "pointer equality is based on equality of underlying value"},
+		{time.Date(2020, 3, 1, 12, 23, 14, 0, time.UTC), time.Date(2020, 3, 1, 12, 23, 14, 0, time.UTC), true, ""},
+		{time.Date(2020, 6, 3, 12, 23, 14, 0, time.UTC), time.Date(2020, 6, 3, 12, 23, 14, 0, time.UTC), true, ""},
 
 		// Not expected to be equal
 		{m["bar"], "something", false, ""},
 		{myType("1"), myType("2"), false, ""},
+		{time.Date(2020, 3, 1, 12, 23, 14, 0, time.UTC), time.Date(2020, 5, 1, 12, 23, 14, 0, time.UTC), true, ""},
+		{time.Date(2020, 6, 3, 12, 23, 14, 0, time.UTC), time.Date(2020, 8, 3, 12, 23, 14, 0, time.UTC), true, ""},
 
 		// A case that might be confusing, especially with numeric literals
 		{10, uint(10), false, ""},
@@ -4209,4 +4213,43 @@ func TestNotErrorAsWithErrorTooLongToPrint(t *testing.T) {
 	Contains(t, mockT.errorString(), `
 	            	in chain: "long: [0 0 0`)
 	Contains(t, mockT.errorString(), "<... truncated>")
+}
+
+func TestKind(t *testing.T) {
+	type myType string
+
+	mockT := new(testing.T)
+	a := 12
+
+	cases := []struct {
+		expected reflect.Kind
+		object   interface{}
+		result   bool
+		remark   string
+	}{
+		{reflect.String, "Hello World", true, "1"},
+		{reflect.Int, 123, true, "2"},
+		{reflect.Array, [6]int{2, 3, 5, 7, 11, 13}, true, "3"},
+		{reflect.Func, Kind, true, "4"},
+		{reflect.Float64, 0.0345, true, "5"},
+		{reflect.Map, make(map[string]int), true, "6"},
+		{reflect.Bool, true, true, "7"},
+		{reflect.Ptr, &a, true, "8"},
+
+		// Not expected to be equal
+		{reflect.String, 13, false, "9"},
+		{reflect.Int, [6]int{2, 3, 5, 7, 11, 13}, false, "10"},
+		{reflect.Float64, 12, false, "11"},
+		{reflect.Bool, make(map[string]int), false, "12"},
+	}
+
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("Kind(%#v, %#v)", c.expected, c.object), func(t *testing.T) {
+			res := Kind(mockT, c.expected, c.object)
+
+			if res != c.result {
+				t.Errorf("Kind(%#v, %#v) should return %#v: %s", c.expected, c.object, c.result, c.remark)
+			}
+		})
+	}
 }

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -608,14 +608,10 @@ func TestEqual(t *testing.T) {
 		{uint64(123), uint64(123), true, ""},
 		{myType("1"), myType("1"), true, ""},
 		{&struct{}{}, &struct{}{}, true, "pointer equality is based on equality of underlying value"},
-		{time.Date(2020, 3, 1, 12, 23, 14, 0, time.UTC), time.Date(2020, 3, 1, 12, 23, 14, 0, time.UTC), true, ""},
-		{time.Date(2020, 6, 3, 12, 23, 14, 0, time.UTC), time.Date(2020, 6, 3, 12, 23, 14, 0, time.UTC), true, ""},
 
 		// Not expected to be equal
 		{m["bar"], "something", false, ""},
 		{myType("1"), myType("2"), false, ""},
-		{time.Date(2020, 3, 1, 12, 23, 14, 0, time.UTC), time.Date(2020, 5, 1, 12, 23, 14, 0, time.UTC), true, ""},
-		{time.Date(2020, 6, 3, 12, 23, 14, 0, time.UTC), time.Date(2020, 8, 3, 12, 23, 14, 0, time.UTC), true, ""},
 
 		// A case that might be confusing, especially with numeric literals
 		{10, uint(10), false, ""},

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -585,6 +585,42 @@ func TestNotIsType(t *testing.T) {
 	}
 }
 
+func TestKind(t *testing.T) {
+	mockT := new(testing.T)
+
+	cases := []struct {
+		expected reflect.Kind
+		object   interface{}
+		result   bool
+		remark   string
+	}{
+		{reflect.String, "Hello World", true, "1"},
+		{reflect.Int, 123, true, "2"},
+		{reflect.Array, [6]int{2, 3, 5, 7, 11, 13}, true, "3"},
+		{reflect.Func, Kind, true, "4"},
+		{reflect.Float64, 0.0345, true, "5"},
+		{reflect.Map, make(map[string]int), true, "6"},
+		{reflect.Bool, true, true, "7"},
+		{reflect.Ptr, new(int), true, "8"},
+
+		// Not expected to be equal
+		{reflect.String, 13, false, "9"},
+		{reflect.Int, [6]int{2, 3, 5, 7, 11, 13}, false, "10"},
+		{reflect.Float64, 12, false, "11"},
+		{reflect.Bool, make(map[string]int), false, "12"},
+	}
+
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("Kind(%#v, %#v)", c.expected, c.object), func(t *testing.T) {
+			res := Kind(mockT, c.expected, c.object)
+
+			if res != c.result {
+				t.Errorf("Kind(%#v, %#v) should return %#v: %s", c.expected, c.object, c.result, c.remark)
+			}
+		})
+	}
+}
+
 func TestEqual(t *testing.T) {
 	t.Parallel()
 
@@ -4209,43 +4245,4 @@ func TestNotErrorAsWithErrorTooLongToPrint(t *testing.T) {
 	Contains(t, mockT.errorString(), `
 	            	in chain: "long: [0 0 0`)
 	Contains(t, mockT.errorString(), "<... truncated>")
-}
-
-func TestKind(t *testing.T) {
-	type myType string
-
-	mockT := new(testing.T)
-	a := 12
-
-	cases := []struct {
-		expected reflect.Kind
-		object   interface{}
-		result   bool
-		remark   string
-	}{
-		{reflect.String, "Hello World", true, "1"},
-		{reflect.Int, 123, true, "2"},
-		{reflect.Array, [6]int{2, 3, 5, 7, 11, 13}, true, "3"},
-		{reflect.Func, Kind, true, "4"},
-		{reflect.Float64, 0.0345, true, "5"},
-		{reflect.Map, make(map[string]int), true, "6"},
-		{reflect.Bool, true, true, "7"},
-		{reflect.Ptr, &a, true, "8"},
-
-		// Not expected to be equal
-		{reflect.String, 13, false, "9"},
-		{reflect.Int, [6]int{2, 3, 5, 7, 11, 13}, false, "10"},
-		{reflect.Float64, 12, false, "11"},
-		{reflect.Bool, make(map[string]int), false, "12"},
-	}
-
-	for _, c := range cases {
-		t.Run(fmt.Sprintf("Kind(%#v, %#v)", c.expected, c.object), func(t *testing.T) {
-			res := Kind(mockT, c.expected, c.object)
-
-			if res != c.result {
-				t.Errorf("Kind(%#v, %#v) should return %#v: %s", c.expected, c.object, c.result, c.remark)
-			}
-		})
-	}
 }

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -594,20 +594,20 @@ func TestKind(t *testing.T) {
 		result   bool
 		remark   string
 	}{
-		{reflect.String, "Hello World", true, "1"},
-		{reflect.Int, 123, true, "2"},
-		{reflect.Array, [6]int{2, 3, 5, 7, 11, 13}, true, "3"},
-		{reflect.Func, Kind, true, "4"},
-		{reflect.Float64, 0.0345, true, "5"},
-		{reflect.Map, make(map[string]int), true, "6"},
-		{reflect.Bool, true, true, "7"},
-		{reflect.Ptr, new(int), true, "8"},
+		{reflect.String, "Hello World", true, "is string"},
+		{reflect.Int, 123, true, "is int"},
+		{reflect.Array, [6]int{2, 3, 5, 7, 11, 13}, true, "is array"},
+		{reflect.Func, Kind, true, "is func"},
+		{reflect.Float64, 0.0345, true, "is float64"},
+		{reflect.Map, make(map[string]int), true, "is map"},
+		{reflect.Bool, true, true, "is bool"},
+		{reflect.Ptr, new(int), true, "is pointer"},
 
 		// Not expected to be equal
-		{reflect.String, 13, false, "9"},
-		{reflect.Int, [6]int{2, 3, 5, 7, 11, 13}, false, "10"},
-		{reflect.Float64, 12, false, "11"},
-		{reflect.Bool, make(map[string]int), false, "12"},
+		{reflect.String, 13, false, "not string"},
+		{reflect.Int, [6]int{2, 3, 5, 7, 11, 13}, false, "not int"},
+		{reflect.Float64, 12, false, "not float64"},
+		{reflect.Bool, make(map[string]int), false, "not bool"},
 	}
 
 	for _, c := range cases {
@@ -616,6 +616,35 @@ func TestKind(t *testing.T) {
 
 			if res != c.result {
 				t.Errorf("Kind(%#v, %#v) should return %#v: %s", c.expected, c.object, c.result, c.remark)
+			}
+		})
+	}
+}
+
+func TestNotKind(t *testing.T) {
+	mockT := new(testing.T)
+
+	cases := []struct {
+		unexpected reflect.Kind
+		object     interface{}
+		result     bool
+		remark     string
+	}{
+		{reflect.String, 123, true, "not string"},
+		{reflect.Int, "hi", true, "not int"},
+		{reflect.Map, []int{1, 2}, true, "not map"},
+		{reflect.Ptr, 99, true, "not pointer"},
+
+		// Should fail when kinds match
+		{reflect.Func, func() {}, false, "is func"},
+		{reflect.Bool, false, false, "is bool"},
+	}
+
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("NotKind(%#v, %#v)", c.unexpected, c.object), func(t *testing.T) {
+			res := NotKind(mockT, c.unexpected, c.object)
+			if res != c.result {
+				t.Errorf("NotKind(%#v, %#v) should return %#v: %s", c.unexpected, c.object, c.result, c.remark)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
<!-- High-level, one sentence summary of what this PR accomplishes -->
Continues work from #1049 by @matinFT.
This PR rebases with the latest master, fixes according the [original PR's](https://github.com/stretchr/testify/pull/1049) comments by @dolmen , and also add `NotKind` to adhere to the API convention.
This fixes [#633](https://github.com/stretchr/testify/issues/633)

## Changes
<!-- * Description of change 1 -->
<!-- * Description of change 2 -->
<!-- ... -->
Add `Kind` and `NotKind` function in `assert` package.

## Motivation
<!-- Why were the changes necessary. -->

<!-- ## Example usage (if applicable) -->
See #633 

## Related issues
<!-- Put `Closes #XXXX` for each issue number this PR fixes/closes -->
Closes #633 
