### PR TITLE
Tag generated assertions as non-generated in new .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# This file is used to configure Git attributes for the repository.
+# It is particularly useful for managing how generated code is treated in pull requests.
+# For more information, see:
+# https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github
+
+# Code for assertions and requirements is generated automatically by _codegen.
+# This also updates code comments and code examples in the documentation.
+# These comments and examples must be reviewed when they change,
+# since updates to the generated code comments may not always be correct.
+assert/*.go  linguist-generated=false
+require/*.go linguist-generated=false


### PR DESCRIPTION
## Summary
Tag `require` and `assert` code as non-generated so they are not collapsed in PRs.

## Changes
- Add `.gitattributes`
- Tag `require` and `assert` files as `linguist-generated=false` (see documentation [here](https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github))

## Motivation
- Ensure generated comments and code examples are reviewed
- Currently GH seems to collapse even the main `assertions.go`, which is not generated. GH's algorithm does not seem to be very sophisticated
- `linguist-generated` should help (not guaranteed, since in the end GH may still apply its own logic)

## Related issues
- no issue created