### PR TITLE
docs(assert/require): clarify allowed rx values for Regexp/NotRegexp (#268, #1793)

### DIFF
--- a/_codegen/main.go
+++ b/_codegen/main.go
@@ -285,11 +285,22 @@ func (f *testFunc) Comment() string {
 }
 
 func (f *testFunc) CommentFormat() string {
-	search := fmt.Sprintf("%s", f.DocInfo.Name)
-	replace := fmt.Sprintf("%sf", f.DocInfo.Name)
-	comment := strings.Replace(f.Comment(), search, replace, -1)
-	exp := regexp.MustCompile(replace + `\(((\(\)|[^\n])+)\)`)
-	return exp.ReplaceAllString(comment, replace+`($1, "error message %s", "formatted")`)
+	// Start from the original comment text
+	comment := f.Comment()
+
+	// Replace only function call occurrences of the current function name with the formatted variant (suffix 'f').
+	// This avoids accidentally changing type names such as "*regexp.Regexp" into "*regexp.Regexpf".
+	// Match patterns like: "Name(" or "Name (" and replace with "Namef(".
+	fnCallPattern := regexp.MustCompile(`\b` + regexp.QuoteMeta(f.DocInfo.Name) + `\s*\(`)
+	comment = fnCallPattern.ReplaceAllString(comment, f.DocInfo.Name+"f(")
+
+	// For all instances of the formatted function calls, append the formatted message arguments.
+	// Transform: Namef(args) -> Namef(args, "error message %s", "formatted")
+	// Keep the original arguments (captured as $1) and append the formatted message args.
+	addArgsStrict := regexp.MustCompile(regexp.QuoteMeta(f.DocInfo.Name+"f") + `\(((\(\)|[^\n])+?)\)`)
+	comment = addArgsStrict.ReplaceAllString(comment, f.DocInfo.Name+`f($1, "error message %s", "formatted")`)
+
+	return comment
 }
 
 func (f *testFunc) CommentWithoutT(receiver string) string {

--- a/_codegen/main.go
+++ b/_codegen/main.go
@@ -288,17 +288,21 @@ func (f *testFunc) CommentFormat() string {
 	// Start from the original comment text
 	comment := f.Comment()
 
-	// Replace only function call occurrences of the current function name with the formatted variant (suffix 'f').
-	// This avoids accidentally changing type names such as "*regexp.Regexp" into "*regexp.Regexpf".
-	// Match patterns like: "Name(" or "Name (" and replace with "Namef(".
+	// 1) Ensure the leading doc header uses the formatted name (e.g., "Equalf asserts ...").
+	// Only change the very first line that starts with "// <Name>".
+	headerPattern := regexp.MustCompile(`^//\s*` + regexp.QuoteMeta(f.DocInfo.Name) + `\b`)
+	comment = headerPattern.ReplaceAllString(comment, "// "+f.DocInfo.Name+"f")
+
+	// 2) Replace only function call occurrences of the current function name with the formatted variant (suffix 'f').
+	//    This avoids accidentally changing type names such as "*regexp.Regexp" into "*regexp.Regexpf" by requiring a following '('.
 	fnCallPattern := regexp.MustCompile(`\b` + regexp.QuoteMeta(f.DocInfo.Name) + `\s*\(`)
 	comment = fnCallPattern.ReplaceAllString(comment, f.DocInfo.Name+"f(")
 
-	// For all instances of the formatted function calls, append the formatted message arguments.
-	// Transform: Namef(args) -> Namef(args, "error message %s", "formatted")
-	// Keep the original arguments (captured as $1) and append the formatted message args.
-	addArgsStrict := regexp.MustCompile(regexp.QuoteMeta(f.DocInfo.Name+"f") + `\(((\(\)|[^\n])+?)\)`)
-	comment = addArgsStrict.ReplaceAllString(comment, f.DocInfo.Name+`f($1, "error message %s", "formatted")`)
+	// 3) Append formatted message args at the end of each Namef(...) call within a single line.
+	//    Use a greedy match until the last closing paren on the same line to avoid inserting inside nested parentheses.
+	//    Example: Namef(t, uint32(123), int32(123)) -> Namef(t, uint32(123), int32(123), "error message %s", "formatted")
+	addArgsLine := regexp.MustCompile(`(?m)` + regexp.QuoteMeta(f.DocInfo.Name+"f(") + `(.*)\)`)
+	comment = addArgsLine.ReplaceAllString(comment, f.DocInfo.Name+`f($1, "error message %s", "formatted")`)
 
 	return comment
 }

--- a/_codegen/main.go
+++ b/_codegen/main.go
@@ -281,7 +281,19 @@ func (f *testFunc) ForwardedParamsFormat() string {
 }
 
 func (f *testFunc) Comment() string {
-	return "// " + strings.Replace(strings.TrimSpace(f.DocInfo.Doc), "\n", "\n// ", -1)
+	// Preserve original indentation, but ensure lines that start with a tab are
+	// prefixed with "//\t" (no extra space) to match canonical formatting of code examples.
+	raw := strings.TrimSpace(f.DocInfo.Doc)
+	lines := strings.Split(raw, "\n")
+	for i, line := range lines {
+		if strings.HasPrefix(line, "\t") {
+			// Example/code line: keep the leading tab directly after //
+			lines[i] = "//\t" + strings.TrimPrefix(line, "\t")
+		} else {
+			lines[i] = "// " + line
+		}
+	}
+	return strings.Join(lines, "\n")
 }
 
 func (f *testFunc) CommentFormat() string {

--- a/assert/assertion_format.go
+++ b/assert/assertion_format.go
@@ -689,8 +689,12 @@ func NotPanicsf(t TestingT, f PanicTestFunc, msg string, args ...interface{}) bo
 
 // NotRegexpf asserts that a specified regexp does not match a string.
 //
+// The rx (expression) argument should be a *regexp.Regexp. For backward
+// compatibility, if rx is any other type, its value will be formatted with
+// %v and compiled using regexp.MustCompile.
+//
 //	assert.NotRegexpf(t, regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
-//	assert.NotRegexpf(t, "^start", "it's not starting", "error message %s", "formatted")
+//	assert.NotRegexpf(t, "^start", "it's not starting", "error message %s", "formatted") // string is compiled
 func NotRegexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -781,8 +785,12 @@ func Positivef(t TestingT, e interface{}, msg string, args ...interface{}) bool 
 
 // Regexpf asserts that a specified regexp matches a string.
 //
+// The rx (expression) argument should be a *regexp.Regexp. For backward
+// compatibility, if rx is any other type, its value will be formatted with
+// %v and compiled using regexp.MustCompile.
+//
 //	assert.Regexpf(t, regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
-//	assert.Regexpf(t, "start...$", "it's not starting", "error message %s", "formatted")
+//	assert.Regexpf(t, "start...$", "it's not starting", "error message %s", "formatted") // string is compiled
 func Regexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()

--- a/assert/assertion_format.go
+++ b/assert/assertion_format.go
@@ -19,9 +19,9 @@ func Conditionf(t TestingT, comp Comparison, msg string, args ...interface{}) bo
 // Containsf asserts that the specified string, list(array, slice...) or map contains the
 // specified substring or element.
 //
-// 	assert.Containsf(t, "Hello World", "World", "error message %s", "formatted")
-// 	assert.Containsf(t, ["Hello", "World"], "World", "error message %s", "formatted")
-// 	assert.Containsf(t, {"Hello": "World"}, "Hello", "error message %s", "formatted")
+//	assert.Containsf(t, "Hello World", "World", "error message %s", "formatted")
+//	assert.Containsf(t, ["Hello", "World"], "World", "error message %s", "formatted")
+//	assert.Containsf(t, {"Hello": "World"}, "Hello", "error message %s", "formatted")
 func Containsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -60,7 +60,7 @@ func ElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string
 //
 // Pointer values are "empty" if the pointer is nil or if the pointed value is "empty".
 //
-// 	assert.Emptyf(t, obj, "error message %s", "formatted")
+//	assert.Emptyf(t, obj, "error message %s", "formatted")
 //
 // [Zero values]: https://go.dev/ref/spec#The_zero_value
 func Emptyf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
@@ -72,7 +72,7 @@ func Emptyf(t TestingT, object interface{}, msg string, args ...interface{}) boo
 
 // Equalf asserts that two objects are equal.
 //
-// 	assert.Equalf(t, 123, 123, "error message %s", "formatted")
+//	assert.Equalf(t, 123, 123, "error message %s", "formatted")
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses). Function equality
@@ -87,8 +87,8 @@ func Equalf(t TestingT, expected interface{}, actual interface{}, msg string, ar
 // EqualErrorf asserts that a function returned a non-nil error (i.e. an error)
 // and that it is equal to the provided error.
 //
-// 	actualObj, err := SomeFunction()
-// 	assert.EqualErrorf(t, err,  expectedErrorString, "error message %s", "formatted")
+//	actualObj, err := SomeFunction()
+//	assert.EqualErrorf(t, err,  expectedErrorString, "error message %s", "formatted")
 func EqualErrorf(t TestingT, theError error, errString string, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -100,12 +100,12 @@ func EqualErrorf(t TestingT, theError error, errString string, msg string, args 
 // fields are also equal. This is useful for comparing structs that have private fields
 // that could potentially differ.
 //
-// 	 type S struct {
-// 		Exported     	int
-// 		notExported   	int
-// 	 }
-// 	 assert.EqualExportedValuesf(t, S{1, 2}, S{1, 3}, "error message %s", "formatted") => true
-// 	 assert.EqualExportedValuesf(t, S{1, 2}, S{2, 3}, "error message %s", "formatted") => false
+//	 type S struct {
+//		Exported     	int
+//		notExported   	int
+//	 }
+//	 assert.EqualExportedValuesf(t, S{1, 2}, S{1, 3}, "error message %s", "formatted") => true
+//	 assert.EqualExportedValuesf(t, S{1, 2}, S{2, 3}, "error message %s", "formatted") => false
 func EqualExportedValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -116,7 +116,7 @@ func EqualExportedValuesf(t TestingT, expected interface{}, actual interface{}, 
 // EqualValuesf asserts that two objects are equal or convertible to the larger
 // type and equal.
 //
-// 	assert.EqualValuesf(t, uint32(123), int32(123), "error message %s", "formatted")
+//	assert.EqualValuesf(t, uint32(123), int32(123), "error message %s", "formatted")
 func EqualValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -126,8 +126,8 @@ func EqualValuesf(t TestingT, expected interface{}, actual interface{}, msg stri
 
 // Errorf asserts that a function returned a non-nil error (ie. an error).
 //
-// 	actualObj, err := SomeFunction()
-// 	assert.Errorf(t, err, "error message %s", "formatted")
+//	actualObj, err := SomeFunction()
+//	assert.Errorf(t, err, "error message %s", "formatted")
 func Errorf(t TestingT, err error, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -147,8 +147,8 @@ func ErrorAsf(t TestingT, err error, target interface{}, msg string, args ...int
 // ErrorContainsf asserts that a function returned a non-nil error (i.e. an
 // error) and that the error contains the specified substring.
 //
-// 	actualObj, err := SomeFunction()
-// 	assert.ErrorContainsf(t, err,  expectedErrorSubString, "error message %s", "formatted")
+//	actualObj, err := SomeFunction()
+//	assert.ErrorContainsf(t, err,  expectedErrorSubString, "error message %s", "formatted")
 func ErrorContainsf(t TestingT, theError error, contains string, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -168,7 +168,7 @@ func ErrorIsf(t TestingT, err error, target error, msg string, args ...interface
 // Eventuallyf asserts that given condition will be met in waitFor time,
 // periodically checking target function each tick.
 //
-// 	assert.Eventuallyf(t, func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+//	assert.Eventuallyf(t, func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
 func Eventuallyf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -185,15 +185,15 @@ func Eventuallyf(t TestingT, condition func() bool, waitFor time.Duration, tick 
 // If the condition is not met before waitFor, the collected errors of
 // the last tick are copied to t.
 //
-// 	externalValue := false
-// 	go func() {
-// 		time.Sleep(8*time.Second)
-// 		externalValue = true
-// 	}()
-// 	assert.EventuallyWithTf(t, func(c *assert.CollectT, "error message %s", "formatted") {
-// 		// add assertions as needed; any assertion failure will fail the current tick
-// 		assert.True(c, externalValue, "expected 'externalValue' to be true")
-// 	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
+//	externalValue := false
+//	go func() {
+//		time.Sleep(8*time.Second)
+//		externalValue = true
+//	}()
+//	assert.EventuallyWithTf(t, func(c *assert.CollectT, "error message %s", "formatted") {
+//		// add assertions as needed; any assertion failure will fail the current tick
+//		assert.True(c, externalValue, "expected 'externalValue' to be true")
+//	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
 func EventuallyWithTf(t TestingT, condition func(collect *CollectT), waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -203,7 +203,7 @@ func EventuallyWithTf(t TestingT, condition func(collect *CollectT), waitFor tim
 
 // Exactlyf asserts that two objects are equal in value and type.
 //
-// 	assert.Exactlyf(t, int32(123), int64(123), "error message %s", "formatted")
+//	assert.Exactlyf(t, int32(123), int64(123), "error message %s", "formatted")
 func Exactlyf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -229,7 +229,7 @@ func FailNowf(t TestingT, failureMessage string, msg string, args ...interface{}
 
 // Falsef asserts that the specified value is false.
 //
-// 	assert.Falsef(t, myBool, "error message %s", "formatted")
+//	assert.Falsef(t, myBool, "error message %s", "formatted")
 func Falsef(t TestingT, value bool, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -248,9 +248,9 @@ func FileExistsf(t TestingT, path string, msg string, args ...interface{}) bool 
 
 // Greaterf asserts that the first element is greater than the second
 //
-// 	assert.Greaterf(t, 2, 1, "error message %s", "formatted")
-// 	assert.Greaterf(t, float64(2), float64(1), "error message %s", "formatted")
-// 	assert.Greaterf(t, "b", "a", "error message %s", "formatted")
+//	assert.Greaterf(t, 2, 1, "error message %s", "formatted")
+//	assert.Greaterf(t, float64(2), float64(1), "error message %s", "formatted")
+//	assert.Greaterf(t, "b", "a", "error message %s", "formatted")
 func Greaterf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -260,10 +260,10 @@ func Greaterf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...in
 
 // GreaterOrEqualf asserts that the first element is greater than or equal to the second
 //
-// 	assert.GreaterOrEqualf(t, 2, 1, "error message %s", "formatted")
-// 	assert.GreaterOrEqualf(t, 2, 2, "error message %s", "formatted")
-// 	assert.GreaterOrEqualf(t, "b", "a", "error message %s", "formatted")
-// 	assert.GreaterOrEqualf(t, "b", "b", "error message %s", "formatted")
+//	assert.GreaterOrEqualf(t, 2, 1, "error message %s", "formatted")
+//	assert.GreaterOrEqualf(t, 2, 2, "error message %s", "formatted")
+//	assert.GreaterOrEqualf(t, "b", "a", "error message %s", "formatted")
+//	assert.GreaterOrEqualf(t, "b", "b", "error message %s", "formatted")
 func GreaterOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -274,7 +274,7 @@ func GreaterOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, arg
 // HTTPBodyContainsf asserts that a specified handler returns a
 // body that contains a string.
 //
-// 	assert.HTTPBodyContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+//	assert.HTTPBodyContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPBodyContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) bool {
@@ -287,7 +287,7 @@ func HTTPBodyContainsf(t TestingT, handler http.HandlerFunc, method string, url 
 // HTTPBodyNotContainsf asserts that a specified handler returns a
 // body that does not contain a string.
 //
-// 	assert.HTTPBodyNotContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+//	assert.HTTPBodyNotContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPBodyNotContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) bool {
@@ -299,7 +299,7 @@ func HTTPBodyNotContainsf(t TestingT, handler http.HandlerFunc, method string, u
 
 // HTTPErrorf asserts that a specified handler returns an error status code.
 //
-// 	assert.HTTPErrorf(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//	assert.HTTPErrorf(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPErrorf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) bool {
@@ -311,7 +311,7 @@ func HTTPErrorf(t TestingT, handler http.HandlerFunc, method string, url string,
 
 // HTTPRedirectf asserts that a specified handler returns a redirect status code.
 //
-// 	assert.HTTPRedirectf(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//	assert.HTTPRedirectf(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPRedirectf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) bool {
@@ -323,7 +323,7 @@ func HTTPRedirectf(t TestingT, handler http.HandlerFunc, method string, url stri
 
 // HTTPStatusCodef asserts that a specified handler returns a specified status code.
 //
-// 	assert.HTTPStatusCodef(t, myHandler, "GET", "/notImplemented", nil, 501, "error message %s", "formatted")
+//	assert.HTTPStatusCodef(t, myHandler, "GET", "/notImplemented", nil, 501, "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPStatusCodef(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msg string, args ...interface{}) bool {
@@ -335,7 +335,7 @@ func HTTPStatusCodef(t TestingT, handler http.HandlerFunc, method string, url st
 
 // HTTPSuccessf asserts that a specified handler returns a success status code.
 //
-// 	assert.HTTPSuccessf(t, myHandler, "POST", "http://www.google.com", nil, "error message %s", "formatted")
+//	assert.HTTPSuccessf(t, myHandler, "POST", "http://www.google.com", nil, "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPSuccessf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) bool {
@@ -347,7 +347,7 @@ func HTTPSuccessf(t TestingT, handler http.HandlerFunc, method string, url strin
 
 // Implementsf asserts that an object is implemented by the specified interface.
 //
-// 	assert.Implementsf(t, (*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
+//	assert.Implementsf(t, (*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
 func Implementsf(t TestingT, interfaceObject interface{}, object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -357,7 +357,7 @@ func Implementsf(t TestingT, interfaceObject interface{}, object interface{}, ms
 
 // InDeltaf asserts that the two numerals are within delta of each other.
 //
-// 	assert.InDeltaf(t, math.Pi, 22/7.0, 0.01, "error message %s", "formatted")
+//	assert.InDeltaf(t, math.Pi, 22/7.0, 0.01, "error message %s", "formatted")
 func InDeltaf(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -399,9 +399,9 @@ func InEpsilonSlicef(t TestingT, expected interface{}, actual interface{}, epsil
 
 // IsDecreasingf asserts that the collection is decreasing
 //
-// 	assert.IsDecreasingf(t, []int{2, 1, 0}, "error message %s", "formatted")
-// 	assert.IsDecreasingf(t, []float{2, 1}, "error message %s", "formatted")
-// 	assert.IsDecreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
+//	assert.IsDecreasingf(t, []int{2, 1, 0}, "error message %s", "formatted")
+//	assert.IsDecreasingf(t, []float{2, 1}, "error message %s", "formatted")
+//	assert.IsDecreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
 func IsDecreasingf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -411,9 +411,9 @@ func IsDecreasingf(t TestingT, object interface{}, msg string, args ...interface
 
 // IsIncreasingf asserts that the collection is increasing
 //
-// 	assert.IsIncreasingf(t, []int{1, 2, 3}, "error message %s", "formatted")
-// 	assert.IsIncreasingf(t, []float{1, 2}, "error message %s", "formatted")
-// 	assert.IsIncreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
+//	assert.IsIncreasingf(t, []int{1, 2, 3}, "error message %s", "formatted")
+//	assert.IsIncreasingf(t, []float{1, 2}, "error message %s", "formatted")
+//	assert.IsIncreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
 func IsIncreasingf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -423,9 +423,9 @@ func IsIncreasingf(t TestingT, object interface{}, msg string, args ...interface
 
 // IsNonDecreasingf asserts that the collection is not decreasing
 //
-// 	assert.IsNonDecreasingf(t, []int{1, 1, 2}, "error message %s", "formatted")
-// 	assert.IsNonDecreasingf(t, []float{1, 2}, "error message %s", "formatted")
-// 	assert.IsNonDecreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
+//	assert.IsNonDecreasingf(t, []int{1, 1, 2}, "error message %s", "formatted")
+//	assert.IsNonDecreasingf(t, []float{1, 2}, "error message %s", "formatted")
+//	assert.IsNonDecreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
 func IsNonDecreasingf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -435,9 +435,9 @@ func IsNonDecreasingf(t TestingT, object interface{}, msg string, args ...interf
 
 // IsNonIncreasingf asserts that the collection is not increasing
 //
-// 	assert.IsNonIncreasingf(t, []int{2, 1, 1}, "error message %s", "formatted")
-// 	assert.IsNonIncreasingf(t, []float{2, 1}, "error message %s", "formatted")
-// 	assert.IsNonIncreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
+//	assert.IsNonIncreasingf(t, []int{2, 1, 1}, "error message %s", "formatted")
+//	assert.IsNonIncreasingf(t, []float{2, 1}, "error message %s", "formatted")
+//	assert.IsNonIncreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
 func IsNonIncreasingf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -447,7 +447,7 @@ func IsNonIncreasingf(t TestingT, object interface{}, msg string, args ...interf
 
 // IsNotTypef asserts that the specified objects are not of the same type.
 //
-// 	assert.IsNotTypef(t, &NotMyStruct{}, &MyStruct{}, "error message %s", "formatted")
+//	assert.IsNotTypef(t, &NotMyStruct{}, &MyStruct{}, "error message %s", "formatted")
 func IsNotTypef(t TestingT, theType interface{}, object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -457,7 +457,7 @@ func IsNotTypef(t TestingT, theType interface{}, object interface{}, msg string,
 
 // IsTypef asserts that the specified objects are of the same type.
 //
-// 	assert.IsTypef(t, &MyStruct{}, &MyStruct{}, "error message %s", "formatted")
+//	assert.IsTypef(t, &MyStruct{}, &MyStruct{}, "error message %s", "formatted")
 func IsTypef(t TestingT, expectedType interface{}, object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -467,7 +467,7 @@ func IsTypef(t TestingT, expectedType interface{}, object interface{}, msg strin
 
 // JSONEqf asserts that two JSON strings are equivalent.
 //
-// 	assert.JSONEqf(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
+//	assert.JSONEqf(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
 func JSONEqf(t TestingT, expected string, actual string, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -478,7 +478,7 @@ func JSONEqf(t TestingT, expected string, actual string, msg string, args ...int
 // Lenf asserts that the specified object has specific length.
 // Len also fails if the object has a type that len() not accept.
 //
-// 	assert.Lenf(t, mySlice, 3, "error message %s", "formatted")
+//	assert.Lenf(t, mySlice, 3, "error message %s", "formatted")
 func Lenf(t TestingT, object interface{}, length int, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -488,9 +488,9 @@ func Lenf(t TestingT, object interface{}, length int, msg string, args ...interf
 
 // Lessf asserts that the first element is less than the second
 //
-// 	assert.Lessf(t, 1, 2, "error message %s", "formatted")
-// 	assert.Lessf(t, float64(1), float64(2), "error message %s", "formatted")
-// 	assert.Lessf(t, "a", "b", "error message %s", "formatted")
+//	assert.Lessf(t, 1, 2, "error message %s", "formatted")
+//	assert.Lessf(t, float64(1), float64(2), "error message %s", "formatted")
+//	assert.Lessf(t, "a", "b", "error message %s", "formatted")
 func Lessf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -500,10 +500,10 @@ func Lessf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...inter
 
 // LessOrEqualf asserts that the first element is less than or equal to the second
 //
-// 	assert.LessOrEqualf(t, 1, 2, "error message %s", "formatted")
-// 	assert.LessOrEqualf(t, 2, 2, "error message %s", "formatted")
-// 	assert.LessOrEqualf(t, "a", "b", "error message %s", "formatted")
-// 	assert.LessOrEqualf(t, "b", "b", "error message %s", "formatted")
+//	assert.LessOrEqualf(t, 1, 2, "error message %s", "formatted")
+//	assert.LessOrEqualf(t, 2, 2, "error message %s", "formatted")
+//	assert.LessOrEqualf(t, "a", "b", "error message %s", "formatted")
+//	assert.LessOrEqualf(t, "b", "b", "error message %s", "formatted")
 func LessOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -513,8 +513,8 @@ func LessOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args .
 
 // Negativef asserts that the specified element is negative
 //
-// 	assert.Negativef(t, -1, "error message %s", "formatted")
-// 	assert.Negativef(t, -1.23, "error message %s", "formatted")
+//	assert.Negativef(t, -1, "error message %s", "formatted")
+//	assert.Negativef(t, -1.23, "error message %s", "formatted")
 func Negativef(t TestingT, e interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -525,7 +525,7 @@ func Negativef(t TestingT, e interface{}, msg string, args ...interface{}) bool 
 // Neverf asserts that the given condition doesn't satisfy in waitFor time,
 // periodically checking the target function each tick.
 //
-// 	assert.Neverf(t, func() bool { return false; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+//	assert.Neverf(t, func() bool { return false; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
 func Neverf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -535,7 +535,7 @@ func Neverf(t TestingT, condition func() bool, waitFor time.Duration, tick time.
 
 // Nilf asserts that the specified object is nil.
 //
-// 	assert.Nilf(t, err, "error message %s", "formatted")
+//	assert.Nilf(t, err, "error message %s", "formatted")
 func Nilf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -554,10 +554,10 @@ func NoDirExistsf(t TestingT, path string, msg string, args ...interface{}) bool
 
 // NoErrorf asserts that a function returned a nil error (ie. no error).
 //
-// 	  actualObj, err := SomeFunction()
-// 	  if assert.NoErrorf(t, err, "error message %s", "formatted") {
-// 		   assert.Equal(t, expectedObj, actualObj)
-// 	  }
+//	  actualObj, err := SomeFunction()
+//	  if assert.NoErrorf(t, err, "error message %s", "formatted") {
+//		   assert.Equal(t, expectedObj, actualObj)
+//	  }
 func NoErrorf(t TestingT, err error, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -577,9 +577,9 @@ func NoFileExistsf(t TestingT, path string, msg string, args ...interface{}) boo
 // NotContainsf asserts that the specified string, list(array, slice...) or map does NOT contain the
 // specified substring or element.
 //
-// 	assert.NotContainsf(t, "Hello World", "Earth", "error message %s", "formatted")
-// 	assert.NotContainsf(t, ["Hello", "World"], "Earth", "error message %s", "formatted")
-// 	assert.NotContainsf(t, {"Hello": "World"}, "Earth", "error message %s", "formatted")
+//	assert.NotContainsf(t, "Hello World", "Earth", "error message %s", "formatted")
+//	assert.NotContainsf(t, ["Hello", "World"], "Earth", "error message %s", "formatted")
+//	assert.NotContainsf(t, {"Hello": "World"}, "Earth", "error message %s", "formatted")
 func NotContainsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -606,9 +606,9 @@ func NotElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg str
 
 // NotEmptyf asserts that the specified object is NOT [Empty].
 //
-// 	if assert.NotEmptyf(t, obj, "error message %s", "formatted") {
-// 	  assert.Equal(t, "two", obj[1])
-// 	}
+//	if assert.NotEmptyf(t, obj, "error message %s", "formatted") {
+//	  assert.Equal(t, "two", obj[1])
+//	}
 func NotEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -618,7 +618,7 @@ func NotEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) 
 
 // NotEqualf asserts that the specified values are NOT equal.
 //
-// 	assert.NotEqualf(t, obj1, obj2, "error message %s", "formatted")
+//	assert.NotEqualf(t, obj1, obj2, "error message %s", "formatted")
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
@@ -631,7 +631,7 @@ func NotEqualf(t TestingT, expected interface{}, actual interface{}, msg string,
 
 // NotEqualValuesf asserts that two objects are not equal even when converted to the same type
 //
-// 	assert.NotEqualValuesf(t, obj1, obj2, "error message %s", "formatted")
+//	assert.NotEqualValuesf(t, obj1, obj2, "error message %s", "formatted")
 func NotEqualValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -659,7 +659,7 @@ func NotErrorIsf(t TestingT, err error, target error, msg string, args ...interf
 
 // NotImplementsf asserts that an object does not implement the specified interface.
 //
-// 	assert.NotImplementsf(t, (*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
+//	assert.NotImplementsf(t, (*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
 func NotImplementsf(t TestingT, interfaceObject interface{}, object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -669,7 +669,7 @@ func NotImplementsf(t TestingT, interfaceObject interface{}, object interface{},
 
 // NotNilf asserts that the specified object is not nil.
 //
-// 	assert.NotNilf(t, err, "error message %s", "formatted")
+//	assert.NotNilf(t, err, "error message %s", "formatted")
 func NotNilf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -679,7 +679,7 @@ func NotNilf(t TestingT, object interface{}, msg string, args ...interface{}) bo
 
 // NotPanicsf asserts that the code inside the specified PanicTestFunc does NOT panic.
 //
-// 	assert.NotPanicsf(t, func(){ RemainCalm() }, "error message %s", "formatted")
+//	assert.NotPanicsf(t, func(){ RemainCalm() }, "error message %s", "formatted")
 func NotPanicsf(t TestingT, f PanicTestFunc, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -695,8 +695,8 @@ func NotPanicsf(t TestingT, f PanicTestFunc, msg string, args ...interface{}) bo
 //
 // Examples:
 //
-// 	assert.NotRegexpf(t, regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
-// 	assert.NotRegexpf(t, "^start", "it's not starting", "error message %s", "formatted") // string is compiled
+//	assert.NotRegexpf(t, regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
+//	assert.NotRegexpf(t, "^start", "it's not starting", "error message %s", "formatted") // string is compiled
 func NotRegexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -706,7 +706,7 @@ func NotRegexpf(t TestingT, rx interface{}, str interface{}, msg string, args ..
 
 // NotSamef asserts that two pointers do not reference the same object.
 //
-// 	assert.NotSamef(t, ptr1, ptr2, "error message %s", "formatted")
+//	assert.NotSamef(t, ptr1, ptr2, "error message %s", "formatted")
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
@@ -722,10 +722,10 @@ func NotSamef(t TestingT, expected interface{}, actual interface{}, msg string, 
 // Map elements are key-value pairs unless compared with an array or slice where
 // only the map key is evaluated.
 //
-// 	assert.NotSubsetf(t, [1, 3, 4], [1, 2], "error message %s", "formatted")
-// 	assert.NotSubsetf(t, {"x": 1, "y": 2}, {"z": 3}, "error message %s", "formatted")
-// 	assert.NotSubsetf(t, [1, 3, 4], {1: "one", 2: "two"}, "error message %s", "formatted")
-// 	assert.NotSubsetf(t, {"x": 1, "y": 2}, ["z"], "error message %s", "formatted")
+//	assert.NotSubsetf(t, [1, 3, 4], [1, 2], "error message %s", "formatted")
+//	assert.NotSubsetf(t, {"x": 1, "y": 2}, {"z": 3}, "error message %s", "formatted")
+//	assert.NotSubsetf(t, [1, 3, 4], {1: "one", 2: "two"}, "error message %s", "formatted")
+//	assert.NotSubsetf(t, {"x": 1, "y": 2}, ["z"], "error message %s", "formatted")
 func NotSubsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -743,7 +743,7 @@ func NotZerof(t TestingT, i interface{}, msg string, args ...interface{}) bool {
 
 // Panicsf asserts that the code inside the specified PanicTestFunc panics.
 //
-// 	assert.Panicsf(t, func(){ GoCrazy() }, "error message %s", "formatted")
+//	assert.Panicsf(t, func(){ GoCrazy() }, "error message %s", "formatted")
 func Panicsf(t TestingT, f PanicTestFunc, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -755,7 +755,7 @@ func Panicsf(t TestingT, f PanicTestFunc, msg string, args ...interface{}) bool 
 // panics, and that the recovered panic value is an error that satisfies the
 // EqualError comparison.
 //
-// 	assert.PanicsWithErrorf(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+//	assert.PanicsWithErrorf(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
 func PanicsWithErrorf(t TestingT, errString string, f PanicTestFunc, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -766,7 +766,7 @@ func PanicsWithErrorf(t TestingT, errString string, f PanicTestFunc, msg string,
 // PanicsWithValuef asserts that the code inside the specified PanicTestFunc panics, and that
 // the recovered panic value equals the expected panic value.
 //
-// 	assert.PanicsWithValuef(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+//	assert.PanicsWithValuef(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
 func PanicsWithValuef(t TestingT, expected interface{}, f PanicTestFunc, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -776,8 +776,8 @@ func PanicsWithValuef(t TestingT, expected interface{}, f PanicTestFunc, msg str
 
 // Positivef asserts that the specified element is positive
 //
-// 	assert.Positivef(t, 1, "error message %s", "formatted")
-// 	assert.Positivef(t, 1.23, "error message %s", "formatted")
+//	assert.Positivef(t, 1, "error message %s", "formatted")
+//	assert.Positivef(t, 1.23, "error message %s", "formatted")
 func Positivef(t TestingT, e interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -793,8 +793,8 @@ func Positivef(t TestingT, e interface{}, msg string, args ...interface{}) bool 
 //
 // Examples:
 //
-// 	assert.Regexpf(t, regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
-// 	assert.Regexpf(t, "start...$", "it's not starting", "error message %s", "formatted") // string is compiled
+//	assert.Regexpf(t, regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
+//	assert.Regexpf(t, "start...$", "it's not starting", "error message %s", "formatted") // string is compiled
 func Regexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -804,7 +804,7 @@ func Regexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...in
 
 // Samef asserts that two pointers reference the same object.
 //
-// 	assert.Samef(t, ptr1, ptr2, "error message %s", "formatted")
+//	assert.Samef(t, ptr1, ptr2, "error message %s", "formatted")
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
@@ -820,10 +820,10 @@ func Samef(t TestingT, expected interface{}, actual interface{}, msg string, arg
 // Map elements are key-value pairs unless compared with an array or slice where
 // only the map key is evaluated.
 //
-// 	assert.Subsetf(t, [1, 2, 3], [1, 2], "error message %s", "formatted")
-// 	assert.Subsetf(t, {"x": 1, "y": 2}, {"x": 1}, "error message %s", "formatted")
-// 	assert.Subsetf(t, [1, 2, 3], {1: "one", 2: "two"}, "error message %s", "formatted")
-// 	assert.Subsetf(t, {"x": 1, "y": 2}, ["x"], "error message %s", "formatted")
+//	assert.Subsetf(t, [1, 2, 3], [1, 2], "error message %s", "formatted")
+//	assert.Subsetf(t, {"x": 1, "y": 2}, {"x": 1}, "error message %s", "formatted")
+//	assert.Subsetf(t, [1, 2, 3], {1: "one", 2: "two"}, "error message %s", "formatted")
+//	assert.Subsetf(t, {"x": 1, "y": 2}, ["x"], "error message %s", "formatted")
 func Subsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -833,7 +833,7 @@ func Subsetf(t TestingT, list interface{}, subset interface{}, msg string, args 
 
 // Truef asserts that the specified value is true.
 //
-// 	assert.Truef(t, myBool, "error message %s", "formatted")
+//	assert.Truef(t, myBool, "error message %s", "formatted")
 func Truef(t TestingT, value bool, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -843,7 +843,7 @@ func Truef(t TestingT, value bool, msg string, args ...interface{}) bool {
 
 // WithinDurationf asserts that the two times are within duration delta of each other.
 //
-// 	assert.WithinDurationf(t, time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
+//	assert.WithinDurationf(t, time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
 func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -853,7 +853,7 @@ func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta tim
 
 // WithinRangef asserts that a time is within a time range (inclusive).
 //
-// 	assert.WithinRangef(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second), "error message %s", "formatted")
+//	assert.WithinRangef(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second), "error message %s", "formatted")
 func WithinRangef(t TestingT, actual time.Time, start time.Time, end time.Time, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -863,17 +863,17 @@ func WithinRangef(t TestingT, actual time.Time, start time.Time, end time.Time, 
 
 // YAMLEqf asserts that the first documents in the two YAML strings are equivalent.
 //
-// 	expected := `---
-// 	key: value
-// 	---
-// 	key: this is a second document, it is not evaluated
-// 	`
-// 	actual := `---
-// 	key: value
-// 	---
-// 	key: this is a subsequent document, it is not evaluated
-// 	`
-// 	assert.YAMLEqf(t, expected, actual, "error message %s", "formatted")
+//	expected := `---
+//	key: value
+//	---
+//	key: this is a second document, it is not evaluated
+//	`
+//	actual := `---
+//	key: value
+//	---
+//	key: this is a subsequent document, it is not evaluated
+//	`
+//	assert.YAMLEqf(t, expected, actual, "error message %s", "formatted")
 func YAMLEqf(t TestingT, expected string, actual string, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()

--- a/assert/assertion_format.go
+++ b/assert/assertion_format.go
@@ -476,7 +476,7 @@ func JSONEqf(t TestingT, expected string, actual string, msg string, args ...int
 }
 
 // Lenf asserts that the specified object has specific length.
-// Lenf also fails if the object has a type that len() not accept.
+// Len also fails if the object has a type that len() not accept.
 //
 // 	assert.Lenf(t, mySlice, 3, "error message %s", "formatted")
 func Lenf(t TestingT, object interface{}, length int, msg string, args ...interface{}) bool {
@@ -694,6 +694,7 @@ func NotPanicsf(t TestingT, f PanicTestFunc, msg string, args ...interface{}) bo
 // %v and compiled using regexp.Compile.
 //
 // Examples:
+//
 // 	assert.NotRegexpf(t, regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
 // 	assert.NotRegexpf(t, "^start", "it's not starting", "error message %s", "formatted") // string is compiled
 func NotRegexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) bool {
@@ -791,6 +792,7 @@ func Positivef(t TestingT, e interface{}, msg string, args ...interface{}) bool 
 // %v and compiled using regexp.Compile.
 //
 // Examples:
+//
 // 	assert.Regexpf(t, regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
 // 	assert.Regexpf(t, "start...$", "it's not starting", "error message %s", "formatted") // string is compiled
 func Regexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) bool {

--- a/assert/assertion_format.go
+++ b/assert/assertion_format.go
@@ -19,9 +19,9 @@ func Conditionf(t TestingT, comp Comparison, msg string, args ...interface{}) bo
 // Containsf asserts that the specified string, list(array, slice...) or map contains the
 // specified substring or element.
 //
-//	assert.Containsf(t, "Hello World", "World", "error message %s", "formatted")
-//	assert.Containsf(t, ["Hello", "World"], "World", "error message %s", "formatted")
-//	assert.Containsf(t, {"Hello": "World"}, "Hello", "error message %s", "formatted")
+// 	assert.Containsf(t, "Hello World", "World", "error message %s", "formatted")
+// 	assert.Containsf(t, ["Hello", "World"], "World", "error message %s", "formatted")
+// 	assert.Containsf(t, {"Hello": "World"}, "Hello", "error message %s", "formatted")
 func Containsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -60,7 +60,7 @@ func ElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string
 //
 // Pointer values are "empty" if the pointer is nil or if the pointed value is "empty".
 //
-//	assert.Emptyf(t, obj, "error message %s", "formatted")
+// 	assert.Emptyf(t, obj, "error message %s", "formatted")
 //
 // [Zero values]: https://go.dev/ref/spec#The_zero_value
 func Emptyf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
@@ -72,7 +72,7 @@ func Emptyf(t TestingT, object interface{}, msg string, args ...interface{}) boo
 
 // Equalf asserts that two objects are equal.
 //
-//	assert.Equalf(t, 123, 123, "error message %s", "formatted")
+// 	assert.Equalf(t, 123, 123, "error message %s", "formatted")
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses). Function equality
@@ -87,8 +87,8 @@ func Equalf(t TestingT, expected interface{}, actual interface{}, msg string, ar
 // EqualErrorf asserts that a function returned a non-nil error (i.e. an error)
 // and that it is equal to the provided error.
 //
-//	actualObj, err := SomeFunction()
-//	assert.EqualErrorf(t, err,  expectedErrorString, "error message %s", "formatted")
+// 	actualObj, err := SomeFunction()
+// 	assert.EqualErrorf(t, err,  expectedErrorString, "error message %s", "formatted")
 func EqualErrorf(t TestingT, theError error, errString string, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -100,12 +100,12 @@ func EqualErrorf(t TestingT, theError error, errString string, msg string, args 
 // fields are also equal. This is useful for comparing structs that have private fields
 // that could potentially differ.
 //
-//	 type S struct {
-//		Exported     	int
-//		notExported   	int
-//	 }
-//	 assert.EqualExportedValuesf(t, S{1, 2}, S{1, 3}, "error message %s", "formatted") => true
-//	 assert.EqualExportedValuesf(t, S{1, 2}, S{2, 3}, "error message %s", "formatted") => false
+// 	 type S struct {
+// 		Exported     	int
+// 		notExported   	int
+// 	 }
+// 	 assert.EqualExportedValuesf(t, S{1, 2}, S{1, 3}, "error message %s", "formatted") => true
+// 	 assert.EqualExportedValuesf(t, S{1, 2}, S{2, 3}, "error message %s", "formatted") => false
 func EqualExportedValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -116,7 +116,7 @@ func EqualExportedValuesf(t TestingT, expected interface{}, actual interface{}, 
 // EqualValuesf asserts that two objects are equal or convertible to the larger
 // type and equal.
 //
-//	assert.EqualValuesf(t, uint32(123), int32(123), "error message %s", "formatted")
+// 	assert.EqualValuesf(t, uint32(123), int32(123), "error message %s", "formatted")
 func EqualValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -126,8 +126,8 @@ func EqualValuesf(t TestingT, expected interface{}, actual interface{}, msg stri
 
 // Errorf asserts that a function returned a non-nil error (ie. an error).
 //
-//	actualObj, err := SomeFunction()
-//	assert.Errorf(t, err, "error message %s", "formatted")
+// 	actualObj, err := SomeFunction()
+// 	assert.Errorf(t, err, "error message %s", "formatted")
 func Errorf(t TestingT, err error, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -147,8 +147,8 @@ func ErrorAsf(t TestingT, err error, target interface{}, msg string, args ...int
 // ErrorContainsf asserts that a function returned a non-nil error (i.e. an
 // error) and that the error contains the specified substring.
 //
-//	actualObj, err := SomeFunction()
-//	assert.ErrorContainsf(t, err,  expectedErrorSubString, "error message %s", "formatted")
+// 	actualObj, err := SomeFunction()
+// 	assert.ErrorContainsf(t, err,  expectedErrorSubString, "error message %s", "formatted")
 func ErrorContainsf(t TestingT, theError error, contains string, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -168,7 +168,7 @@ func ErrorIsf(t TestingT, err error, target error, msg string, args ...interface
 // Eventuallyf asserts that given condition will be met in waitFor time,
 // periodically checking target function each tick.
 //
-//	assert.Eventuallyf(t, func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+// 	assert.Eventuallyf(t, func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
 func Eventuallyf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -185,15 +185,15 @@ func Eventuallyf(t TestingT, condition func() bool, waitFor time.Duration, tick 
 // If the condition is not met before waitFor, the collected errors of
 // the last tick are copied to t.
 //
-//	externalValue := false
-//	go func() {
-//		time.Sleep(8*time.Second)
-//		externalValue = true
-//	}()
-//	assert.EventuallyWithTf(t, func(c *assert.CollectT, "error message %s", "formatted") {
-//		// add assertions as needed; any assertion failure will fail the current tick
-//		assert.True(c, externalValue, "expected 'externalValue' to be true")
-//	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
+// 	externalValue := false
+// 	go func() {
+// 		time.Sleep(8*time.Second)
+// 		externalValue = true
+// 	}()
+// 	assert.EventuallyWithTf(t, func(c *assert.CollectT, "error message %s", "formatted") {
+// 		// add assertions as needed; any assertion failure will fail the current tick
+// 		assert.True(c, externalValue, "expected 'externalValue' to be true")
+// 	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
 func EventuallyWithTf(t TestingT, condition func(collect *CollectT), waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -203,7 +203,7 @@ func EventuallyWithTf(t TestingT, condition func(collect *CollectT), waitFor tim
 
 // Exactlyf asserts that two objects are equal in value and type.
 //
-//	assert.Exactlyf(t, int32(123), int64(123), "error message %s", "formatted")
+// 	assert.Exactlyf(t, int32(123), int64(123), "error message %s", "formatted")
 func Exactlyf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -229,7 +229,7 @@ func FailNowf(t TestingT, failureMessage string, msg string, args ...interface{}
 
 // Falsef asserts that the specified value is false.
 //
-//	assert.Falsef(t, myBool, "error message %s", "formatted")
+// 	assert.Falsef(t, myBool, "error message %s", "formatted")
 func Falsef(t TestingT, value bool, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -248,9 +248,9 @@ func FileExistsf(t TestingT, path string, msg string, args ...interface{}) bool 
 
 // Greaterf asserts that the first element is greater than the second
 //
-//	assert.Greaterf(t, 2, 1, "error message %s", "formatted")
-//	assert.Greaterf(t, float64(2), float64(1), "error message %s", "formatted")
-//	assert.Greaterf(t, "b", "a", "error message %s", "formatted")
+// 	assert.Greaterf(t, 2, 1, "error message %s", "formatted")
+// 	assert.Greaterf(t, float64(2), float64(1), "error message %s", "formatted")
+// 	assert.Greaterf(t, "b", "a", "error message %s", "formatted")
 func Greaterf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -260,10 +260,10 @@ func Greaterf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...in
 
 // GreaterOrEqualf asserts that the first element is greater than or equal to the second
 //
-//	assert.GreaterOrEqualf(t, 2, 1, "error message %s", "formatted")
-//	assert.GreaterOrEqualf(t, 2, 2, "error message %s", "formatted")
-//	assert.GreaterOrEqualf(t, "b", "a", "error message %s", "formatted")
-//	assert.GreaterOrEqualf(t, "b", "b", "error message %s", "formatted")
+// 	assert.GreaterOrEqualf(t, 2, 1, "error message %s", "formatted")
+// 	assert.GreaterOrEqualf(t, 2, 2, "error message %s", "formatted")
+// 	assert.GreaterOrEqualf(t, "b", "a", "error message %s", "formatted")
+// 	assert.GreaterOrEqualf(t, "b", "b", "error message %s", "formatted")
 func GreaterOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -274,7 +274,7 @@ func GreaterOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, arg
 // HTTPBodyContainsf asserts that a specified handler returns a
 // body that contains a string.
 //
-//	assert.HTTPBodyContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+// 	assert.HTTPBodyContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPBodyContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) bool {
@@ -287,7 +287,7 @@ func HTTPBodyContainsf(t TestingT, handler http.HandlerFunc, method string, url 
 // HTTPBodyNotContainsf asserts that a specified handler returns a
 // body that does not contain a string.
 //
-//	assert.HTTPBodyNotContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+// 	assert.HTTPBodyNotContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPBodyNotContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) bool {
@@ -299,7 +299,7 @@ func HTTPBodyNotContainsf(t TestingT, handler http.HandlerFunc, method string, u
 
 // HTTPErrorf asserts that a specified handler returns an error status code.
 //
-//	assert.HTTPErrorf(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+// 	assert.HTTPErrorf(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPErrorf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) bool {
@@ -311,7 +311,7 @@ func HTTPErrorf(t TestingT, handler http.HandlerFunc, method string, url string,
 
 // HTTPRedirectf asserts that a specified handler returns a redirect status code.
 //
-//	assert.HTTPRedirectf(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+// 	assert.HTTPRedirectf(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPRedirectf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) bool {
@@ -323,7 +323,7 @@ func HTTPRedirectf(t TestingT, handler http.HandlerFunc, method string, url stri
 
 // HTTPStatusCodef asserts that a specified handler returns a specified status code.
 //
-//	assert.HTTPStatusCodef(t, myHandler, "GET", "/notImplemented", nil, 501, "error message %s", "formatted")
+// 	assert.HTTPStatusCodef(t, myHandler, "GET", "/notImplemented", nil, 501, "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPStatusCodef(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msg string, args ...interface{}) bool {
@@ -335,7 +335,7 @@ func HTTPStatusCodef(t TestingT, handler http.HandlerFunc, method string, url st
 
 // HTTPSuccessf asserts that a specified handler returns a success status code.
 //
-//	assert.HTTPSuccessf(t, myHandler, "POST", "http://www.google.com", nil, "error message %s", "formatted")
+// 	assert.HTTPSuccessf(t, myHandler, "POST", "http://www.google.com", nil, "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPSuccessf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) bool {
@@ -347,7 +347,7 @@ func HTTPSuccessf(t TestingT, handler http.HandlerFunc, method string, url strin
 
 // Implementsf asserts that an object is implemented by the specified interface.
 //
-//	assert.Implementsf(t, (*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
+// 	assert.Implementsf(t, (*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
 func Implementsf(t TestingT, interfaceObject interface{}, object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -357,7 +357,7 @@ func Implementsf(t TestingT, interfaceObject interface{}, object interface{}, ms
 
 // InDeltaf asserts that the two numerals are within delta of each other.
 //
-//	assert.InDeltaf(t, math.Pi, 22/7.0, 0.01, "error message %s", "formatted")
+// 	assert.InDeltaf(t, math.Pi, 22/7.0, 0.01, "error message %s", "formatted")
 func InDeltaf(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -399,9 +399,9 @@ func InEpsilonSlicef(t TestingT, expected interface{}, actual interface{}, epsil
 
 // IsDecreasingf asserts that the collection is decreasing
 //
-//	assert.IsDecreasingf(t, []int{2, 1, 0}, "error message %s", "formatted")
-//	assert.IsDecreasingf(t, []float{2, 1}, "error message %s", "formatted")
-//	assert.IsDecreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
+// 	assert.IsDecreasingf(t, []int{2, 1, 0}, "error message %s", "formatted")
+// 	assert.IsDecreasingf(t, []float{2, 1}, "error message %s", "formatted")
+// 	assert.IsDecreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
 func IsDecreasingf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -411,9 +411,9 @@ func IsDecreasingf(t TestingT, object interface{}, msg string, args ...interface
 
 // IsIncreasingf asserts that the collection is increasing
 //
-//	assert.IsIncreasingf(t, []int{1, 2, 3}, "error message %s", "formatted")
-//	assert.IsIncreasingf(t, []float{1, 2}, "error message %s", "formatted")
-//	assert.IsIncreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
+// 	assert.IsIncreasingf(t, []int{1, 2, 3}, "error message %s", "formatted")
+// 	assert.IsIncreasingf(t, []float{1, 2}, "error message %s", "formatted")
+// 	assert.IsIncreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
 func IsIncreasingf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -423,9 +423,9 @@ func IsIncreasingf(t TestingT, object interface{}, msg string, args ...interface
 
 // IsNonDecreasingf asserts that the collection is not decreasing
 //
-//	assert.IsNonDecreasingf(t, []int{1, 1, 2}, "error message %s", "formatted")
-//	assert.IsNonDecreasingf(t, []float{1, 2}, "error message %s", "formatted")
-//	assert.IsNonDecreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
+// 	assert.IsNonDecreasingf(t, []int{1, 1, 2}, "error message %s", "formatted")
+// 	assert.IsNonDecreasingf(t, []float{1, 2}, "error message %s", "formatted")
+// 	assert.IsNonDecreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
 func IsNonDecreasingf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -435,9 +435,9 @@ func IsNonDecreasingf(t TestingT, object interface{}, msg string, args ...interf
 
 // IsNonIncreasingf asserts that the collection is not increasing
 //
-//	assert.IsNonIncreasingf(t, []int{2, 1, 1}, "error message %s", "formatted")
-//	assert.IsNonIncreasingf(t, []float{2, 1}, "error message %s", "formatted")
-//	assert.IsNonIncreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
+// 	assert.IsNonIncreasingf(t, []int{2, 1, 1}, "error message %s", "formatted")
+// 	assert.IsNonIncreasingf(t, []float{2, 1}, "error message %s", "formatted")
+// 	assert.IsNonIncreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
 func IsNonIncreasingf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -447,7 +447,7 @@ func IsNonIncreasingf(t TestingT, object interface{}, msg string, args ...interf
 
 // IsNotTypef asserts that the specified objects are not of the same type.
 //
-//	assert.IsNotTypef(t, &NotMyStruct{}, &MyStruct{}, "error message %s", "formatted")
+// 	assert.IsNotTypef(t, &NotMyStruct{}, &MyStruct{}, "error message %s", "formatted")
 func IsNotTypef(t TestingT, theType interface{}, object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -457,7 +457,7 @@ func IsNotTypef(t TestingT, theType interface{}, object interface{}, msg string,
 
 // IsTypef asserts that the specified objects are of the same type.
 //
-//	assert.IsTypef(t, &MyStruct{}, &MyStruct{}, "error message %s", "formatted")
+// 	assert.IsTypef(t, &MyStruct{}, &MyStruct{}, "error message %s", "formatted")
 func IsTypef(t TestingT, expectedType interface{}, object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -467,7 +467,7 @@ func IsTypef(t TestingT, expectedType interface{}, object interface{}, msg strin
 
 // JSONEqf asserts that two JSON strings are equivalent.
 //
-//	assert.JSONEqf(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
+// 	assert.JSONEqf(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
 func JSONEqf(t TestingT, expected string, actual string, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -478,7 +478,7 @@ func JSONEqf(t TestingT, expected string, actual string, msg string, args ...int
 // Lenf asserts that the specified object has specific length.
 // Lenf also fails if the object has a type that len() not accept.
 //
-//	assert.Lenf(t, mySlice, 3, "error message %s", "formatted")
+// 	assert.Lenf(t, mySlice, 3, "error message %s", "formatted")
 func Lenf(t TestingT, object interface{}, length int, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -488,9 +488,9 @@ func Lenf(t TestingT, object interface{}, length int, msg string, args ...interf
 
 // Lessf asserts that the first element is less than the second
 //
-//	assert.Lessf(t, 1, 2, "error message %s", "formatted")
-//	assert.Lessf(t, float64(1), float64(2), "error message %s", "formatted")
-//	assert.Lessf(t, "a", "b", "error message %s", "formatted")
+// 	assert.Lessf(t, 1, 2, "error message %s", "formatted")
+// 	assert.Lessf(t, float64(1), float64(2), "error message %s", "formatted")
+// 	assert.Lessf(t, "a", "b", "error message %s", "formatted")
 func Lessf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -500,10 +500,10 @@ func Lessf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...inter
 
 // LessOrEqualf asserts that the first element is less than or equal to the second
 //
-//	assert.LessOrEqualf(t, 1, 2, "error message %s", "formatted")
-//	assert.LessOrEqualf(t, 2, 2, "error message %s", "formatted")
-//	assert.LessOrEqualf(t, "a", "b", "error message %s", "formatted")
-//	assert.LessOrEqualf(t, "b", "b", "error message %s", "formatted")
+// 	assert.LessOrEqualf(t, 1, 2, "error message %s", "formatted")
+// 	assert.LessOrEqualf(t, 2, 2, "error message %s", "formatted")
+// 	assert.LessOrEqualf(t, "a", "b", "error message %s", "formatted")
+// 	assert.LessOrEqualf(t, "b", "b", "error message %s", "formatted")
 func LessOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -513,8 +513,8 @@ func LessOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args .
 
 // Negativef asserts that the specified element is negative
 //
-//	assert.Negativef(t, -1, "error message %s", "formatted")
-//	assert.Negativef(t, -1.23, "error message %s", "formatted")
+// 	assert.Negativef(t, -1, "error message %s", "formatted")
+// 	assert.Negativef(t, -1.23, "error message %s", "formatted")
 func Negativef(t TestingT, e interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -525,7 +525,7 @@ func Negativef(t TestingT, e interface{}, msg string, args ...interface{}) bool 
 // Neverf asserts that the given condition doesn't satisfy in waitFor time,
 // periodically checking the target function each tick.
 //
-//	assert.Neverf(t, func() bool { return false; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+// 	assert.Neverf(t, func() bool { return false; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
 func Neverf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -535,7 +535,7 @@ func Neverf(t TestingT, condition func() bool, waitFor time.Duration, tick time.
 
 // Nilf asserts that the specified object is nil.
 //
-//	assert.Nilf(t, err, "error message %s", "formatted")
+// 	assert.Nilf(t, err, "error message %s", "formatted")
 func Nilf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -554,10 +554,10 @@ func NoDirExistsf(t TestingT, path string, msg string, args ...interface{}) bool
 
 // NoErrorf asserts that a function returned a nil error (ie. no error).
 //
-//	  actualObj, err := SomeFunction()
-//	  if assert.NoErrorf(t, err, "error message %s", "formatted") {
-//		   assert.Equal(t, expectedObj, actualObj)
-//	  }
+// 	  actualObj, err := SomeFunction()
+// 	  if assert.NoErrorf(t, err, "error message %s", "formatted") {
+// 		   assert.Equal(t, expectedObj, actualObj)
+// 	  }
 func NoErrorf(t TestingT, err error, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -577,9 +577,9 @@ func NoFileExistsf(t TestingT, path string, msg string, args ...interface{}) boo
 // NotContainsf asserts that the specified string, list(array, slice...) or map does NOT contain the
 // specified substring or element.
 //
-//	assert.NotContainsf(t, "Hello World", "Earth", "error message %s", "formatted")
-//	assert.NotContainsf(t, ["Hello", "World"], "Earth", "error message %s", "formatted")
-//	assert.NotContainsf(t, {"Hello": "World"}, "Earth", "error message %s", "formatted")
+// 	assert.NotContainsf(t, "Hello World", "Earth", "error message %s", "formatted")
+// 	assert.NotContainsf(t, ["Hello", "World"], "Earth", "error message %s", "formatted")
+// 	assert.NotContainsf(t, {"Hello": "World"}, "Earth", "error message %s", "formatted")
 func NotContainsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -606,9 +606,9 @@ func NotElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg str
 
 // NotEmptyf asserts that the specified object is NOT [Empty].
 //
-//	if assert.NotEmptyf(t, obj, "error message %s", "formatted") {
-//	  assert.Equal(t, "two", obj[1])
-//	}
+// 	if assert.NotEmptyf(t, obj, "error message %s", "formatted") {
+// 	  assert.Equal(t, "two", obj[1])
+// 	}
 func NotEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -618,7 +618,7 @@ func NotEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) 
 
 // NotEqualf asserts that the specified values are NOT equal.
 //
-//	assert.NotEqualf(t, obj1, obj2, "error message %s", "formatted")
+// 	assert.NotEqualf(t, obj1, obj2, "error message %s", "formatted")
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
@@ -631,7 +631,7 @@ func NotEqualf(t TestingT, expected interface{}, actual interface{}, msg string,
 
 // NotEqualValuesf asserts that two objects are not equal even when converted to the same type
 //
-//	assert.NotEqualValuesf(t, obj1, obj2, "error message %s", "formatted")
+// 	assert.NotEqualValuesf(t, obj1, obj2, "error message %s", "formatted")
 func NotEqualValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -659,7 +659,7 @@ func NotErrorIsf(t TestingT, err error, target error, msg string, args ...interf
 
 // NotImplementsf asserts that an object does not implement the specified interface.
 //
-//	assert.NotImplementsf(t, (*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
+// 	assert.NotImplementsf(t, (*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
 func NotImplementsf(t TestingT, interfaceObject interface{}, object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -669,7 +669,7 @@ func NotImplementsf(t TestingT, interfaceObject interface{}, object interface{},
 
 // NotNilf asserts that the specified object is not nil.
 //
-//	assert.NotNilf(t, err, "error message %s", "formatted")
+// 	assert.NotNilf(t, err, "error message %s", "formatted")
 func NotNilf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -679,7 +679,7 @@ func NotNilf(t TestingT, object interface{}, msg string, args ...interface{}) bo
 
 // NotPanicsf asserts that the code inside the specified PanicTestFunc does NOT panic.
 //
-//	assert.NotPanicsf(t, func(){ RemainCalm() }, "error message %s", "formatted")
+// 	assert.NotPanicsf(t, func(){ RemainCalm() }, "error message %s", "formatted")
 func NotPanicsf(t TestingT, f PanicTestFunc, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -691,10 +691,11 @@ func NotPanicsf(t TestingT, f PanicTestFunc, msg string, args ...interface{}) bo
 //
 // The rx (expression) argument should be a *regexp.Regexp. For backward
 // compatibility, if rx is any other type, its value will be formatted with
-// %v and compiled using regexp.MustCompile.
+// %v and compiled using regexp.Compile.
 //
-//	assert.NotRegexpf(t, regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
-//	assert.NotRegexpf(t, "^start", "it's not starting", "error message %s", "formatted") // string is compiled
+// Examples:
+// 	assert.NotRegexpf(t, regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
+// 	assert.NotRegexpf(t, "^start", "it's not starting", "error message %s", "formatted") // string is compiled
 func NotRegexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -704,7 +705,7 @@ func NotRegexpf(t TestingT, rx interface{}, str interface{}, msg string, args ..
 
 // NotSamef asserts that two pointers do not reference the same object.
 //
-//	assert.NotSamef(t, ptr1, ptr2, "error message %s", "formatted")
+// 	assert.NotSamef(t, ptr1, ptr2, "error message %s", "formatted")
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
@@ -720,10 +721,10 @@ func NotSamef(t TestingT, expected interface{}, actual interface{}, msg string, 
 // Map elements are key-value pairs unless compared with an array or slice where
 // only the map key is evaluated.
 //
-//	assert.NotSubsetf(t, [1, 3, 4], [1, 2], "error message %s", "formatted")
-//	assert.NotSubsetf(t, {"x": 1, "y": 2}, {"z": 3}, "error message %s", "formatted")
-//	assert.NotSubsetf(t, [1, 3, 4], {1: "one", 2: "two"}, "error message %s", "formatted")
-//	assert.NotSubsetf(t, {"x": 1, "y": 2}, ["z"], "error message %s", "formatted")
+// 	assert.NotSubsetf(t, [1, 3, 4], [1, 2], "error message %s", "formatted")
+// 	assert.NotSubsetf(t, {"x": 1, "y": 2}, {"z": 3}, "error message %s", "formatted")
+// 	assert.NotSubsetf(t, [1, 3, 4], {1: "one", 2: "two"}, "error message %s", "formatted")
+// 	assert.NotSubsetf(t, {"x": 1, "y": 2}, ["z"], "error message %s", "formatted")
 func NotSubsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -741,7 +742,7 @@ func NotZerof(t TestingT, i interface{}, msg string, args ...interface{}) bool {
 
 // Panicsf asserts that the code inside the specified PanicTestFunc panics.
 //
-//	assert.Panicsf(t, func(){ GoCrazy() }, "error message %s", "formatted")
+// 	assert.Panicsf(t, func(){ GoCrazy() }, "error message %s", "formatted")
 func Panicsf(t TestingT, f PanicTestFunc, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -753,7 +754,7 @@ func Panicsf(t TestingT, f PanicTestFunc, msg string, args ...interface{}) bool 
 // panics, and that the recovered panic value is an error that satisfies the
 // EqualError comparison.
 //
-//	assert.PanicsWithErrorf(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+// 	assert.PanicsWithErrorf(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
 func PanicsWithErrorf(t TestingT, errString string, f PanicTestFunc, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -764,7 +765,7 @@ func PanicsWithErrorf(t TestingT, errString string, f PanicTestFunc, msg string,
 // PanicsWithValuef asserts that the code inside the specified PanicTestFunc panics, and that
 // the recovered panic value equals the expected panic value.
 //
-//	assert.PanicsWithValuef(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+// 	assert.PanicsWithValuef(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
 func PanicsWithValuef(t TestingT, expected interface{}, f PanicTestFunc, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -774,8 +775,8 @@ func PanicsWithValuef(t TestingT, expected interface{}, f PanicTestFunc, msg str
 
 // Positivef asserts that the specified element is positive
 //
-//	assert.Positivef(t, 1, "error message %s", "formatted")
-//	assert.Positivef(t, 1.23, "error message %s", "formatted")
+// 	assert.Positivef(t, 1, "error message %s", "formatted")
+// 	assert.Positivef(t, 1.23, "error message %s", "formatted")
 func Positivef(t TestingT, e interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -787,10 +788,11 @@ func Positivef(t TestingT, e interface{}, msg string, args ...interface{}) bool 
 //
 // The rx (expression) argument should be a *regexp.Regexp. For backward
 // compatibility, if rx is any other type, its value will be formatted with
-// %v and compiled using regexp.MustCompile.
+// %v and compiled using regexp.Compile.
 //
-//	assert.Regexpf(t, regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
-//	assert.Regexpf(t, "start...$", "it's not starting", "error message %s", "formatted") // string is compiled
+// Examples:
+// 	assert.Regexpf(t, regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
+// 	assert.Regexpf(t, "start...$", "it's not starting", "error message %s", "formatted") // string is compiled
 func Regexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -800,7 +802,7 @@ func Regexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...in
 
 // Samef asserts that two pointers reference the same object.
 //
-//	assert.Samef(t, ptr1, ptr2, "error message %s", "formatted")
+// 	assert.Samef(t, ptr1, ptr2, "error message %s", "formatted")
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
@@ -816,10 +818,10 @@ func Samef(t TestingT, expected interface{}, actual interface{}, msg string, arg
 // Map elements are key-value pairs unless compared with an array or slice where
 // only the map key is evaluated.
 //
-//	assert.Subsetf(t, [1, 2, 3], [1, 2], "error message %s", "formatted")
-//	assert.Subsetf(t, {"x": 1, "y": 2}, {"x": 1}, "error message %s", "formatted")
-//	assert.Subsetf(t, [1, 2, 3], {1: "one", 2: "two"}, "error message %s", "formatted")
-//	assert.Subsetf(t, {"x": 1, "y": 2}, ["x"], "error message %s", "formatted")
+// 	assert.Subsetf(t, [1, 2, 3], [1, 2], "error message %s", "formatted")
+// 	assert.Subsetf(t, {"x": 1, "y": 2}, {"x": 1}, "error message %s", "formatted")
+// 	assert.Subsetf(t, [1, 2, 3], {1: "one", 2: "two"}, "error message %s", "formatted")
+// 	assert.Subsetf(t, {"x": 1, "y": 2}, ["x"], "error message %s", "formatted")
 func Subsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -829,7 +831,7 @@ func Subsetf(t TestingT, list interface{}, subset interface{}, msg string, args 
 
 // Truef asserts that the specified value is true.
 //
-//	assert.Truef(t, myBool, "error message %s", "formatted")
+// 	assert.Truef(t, myBool, "error message %s", "formatted")
 func Truef(t TestingT, value bool, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -839,7 +841,7 @@ func Truef(t TestingT, value bool, msg string, args ...interface{}) bool {
 
 // WithinDurationf asserts that the two times are within duration delta of each other.
 //
-//	assert.WithinDurationf(t, time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
+// 	assert.WithinDurationf(t, time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
 func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -849,7 +851,7 @@ func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta tim
 
 // WithinRangef asserts that a time is within a time range (inclusive).
 //
-//	assert.WithinRangef(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second), "error message %s", "formatted")
+// 	assert.WithinRangef(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second), "error message %s", "formatted")
 func WithinRangef(t TestingT, actual time.Time, start time.Time, end time.Time, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -859,17 +861,17 @@ func WithinRangef(t TestingT, actual time.Time, start time.Time, end time.Time, 
 
 // YAMLEqf asserts that the first documents in the two YAML strings are equivalent.
 //
-//	expected := `---
-//	key: value
-//	---
-//	key: this is a second document, it is not evaluated
-//	`
-//	actual := `---
-//	key: value
-//	---
-//	key: this is a subsequent document, it is not evaluated
-//	`
-//	assert.YAMLEqf(t, expected, actual, "error message %s", "formatted")
+// 	expected := `---
+// 	key: value
+// 	---
+// 	key: this is a second document, it is not evaluated
+// 	`
+// 	actual := `---
+// 	key: value
+// 	---
+// 	key: this is a subsequent document, it is not evaluated
+// 	`
+// 	assert.YAMLEqf(t, expected, actual, "error message %s", "formatted")
 func YAMLEqf(t TestingT, expected string, actual string, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()

--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -1368,8 +1368,12 @@ func (a *Assertions) NotPanicsf(f PanicTestFunc, msg string, args ...interface{}
 
 // NotRegexp asserts that a specified regexp does not match a string.
 //
+// The rx (expression) argument should be a *regexp.Regexp. For backward
+// compatibility, if rx is any other type, its value will be formatted with
+// %v and compiled using regexp.MustCompile.
+//
 //	a.NotRegexp(regexp.MustCompile("starts"), "it's starting")
-//	a.NotRegexp("^start", "it's not starting")
+//	a.NotRegexp("^start", "it's not starting") // string is compiled
 func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1379,8 +1383,12 @@ func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...in
 
 // NotRegexpf asserts that a specified regexp does not match a string.
 //
+// The rx (expression) argument should be a *regexp.Regexp. For backward
+// compatibility, if rx is any other type, its value will be formatted with
+// %v and compiled using regexp.MustCompile.
+//
 //	a.NotRegexpf(regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
-//	a.NotRegexpf("^start", "it's not starting", "error message %s", "formatted")
+//	a.NotRegexpf("^start", "it's not starting", "error message %s", "formatted") // string is compiled
 func (a *Assertions) NotRegexpf(rx interface{}, str interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1552,8 +1560,12 @@ func (a *Assertions) Positivef(e interface{}, msg string, args ...interface{}) b
 
 // Regexp asserts that a specified regexp matches a string.
 //
+// The rx (expression) argument should be a *regexp.Regexp. For backward
+// compatibility, if rx is any other type, its value will be formatted with
+// %v and compiled using regexp.MustCompile.
+//
 //	a.Regexp(regexp.MustCompile("start"), "it's starting")
-//	a.Regexp("start...$", "it's not starting")
+//	a.Regexp("start...$", "it's not starting") // string is compiled
 func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1563,8 +1575,12 @@ func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...inter
 
 // Regexpf asserts that a specified regexp matches a string.
 //
+// The rx (expression) argument should be a *regexp.Regexp. For backward
+// compatibility, if rx is any other type, its value will be formatted with
+// %v and compiled using regexp.MustCompile.
+//
 //	a.Regexpf(regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
-//	a.Regexpf("start...$", "it's not starting", "error message %s", "formatted")
+//	a.Regexpf("start...$", "it's not starting", "error message %s", "formatted") // string is compiled
 func (a *Assertions) Regexpf(rx interface{}, str interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()

--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -954,7 +954,7 @@ func (a *Assertions) Len(object interface{}, length int, msgAndArgs ...interface
 }
 
 // Lenf asserts that the specified object has specific length.
-// Lenf also fails if the object has a type that len() not accept.
+// Len also fails if the object has a type that len() not accept.
 //
 // 	a.Lenf(mySlice, 3, "error message %s", "formatted")
 func (a *Assertions) Lenf(object interface{}, length int, msg string, args ...interface{}) bool {
@@ -1373,6 +1373,7 @@ func (a *Assertions) NotPanicsf(f PanicTestFunc, msg string, args ...interface{}
 // %v and compiled using regexp.Compile.
 //
 // Examples:
+//
 // 	a.NotRegexp(regexp.MustCompile("starts"), "it's starting")
 // 	a.NotRegexp("^start", "it's not starting") // string is compiled
 func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) bool {
@@ -1389,6 +1390,7 @@ func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...in
 // %v and compiled using regexp.Compile.
 //
 // Examples:
+//
 // 	a.NotRegexpf(regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
 // 	a.NotRegexpf("^start", "it's not starting", "error message %s", "formatted") // string is compiled
 func (a *Assertions) NotRegexpf(rx interface{}, str interface{}, msg string, args ...interface{}) bool {
@@ -1567,6 +1569,7 @@ func (a *Assertions) Positivef(e interface{}, msg string, args ...interface{}) b
 // %v and compiled using regexp.Compile.
 //
 // Examples:
+//
 // 	a.Regexp(regexp.MustCompile("start"), "it's starting")
 // 	a.Regexp("start...$", "it's not starting") // string is compiled
 func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) bool {
@@ -1583,6 +1586,7 @@ func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...inter
 // %v and compiled using regexp.Compile.
 //
 // Examples:
+//
 // 	a.Regexpf(regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
 // 	a.Regexpf("start...$", "it's not starting", "error message %s", "formatted") // string is compiled
 func (a *Assertions) Regexpf(rx interface{}, str interface{}, msg string, args ...interface{}) bool {

--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -27,9 +27,9 @@ func (a *Assertions) Conditionf(comp Comparison, msg string, args ...interface{}
 // Contains asserts that the specified string, list(array, slice...) or map contains the
 // specified substring or element.
 //
-//	a.Contains("Hello World", "World")
-//	a.Contains(["Hello", "World"], "World")
-//	a.Contains({"Hello": "World"}, "Hello")
+// 	a.Contains("Hello World", "World")
+// 	a.Contains(["Hello", "World"], "World")
+// 	a.Contains({"Hello": "World"}, "Hello")
 func (a *Assertions) Contains(s interface{}, contains interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -40,9 +40,9 @@ func (a *Assertions) Contains(s interface{}, contains interface{}, msgAndArgs ..
 // Containsf asserts that the specified string, list(array, slice...) or map contains the
 // specified substring or element.
 //
-//	a.Containsf("Hello World", "World", "error message %s", "formatted")
-//	a.Containsf(["Hello", "World"], "World", "error message %s", "formatted")
-//	a.Containsf({"Hello": "World"}, "Hello", "error message %s", "formatted")
+// 	a.Containsf("Hello World", "World", "error message %s", "formatted")
+// 	a.Containsf(["Hello", "World"], "World", "error message %s", "formatted")
+// 	a.Containsf({"Hello": "World"}, "Hello", "error message %s", "formatted")
 func (a *Assertions) Containsf(s interface{}, contains interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -102,7 +102,7 @@ func (a *Assertions) ElementsMatchf(listA interface{}, listB interface{}, msg st
 //
 // Pointer values are "empty" if the pointer is nil or if the pointed value is "empty".
 //
-//	a.Empty(obj)
+// 	a.Empty(obj)
 //
 // [Zero values]: https://go.dev/ref/spec#The_zero_value
 func (a *Assertions) Empty(object interface{}, msgAndArgs ...interface{}) bool {
@@ -122,7 +122,7 @@ func (a *Assertions) Empty(object interface{}, msgAndArgs ...interface{}) bool {
 //
 // Pointer values are "empty" if the pointer is nil or if the pointed value is "empty".
 //
-//	a.Emptyf(obj, "error message %s", "formatted")
+// 	a.Emptyf(obj, "error message %s", "formatted")
 //
 // [Zero values]: https://go.dev/ref/spec#The_zero_value
 func (a *Assertions) Emptyf(object interface{}, msg string, args ...interface{}) bool {
@@ -134,7 +134,7 @@ func (a *Assertions) Emptyf(object interface{}, msg string, args ...interface{})
 
 // Equal asserts that two objects are equal.
 //
-//	a.Equal(123, 123)
+// 	a.Equal(123, 123)
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses). Function equality
@@ -149,8 +149,8 @@ func (a *Assertions) Equal(expected interface{}, actual interface{}, msgAndArgs 
 // EqualError asserts that a function returned a non-nil error (i.e. an error)
 // and that it is equal to the provided error.
 //
-//	actualObj, err := SomeFunction()
-//	a.EqualError(err,  expectedErrorString)
+// 	actualObj, err := SomeFunction()
+// 	a.EqualError(err,  expectedErrorString)
 func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -161,8 +161,8 @@ func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...
 // EqualErrorf asserts that a function returned a non-nil error (i.e. an error)
 // and that it is equal to the provided error.
 //
-//	actualObj, err := SomeFunction()
-//	a.EqualErrorf(err,  expectedErrorString, "error message %s", "formatted")
+// 	actualObj, err := SomeFunction()
+// 	a.EqualErrorf(err,  expectedErrorString, "error message %s", "formatted")
 func (a *Assertions) EqualErrorf(theError error, errString string, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -174,12 +174,12 @@ func (a *Assertions) EqualErrorf(theError error, errString string, msg string, a
 // fields are also equal. This is useful for comparing structs that have private fields
 // that could potentially differ.
 //
-//	 type S struct {
-//		Exported     	int
-//		notExported   	int
-//	 }
-//	 a.EqualExportedValues(S{1, 2}, S{1, 3}) => true
-//	 a.EqualExportedValues(S{1, 2}, S{2, 3}) => false
+// 	 type S struct {
+// 		Exported     	int
+// 		notExported   	int
+// 	 }
+// 	 a.EqualExportedValues(S{1, 2}, S{1, 3}) => true
+// 	 a.EqualExportedValues(S{1, 2}, S{2, 3}) => false
 func (a *Assertions) EqualExportedValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -191,12 +191,12 @@ func (a *Assertions) EqualExportedValues(expected interface{}, actual interface{
 // fields are also equal. This is useful for comparing structs that have private fields
 // that could potentially differ.
 //
-//	 type S struct {
-//		Exported     	int
-//		notExported   	int
-//	 }
-//	 a.EqualExportedValuesf(S{1, 2}, S{1, 3}, "error message %s", "formatted") => true
-//	 a.EqualExportedValuesf(S{1, 2}, S{2, 3}, "error message %s", "formatted") => false
+// 	 type S struct {
+// 		Exported     	int
+// 		notExported   	int
+// 	 }
+// 	 a.EqualExportedValuesf(S{1, 2}, S{1, 3}, "error message %s", "formatted") => true
+// 	 a.EqualExportedValuesf(S{1, 2}, S{2, 3}, "error message %s", "formatted") => false
 func (a *Assertions) EqualExportedValuesf(expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -207,7 +207,7 @@ func (a *Assertions) EqualExportedValuesf(expected interface{}, actual interface
 // EqualValues asserts that two objects are equal or convertible to the larger
 // type and equal.
 //
-//	a.EqualValues(uint32(123), int32(123))
+// 	a.EqualValues(uint32(123), int32(123))
 func (a *Assertions) EqualValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -218,7 +218,7 @@ func (a *Assertions) EqualValues(expected interface{}, actual interface{}, msgAn
 // EqualValuesf asserts that two objects are equal or convertible to the larger
 // type and equal.
 //
-//	a.EqualValuesf(uint32(123), int32(123), "error message %s", "formatted")
+// 	a.EqualValuesf(uint32(123), int32(123), "error message %s", "formatted")
 func (a *Assertions) EqualValuesf(expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -228,7 +228,7 @@ func (a *Assertions) EqualValuesf(expected interface{}, actual interface{}, msg 
 
 // Equalf asserts that two objects are equal.
 //
-//	a.Equalf(123, 123, "error message %s", "formatted")
+// 	a.Equalf(123, 123, "error message %s", "formatted")
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses). Function equality
@@ -242,8 +242,8 @@ func (a *Assertions) Equalf(expected interface{}, actual interface{}, msg string
 
 // Error asserts that a function returned a non-nil error (ie. an error).
 //
-//	actualObj, err := SomeFunction()
-//	a.Error(err)
+// 	actualObj, err := SomeFunction()
+// 	a.Error(err)
 func (a *Assertions) Error(err error, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -272,8 +272,8 @@ func (a *Assertions) ErrorAsf(err error, target interface{}, msg string, args ..
 // ErrorContains asserts that a function returned a non-nil error (i.e. an
 // error) and that the error contains the specified substring.
 //
-//	actualObj, err := SomeFunction()
-//	a.ErrorContains(err,  expectedErrorSubString)
+// 	actualObj, err := SomeFunction()
+// 	a.ErrorContains(err,  expectedErrorSubString)
 func (a *Assertions) ErrorContains(theError error, contains string, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -284,8 +284,8 @@ func (a *Assertions) ErrorContains(theError error, contains string, msgAndArgs .
 // ErrorContainsf asserts that a function returned a non-nil error (i.e. an
 // error) and that the error contains the specified substring.
 //
-//	actualObj, err := SomeFunction()
-//	a.ErrorContainsf(err,  expectedErrorSubString, "error message %s", "formatted")
+// 	actualObj, err := SomeFunction()
+// 	a.ErrorContainsf(err,  expectedErrorSubString, "error message %s", "formatted")
 func (a *Assertions) ErrorContainsf(theError error, contains string, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -313,8 +313,8 @@ func (a *Assertions) ErrorIsf(err error, target error, msg string, args ...inter
 
 // Errorf asserts that a function returned a non-nil error (ie. an error).
 //
-//	actualObj, err := SomeFunction()
-//	a.Errorf(err, "error message %s", "formatted")
+// 	actualObj, err := SomeFunction()
+// 	a.Errorf(err, "error message %s", "formatted")
 func (a *Assertions) Errorf(err error, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -325,7 +325,7 @@ func (a *Assertions) Errorf(err error, msg string, args ...interface{}) bool {
 // Eventually asserts that given condition will be met in waitFor time,
 // periodically checking target function each tick.
 //
-//	a.Eventually(func() bool { return true; }, time.Second, 10*time.Millisecond)
+// 	a.Eventually(func() bool { return true; }, time.Second, 10*time.Millisecond)
 func (a *Assertions) Eventually(condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -342,15 +342,15 @@ func (a *Assertions) Eventually(condition func() bool, waitFor time.Duration, ti
 // If the condition is not met before waitFor, the collected errors of
 // the last tick are copied to t.
 //
-//	externalValue := false
-//	go func() {
-//		time.Sleep(8*time.Second)
-//		externalValue = true
-//	}()
-//	a.EventuallyWithT(func(c *assert.CollectT) {
-//		// add assertions as needed; any assertion failure will fail the current tick
-//		assert.True(c, externalValue, "expected 'externalValue' to be true")
-//	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
+// 	externalValue := false
+// 	go func() {
+// 		time.Sleep(8*time.Second)
+// 		externalValue = true
+// 	}()
+// 	a.EventuallyWithT(func(c *assert.CollectT) {
+// 		// add assertions as needed; any assertion failure will fail the current tick
+// 		assert.True(c, externalValue, "expected 'externalValue' to be true")
+// 	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
 func (a *Assertions) EventuallyWithT(condition func(collect *CollectT), waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -367,15 +367,15 @@ func (a *Assertions) EventuallyWithT(condition func(collect *CollectT), waitFor 
 // If the condition is not met before waitFor, the collected errors of
 // the last tick are copied to t.
 //
-//	externalValue := false
-//	go func() {
-//		time.Sleep(8*time.Second)
-//		externalValue = true
-//	}()
-//	a.EventuallyWithTf(func(c *assert.CollectT, "error message %s", "formatted") {
-//		// add assertions as needed; any assertion failure will fail the current tick
-//		assert.True(c, externalValue, "expected 'externalValue' to be true")
-//	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
+// 	externalValue := false
+// 	go func() {
+// 		time.Sleep(8*time.Second)
+// 		externalValue = true
+// 	}()
+// 	a.EventuallyWithTf(func(c *assert.CollectT, "error message %s", "formatted") {
+// 		// add assertions as needed; any assertion failure will fail the current tick
+// 		assert.True(c, externalValue, "expected 'externalValue' to be true")
+// 	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
 func (a *Assertions) EventuallyWithTf(condition func(collect *CollectT), waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -386,7 +386,7 @@ func (a *Assertions) EventuallyWithTf(condition func(collect *CollectT), waitFor
 // Eventuallyf asserts that given condition will be met in waitFor time,
 // periodically checking target function each tick.
 //
-//	a.Eventuallyf(func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+// 	a.Eventuallyf(func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
 func (a *Assertions) Eventuallyf(condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -396,7 +396,7 @@ func (a *Assertions) Eventuallyf(condition func() bool, waitFor time.Duration, t
 
 // Exactly asserts that two objects are equal in value and type.
 //
-//	a.Exactly(int32(123), int64(123))
+// 	a.Exactly(int32(123), int64(123))
 func (a *Assertions) Exactly(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -406,7 +406,7 @@ func (a *Assertions) Exactly(expected interface{}, actual interface{}, msgAndArg
 
 // Exactlyf asserts that two objects are equal in value and type.
 //
-//	a.Exactlyf(int32(123), int64(123), "error message %s", "formatted")
+// 	a.Exactlyf(int32(123), int64(123), "error message %s", "formatted")
 func (a *Assertions) Exactlyf(expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -448,7 +448,7 @@ func (a *Assertions) Failf(failureMessage string, msg string, args ...interface{
 
 // False asserts that the specified value is false.
 //
-//	a.False(myBool)
+// 	a.False(myBool)
 func (a *Assertions) False(value bool, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -458,7 +458,7 @@ func (a *Assertions) False(value bool, msgAndArgs ...interface{}) bool {
 
 // Falsef asserts that the specified value is false.
 //
-//	a.Falsef(myBool, "error message %s", "formatted")
+// 	a.Falsef(myBool, "error message %s", "formatted")
 func (a *Assertions) Falsef(value bool, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -486,9 +486,9 @@ func (a *Assertions) FileExistsf(path string, msg string, args ...interface{}) b
 
 // Greater asserts that the first element is greater than the second
 //
-//	a.Greater(2, 1)
-//	a.Greater(float64(2), float64(1))
-//	a.Greater("b", "a")
+// 	a.Greater(2, 1)
+// 	a.Greater(float64(2), float64(1))
+// 	a.Greater("b", "a")
 func (a *Assertions) Greater(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -498,10 +498,10 @@ func (a *Assertions) Greater(e1 interface{}, e2 interface{}, msgAndArgs ...inter
 
 // GreaterOrEqual asserts that the first element is greater than or equal to the second
 //
-//	a.GreaterOrEqual(2, 1)
-//	a.GreaterOrEqual(2, 2)
-//	a.GreaterOrEqual("b", "a")
-//	a.GreaterOrEqual("b", "b")
+// 	a.GreaterOrEqual(2, 1)
+// 	a.GreaterOrEqual(2, 2)
+// 	a.GreaterOrEqual("b", "a")
+// 	a.GreaterOrEqual("b", "b")
 func (a *Assertions) GreaterOrEqual(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -511,10 +511,10 @@ func (a *Assertions) GreaterOrEqual(e1 interface{}, e2 interface{}, msgAndArgs .
 
 // GreaterOrEqualf asserts that the first element is greater than or equal to the second
 //
-//	a.GreaterOrEqualf(2, 1, "error message %s", "formatted")
-//	a.GreaterOrEqualf(2, 2, "error message %s", "formatted")
-//	a.GreaterOrEqualf("b", "a", "error message %s", "formatted")
-//	a.GreaterOrEqualf("b", "b", "error message %s", "formatted")
+// 	a.GreaterOrEqualf(2, 1, "error message %s", "formatted")
+// 	a.GreaterOrEqualf(2, 2, "error message %s", "formatted")
+// 	a.GreaterOrEqualf("b", "a", "error message %s", "formatted")
+// 	a.GreaterOrEqualf("b", "b", "error message %s", "formatted")
 func (a *Assertions) GreaterOrEqualf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -524,9 +524,9 @@ func (a *Assertions) GreaterOrEqualf(e1 interface{}, e2 interface{}, msg string,
 
 // Greaterf asserts that the first element is greater than the second
 //
-//	a.Greaterf(2, 1, "error message %s", "formatted")
-//	a.Greaterf(float64(2), float64(1), "error message %s", "formatted")
-//	a.Greaterf("b", "a", "error message %s", "formatted")
+// 	a.Greaterf(2, 1, "error message %s", "formatted")
+// 	a.Greaterf(float64(2), float64(1), "error message %s", "formatted")
+// 	a.Greaterf("b", "a", "error message %s", "formatted")
 func (a *Assertions) Greaterf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -537,7 +537,7 @@ func (a *Assertions) Greaterf(e1 interface{}, e2 interface{}, msg string, args .
 // HTTPBodyContains asserts that a specified handler returns a
 // body that contains a string.
 //
-//	a.HTTPBodyContains(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
+// 	a.HTTPBodyContains(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPBodyContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) bool {
@@ -550,7 +550,7 @@ func (a *Assertions) HTTPBodyContains(handler http.HandlerFunc, method string, u
 // HTTPBodyContainsf asserts that a specified handler returns a
 // body that contains a string.
 //
-//	a.HTTPBodyContainsf(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+// 	a.HTTPBodyContainsf(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPBodyContainsf(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) bool {
@@ -563,7 +563,7 @@ func (a *Assertions) HTTPBodyContainsf(handler http.HandlerFunc, method string, 
 // HTTPBodyNotContains asserts that a specified handler returns a
 // body that does not contain a string.
 //
-//	a.HTTPBodyNotContains(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
+// 	a.HTTPBodyNotContains(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPBodyNotContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) bool {
@@ -576,7 +576,7 @@ func (a *Assertions) HTTPBodyNotContains(handler http.HandlerFunc, method string
 // HTTPBodyNotContainsf asserts that a specified handler returns a
 // body that does not contain a string.
 //
-//	a.HTTPBodyNotContainsf(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+// 	a.HTTPBodyNotContainsf(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPBodyNotContainsf(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) bool {
@@ -588,7 +588,7 @@ func (a *Assertions) HTTPBodyNotContainsf(handler http.HandlerFunc, method strin
 
 // HTTPError asserts that a specified handler returns an error status code.
 //
-//	a.HTTPError(myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+// 	a.HTTPError(myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPError(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) bool {
@@ -600,7 +600,7 @@ func (a *Assertions) HTTPError(handler http.HandlerFunc, method string, url stri
 
 // HTTPErrorf asserts that a specified handler returns an error status code.
 //
-//	a.HTTPErrorf(myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+// 	a.HTTPErrorf(myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPErrorf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) bool {
@@ -612,7 +612,7 @@ func (a *Assertions) HTTPErrorf(handler http.HandlerFunc, method string, url str
 
 // HTTPRedirect asserts that a specified handler returns a redirect status code.
 //
-//	a.HTTPRedirect(myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+// 	a.HTTPRedirect(myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPRedirect(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) bool {
@@ -624,7 +624,7 @@ func (a *Assertions) HTTPRedirect(handler http.HandlerFunc, method string, url s
 
 // HTTPRedirectf asserts that a specified handler returns a redirect status code.
 //
-//	a.HTTPRedirectf(myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+// 	a.HTTPRedirectf(myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPRedirectf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) bool {
@@ -636,7 +636,7 @@ func (a *Assertions) HTTPRedirectf(handler http.HandlerFunc, method string, url 
 
 // HTTPStatusCode asserts that a specified handler returns a specified status code.
 //
-//	a.HTTPStatusCode(myHandler, "GET", "/notImplemented", nil, 501)
+// 	a.HTTPStatusCode(myHandler, "GET", "/notImplemented", nil, 501)
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPStatusCode(handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msgAndArgs ...interface{}) bool {
@@ -648,7 +648,7 @@ func (a *Assertions) HTTPStatusCode(handler http.HandlerFunc, method string, url
 
 // HTTPStatusCodef asserts that a specified handler returns a specified status code.
 //
-//	a.HTTPStatusCodef(myHandler, "GET", "/notImplemented", nil, 501, "error message %s", "formatted")
+// 	a.HTTPStatusCodef(myHandler, "GET", "/notImplemented", nil, 501, "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPStatusCodef(handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msg string, args ...interface{}) bool {
@@ -660,7 +660,7 @@ func (a *Assertions) HTTPStatusCodef(handler http.HandlerFunc, method string, ur
 
 // HTTPSuccess asserts that a specified handler returns a success status code.
 //
-//	a.HTTPSuccess(myHandler, "POST", "http://www.google.com", nil)
+// 	a.HTTPSuccess(myHandler, "POST", "http://www.google.com", nil)
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPSuccess(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) bool {
@@ -672,7 +672,7 @@ func (a *Assertions) HTTPSuccess(handler http.HandlerFunc, method string, url st
 
 // HTTPSuccessf asserts that a specified handler returns a success status code.
 //
-//	a.HTTPSuccessf(myHandler, "POST", "http://www.google.com", nil, "error message %s", "formatted")
+// 	a.HTTPSuccessf(myHandler, "POST", "http://www.google.com", nil, "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPSuccessf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) bool {
@@ -684,7 +684,7 @@ func (a *Assertions) HTTPSuccessf(handler http.HandlerFunc, method string, url s
 
 // Implements asserts that an object is implemented by the specified interface.
 //
-//	a.Implements((*MyInterface)(nil), new(MyObject))
+// 	a.Implements((*MyInterface)(nil), new(MyObject))
 func (a *Assertions) Implements(interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -694,7 +694,7 @@ func (a *Assertions) Implements(interfaceObject interface{}, object interface{},
 
 // Implementsf asserts that an object is implemented by the specified interface.
 //
-//	a.Implementsf((*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
+// 	a.Implementsf((*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
 func (a *Assertions) Implementsf(interfaceObject interface{}, object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -704,7 +704,7 @@ func (a *Assertions) Implementsf(interfaceObject interface{}, object interface{}
 
 // InDelta asserts that the two numerals are within delta of each other.
 //
-//	a.InDelta(math.Pi, 22/7.0, 0.01)
+// 	a.InDelta(math.Pi, 22/7.0, 0.01)
 func (a *Assertions) InDelta(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -746,7 +746,7 @@ func (a *Assertions) InDeltaSlicef(expected interface{}, actual interface{}, del
 
 // InDeltaf asserts that the two numerals are within delta of each other.
 //
-//	a.InDeltaf(math.Pi, 22/7.0, 0.01, "error message %s", "formatted")
+// 	a.InDeltaf(math.Pi, 22/7.0, 0.01, "error message %s", "formatted")
 func (a *Assertions) InDeltaf(expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -788,9 +788,9 @@ func (a *Assertions) InEpsilonf(expected interface{}, actual interface{}, epsilo
 
 // IsDecreasing asserts that the collection is decreasing
 //
-//	a.IsDecreasing([]int{2, 1, 0})
-//	a.IsDecreasing([]float{2, 1})
-//	a.IsDecreasing([]string{"b", "a"})
+// 	a.IsDecreasing([]int{2, 1, 0})
+// 	a.IsDecreasing([]float{2, 1})
+// 	a.IsDecreasing([]string{"b", "a"})
 func (a *Assertions) IsDecreasing(object interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -800,9 +800,9 @@ func (a *Assertions) IsDecreasing(object interface{}, msgAndArgs ...interface{})
 
 // IsDecreasingf asserts that the collection is decreasing
 //
-//	a.IsDecreasingf([]int{2, 1, 0}, "error message %s", "formatted")
-//	a.IsDecreasingf([]float{2, 1}, "error message %s", "formatted")
-//	a.IsDecreasingf([]string{"b", "a"}, "error message %s", "formatted")
+// 	a.IsDecreasingf([]int{2, 1, 0}, "error message %s", "formatted")
+// 	a.IsDecreasingf([]float{2, 1}, "error message %s", "formatted")
+// 	a.IsDecreasingf([]string{"b", "a"}, "error message %s", "formatted")
 func (a *Assertions) IsDecreasingf(object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -812,9 +812,9 @@ func (a *Assertions) IsDecreasingf(object interface{}, msg string, args ...inter
 
 // IsIncreasing asserts that the collection is increasing
 //
-//	a.IsIncreasing([]int{1, 2, 3})
-//	a.IsIncreasing([]float{1, 2})
-//	a.IsIncreasing([]string{"a", "b"})
+// 	a.IsIncreasing([]int{1, 2, 3})
+// 	a.IsIncreasing([]float{1, 2})
+// 	a.IsIncreasing([]string{"a", "b"})
 func (a *Assertions) IsIncreasing(object interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -824,9 +824,9 @@ func (a *Assertions) IsIncreasing(object interface{}, msgAndArgs ...interface{})
 
 // IsIncreasingf asserts that the collection is increasing
 //
-//	a.IsIncreasingf([]int{1, 2, 3}, "error message %s", "formatted")
-//	a.IsIncreasingf([]float{1, 2}, "error message %s", "formatted")
-//	a.IsIncreasingf([]string{"a", "b"}, "error message %s", "formatted")
+// 	a.IsIncreasingf([]int{1, 2, 3}, "error message %s", "formatted")
+// 	a.IsIncreasingf([]float{1, 2}, "error message %s", "formatted")
+// 	a.IsIncreasingf([]string{"a", "b"}, "error message %s", "formatted")
 func (a *Assertions) IsIncreasingf(object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -836,9 +836,9 @@ func (a *Assertions) IsIncreasingf(object interface{}, msg string, args ...inter
 
 // IsNonDecreasing asserts that the collection is not decreasing
 //
-//	a.IsNonDecreasing([]int{1, 1, 2})
-//	a.IsNonDecreasing([]float{1, 2})
-//	a.IsNonDecreasing([]string{"a", "b"})
+// 	a.IsNonDecreasing([]int{1, 1, 2})
+// 	a.IsNonDecreasing([]float{1, 2})
+// 	a.IsNonDecreasing([]string{"a", "b"})
 func (a *Assertions) IsNonDecreasing(object interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -848,9 +848,9 @@ func (a *Assertions) IsNonDecreasing(object interface{}, msgAndArgs ...interface
 
 // IsNonDecreasingf asserts that the collection is not decreasing
 //
-//	a.IsNonDecreasingf([]int{1, 1, 2}, "error message %s", "formatted")
-//	a.IsNonDecreasingf([]float{1, 2}, "error message %s", "formatted")
-//	a.IsNonDecreasingf([]string{"a", "b"}, "error message %s", "formatted")
+// 	a.IsNonDecreasingf([]int{1, 1, 2}, "error message %s", "formatted")
+// 	a.IsNonDecreasingf([]float{1, 2}, "error message %s", "formatted")
+// 	a.IsNonDecreasingf([]string{"a", "b"}, "error message %s", "formatted")
 func (a *Assertions) IsNonDecreasingf(object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -860,9 +860,9 @@ func (a *Assertions) IsNonDecreasingf(object interface{}, msg string, args ...in
 
 // IsNonIncreasing asserts that the collection is not increasing
 //
-//	a.IsNonIncreasing([]int{2, 1, 1})
-//	a.IsNonIncreasing([]float{2, 1})
-//	a.IsNonIncreasing([]string{"b", "a"})
+// 	a.IsNonIncreasing([]int{2, 1, 1})
+// 	a.IsNonIncreasing([]float{2, 1})
+// 	a.IsNonIncreasing([]string{"b", "a"})
 func (a *Assertions) IsNonIncreasing(object interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -872,9 +872,9 @@ func (a *Assertions) IsNonIncreasing(object interface{}, msgAndArgs ...interface
 
 // IsNonIncreasingf asserts that the collection is not increasing
 //
-//	a.IsNonIncreasingf([]int{2, 1, 1}, "error message %s", "formatted")
-//	a.IsNonIncreasingf([]float{2, 1}, "error message %s", "formatted")
-//	a.IsNonIncreasingf([]string{"b", "a"}, "error message %s", "formatted")
+// 	a.IsNonIncreasingf([]int{2, 1, 1}, "error message %s", "formatted")
+// 	a.IsNonIncreasingf([]float{2, 1}, "error message %s", "formatted")
+// 	a.IsNonIncreasingf([]string{"b", "a"}, "error message %s", "formatted")
 func (a *Assertions) IsNonIncreasingf(object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -884,7 +884,7 @@ func (a *Assertions) IsNonIncreasingf(object interface{}, msg string, args ...in
 
 // IsNotType asserts that the specified objects are not of the same type.
 //
-//	a.IsNotType(&NotMyStruct{}, &MyStruct{})
+// 	a.IsNotType(&NotMyStruct{}, &MyStruct{})
 func (a *Assertions) IsNotType(theType interface{}, object interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -894,7 +894,7 @@ func (a *Assertions) IsNotType(theType interface{}, object interface{}, msgAndAr
 
 // IsNotTypef asserts that the specified objects are not of the same type.
 //
-//	a.IsNotTypef(&NotMyStruct{}, &MyStruct{}, "error message %s", "formatted")
+// 	a.IsNotTypef(&NotMyStruct{}, &MyStruct{}, "error message %s", "formatted")
 func (a *Assertions) IsNotTypef(theType interface{}, object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -904,7 +904,7 @@ func (a *Assertions) IsNotTypef(theType interface{}, object interface{}, msg str
 
 // IsType asserts that the specified objects are of the same type.
 //
-//	a.IsType(&MyStruct{}, &MyStruct{})
+// 	a.IsType(&MyStruct{}, &MyStruct{})
 func (a *Assertions) IsType(expectedType interface{}, object interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -914,7 +914,7 @@ func (a *Assertions) IsType(expectedType interface{}, object interface{}, msgAnd
 
 // IsTypef asserts that the specified objects are of the same type.
 //
-//	a.IsTypef(&MyStruct{}, &MyStruct{}, "error message %s", "formatted")
+// 	a.IsTypef(&MyStruct{}, &MyStruct{}, "error message %s", "formatted")
 func (a *Assertions) IsTypef(expectedType interface{}, object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -924,7 +924,7 @@ func (a *Assertions) IsTypef(expectedType interface{}, object interface{}, msg s
 
 // JSONEq asserts that two JSON strings are equivalent.
 //
-//	a.JSONEq(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
+// 	a.JSONEq(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
 func (a *Assertions) JSONEq(expected string, actual string, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -934,7 +934,7 @@ func (a *Assertions) JSONEq(expected string, actual string, msgAndArgs ...interf
 
 // JSONEqf asserts that two JSON strings are equivalent.
 //
-//	a.JSONEqf(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
+// 	a.JSONEqf(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
 func (a *Assertions) JSONEqf(expected string, actual string, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -945,7 +945,7 @@ func (a *Assertions) JSONEqf(expected string, actual string, msg string, args ..
 // Len asserts that the specified object has specific length.
 // Len also fails if the object has a type that len() not accept.
 //
-//	a.Len(mySlice, 3)
+// 	a.Len(mySlice, 3)
 func (a *Assertions) Len(object interface{}, length int, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -956,7 +956,7 @@ func (a *Assertions) Len(object interface{}, length int, msgAndArgs ...interface
 // Lenf asserts that the specified object has specific length.
 // Lenf also fails if the object has a type that len() not accept.
 //
-//	a.Lenf(mySlice, 3, "error message %s", "formatted")
+// 	a.Lenf(mySlice, 3, "error message %s", "formatted")
 func (a *Assertions) Lenf(object interface{}, length int, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -966,9 +966,9 @@ func (a *Assertions) Lenf(object interface{}, length int, msg string, args ...in
 
 // Less asserts that the first element is less than the second
 //
-//	a.Less(1, 2)
-//	a.Less(float64(1), float64(2))
-//	a.Less("a", "b")
+// 	a.Less(1, 2)
+// 	a.Less(float64(1), float64(2))
+// 	a.Less("a", "b")
 func (a *Assertions) Less(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -978,10 +978,10 @@ func (a *Assertions) Less(e1 interface{}, e2 interface{}, msgAndArgs ...interfac
 
 // LessOrEqual asserts that the first element is less than or equal to the second
 //
-//	a.LessOrEqual(1, 2)
-//	a.LessOrEqual(2, 2)
-//	a.LessOrEqual("a", "b")
-//	a.LessOrEqual("b", "b")
+// 	a.LessOrEqual(1, 2)
+// 	a.LessOrEqual(2, 2)
+// 	a.LessOrEqual("a", "b")
+// 	a.LessOrEqual("b", "b")
 func (a *Assertions) LessOrEqual(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -991,10 +991,10 @@ func (a *Assertions) LessOrEqual(e1 interface{}, e2 interface{}, msgAndArgs ...i
 
 // LessOrEqualf asserts that the first element is less than or equal to the second
 //
-//	a.LessOrEqualf(1, 2, "error message %s", "formatted")
-//	a.LessOrEqualf(2, 2, "error message %s", "formatted")
-//	a.LessOrEqualf("a", "b", "error message %s", "formatted")
-//	a.LessOrEqualf("b", "b", "error message %s", "formatted")
+// 	a.LessOrEqualf(1, 2, "error message %s", "formatted")
+// 	a.LessOrEqualf(2, 2, "error message %s", "formatted")
+// 	a.LessOrEqualf("a", "b", "error message %s", "formatted")
+// 	a.LessOrEqualf("b", "b", "error message %s", "formatted")
 func (a *Assertions) LessOrEqualf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1004,9 +1004,9 @@ func (a *Assertions) LessOrEqualf(e1 interface{}, e2 interface{}, msg string, ar
 
 // Lessf asserts that the first element is less than the second
 //
-//	a.Lessf(1, 2, "error message %s", "formatted")
-//	a.Lessf(float64(1), float64(2), "error message %s", "formatted")
-//	a.Lessf("a", "b", "error message %s", "formatted")
+// 	a.Lessf(1, 2, "error message %s", "formatted")
+// 	a.Lessf(float64(1), float64(2), "error message %s", "formatted")
+// 	a.Lessf("a", "b", "error message %s", "formatted")
 func (a *Assertions) Lessf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1016,8 +1016,8 @@ func (a *Assertions) Lessf(e1 interface{}, e2 interface{}, msg string, args ...i
 
 // Negative asserts that the specified element is negative
 //
-//	a.Negative(-1)
-//	a.Negative(-1.23)
+// 	a.Negative(-1)
+// 	a.Negative(-1.23)
 func (a *Assertions) Negative(e interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1027,8 +1027,8 @@ func (a *Assertions) Negative(e interface{}, msgAndArgs ...interface{}) bool {
 
 // Negativef asserts that the specified element is negative
 //
-//	a.Negativef(-1, "error message %s", "formatted")
-//	a.Negativef(-1.23, "error message %s", "formatted")
+// 	a.Negativef(-1, "error message %s", "formatted")
+// 	a.Negativef(-1.23, "error message %s", "formatted")
 func (a *Assertions) Negativef(e interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1039,7 +1039,7 @@ func (a *Assertions) Negativef(e interface{}, msg string, args ...interface{}) b
 // Never asserts that the given condition doesn't satisfy in waitFor time,
 // periodically checking the target function each tick.
 //
-//	a.Never(func() bool { return false; }, time.Second, 10*time.Millisecond)
+// 	a.Never(func() bool { return false; }, time.Second, 10*time.Millisecond)
 func (a *Assertions) Never(condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1050,7 +1050,7 @@ func (a *Assertions) Never(condition func() bool, waitFor time.Duration, tick ti
 // Neverf asserts that the given condition doesn't satisfy in waitFor time,
 // periodically checking the target function each tick.
 //
-//	a.Neverf(func() bool { return false; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+// 	a.Neverf(func() bool { return false; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
 func (a *Assertions) Neverf(condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1060,7 +1060,7 @@ func (a *Assertions) Neverf(condition func() bool, waitFor time.Duration, tick t
 
 // Nil asserts that the specified object is nil.
 //
-//	a.Nil(err)
+// 	a.Nil(err)
 func (a *Assertions) Nil(object interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1070,7 +1070,7 @@ func (a *Assertions) Nil(object interface{}, msgAndArgs ...interface{}) bool {
 
 // Nilf asserts that the specified object is nil.
 //
-//	a.Nilf(err, "error message %s", "formatted")
+// 	a.Nilf(err, "error message %s", "formatted")
 func (a *Assertions) Nilf(object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1098,10 +1098,10 @@ func (a *Assertions) NoDirExistsf(path string, msg string, args ...interface{}) 
 
 // NoError asserts that a function returned a nil error (ie. no error).
 //
-//	  actualObj, err := SomeFunction()
-//	  if a.NoError(err) {
-//		   assert.Equal(t, expectedObj, actualObj)
-//	  }
+// 	  actualObj, err := SomeFunction()
+// 	  if a.NoError(err) {
+// 		   assert.Equal(t, expectedObj, actualObj)
+// 	  }
 func (a *Assertions) NoError(err error, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1111,10 +1111,10 @@ func (a *Assertions) NoError(err error, msgAndArgs ...interface{}) bool {
 
 // NoErrorf asserts that a function returned a nil error (ie. no error).
 //
-//	  actualObj, err := SomeFunction()
-//	  if a.NoErrorf(err, "error message %s", "formatted") {
-//		   assert.Equal(t, expectedObj, actualObj)
-//	  }
+// 	  actualObj, err := SomeFunction()
+// 	  if a.NoErrorf(err, "error message %s", "formatted") {
+// 		   assert.Equal(t, expectedObj, actualObj)
+// 	  }
 func (a *Assertions) NoErrorf(err error, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1143,9 +1143,9 @@ func (a *Assertions) NoFileExistsf(path string, msg string, args ...interface{})
 // NotContains asserts that the specified string, list(array, slice...) or map does NOT contain the
 // specified substring or element.
 //
-//	a.NotContains("Hello World", "Earth")
-//	a.NotContains(["Hello", "World"], "Earth")
-//	a.NotContains({"Hello": "World"}, "Earth")
+// 	a.NotContains("Hello World", "Earth")
+// 	a.NotContains(["Hello", "World"], "Earth")
+// 	a.NotContains({"Hello": "World"}, "Earth")
 func (a *Assertions) NotContains(s interface{}, contains interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1156,9 +1156,9 @@ func (a *Assertions) NotContains(s interface{}, contains interface{}, msgAndArgs
 // NotContainsf asserts that the specified string, list(array, slice...) or map does NOT contain the
 // specified substring or element.
 //
-//	a.NotContainsf("Hello World", "Earth", "error message %s", "formatted")
-//	a.NotContainsf(["Hello", "World"], "Earth", "error message %s", "formatted")
-//	a.NotContainsf({"Hello": "World"}, "Earth", "error message %s", "formatted")
+// 	a.NotContainsf("Hello World", "Earth", "error message %s", "formatted")
+// 	a.NotContainsf(["Hello", "World"], "Earth", "error message %s", "formatted")
+// 	a.NotContainsf({"Hello": "World"}, "Earth", "error message %s", "formatted")
 func (a *Assertions) NotContainsf(s interface{}, contains interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1202,9 +1202,9 @@ func (a *Assertions) NotElementsMatchf(listA interface{}, listB interface{}, msg
 
 // NotEmpty asserts that the specified object is NOT [Empty].
 //
-//	if a.NotEmpty(obj) {
-//	  assert.Equal(t, "two", obj[1])
-//	}
+// 	if a.NotEmpty(obj) {
+// 	  assert.Equal(t, "two", obj[1])
+// 	}
 func (a *Assertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1214,9 +1214,9 @@ func (a *Assertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) boo
 
 // NotEmptyf asserts that the specified object is NOT [Empty].
 //
-//	if a.NotEmptyf(obj, "error message %s", "formatted") {
-//	  assert.Equal(t, "two", obj[1])
-//	}
+// 	if a.NotEmptyf(obj, "error message %s", "formatted") {
+// 	  assert.Equal(t, "two", obj[1])
+// 	}
 func (a *Assertions) NotEmptyf(object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1226,7 +1226,7 @@ func (a *Assertions) NotEmptyf(object interface{}, msg string, args ...interface
 
 // NotEqual asserts that the specified values are NOT equal.
 //
-//	a.NotEqual(obj1, obj2)
+// 	a.NotEqual(obj1, obj2)
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
@@ -1239,7 +1239,7 @@ func (a *Assertions) NotEqual(expected interface{}, actual interface{}, msgAndAr
 
 // NotEqualValues asserts that two objects are not equal even when converted to the same type
 //
-//	a.NotEqualValues(obj1, obj2)
+// 	a.NotEqualValues(obj1, obj2)
 func (a *Assertions) NotEqualValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1249,7 +1249,7 @@ func (a *Assertions) NotEqualValues(expected interface{}, actual interface{}, ms
 
 // NotEqualValuesf asserts that two objects are not equal even when converted to the same type
 //
-//	a.NotEqualValuesf(obj1, obj2, "error message %s", "formatted")
+// 	a.NotEqualValuesf(obj1, obj2, "error message %s", "formatted")
 func (a *Assertions) NotEqualValuesf(expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1259,7 +1259,7 @@ func (a *Assertions) NotEqualValuesf(expected interface{}, actual interface{}, m
 
 // NotEqualf asserts that the specified values are NOT equal.
 //
-//	a.NotEqualf(obj1, obj2, "error message %s", "formatted")
+// 	a.NotEqualf(obj1, obj2, "error message %s", "formatted")
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
@@ -1308,7 +1308,7 @@ func (a *Assertions) NotErrorIsf(err error, target error, msg string, args ...in
 
 // NotImplements asserts that an object does not implement the specified interface.
 //
-//	a.NotImplements((*MyInterface)(nil), new(MyObject))
+// 	a.NotImplements((*MyInterface)(nil), new(MyObject))
 func (a *Assertions) NotImplements(interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1318,7 +1318,7 @@ func (a *Assertions) NotImplements(interfaceObject interface{}, object interface
 
 // NotImplementsf asserts that an object does not implement the specified interface.
 //
-//	a.NotImplementsf((*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
+// 	a.NotImplementsf((*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
 func (a *Assertions) NotImplementsf(interfaceObject interface{}, object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1328,7 +1328,7 @@ func (a *Assertions) NotImplementsf(interfaceObject interface{}, object interfac
 
 // NotNil asserts that the specified object is not nil.
 //
-//	a.NotNil(err)
+// 	a.NotNil(err)
 func (a *Assertions) NotNil(object interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1338,7 +1338,7 @@ func (a *Assertions) NotNil(object interface{}, msgAndArgs ...interface{}) bool 
 
 // NotNilf asserts that the specified object is not nil.
 //
-//	a.NotNilf(err, "error message %s", "formatted")
+// 	a.NotNilf(err, "error message %s", "formatted")
 func (a *Assertions) NotNilf(object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1348,7 +1348,7 @@ func (a *Assertions) NotNilf(object interface{}, msg string, args ...interface{}
 
 // NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
 //
-//	a.NotPanics(func(){ RemainCalm() })
+// 	a.NotPanics(func(){ RemainCalm() })
 func (a *Assertions) NotPanics(f PanicTestFunc, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1358,7 +1358,7 @@ func (a *Assertions) NotPanics(f PanicTestFunc, msgAndArgs ...interface{}) bool 
 
 // NotPanicsf asserts that the code inside the specified PanicTestFunc does NOT panic.
 //
-//	a.NotPanicsf(func(){ RemainCalm() }, "error message %s", "formatted")
+// 	a.NotPanicsf(func(){ RemainCalm() }, "error message %s", "formatted")
 func (a *Assertions) NotPanicsf(f PanicTestFunc, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1370,10 +1370,11 @@ func (a *Assertions) NotPanicsf(f PanicTestFunc, msg string, args ...interface{}
 //
 // The rx (expression) argument should be a *regexp.Regexp. For backward
 // compatibility, if rx is any other type, its value will be formatted with
-// %v and compiled using regexp.MustCompile.
+// %v and compiled using regexp.Compile.
 //
-//	a.NotRegexp(regexp.MustCompile("starts"), "it's starting")
-//	a.NotRegexp("^start", "it's not starting") // string is compiled
+// Examples:
+// 	a.NotRegexp(regexp.MustCompile("starts"), "it's starting")
+// 	a.NotRegexp("^start", "it's not starting") // string is compiled
 func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1385,10 +1386,11 @@ func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...in
 //
 // The rx (expression) argument should be a *regexp.Regexp. For backward
 // compatibility, if rx is any other type, its value will be formatted with
-// %v and compiled using regexp.MustCompile.
+// %v and compiled using regexp.Compile.
 //
-//	a.NotRegexpf(regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
-//	a.NotRegexpf("^start", "it's not starting", "error message %s", "formatted") // string is compiled
+// Examples:
+// 	a.NotRegexpf(regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
+// 	a.NotRegexpf("^start", "it's not starting", "error message %s", "formatted") // string is compiled
 func (a *Assertions) NotRegexpf(rx interface{}, str interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1398,7 +1400,7 @@ func (a *Assertions) NotRegexpf(rx interface{}, str interface{}, msg string, arg
 
 // NotSame asserts that two pointers do not reference the same object.
 //
-//	a.NotSame(ptr1, ptr2)
+// 	a.NotSame(ptr1, ptr2)
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
@@ -1411,7 +1413,7 @@ func (a *Assertions) NotSame(expected interface{}, actual interface{}, msgAndArg
 
 // NotSamef asserts that two pointers do not reference the same object.
 //
-//	a.NotSamef(ptr1, ptr2, "error message %s", "formatted")
+// 	a.NotSamef(ptr1, ptr2, "error message %s", "formatted")
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
@@ -1427,10 +1429,10 @@ func (a *Assertions) NotSamef(expected interface{}, actual interface{}, msg stri
 // Map elements are key-value pairs unless compared with an array or slice where
 // only the map key is evaluated.
 //
-//	a.NotSubset([1, 3, 4], [1, 2])
-//	a.NotSubset({"x": 1, "y": 2}, {"z": 3})
-//	a.NotSubset([1, 3, 4], {1: "one", 2: "two"})
-//	a.NotSubset({"x": 1, "y": 2}, ["z"])
+// 	a.NotSubset([1, 3, 4], [1, 2])
+// 	a.NotSubset({"x": 1, "y": 2}, {"z": 3})
+// 	a.NotSubset([1, 3, 4], {1: "one", 2: "two"})
+// 	a.NotSubset({"x": 1, "y": 2}, ["z"])
 func (a *Assertions) NotSubset(list interface{}, subset interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1443,10 +1445,10 @@ func (a *Assertions) NotSubset(list interface{}, subset interface{}, msgAndArgs 
 // Map elements are key-value pairs unless compared with an array or slice where
 // only the map key is evaluated.
 //
-//	a.NotSubsetf([1, 3, 4], [1, 2], "error message %s", "formatted")
-//	a.NotSubsetf({"x": 1, "y": 2}, {"z": 3}, "error message %s", "formatted")
-//	a.NotSubsetf([1, 3, 4], {1: "one", 2: "two"}, "error message %s", "formatted")
-//	a.NotSubsetf({"x": 1, "y": 2}, ["z"], "error message %s", "formatted")
+// 	a.NotSubsetf([1, 3, 4], [1, 2], "error message %s", "formatted")
+// 	a.NotSubsetf({"x": 1, "y": 2}, {"z": 3}, "error message %s", "formatted")
+// 	a.NotSubsetf([1, 3, 4], {1: "one", 2: "two"}, "error message %s", "formatted")
+// 	a.NotSubsetf({"x": 1, "y": 2}, ["z"], "error message %s", "formatted")
 func (a *Assertions) NotSubsetf(list interface{}, subset interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1472,7 +1474,7 @@ func (a *Assertions) NotZerof(i interface{}, msg string, args ...interface{}) bo
 
 // Panics asserts that the code inside the specified PanicTestFunc panics.
 //
-//	a.Panics(func(){ GoCrazy() })
+// 	a.Panics(func(){ GoCrazy() })
 func (a *Assertions) Panics(f PanicTestFunc, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1484,7 +1486,7 @@ func (a *Assertions) Panics(f PanicTestFunc, msgAndArgs ...interface{}) bool {
 // panics, and that the recovered panic value is an error that satisfies the
 // EqualError comparison.
 //
-//	a.PanicsWithError("crazy error", func(){ GoCrazy() })
+// 	a.PanicsWithError("crazy error", func(){ GoCrazy() })
 func (a *Assertions) PanicsWithError(errString string, f PanicTestFunc, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1496,7 +1498,7 @@ func (a *Assertions) PanicsWithError(errString string, f PanicTestFunc, msgAndAr
 // panics, and that the recovered panic value is an error that satisfies the
 // EqualError comparison.
 //
-//	a.PanicsWithErrorf("crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+// 	a.PanicsWithErrorf("crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
 func (a *Assertions) PanicsWithErrorf(errString string, f PanicTestFunc, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1507,7 +1509,7 @@ func (a *Assertions) PanicsWithErrorf(errString string, f PanicTestFunc, msg str
 // PanicsWithValue asserts that the code inside the specified PanicTestFunc panics, and that
 // the recovered panic value equals the expected panic value.
 //
-//	a.PanicsWithValue("crazy error", func(){ GoCrazy() })
+// 	a.PanicsWithValue("crazy error", func(){ GoCrazy() })
 func (a *Assertions) PanicsWithValue(expected interface{}, f PanicTestFunc, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1518,7 +1520,7 @@ func (a *Assertions) PanicsWithValue(expected interface{}, f PanicTestFunc, msgA
 // PanicsWithValuef asserts that the code inside the specified PanicTestFunc panics, and that
 // the recovered panic value equals the expected panic value.
 //
-//	a.PanicsWithValuef("crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+// 	a.PanicsWithValuef("crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
 func (a *Assertions) PanicsWithValuef(expected interface{}, f PanicTestFunc, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1528,7 +1530,7 @@ func (a *Assertions) PanicsWithValuef(expected interface{}, f PanicTestFunc, msg
 
 // Panicsf asserts that the code inside the specified PanicTestFunc panics.
 //
-//	a.Panicsf(func(){ GoCrazy() }, "error message %s", "formatted")
+// 	a.Panicsf(func(){ GoCrazy() }, "error message %s", "formatted")
 func (a *Assertions) Panicsf(f PanicTestFunc, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1538,8 +1540,8 @@ func (a *Assertions) Panicsf(f PanicTestFunc, msg string, args ...interface{}) b
 
 // Positive asserts that the specified element is positive
 //
-//	a.Positive(1)
-//	a.Positive(1.23)
+// 	a.Positive(1)
+// 	a.Positive(1.23)
 func (a *Assertions) Positive(e interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1549,8 +1551,8 @@ func (a *Assertions) Positive(e interface{}, msgAndArgs ...interface{}) bool {
 
 // Positivef asserts that the specified element is positive
 //
-//	a.Positivef(1, "error message %s", "formatted")
-//	a.Positivef(1.23, "error message %s", "formatted")
+// 	a.Positivef(1, "error message %s", "formatted")
+// 	a.Positivef(1.23, "error message %s", "formatted")
 func (a *Assertions) Positivef(e interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1562,10 +1564,11 @@ func (a *Assertions) Positivef(e interface{}, msg string, args ...interface{}) b
 //
 // The rx (expression) argument should be a *regexp.Regexp. For backward
 // compatibility, if rx is any other type, its value will be formatted with
-// %v and compiled using regexp.MustCompile.
+// %v and compiled using regexp.Compile.
 //
-//	a.Regexp(regexp.MustCompile("start"), "it's starting")
-//	a.Regexp("start...$", "it's not starting") // string is compiled
+// Examples:
+// 	a.Regexp(regexp.MustCompile("start"), "it's starting")
+// 	a.Regexp("start...$", "it's not starting") // string is compiled
 func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1577,10 +1580,11 @@ func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...inter
 //
 // The rx (expression) argument should be a *regexp.Regexp. For backward
 // compatibility, if rx is any other type, its value will be formatted with
-// %v and compiled using regexp.MustCompile.
+// %v and compiled using regexp.Compile.
 //
-//	a.Regexpf(regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
-//	a.Regexpf("start...$", "it's not starting", "error message %s", "formatted") // string is compiled
+// Examples:
+// 	a.Regexpf(regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
+// 	a.Regexpf("start...$", "it's not starting", "error message %s", "formatted") // string is compiled
 func (a *Assertions) Regexpf(rx interface{}, str interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1590,7 +1594,7 @@ func (a *Assertions) Regexpf(rx interface{}, str interface{}, msg string, args .
 
 // Same asserts that two pointers reference the same object.
 //
-//	a.Same(ptr1, ptr2)
+// 	a.Same(ptr1, ptr2)
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
@@ -1603,7 +1607,7 @@ func (a *Assertions) Same(expected interface{}, actual interface{}, msgAndArgs .
 
 // Samef asserts that two pointers reference the same object.
 //
-//	a.Samef(ptr1, ptr2, "error message %s", "formatted")
+// 	a.Samef(ptr1, ptr2, "error message %s", "formatted")
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
@@ -1619,10 +1623,10 @@ func (a *Assertions) Samef(expected interface{}, actual interface{}, msg string,
 // Map elements are key-value pairs unless compared with an array or slice where
 // only the map key is evaluated.
 //
-//	a.Subset([1, 2, 3], [1, 2])
-//	a.Subset({"x": 1, "y": 2}, {"x": 1})
-//	a.Subset([1, 2, 3], {1: "one", 2: "two"})
-//	a.Subset({"x": 1, "y": 2}, ["x"])
+// 	a.Subset([1, 2, 3], [1, 2])
+// 	a.Subset({"x": 1, "y": 2}, {"x": 1})
+// 	a.Subset([1, 2, 3], {1: "one", 2: "two"})
+// 	a.Subset({"x": 1, "y": 2}, ["x"])
 func (a *Assertions) Subset(list interface{}, subset interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1635,10 +1639,10 @@ func (a *Assertions) Subset(list interface{}, subset interface{}, msgAndArgs ...
 // Map elements are key-value pairs unless compared with an array or slice where
 // only the map key is evaluated.
 //
-//	a.Subsetf([1, 2, 3], [1, 2], "error message %s", "formatted")
-//	a.Subsetf({"x": 1, "y": 2}, {"x": 1}, "error message %s", "formatted")
-//	a.Subsetf([1, 2, 3], {1: "one", 2: "two"}, "error message %s", "formatted")
-//	a.Subsetf({"x": 1, "y": 2}, ["x"], "error message %s", "formatted")
+// 	a.Subsetf([1, 2, 3], [1, 2], "error message %s", "formatted")
+// 	a.Subsetf({"x": 1, "y": 2}, {"x": 1}, "error message %s", "formatted")
+// 	a.Subsetf([1, 2, 3], {1: "one", 2: "two"}, "error message %s", "formatted")
+// 	a.Subsetf({"x": 1, "y": 2}, ["x"], "error message %s", "formatted")
 func (a *Assertions) Subsetf(list interface{}, subset interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1648,7 +1652,7 @@ func (a *Assertions) Subsetf(list interface{}, subset interface{}, msg string, a
 
 // True asserts that the specified value is true.
 //
-//	a.True(myBool)
+// 	a.True(myBool)
 func (a *Assertions) True(value bool, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1658,7 +1662,7 @@ func (a *Assertions) True(value bool, msgAndArgs ...interface{}) bool {
 
 // Truef asserts that the specified value is true.
 //
-//	a.Truef(myBool, "error message %s", "formatted")
+// 	a.Truef(myBool, "error message %s", "formatted")
 func (a *Assertions) Truef(value bool, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1668,7 +1672,7 @@ func (a *Assertions) Truef(value bool, msg string, args ...interface{}) bool {
 
 // WithinDuration asserts that the two times are within duration delta of each other.
 //
-//	a.WithinDuration(time.Now(), time.Now(), 10*time.Second)
+// 	a.WithinDuration(time.Now(), time.Now(), 10*time.Second)
 func (a *Assertions) WithinDuration(expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1678,7 +1682,7 @@ func (a *Assertions) WithinDuration(expected time.Time, actual time.Time, delta 
 
 // WithinDurationf asserts that the two times are within duration delta of each other.
 //
-//	a.WithinDurationf(time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
+// 	a.WithinDurationf(time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
 func (a *Assertions) WithinDurationf(expected time.Time, actual time.Time, delta time.Duration, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1688,7 +1692,7 @@ func (a *Assertions) WithinDurationf(expected time.Time, actual time.Time, delta
 
 // WithinRange asserts that a time is within a time range (inclusive).
 //
-//	a.WithinRange(time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second))
+// 	a.WithinRange(time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second))
 func (a *Assertions) WithinRange(actual time.Time, start time.Time, end time.Time, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1698,7 +1702,7 @@ func (a *Assertions) WithinRange(actual time.Time, start time.Time, end time.Tim
 
 // WithinRangef asserts that a time is within a time range (inclusive).
 //
-//	a.WithinRangef(time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second), "error message %s", "formatted")
+// 	a.WithinRangef(time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second), "error message %s", "formatted")
 func (a *Assertions) WithinRangef(actual time.Time, start time.Time, end time.Time, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1708,17 +1712,17 @@ func (a *Assertions) WithinRangef(actual time.Time, start time.Time, end time.Ti
 
 // YAMLEq asserts that the first documents in the two YAML strings are equivalent.
 //
-//	expected := `---
-//	key: value
-//	---
-//	key: this is a second document, it is not evaluated
-//	`
-//	actual := `---
-//	key: value
-//	---
-//	key: this is a subsequent document, it is not evaluated
-//	`
-//	a.YAMLEq(expected, actual)
+// 	expected := `---
+// 	key: value
+// 	---
+// 	key: this is a second document, it is not evaluated
+// 	`
+// 	actual := `---
+// 	key: value
+// 	---
+// 	key: this is a subsequent document, it is not evaluated
+// 	`
+// 	a.YAMLEq(expected, actual)
 func (a *Assertions) YAMLEq(expected string, actual string, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1728,17 +1732,17 @@ func (a *Assertions) YAMLEq(expected string, actual string, msgAndArgs ...interf
 
 // YAMLEqf asserts that the first documents in the two YAML strings are equivalent.
 //
-//	expected := `---
-//	key: value
-//	---
-//	key: this is a second document, it is not evaluated
-//	`
-//	actual := `---
-//	key: value
-//	---
-//	key: this is a subsequent document, it is not evaluated
-//	`
-//	a.YAMLEqf(expected, actual, "error message %s", "formatted")
+// 	expected := `---
+// 	key: value
+// 	---
+// 	key: this is a second document, it is not evaluated
+// 	`
+// 	actual := `---
+// 	key: value
+// 	---
+// 	key: this is a subsequent document, it is not evaluated
+// 	`
+// 	a.YAMLEqf(expected, actual, "error message %s", "formatted")
 func (a *Assertions) YAMLEqf(expected string, actual string, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()

--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -27,9 +27,9 @@ func (a *Assertions) Conditionf(comp Comparison, msg string, args ...interface{}
 // Contains asserts that the specified string, list(array, slice...) or map contains the
 // specified substring or element.
 //
-// 	a.Contains("Hello World", "World")
-// 	a.Contains(["Hello", "World"], "World")
-// 	a.Contains({"Hello": "World"}, "Hello")
+//	a.Contains("Hello World", "World")
+//	a.Contains(["Hello", "World"], "World")
+//	a.Contains({"Hello": "World"}, "Hello")
 func (a *Assertions) Contains(s interface{}, contains interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -40,9 +40,9 @@ func (a *Assertions) Contains(s interface{}, contains interface{}, msgAndArgs ..
 // Containsf asserts that the specified string, list(array, slice...) or map contains the
 // specified substring or element.
 //
-// 	a.Containsf("Hello World", "World", "error message %s", "formatted")
-// 	a.Containsf(["Hello", "World"], "World", "error message %s", "formatted")
-// 	a.Containsf({"Hello": "World"}, "Hello", "error message %s", "formatted")
+//	a.Containsf("Hello World", "World", "error message %s", "formatted")
+//	a.Containsf(["Hello", "World"], "World", "error message %s", "formatted")
+//	a.Containsf({"Hello": "World"}, "Hello", "error message %s", "formatted")
 func (a *Assertions) Containsf(s interface{}, contains interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -102,7 +102,7 @@ func (a *Assertions) ElementsMatchf(listA interface{}, listB interface{}, msg st
 //
 // Pointer values are "empty" if the pointer is nil or if the pointed value is "empty".
 //
-// 	a.Empty(obj)
+//	a.Empty(obj)
 //
 // [Zero values]: https://go.dev/ref/spec#The_zero_value
 func (a *Assertions) Empty(object interface{}, msgAndArgs ...interface{}) bool {
@@ -122,7 +122,7 @@ func (a *Assertions) Empty(object interface{}, msgAndArgs ...interface{}) bool {
 //
 // Pointer values are "empty" if the pointer is nil or if the pointed value is "empty".
 //
-// 	a.Emptyf(obj, "error message %s", "formatted")
+//	a.Emptyf(obj, "error message %s", "formatted")
 //
 // [Zero values]: https://go.dev/ref/spec#The_zero_value
 func (a *Assertions) Emptyf(object interface{}, msg string, args ...interface{}) bool {
@@ -134,7 +134,7 @@ func (a *Assertions) Emptyf(object interface{}, msg string, args ...interface{})
 
 // Equal asserts that two objects are equal.
 //
-// 	a.Equal(123, 123)
+//	a.Equal(123, 123)
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses). Function equality
@@ -149,8 +149,8 @@ func (a *Assertions) Equal(expected interface{}, actual interface{}, msgAndArgs 
 // EqualError asserts that a function returned a non-nil error (i.e. an error)
 // and that it is equal to the provided error.
 //
-// 	actualObj, err := SomeFunction()
-// 	a.EqualError(err,  expectedErrorString)
+//	actualObj, err := SomeFunction()
+//	a.EqualError(err,  expectedErrorString)
 func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -161,8 +161,8 @@ func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...
 // EqualErrorf asserts that a function returned a non-nil error (i.e. an error)
 // and that it is equal to the provided error.
 //
-// 	actualObj, err := SomeFunction()
-// 	a.EqualErrorf(err,  expectedErrorString, "error message %s", "formatted")
+//	actualObj, err := SomeFunction()
+//	a.EqualErrorf(err,  expectedErrorString, "error message %s", "formatted")
 func (a *Assertions) EqualErrorf(theError error, errString string, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -174,12 +174,12 @@ func (a *Assertions) EqualErrorf(theError error, errString string, msg string, a
 // fields are also equal. This is useful for comparing structs that have private fields
 // that could potentially differ.
 //
-// 	 type S struct {
-// 		Exported     	int
-// 		notExported   	int
-// 	 }
-// 	 a.EqualExportedValues(S{1, 2}, S{1, 3}) => true
-// 	 a.EqualExportedValues(S{1, 2}, S{2, 3}) => false
+//	 type S struct {
+//		Exported     	int
+//		notExported   	int
+//	 }
+//	 a.EqualExportedValues(S{1, 2}, S{1, 3}) => true
+//	 a.EqualExportedValues(S{1, 2}, S{2, 3}) => false
 func (a *Assertions) EqualExportedValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -191,12 +191,12 @@ func (a *Assertions) EqualExportedValues(expected interface{}, actual interface{
 // fields are also equal. This is useful for comparing structs that have private fields
 // that could potentially differ.
 //
-// 	 type S struct {
-// 		Exported     	int
-// 		notExported   	int
-// 	 }
-// 	 a.EqualExportedValuesf(S{1, 2}, S{1, 3}, "error message %s", "formatted") => true
-// 	 a.EqualExportedValuesf(S{1, 2}, S{2, 3}, "error message %s", "formatted") => false
+//	 type S struct {
+//		Exported     	int
+//		notExported   	int
+//	 }
+//	 a.EqualExportedValuesf(S{1, 2}, S{1, 3}, "error message %s", "formatted") => true
+//	 a.EqualExportedValuesf(S{1, 2}, S{2, 3}, "error message %s", "formatted") => false
 func (a *Assertions) EqualExportedValuesf(expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -207,7 +207,7 @@ func (a *Assertions) EqualExportedValuesf(expected interface{}, actual interface
 // EqualValues asserts that two objects are equal or convertible to the larger
 // type and equal.
 //
-// 	a.EqualValues(uint32(123), int32(123))
+//	a.EqualValues(uint32(123), int32(123))
 func (a *Assertions) EqualValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -218,7 +218,7 @@ func (a *Assertions) EqualValues(expected interface{}, actual interface{}, msgAn
 // EqualValuesf asserts that two objects are equal or convertible to the larger
 // type and equal.
 //
-// 	a.EqualValuesf(uint32(123), int32(123), "error message %s", "formatted")
+//	a.EqualValuesf(uint32(123), int32(123), "error message %s", "formatted")
 func (a *Assertions) EqualValuesf(expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -228,7 +228,7 @@ func (a *Assertions) EqualValuesf(expected interface{}, actual interface{}, msg 
 
 // Equalf asserts that two objects are equal.
 //
-// 	a.Equalf(123, 123, "error message %s", "formatted")
+//	a.Equalf(123, 123, "error message %s", "formatted")
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses). Function equality
@@ -242,8 +242,8 @@ func (a *Assertions) Equalf(expected interface{}, actual interface{}, msg string
 
 // Error asserts that a function returned a non-nil error (ie. an error).
 //
-// 	actualObj, err := SomeFunction()
-// 	a.Error(err)
+//	actualObj, err := SomeFunction()
+//	a.Error(err)
 func (a *Assertions) Error(err error, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -272,8 +272,8 @@ func (a *Assertions) ErrorAsf(err error, target interface{}, msg string, args ..
 // ErrorContains asserts that a function returned a non-nil error (i.e. an
 // error) and that the error contains the specified substring.
 //
-// 	actualObj, err := SomeFunction()
-// 	a.ErrorContains(err,  expectedErrorSubString)
+//	actualObj, err := SomeFunction()
+//	a.ErrorContains(err,  expectedErrorSubString)
 func (a *Assertions) ErrorContains(theError error, contains string, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -284,8 +284,8 @@ func (a *Assertions) ErrorContains(theError error, contains string, msgAndArgs .
 // ErrorContainsf asserts that a function returned a non-nil error (i.e. an
 // error) and that the error contains the specified substring.
 //
-// 	actualObj, err := SomeFunction()
-// 	a.ErrorContainsf(err,  expectedErrorSubString, "error message %s", "formatted")
+//	actualObj, err := SomeFunction()
+//	a.ErrorContainsf(err,  expectedErrorSubString, "error message %s", "formatted")
 func (a *Assertions) ErrorContainsf(theError error, contains string, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -313,8 +313,8 @@ func (a *Assertions) ErrorIsf(err error, target error, msg string, args ...inter
 
 // Errorf asserts that a function returned a non-nil error (ie. an error).
 //
-// 	actualObj, err := SomeFunction()
-// 	a.Errorf(err, "error message %s", "formatted")
+//	actualObj, err := SomeFunction()
+//	a.Errorf(err, "error message %s", "formatted")
 func (a *Assertions) Errorf(err error, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -325,7 +325,7 @@ func (a *Assertions) Errorf(err error, msg string, args ...interface{}) bool {
 // Eventually asserts that given condition will be met in waitFor time,
 // periodically checking target function each tick.
 //
-// 	a.Eventually(func() bool { return true; }, time.Second, 10*time.Millisecond)
+//	a.Eventually(func() bool { return true; }, time.Second, 10*time.Millisecond)
 func (a *Assertions) Eventually(condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -342,15 +342,15 @@ func (a *Assertions) Eventually(condition func() bool, waitFor time.Duration, ti
 // If the condition is not met before waitFor, the collected errors of
 // the last tick are copied to t.
 //
-// 	externalValue := false
-// 	go func() {
-// 		time.Sleep(8*time.Second)
-// 		externalValue = true
-// 	}()
-// 	a.EventuallyWithT(func(c *assert.CollectT) {
-// 		// add assertions as needed; any assertion failure will fail the current tick
-// 		assert.True(c, externalValue, "expected 'externalValue' to be true")
-// 	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
+//	externalValue := false
+//	go func() {
+//		time.Sleep(8*time.Second)
+//		externalValue = true
+//	}()
+//	a.EventuallyWithT(func(c *assert.CollectT) {
+//		// add assertions as needed; any assertion failure will fail the current tick
+//		assert.True(c, externalValue, "expected 'externalValue' to be true")
+//	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
 func (a *Assertions) EventuallyWithT(condition func(collect *CollectT), waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -367,15 +367,15 @@ func (a *Assertions) EventuallyWithT(condition func(collect *CollectT), waitFor 
 // If the condition is not met before waitFor, the collected errors of
 // the last tick are copied to t.
 //
-// 	externalValue := false
-// 	go func() {
-// 		time.Sleep(8*time.Second)
-// 		externalValue = true
-// 	}()
-// 	a.EventuallyWithTf(func(c *assert.CollectT, "error message %s", "formatted") {
-// 		// add assertions as needed; any assertion failure will fail the current tick
-// 		assert.True(c, externalValue, "expected 'externalValue' to be true")
-// 	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
+//	externalValue := false
+//	go func() {
+//		time.Sleep(8*time.Second)
+//		externalValue = true
+//	}()
+//	a.EventuallyWithTf(func(c *assert.CollectT, "error message %s", "formatted") {
+//		// add assertions as needed; any assertion failure will fail the current tick
+//		assert.True(c, externalValue, "expected 'externalValue' to be true")
+//	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
 func (a *Assertions) EventuallyWithTf(condition func(collect *CollectT), waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -386,7 +386,7 @@ func (a *Assertions) EventuallyWithTf(condition func(collect *CollectT), waitFor
 // Eventuallyf asserts that given condition will be met in waitFor time,
 // periodically checking target function each tick.
 //
-// 	a.Eventuallyf(func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+//	a.Eventuallyf(func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
 func (a *Assertions) Eventuallyf(condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -396,7 +396,7 @@ func (a *Assertions) Eventuallyf(condition func() bool, waitFor time.Duration, t
 
 // Exactly asserts that two objects are equal in value and type.
 //
-// 	a.Exactly(int32(123), int64(123))
+//	a.Exactly(int32(123), int64(123))
 func (a *Assertions) Exactly(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -406,7 +406,7 @@ func (a *Assertions) Exactly(expected interface{}, actual interface{}, msgAndArg
 
 // Exactlyf asserts that two objects are equal in value and type.
 //
-// 	a.Exactlyf(int32(123), int64(123), "error message %s", "formatted")
+//	a.Exactlyf(int32(123), int64(123), "error message %s", "formatted")
 func (a *Assertions) Exactlyf(expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -448,7 +448,7 @@ func (a *Assertions) Failf(failureMessage string, msg string, args ...interface{
 
 // False asserts that the specified value is false.
 //
-// 	a.False(myBool)
+//	a.False(myBool)
 func (a *Assertions) False(value bool, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -458,7 +458,7 @@ func (a *Assertions) False(value bool, msgAndArgs ...interface{}) bool {
 
 // Falsef asserts that the specified value is false.
 //
-// 	a.Falsef(myBool, "error message %s", "formatted")
+//	a.Falsef(myBool, "error message %s", "formatted")
 func (a *Assertions) Falsef(value bool, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -486,9 +486,9 @@ func (a *Assertions) FileExistsf(path string, msg string, args ...interface{}) b
 
 // Greater asserts that the first element is greater than the second
 //
-// 	a.Greater(2, 1)
-// 	a.Greater(float64(2), float64(1))
-// 	a.Greater("b", "a")
+//	a.Greater(2, 1)
+//	a.Greater(float64(2), float64(1))
+//	a.Greater("b", "a")
 func (a *Assertions) Greater(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -498,10 +498,10 @@ func (a *Assertions) Greater(e1 interface{}, e2 interface{}, msgAndArgs ...inter
 
 // GreaterOrEqual asserts that the first element is greater than or equal to the second
 //
-// 	a.GreaterOrEqual(2, 1)
-// 	a.GreaterOrEqual(2, 2)
-// 	a.GreaterOrEqual("b", "a")
-// 	a.GreaterOrEqual("b", "b")
+//	a.GreaterOrEqual(2, 1)
+//	a.GreaterOrEqual(2, 2)
+//	a.GreaterOrEqual("b", "a")
+//	a.GreaterOrEqual("b", "b")
 func (a *Assertions) GreaterOrEqual(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -511,10 +511,10 @@ func (a *Assertions) GreaterOrEqual(e1 interface{}, e2 interface{}, msgAndArgs .
 
 // GreaterOrEqualf asserts that the first element is greater than or equal to the second
 //
-// 	a.GreaterOrEqualf(2, 1, "error message %s", "formatted")
-// 	a.GreaterOrEqualf(2, 2, "error message %s", "formatted")
-// 	a.GreaterOrEqualf("b", "a", "error message %s", "formatted")
-// 	a.GreaterOrEqualf("b", "b", "error message %s", "formatted")
+//	a.GreaterOrEqualf(2, 1, "error message %s", "formatted")
+//	a.GreaterOrEqualf(2, 2, "error message %s", "formatted")
+//	a.GreaterOrEqualf("b", "a", "error message %s", "formatted")
+//	a.GreaterOrEqualf("b", "b", "error message %s", "formatted")
 func (a *Assertions) GreaterOrEqualf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -524,9 +524,9 @@ func (a *Assertions) GreaterOrEqualf(e1 interface{}, e2 interface{}, msg string,
 
 // Greaterf asserts that the first element is greater than the second
 //
-// 	a.Greaterf(2, 1, "error message %s", "formatted")
-// 	a.Greaterf(float64(2), float64(1), "error message %s", "formatted")
-// 	a.Greaterf("b", "a", "error message %s", "formatted")
+//	a.Greaterf(2, 1, "error message %s", "formatted")
+//	a.Greaterf(float64(2), float64(1), "error message %s", "formatted")
+//	a.Greaterf("b", "a", "error message %s", "formatted")
 func (a *Assertions) Greaterf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -537,7 +537,7 @@ func (a *Assertions) Greaterf(e1 interface{}, e2 interface{}, msg string, args .
 // HTTPBodyContains asserts that a specified handler returns a
 // body that contains a string.
 //
-// 	a.HTTPBodyContains(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
+//	a.HTTPBodyContains(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPBodyContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) bool {
@@ -550,7 +550,7 @@ func (a *Assertions) HTTPBodyContains(handler http.HandlerFunc, method string, u
 // HTTPBodyContainsf asserts that a specified handler returns a
 // body that contains a string.
 //
-// 	a.HTTPBodyContainsf(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+//	a.HTTPBodyContainsf(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPBodyContainsf(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) bool {
@@ -563,7 +563,7 @@ func (a *Assertions) HTTPBodyContainsf(handler http.HandlerFunc, method string, 
 // HTTPBodyNotContains asserts that a specified handler returns a
 // body that does not contain a string.
 //
-// 	a.HTTPBodyNotContains(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
+//	a.HTTPBodyNotContains(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPBodyNotContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) bool {
@@ -576,7 +576,7 @@ func (a *Assertions) HTTPBodyNotContains(handler http.HandlerFunc, method string
 // HTTPBodyNotContainsf asserts that a specified handler returns a
 // body that does not contain a string.
 //
-// 	a.HTTPBodyNotContainsf(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+//	a.HTTPBodyNotContainsf(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPBodyNotContainsf(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) bool {
@@ -588,7 +588,7 @@ func (a *Assertions) HTTPBodyNotContainsf(handler http.HandlerFunc, method strin
 
 // HTTPError asserts that a specified handler returns an error status code.
 //
-// 	a.HTTPError(myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//	a.HTTPError(myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPError(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) bool {
@@ -600,7 +600,7 @@ func (a *Assertions) HTTPError(handler http.HandlerFunc, method string, url stri
 
 // HTTPErrorf asserts that a specified handler returns an error status code.
 //
-// 	a.HTTPErrorf(myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//	a.HTTPErrorf(myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPErrorf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) bool {
@@ -612,7 +612,7 @@ func (a *Assertions) HTTPErrorf(handler http.HandlerFunc, method string, url str
 
 // HTTPRedirect asserts that a specified handler returns a redirect status code.
 //
-// 	a.HTTPRedirect(myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//	a.HTTPRedirect(myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPRedirect(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) bool {
@@ -624,7 +624,7 @@ func (a *Assertions) HTTPRedirect(handler http.HandlerFunc, method string, url s
 
 // HTTPRedirectf asserts that a specified handler returns a redirect status code.
 //
-// 	a.HTTPRedirectf(myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//	a.HTTPRedirectf(myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPRedirectf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) bool {
@@ -636,7 +636,7 @@ func (a *Assertions) HTTPRedirectf(handler http.HandlerFunc, method string, url 
 
 // HTTPStatusCode asserts that a specified handler returns a specified status code.
 //
-// 	a.HTTPStatusCode(myHandler, "GET", "/notImplemented", nil, 501)
+//	a.HTTPStatusCode(myHandler, "GET", "/notImplemented", nil, 501)
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPStatusCode(handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msgAndArgs ...interface{}) bool {
@@ -648,7 +648,7 @@ func (a *Assertions) HTTPStatusCode(handler http.HandlerFunc, method string, url
 
 // HTTPStatusCodef asserts that a specified handler returns a specified status code.
 //
-// 	a.HTTPStatusCodef(myHandler, "GET", "/notImplemented", nil, 501, "error message %s", "formatted")
+//	a.HTTPStatusCodef(myHandler, "GET", "/notImplemented", nil, 501, "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPStatusCodef(handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msg string, args ...interface{}) bool {
@@ -660,7 +660,7 @@ func (a *Assertions) HTTPStatusCodef(handler http.HandlerFunc, method string, ur
 
 // HTTPSuccess asserts that a specified handler returns a success status code.
 //
-// 	a.HTTPSuccess(myHandler, "POST", "http://www.google.com", nil)
+//	a.HTTPSuccess(myHandler, "POST", "http://www.google.com", nil)
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPSuccess(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) bool {
@@ -672,7 +672,7 @@ func (a *Assertions) HTTPSuccess(handler http.HandlerFunc, method string, url st
 
 // HTTPSuccessf asserts that a specified handler returns a success status code.
 //
-// 	a.HTTPSuccessf(myHandler, "POST", "http://www.google.com", nil, "error message %s", "formatted")
+//	a.HTTPSuccessf(myHandler, "POST", "http://www.google.com", nil, "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPSuccessf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) bool {
@@ -684,7 +684,7 @@ func (a *Assertions) HTTPSuccessf(handler http.HandlerFunc, method string, url s
 
 // Implements asserts that an object is implemented by the specified interface.
 //
-// 	a.Implements((*MyInterface)(nil), new(MyObject))
+//	a.Implements((*MyInterface)(nil), new(MyObject))
 func (a *Assertions) Implements(interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -694,7 +694,7 @@ func (a *Assertions) Implements(interfaceObject interface{}, object interface{},
 
 // Implementsf asserts that an object is implemented by the specified interface.
 //
-// 	a.Implementsf((*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
+//	a.Implementsf((*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
 func (a *Assertions) Implementsf(interfaceObject interface{}, object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -704,7 +704,7 @@ func (a *Assertions) Implementsf(interfaceObject interface{}, object interface{}
 
 // InDelta asserts that the two numerals are within delta of each other.
 //
-// 	a.InDelta(math.Pi, 22/7.0, 0.01)
+//	a.InDelta(math.Pi, 22/7.0, 0.01)
 func (a *Assertions) InDelta(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -746,7 +746,7 @@ func (a *Assertions) InDeltaSlicef(expected interface{}, actual interface{}, del
 
 // InDeltaf asserts that the two numerals are within delta of each other.
 //
-// 	a.InDeltaf(math.Pi, 22/7.0, 0.01, "error message %s", "formatted")
+//	a.InDeltaf(math.Pi, 22/7.0, 0.01, "error message %s", "formatted")
 func (a *Assertions) InDeltaf(expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -788,9 +788,9 @@ func (a *Assertions) InEpsilonf(expected interface{}, actual interface{}, epsilo
 
 // IsDecreasing asserts that the collection is decreasing
 //
-// 	a.IsDecreasing([]int{2, 1, 0})
-// 	a.IsDecreasing([]float{2, 1})
-// 	a.IsDecreasing([]string{"b", "a"})
+//	a.IsDecreasing([]int{2, 1, 0})
+//	a.IsDecreasing([]float{2, 1})
+//	a.IsDecreasing([]string{"b", "a"})
 func (a *Assertions) IsDecreasing(object interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -800,9 +800,9 @@ func (a *Assertions) IsDecreasing(object interface{}, msgAndArgs ...interface{})
 
 // IsDecreasingf asserts that the collection is decreasing
 //
-// 	a.IsDecreasingf([]int{2, 1, 0}, "error message %s", "formatted")
-// 	a.IsDecreasingf([]float{2, 1}, "error message %s", "formatted")
-// 	a.IsDecreasingf([]string{"b", "a"}, "error message %s", "formatted")
+//	a.IsDecreasingf([]int{2, 1, 0}, "error message %s", "formatted")
+//	a.IsDecreasingf([]float{2, 1}, "error message %s", "formatted")
+//	a.IsDecreasingf([]string{"b", "a"}, "error message %s", "formatted")
 func (a *Assertions) IsDecreasingf(object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -812,9 +812,9 @@ func (a *Assertions) IsDecreasingf(object interface{}, msg string, args ...inter
 
 // IsIncreasing asserts that the collection is increasing
 //
-// 	a.IsIncreasing([]int{1, 2, 3})
-// 	a.IsIncreasing([]float{1, 2})
-// 	a.IsIncreasing([]string{"a", "b"})
+//	a.IsIncreasing([]int{1, 2, 3})
+//	a.IsIncreasing([]float{1, 2})
+//	a.IsIncreasing([]string{"a", "b"})
 func (a *Assertions) IsIncreasing(object interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -824,9 +824,9 @@ func (a *Assertions) IsIncreasing(object interface{}, msgAndArgs ...interface{})
 
 // IsIncreasingf asserts that the collection is increasing
 //
-// 	a.IsIncreasingf([]int{1, 2, 3}, "error message %s", "formatted")
-// 	a.IsIncreasingf([]float{1, 2}, "error message %s", "formatted")
-// 	a.IsIncreasingf([]string{"a", "b"}, "error message %s", "formatted")
+//	a.IsIncreasingf([]int{1, 2, 3}, "error message %s", "formatted")
+//	a.IsIncreasingf([]float{1, 2}, "error message %s", "formatted")
+//	a.IsIncreasingf([]string{"a", "b"}, "error message %s", "formatted")
 func (a *Assertions) IsIncreasingf(object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -836,9 +836,9 @@ func (a *Assertions) IsIncreasingf(object interface{}, msg string, args ...inter
 
 // IsNonDecreasing asserts that the collection is not decreasing
 //
-// 	a.IsNonDecreasing([]int{1, 1, 2})
-// 	a.IsNonDecreasing([]float{1, 2})
-// 	a.IsNonDecreasing([]string{"a", "b"})
+//	a.IsNonDecreasing([]int{1, 1, 2})
+//	a.IsNonDecreasing([]float{1, 2})
+//	a.IsNonDecreasing([]string{"a", "b"})
 func (a *Assertions) IsNonDecreasing(object interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -848,9 +848,9 @@ func (a *Assertions) IsNonDecreasing(object interface{}, msgAndArgs ...interface
 
 // IsNonDecreasingf asserts that the collection is not decreasing
 //
-// 	a.IsNonDecreasingf([]int{1, 1, 2}, "error message %s", "formatted")
-// 	a.IsNonDecreasingf([]float{1, 2}, "error message %s", "formatted")
-// 	a.IsNonDecreasingf([]string{"a", "b"}, "error message %s", "formatted")
+//	a.IsNonDecreasingf([]int{1, 1, 2}, "error message %s", "formatted")
+//	a.IsNonDecreasingf([]float{1, 2}, "error message %s", "formatted")
+//	a.IsNonDecreasingf([]string{"a", "b"}, "error message %s", "formatted")
 func (a *Assertions) IsNonDecreasingf(object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -860,9 +860,9 @@ func (a *Assertions) IsNonDecreasingf(object interface{}, msg string, args ...in
 
 // IsNonIncreasing asserts that the collection is not increasing
 //
-// 	a.IsNonIncreasing([]int{2, 1, 1})
-// 	a.IsNonIncreasing([]float{2, 1})
-// 	a.IsNonIncreasing([]string{"b", "a"})
+//	a.IsNonIncreasing([]int{2, 1, 1})
+//	a.IsNonIncreasing([]float{2, 1})
+//	a.IsNonIncreasing([]string{"b", "a"})
 func (a *Assertions) IsNonIncreasing(object interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -872,9 +872,9 @@ func (a *Assertions) IsNonIncreasing(object interface{}, msgAndArgs ...interface
 
 // IsNonIncreasingf asserts that the collection is not increasing
 //
-// 	a.IsNonIncreasingf([]int{2, 1, 1}, "error message %s", "formatted")
-// 	a.IsNonIncreasingf([]float{2, 1}, "error message %s", "formatted")
-// 	a.IsNonIncreasingf([]string{"b", "a"}, "error message %s", "formatted")
+//	a.IsNonIncreasingf([]int{2, 1, 1}, "error message %s", "formatted")
+//	a.IsNonIncreasingf([]float{2, 1}, "error message %s", "formatted")
+//	a.IsNonIncreasingf([]string{"b", "a"}, "error message %s", "formatted")
 func (a *Assertions) IsNonIncreasingf(object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -884,7 +884,7 @@ func (a *Assertions) IsNonIncreasingf(object interface{}, msg string, args ...in
 
 // IsNotType asserts that the specified objects are not of the same type.
 //
-// 	a.IsNotType(&NotMyStruct{}, &MyStruct{})
+//	a.IsNotType(&NotMyStruct{}, &MyStruct{})
 func (a *Assertions) IsNotType(theType interface{}, object interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -894,7 +894,7 @@ func (a *Assertions) IsNotType(theType interface{}, object interface{}, msgAndAr
 
 // IsNotTypef asserts that the specified objects are not of the same type.
 //
-// 	a.IsNotTypef(&NotMyStruct{}, &MyStruct{}, "error message %s", "formatted")
+//	a.IsNotTypef(&NotMyStruct{}, &MyStruct{}, "error message %s", "formatted")
 func (a *Assertions) IsNotTypef(theType interface{}, object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -904,7 +904,7 @@ func (a *Assertions) IsNotTypef(theType interface{}, object interface{}, msg str
 
 // IsType asserts that the specified objects are of the same type.
 //
-// 	a.IsType(&MyStruct{}, &MyStruct{})
+//	a.IsType(&MyStruct{}, &MyStruct{})
 func (a *Assertions) IsType(expectedType interface{}, object interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -914,7 +914,7 @@ func (a *Assertions) IsType(expectedType interface{}, object interface{}, msgAnd
 
 // IsTypef asserts that the specified objects are of the same type.
 //
-// 	a.IsTypef(&MyStruct{}, &MyStruct{}, "error message %s", "formatted")
+//	a.IsTypef(&MyStruct{}, &MyStruct{}, "error message %s", "formatted")
 func (a *Assertions) IsTypef(expectedType interface{}, object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -924,7 +924,7 @@ func (a *Assertions) IsTypef(expectedType interface{}, object interface{}, msg s
 
 // JSONEq asserts that two JSON strings are equivalent.
 //
-// 	a.JSONEq(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
+//	a.JSONEq(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
 func (a *Assertions) JSONEq(expected string, actual string, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -934,7 +934,7 @@ func (a *Assertions) JSONEq(expected string, actual string, msgAndArgs ...interf
 
 // JSONEqf asserts that two JSON strings are equivalent.
 //
-// 	a.JSONEqf(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
+//	a.JSONEqf(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
 func (a *Assertions) JSONEqf(expected string, actual string, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -945,7 +945,7 @@ func (a *Assertions) JSONEqf(expected string, actual string, msg string, args ..
 // Len asserts that the specified object has specific length.
 // Len also fails if the object has a type that len() not accept.
 //
-// 	a.Len(mySlice, 3)
+//	a.Len(mySlice, 3)
 func (a *Assertions) Len(object interface{}, length int, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -956,7 +956,7 @@ func (a *Assertions) Len(object interface{}, length int, msgAndArgs ...interface
 // Lenf asserts that the specified object has specific length.
 // Len also fails if the object has a type that len() not accept.
 //
-// 	a.Lenf(mySlice, 3, "error message %s", "formatted")
+//	a.Lenf(mySlice, 3, "error message %s", "formatted")
 func (a *Assertions) Lenf(object interface{}, length int, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -966,9 +966,9 @@ func (a *Assertions) Lenf(object interface{}, length int, msg string, args ...in
 
 // Less asserts that the first element is less than the second
 //
-// 	a.Less(1, 2)
-// 	a.Less(float64(1), float64(2))
-// 	a.Less("a", "b")
+//	a.Less(1, 2)
+//	a.Less(float64(1), float64(2))
+//	a.Less("a", "b")
 func (a *Assertions) Less(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -978,10 +978,10 @@ func (a *Assertions) Less(e1 interface{}, e2 interface{}, msgAndArgs ...interfac
 
 // LessOrEqual asserts that the first element is less than or equal to the second
 //
-// 	a.LessOrEqual(1, 2)
-// 	a.LessOrEqual(2, 2)
-// 	a.LessOrEqual("a", "b")
-// 	a.LessOrEqual("b", "b")
+//	a.LessOrEqual(1, 2)
+//	a.LessOrEqual(2, 2)
+//	a.LessOrEqual("a", "b")
+//	a.LessOrEqual("b", "b")
 func (a *Assertions) LessOrEqual(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -991,10 +991,10 @@ func (a *Assertions) LessOrEqual(e1 interface{}, e2 interface{}, msgAndArgs ...i
 
 // LessOrEqualf asserts that the first element is less than or equal to the second
 //
-// 	a.LessOrEqualf(1, 2, "error message %s", "formatted")
-// 	a.LessOrEqualf(2, 2, "error message %s", "formatted")
-// 	a.LessOrEqualf("a", "b", "error message %s", "formatted")
-// 	a.LessOrEqualf("b", "b", "error message %s", "formatted")
+//	a.LessOrEqualf(1, 2, "error message %s", "formatted")
+//	a.LessOrEqualf(2, 2, "error message %s", "formatted")
+//	a.LessOrEqualf("a", "b", "error message %s", "formatted")
+//	a.LessOrEqualf("b", "b", "error message %s", "formatted")
 func (a *Assertions) LessOrEqualf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1004,9 +1004,9 @@ func (a *Assertions) LessOrEqualf(e1 interface{}, e2 interface{}, msg string, ar
 
 // Lessf asserts that the first element is less than the second
 //
-// 	a.Lessf(1, 2, "error message %s", "formatted")
-// 	a.Lessf(float64(1), float64(2), "error message %s", "formatted")
-// 	a.Lessf("a", "b", "error message %s", "formatted")
+//	a.Lessf(1, 2, "error message %s", "formatted")
+//	a.Lessf(float64(1), float64(2), "error message %s", "formatted")
+//	a.Lessf("a", "b", "error message %s", "formatted")
 func (a *Assertions) Lessf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1016,8 +1016,8 @@ func (a *Assertions) Lessf(e1 interface{}, e2 interface{}, msg string, args ...i
 
 // Negative asserts that the specified element is negative
 //
-// 	a.Negative(-1)
-// 	a.Negative(-1.23)
+//	a.Negative(-1)
+//	a.Negative(-1.23)
 func (a *Assertions) Negative(e interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1027,8 +1027,8 @@ func (a *Assertions) Negative(e interface{}, msgAndArgs ...interface{}) bool {
 
 // Negativef asserts that the specified element is negative
 //
-// 	a.Negativef(-1, "error message %s", "formatted")
-// 	a.Negativef(-1.23, "error message %s", "formatted")
+//	a.Negativef(-1, "error message %s", "formatted")
+//	a.Negativef(-1.23, "error message %s", "formatted")
 func (a *Assertions) Negativef(e interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1039,7 +1039,7 @@ func (a *Assertions) Negativef(e interface{}, msg string, args ...interface{}) b
 // Never asserts that the given condition doesn't satisfy in waitFor time,
 // periodically checking the target function each tick.
 //
-// 	a.Never(func() bool { return false; }, time.Second, 10*time.Millisecond)
+//	a.Never(func() bool { return false; }, time.Second, 10*time.Millisecond)
 func (a *Assertions) Never(condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1050,7 +1050,7 @@ func (a *Assertions) Never(condition func() bool, waitFor time.Duration, tick ti
 // Neverf asserts that the given condition doesn't satisfy in waitFor time,
 // periodically checking the target function each tick.
 //
-// 	a.Neverf(func() bool { return false; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+//	a.Neverf(func() bool { return false; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
 func (a *Assertions) Neverf(condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1060,7 +1060,7 @@ func (a *Assertions) Neverf(condition func() bool, waitFor time.Duration, tick t
 
 // Nil asserts that the specified object is nil.
 //
-// 	a.Nil(err)
+//	a.Nil(err)
 func (a *Assertions) Nil(object interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1070,7 +1070,7 @@ func (a *Assertions) Nil(object interface{}, msgAndArgs ...interface{}) bool {
 
 // Nilf asserts that the specified object is nil.
 //
-// 	a.Nilf(err, "error message %s", "formatted")
+//	a.Nilf(err, "error message %s", "formatted")
 func (a *Assertions) Nilf(object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1098,10 +1098,10 @@ func (a *Assertions) NoDirExistsf(path string, msg string, args ...interface{}) 
 
 // NoError asserts that a function returned a nil error (ie. no error).
 //
-// 	  actualObj, err := SomeFunction()
-// 	  if a.NoError(err) {
-// 		   assert.Equal(t, expectedObj, actualObj)
-// 	  }
+//	  actualObj, err := SomeFunction()
+//	  if a.NoError(err) {
+//		   assert.Equal(t, expectedObj, actualObj)
+//	  }
 func (a *Assertions) NoError(err error, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1111,10 +1111,10 @@ func (a *Assertions) NoError(err error, msgAndArgs ...interface{}) bool {
 
 // NoErrorf asserts that a function returned a nil error (ie. no error).
 //
-// 	  actualObj, err := SomeFunction()
-// 	  if a.NoErrorf(err, "error message %s", "formatted") {
-// 		   assert.Equal(t, expectedObj, actualObj)
-// 	  }
+//	  actualObj, err := SomeFunction()
+//	  if a.NoErrorf(err, "error message %s", "formatted") {
+//		   assert.Equal(t, expectedObj, actualObj)
+//	  }
 func (a *Assertions) NoErrorf(err error, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1143,9 +1143,9 @@ func (a *Assertions) NoFileExistsf(path string, msg string, args ...interface{})
 // NotContains asserts that the specified string, list(array, slice...) or map does NOT contain the
 // specified substring or element.
 //
-// 	a.NotContains("Hello World", "Earth")
-// 	a.NotContains(["Hello", "World"], "Earth")
-// 	a.NotContains({"Hello": "World"}, "Earth")
+//	a.NotContains("Hello World", "Earth")
+//	a.NotContains(["Hello", "World"], "Earth")
+//	a.NotContains({"Hello": "World"}, "Earth")
 func (a *Assertions) NotContains(s interface{}, contains interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1156,9 +1156,9 @@ func (a *Assertions) NotContains(s interface{}, contains interface{}, msgAndArgs
 // NotContainsf asserts that the specified string, list(array, slice...) or map does NOT contain the
 // specified substring or element.
 //
-// 	a.NotContainsf("Hello World", "Earth", "error message %s", "formatted")
-// 	a.NotContainsf(["Hello", "World"], "Earth", "error message %s", "formatted")
-// 	a.NotContainsf({"Hello": "World"}, "Earth", "error message %s", "formatted")
+//	a.NotContainsf("Hello World", "Earth", "error message %s", "formatted")
+//	a.NotContainsf(["Hello", "World"], "Earth", "error message %s", "formatted")
+//	a.NotContainsf({"Hello": "World"}, "Earth", "error message %s", "formatted")
 func (a *Assertions) NotContainsf(s interface{}, contains interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1202,9 +1202,9 @@ func (a *Assertions) NotElementsMatchf(listA interface{}, listB interface{}, msg
 
 // NotEmpty asserts that the specified object is NOT [Empty].
 //
-// 	if a.NotEmpty(obj) {
-// 	  assert.Equal(t, "two", obj[1])
-// 	}
+//	if a.NotEmpty(obj) {
+//	  assert.Equal(t, "two", obj[1])
+//	}
 func (a *Assertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1214,9 +1214,9 @@ func (a *Assertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) boo
 
 // NotEmptyf asserts that the specified object is NOT [Empty].
 //
-// 	if a.NotEmptyf(obj, "error message %s", "formatted") {
-// 	  assert.Equal(t, "two", obj[1])
-// 	}
+//	if a.NotEmptyf(obj, "error message %s", "formatted") {
+//	  assert.Equal(t, "two", obj[1])
+//	}
 func (a *Assertions) NotEmptyf(object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1226,7 +1226,7 @@ func (a *Assertions) NotEmptyf(object interface{}, msg string, args ...interface
 
 // NotEqual asserts that the specified values are NOT equal.
 //
-// 	a.NotEqual(obj1, obj2)
+//	a.NotEqual(obj1, obj2)
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
@@ -1239,7 +1239,7 @@ func (a *Assertions) NotEqual(expected interface{}, actual interface{}, msgAndAr
 
 // NotEqualValues asserts that two objects are not equal even when converted to the same type
 //
-// 	a.NotEqualValues(obj1, obj2)
+//	a.NotEqualValues(obj1, obj2)
 func (a *Assertions) NotEqualValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1249,7 +1249,7 @@ func (a *Assertions) NotEqualValues(expected interface{}, actual interface{}, ms
 
 // NotEqualValuesf asserts that two objects are not equal even when converted to the same type
 //
-// 	a.NotEqualValuesf(obj1, obj2, "error message %s", "formatted")
+//	a.NotEqualValuesf(obj1, obj2, "error message %s", "formatted")
 func (a *Assertions) NotEqualValuesf(expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1259,7 +1259,7 @@ func (a *Assertions) NotEqualValuesf(expected interface{}, actual interface{}, m
 
 // NotEqualf asserts that the specified values are NOT equal.
 //
-// 	a.NotEqualf(obj1, obj2, "error message %s", "formatted")
+//	a.NotEqualf(obj1, obj2, "error message %s", "formatted")
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
@@ -1308,7 +1308,7 @@ func (a *Assertions) NotErrorIsf(err error, target error, msg string, args ...in
 
 // NotImplements asserts that an object does not implement the specified interface.
 //
-// 	a.NotImplements((*MyInterface)(nil), new(MyObject))
+//	a.NotImplements((*MyInterface)(nil), new(MyObject))
 func (a *Assertions) NotImplements(interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1318,7 +1318,7 @@ func (a *Assertions) NotImplements(interfaceObject interface{}, object interface
 
 // NotImplementsf asserts that an object does not implement the specified interface.
 //
-// 	a.NotImplementsf((*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
+//	a.NotImplementsf((*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
 func (a *Assertions) NotImplementsf(interfaceObject interface{}, object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1328,7 +1328,7 @@ func (a *Assertions) NotImplementsf(interfaceObject interface{}, object interfac
 
 // NotNil asserts that the specified object is not nil.
 //
-// 	a.NotNil(err)
+//	a.NotNil(err)
 func (a *Assertions) NotNil(object interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1338,7 +1338,7 @@ func (a *Assertions) NotNil(object interface{}, msgAndArgs ...interface{}) bool 
 
 // NotNilf asserts that the specified object is not nil.
 //
-// 	a.NotNilf(err, "error message %s", "formatted")
+//	a.NotNilf(err, "error message %s", "formatted")
 func (a *Assertions) NotNilf(object interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1348,7 +1348,7 @@ func (a *Assertions) NotNilf(object interface{}, msg string, args ...interface{}
 
 // NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
 //
-// 	a.NotPanics(func(){ RemainCalm() })
+//	a.NotPanics(func(){ RemainCalm() })
 func (a *Assertions) NotPanics(f PanicTestFunc, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1358,7 +1358,7 @@ func (a *Assertions) NotPanics(f PanicTestFunc, msgAndArgs ...interface{}) bool 
 
 // NotPanicsf asserts that the code inside the specified PanicTestFunc does NOT panic.
 //
-// 	a.NotPanicsf(func(){ RemainCalm() }, "error message %s", "formatted")
+//	a.NotPanicsf(func(){ RemainCalm() }, "error message %s", "formatted")
 func (a *Assertions) NotPanicsf(f PanicTestFunc, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1374,8 +1374,8 @@ func (a *Assertions) NotPanicsf(f PanicTestFunc, msg string, args ...interface{}
 //
 // Examples:
 //
-// 	a.NotRegexp(regexp.MustCompile("starts"), "it's starting")
-// 	a.NotRegexp("^start", "it's not starting") // string is compiled
+//	a.NotRegexp(regexp.MustCompile("starts"), "it's starting")
+//	a.NotRegexp("^start", "it's not starting") // string is compiled
 func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1391,8 +1391,8 @@ func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...in
 //
 // Examples:
 //
-// 	a.NotRegexpf(regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
-// 	a.NotRegexpf("^start", "it's not starting", "error message %s", "formatted") // string is compiled
+//	a.NotRegexpf(regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
+//	a.NotRegexpf("^start", "it's not starting", "error message %s", "formatted") // string is compiled
 func (a *Assertions) NotRegexpf(rx interface{}, str interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1402,7 +1402,7 @@ func (a *Assertions) NotRegexpf(rx interface{}, str interface{}, msg string, arg
 
 // NotSame asserts that two pointers do not reference the same object.
 //
-// 	a.NotSame(ptr1, ptr2)
+//	a.NotSame(ptr1, ptr2)
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
@@ -1415,7 +1415,7 @@ func (a *Assertions) NotSame(expected interface{}, actual interface{}, msgAndArg
 
 // NotSamef asserts that two pointers do not reference the same object.
 //
-// 	a.NotSamef(ptr1, ptr2, "error message %s", "formatted")
+//	a.NotSamef(ptr1, ptr2, "error message %s", "formatted")
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
@@ -1431,10 +1431,10 @@ func (a *Assertions) NotSamef(expected interface{}, actual interface{}, msg stri
 // Map elements are key-value pairs unless compared with an array or slice where
 // only the map key is evaluated.
 //
-// 	a.NotSubset([1, 3, 4], [1, 2])
-// 	a.NotSubset({"x": 1, "y": 2}, {"z": 3})
-// 	a.NotSubset([1, 3, 4], {1: "one", 2: "two"})
-// 	a.NotSubset({"x": 1, "y": 2}, ["z"])
+//	a.NotSubset([1, 3, 4], [1, 2])
+//	a.NotSubset({"x": 1, "y": 2}, {"z": 3})
+//	a.NotSubset([1, 3, 4], {1: "one", 2: "two"})
+//	a.NotSubset({"x": 1, "y": 2}, ["z"])
 func (a *Assertions) NotSubset(list interface{}, subset interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1447,10 +1447,10 @@ func (a *Assertions) NotSubset(list interface{}, subset interface{}, msgAndArgs 
 // Map elements are key-value pairs unless compared with an array or slice where
 // only the map key is evaluated.
 //
-// 	a.NotSubsetf([1, 3, 4], [1, 2], "error message %s", "formatted")
-// 	a.NotSubsetf({"x": 1, "y": 2}, {"z": 3}, "error message %s", "formatted")
-// 	a.NotSubsetf([1, 3, 4], {1: "one", 2: "two"}, "error message %s", "formatted")
-// 	a.NotSubsetf({"x": 1, "y": 2}, ["z"], "error message %s", "formatted")
+//	a.NotSubsetf([1, 3, 4], [1, 2], "error message %s", "formatted")
+//	a.NotSubsetf({"x": 1, "y": 2}, {"z": 3}, "error message %s", "formatted")
+//	a.NotSubsetf([1, 3, 4], {1: "one", 2: "two"}, "error message %s", "formatted")
+//	a.NotSubsetf({"x": 1, "y": 2}, ["z"], "error message %s", "formatted")
 func (a *Assertions) NotSubsetf(list interface{}, subset interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1476,7 +1476,7 @@ func (a *Assertions) NotZerof(i interface{}, msg string, args ...interface{}) bo
 
 // Panics asserts that the code inside the specified PanicTestFunc panics.
 //
-// 	a.Panics(func(){ GoCrazy() })
+//	a.Panics(func(){ GoCrazy() })
 func (a *Assertions) Panics(f PanicTestFunc, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1488,7 +1488,7 @@ func (a *Assertions) Panics(f PanicTestFunc, msgAndArgs ...interface{}) bool {
 // panics, and that the recovered panic value is an error that satisfies the
 // EqualError comparison.
 //
-// 	a.PanicsWithError("crazy error", func(){ GoCrazy() })
+//	a.PanicsWithError("crazy error", func(){ GoCrazy() })
 func (a *Assertions) PanicsWithError(errString string, f PanicTestFunc, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1500,7 +1500,7 @@ func (a *Assertions) PanicsWithError(errString string, f PanicTestFunc, msgAndAr
 // panics, and that the recovered panic value is an error that satisfies the
 // EqualError comparison.
 //
-// 	a.PanicsWithErrorf("crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+//	a.PanicsWithErrorf("crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
 func (a *Assertions) PanicsWithErrorf(errString string, f PanicTestFunc, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1511,7 +1511,7 @@ func (a *Assertions) PanicsWithErrorf(errString string, f PanicTestFunc, msg str
 // PanicsWithValue asserts that the code inside the specified PanicTestFunc panics, and that
 // the recovered panic value equals the expected panic value.
 //
-// 	a.PanicsWithValue("crazy error", func(){ GoCrazy() })
+//	a.PanicsWithValue("crazy error", func(){ GoCrazy() })
 func (a *Assertions) PanicsWithValue(expected interface{}, f PanicTestFunc, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1522,7 +1522,7 @@ func (a *Assertions) PanicsWithValue(expected interface{}, f PanicTestFunc, msgA
 // PanicsWithValuef asserts that the code inside the specified PanicTestFunc panics, and that
 // the recovered panic value equals the expected panic value.
 //
-// 	a.PanicsWithValuef("crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+//	a.PanicsWithValuef("crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
 func (a *Assertions) PanicsWithValuef(expected interface{}, f PanicTestFunc, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1532,7 +1532,7 @@ func (a *Assertions) PanicsWithValuef(expected interface{}, f PanicTestFunc, msg
 
 // Panicsf asserts that the code inside the specified PanicTestFunc panics.
 //
-// 	a.Panicsf(func(){ GoCrazy() }, "error message %s", "formatted")
+//	a.Panicsf(func(){ GoCrazy() }, "error message %s", "formatted")
 func (a *Assertions) Panicsf(f PanicTestFunc, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1542,8 +1542,8 @@ func (a *Assertions) Panicsf(f PanicTestFunc, msg string, args ...interface{}) b
 
 // Positive asserts that the specified element is positive
 //
-// 	a.Positive(1)
-// 	a.Positive(1.23)
+//	a.Positive(1)
+//	a.Positive(1.23)
 func (a *Assertions) Positive(e interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1553,8 +1553,8 @@ func (a *Assertions) Positive(e interface{}, msgAndArgs ...interface{}) bool {
 
 // Positivef asserts that the specified element is positive
 //
-// 	a.Positivef(1, "error message %s", "formatted")
-// 	a.Positivef(1.23, "error message %s", "formatted")
+//	a.Positivef(1, "error message %s", "formatted")
+//	a.Positivef(1.23, "error message %s", "formatted")
 func (a *Assertions) Positivef(e interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1570,8 +1570,8 @@ func (a *Assertions) Positivef(e interface{}, msg string, args ...interface{}) b
 //
 // Examples:
 //
-// 	a.Regexp(regexp.MustCompile("start"), "it's starting")
-// 	a.Regexp("start...$", "it's not starting") // string is compiled
+//	a.Regexp(regexp.MustCompile("start"), "it's starting")
+//	a.Regexp("start...$", "it's not starting") // string is compiled
 func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1587,8 +1587,8 @@ func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...inter
 //
 // Examples:
 //
-// 	a.Regexpf(regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
-// 	a.Regexpf("start...$", "it's not starting", "error message %s", "formatted") // string is compiled
+//	a.Regexpf(regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
+//	a.Regexpf("start...$", "it's not starting", "error message %s", "formatted") // string is compiled
 func (a *Assertions) Regexpf(rx interface{}, str interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1598,7 +1598,7 @@ func (a *Assertions) Regexpf(rx interface{}, str interface{}, msg string, args .
 
 // Same asserts that two pointers reference the same object.
 //
-// 	a.Same(ptr1, ptr2)
+//	a.Same(ptr1, ptr2)
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
@@ -1611,7 +1611,7 @@ func (a *Assertions) Same(expected interface{}, actual interface{}, msgAndArgs .
 
 // Samef asserts that two pointers reference the same object.
 //
-// 	a.Samef(ptr1, ptr2, "error message %s", "formatted")
+//	a.Samef(ptr1, ptr2, "error message %s", "formatted")
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
@@ -1627,10 +1627,10 @@ func (a *Assertions) Samef(expected interface{}, actual interface{}, msg string,
 // Map elements are key-value pairs unless compared with an array or slice where
 // only the map key is evaluated.
 //
-// 	a.Subset([1, 2, 3], [1, 2])
-// 	a.Subset({"x": 1, "y": 2}, {"x": 1})
-// 	a.Subset([1, 2, 3], {1: "one", 2: "two"})
-// 	a.Subset({"x": 1, "y": 2}, ["x"])
+//	a.Subset([1, 2, 3], [1, 2])
+//	a.Subset({"x": 1, "y": 2}, {"x": 1})
+//	a.Subset([1, 2, 3], {1: "one", 2: "two"})
+//	a.Subset({"x": 1, "y": 2}, ["x"])
 func (a *Assertions) Subset(list interface{}, subset interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1643,10 +1643,10 @@ func (a *Assertions) Subset(list interface{}, subset interface{}, msgAndArgs ...
 // Map elements are key-value pairs unless compared with an array or slice where
 // only the map key is evaluated.
 //
-// 	a.Subsetf([1, 2, 3], [1, 2], "error message %s", "formatted")
-// 	a.Subsetf({"x": 1, "y": 2}, {"x": 1}, "error message %s", "formatted")
-// 	a.Subsetf([1, 2, 3], {1: "one", 2: "two"}, "error message %s", "formatted")
-// 	a.Subsetf({"x": 1, "y": 2}, ["x"], "error message %s", "formatted")
+//	a.Subsetf([1, 2, 3], [1, 2], "error message %s", "formatted")
+//	a.Subsetf({"x": 1, "y": 2}, {"x": 1}, "error message %s", "formatted")
+//	a.Subsetf([1, 2, 3], {1: "one", 2: "two"}, "error message %s", "formatted")
+//	a.Subsetf({"x": 1, "y": 2}, ["x"], "error message %s", "formatted")
 func (a *Assertions) Subsetf(list interface{}, subset interface{}, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1656,7 +1656,7 @@ func (a *Assertions) Subsetf(list interface{}, subset interface{}, msg string, a
 
 // True asserts that the specified value is true.
 //
-// 	a.True(myBool)
+//	a.True(myBool)
 func (a *Assertions) True(value bool, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1666,7 +1666,7 @@ func (a *Assertions) True(value bool, msgAndArgs ...interface{}) bool {
 
 // Truef asserts that the specified value is true.
 //
-// 	a.Truef(myBool, "error message %s", "formatted")
+//	a.Truef(myBool, "error message %s", "formatted")
 func (a *Assertions) Truef(value bool, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1676,7 +1676,7 @@ func (a *Assertions) Truef(value bool, msg string, args ...interface{}) bool {
 
 // WithinDuration asserts that the two times are within duration delta of each other.
 //
-// 	a.WithinDuration(time.Now(), time.Now(), 10*time.Second)
+//	a.WithinDuration(time.Now(), time.Now(), 10*time.Second)
 func (a *Assertions) WithinDuration(expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1686,7 +1686,7 @@ func (a *Assertions) WithinDuration(expected time.Time, actual time.Time, delta 
 
 // WithinDurationf asserts that the two times are within duration delta of each other.
 //
-// 	a.WithinDurationf(time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
+//	a.WithinDurationf(time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
 func (a *Assertions) WithinDurationf(expected time.Time, actual time.Time, delta time.Duration, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1696,7 +1696,7 @@ func (a *Assertions) WithinDurationf(expected time.Time, actual time.Time, delta
 
 // WithinRange asserts that a time is within a time range (inclusive).
 //
-// 	a.WithinRange(time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second))
+//	a.WithinRange(time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second))
 func (a *Assertions) WithinRange(actual time.Time, start time.Time, end time.Time, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1706,7 +1706,7 @@ func (a *Assertions) WithinRange(actual time.Time, start time.Time, end time.Tim
 
 // WithinRangef asserts that a time is within a time range (inclusive).
 //
-// 	a.WithinRangef(time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second), "error message %s", "formatted")
+//	a.WithinRangef(time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second), "error message %s", "formatted")
 func (a *Assertions) WithinRangef(actual time.Time, start time.Time, end time.Time, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1716,17 +1716,17 @@ func (a *Assertions) WithinRangef(actual time.Time, start time.Time, end time.Ti
 
 // YAMLEq asserts that the first documents in the two YAML strings are equivalent.
 //
-// 	expected := `---
-// 	key: value
-// 	---
-// 	key: this is a second document, it is not evaluated
-// 	`
-// 	actual := `---
-// 	key: value
-// 	---
-// 	key: this is a subsequent document, it is not evaluated
-// 	`
-// 	a.YAMLEq(expected, actual)
+//	expected := `---
+//	key: value
+//	---
+//	key: this is a second document, it is not evaluated
+//	`
+//	actual := `---
+//	key: value
+//	---
+//	key: this is a subsequent document, it is not evaluated
+//	`
+//	a.YAMLEq(expected, actual)
 func (a *Assertions) YAMLEq(expected string, actual string, msgAndArgs ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1736,17 +1736,17 @@ func (a *Assertions) YAMLEq(expected string, actual string, msgAndArgs ...interf
 
 // YAMLEqf asserts that the first documents in the two YAML strings are equivalent.
 //
-// 	expected := `---
-// 	key: value
-// 	---
-// 	key: this is a second document, it is not evaluated
-// 	`
-// 	actual := `---
-// 	key: value
-// 	---
-// 	key: this is a subsequent document, it is not evaluated
-// 	`
-// 	a.YAMLEqf(expected, actual, "error message %s", "formatted")
+//	expected := `---
+//	key: value
+//	---
+//	key: this is a second document, it is not evaluated
+//	`
+//	actual := `---
+//	key: value
+//	---
+//	key: this is a subsequent document, it is not evaluated
+//	`
+//	a.YAMLEqf(expected, actual, "error message %s", "formatted")
 func (a *Assertions) YAMLEqf(expected string, actual string, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1729,8 +1729,13 @@ func matchRegexp(rx interface{}, str interface{}) bool {
 
 // Regexp asserts that a specified regexp matches a string.
 //
+// The rx (expression) argument should be a *regexp.Regexp. For backward
+// compatibility, if rx is any other type, its value will be formatted with
+// %v and compiled using regexp.MustCompile.
+//
+// Examples:
 //	assert.Regexp(t, regexp.MustCompile("start"), "it's starting")
-//	assert.Regexp(t, "start...$", "it's not starting")
+//	assert.Regexp(t, "start...$", "it's not starting") // string is compiled
 func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1747,8 +1752,13 @@ func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface
 
 // NotRegexp asserts that a specified regexp does not match a string.
 //
+// The rx (expression) argument should be a *regexp.Regexp. For backward
+// compatibility, if rx is any other type, its value will be formatted with
+// %v and compiled using regexp.MustCompile.
+//
+// Examples:
 //	assert.NotRegexp(t, regexp.MustCompile("starts"), "it's starting")
-//	assert.NotRegexp(t, "^start", "it's not starting")
+//	assert.NotRegexp(t, "^start", "it's not starting") // string is compiled
 func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1708,22 +1708,28 @@ func ErrorContains(t TestingT, theError error, contains string, msgAndArgs ...in
 	return true
 }
 
-// matchRegexp return true if a specified regexp matches a string.
-func matchRegexp(rx interface{}, str interface{}) bool {
+// matchRegexp returns whether the provided regular expression matches the input string.
+// If the rx cannot be compiled into a valid regexp, an error is returned.
+func matchRegexp(rx interface{}, str interface{}) (bool, error) {
 	var r *regexp.Regexp
 	if rr, ok := rx.(*regexp.Regexp); ok {
 		r = rr
 	} else {
-		r = regexp.MustCompile(fmt.Sprint(rx))
+		// Safely attempt to compile the pattern; on error, report it so callers can fail the assertion.
+		compiled, err := regexp.Compile(fmt.Sprint(rx))
+		if err != nil {
+			return false, err
+		}
+		r = compiled
 	}
 
 	switch v := str.(type) {
 	case []byte:
-		return r.Match(v)
+		return r.Match(v), nil
 	case string:
-		return r.MatchString(v)
+		return r.MatchString(v), nil
 	default:
-		return r.MatchString(fmt.Sprint(v))
+		return r.MatchString(fmt.Sprint(v)), nil
 	}
 }
 
@@ -1731,7 +1737,7 @@ func matchRegexp(rx interface{}, str interface{}) bool {
 //
 // The rx (expression) argument should be a *regexp.Regexp. For backward
 // compatibility, if rx is any other type, its value will be formatted with
-// %v and compiled using regexp.MustCompile.
+// %v and compiled using regexp.Compile.
 //
 // Examples:
 //	assert.Regexp(t, regexp.MustCompile("start"), "it's starting")
@@ -1741,7 +1747,11 @@ func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface
 		h.Helper()
 	}
 
-	match := matchRegexp(rx, str)
+	match, err := matchRegexp(rx, str)
+	if err != nil {
+		Fail(t, fmt.Sprintf("Invalid regular expression: %v", err), msgAndArgs...)
+		return false
+	}
 
 	if !match {
 		Fail(t, fmt.Sprintf("Expect \"%v\" to match \"%v\"", str, rx), msgAndArgs...)
@@ -1754,7 +1764,7 @@ func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface
 //
 // The rx (expression) argument should be a *regexp.Regexp. For backward
 // compatibility, if rx is any other type, its value will be formatted with
-// %v and compiled using regexp.MustCompile.
+// %v and compiled using regexp.Compile.
 //
 // Examples:
 //	assert.NotRegexp(t, regexp.MustCompile("starts"), "it's starting")
@@ -1763,7 +1773,11 @@ func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interf
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	match := matchRegexp(rx, str)
+	match, err := matchRegexp(rx, str)
+	if err != nil {
+		Fail(t, fmt.Sprintf("Invalid regular expression: %v", err), msgAndArgs...)
+		return false
+	}
 
 	if match {
 		Fail(t, fmt.Sprintf("Expect \"%v\" to NOT match \"%v\"", str, rx), msgAndArgs...)

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1740,6 +1740,7 @@ func matchRegexp(rx interface{}, str interface{}) (bool, error) {
 // %v and compiled using regexp.Compile.
 //
 // Examples:
+//
 //	assert.Regexp(t, regexp.MustCompile("start"), "it's starting")
 //	assert.Regexp(t, "start...$", "it's not starting") // string is compiled
 func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) bool {
@@ -1767,6 +1768,7 @@ func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface
 // %v and compiled using regexp.Compile.
 //
 // Examples:
+//
 //	assert.NotRegexp(t, regexp.MustCompile("starts"), "it's starting")
 //	assert.NotRegexp(t, "^start", "it's not starting") // string is compiled
 func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) bool {

--- a/assert/regexp_invalid_test.go
+++ b/assert/regexp_invalid_test.go
@@ -1,0 +1,19 @@
+package assert
+
+import "testing"
+
+// Verifies that invalid patterns no longer cause a panic when using Regexp/NotRegexp.
+// Instead, the assertion should fail and return false.
+func TestRegexp_InvalidPattern_NoPanic(t *testing.T) {
+	NotPanics(t, func() {
+		mockT := new(testing.T)
+		False(t, Regexp(mockT, "\\C", "whatever"))
+	})
+}
+
+func TestNotRegexp_InvalidPattern_NoPanic(t *testing.T) {
+	NotPanics(t, func() {
+		mockT := new(testing.T)
+		False(t, NotRegexp(mockT, "\\C", "whatever"))
+	})
+}

--- a/require/require.go
+++ b/require/require.go
@@ -1729,8 +1729,12 @@ func NotPanicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interfac
 
 // NotRegexp asserts that a specified regexp does not match a string.
 //
+// The rx (expression) argument should be a *regexp.Regexp. For backward
+// compatibility, if rx is any other type, its value will be formatted with
+// %v and compiled using regexp.MustCompile.
+//
 //	require.NotRegexp(t, regexp.MustCompile("starts"), "it's starting")
-//	require.NotRegexp(t, "^start", "it's not starting")
+//	require.NotRegexp(t, "^start", "it's not starting") // string is compiled
 func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1743,8 +1747,12 @@ func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interf
 
 // NotRegexpf asserts that a specified regexp does not match a string.
 //
+// The rx (expression) argument should be a *regexp.Regexp. For backward
+// compatibility, if rx is any other type, its value will be formatted with
+// %v and compiled using regexp.MustCompile.
+//
 //	require.NotRegexpf(t, regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
-//	require.NotRegexpf(t, "^start", "it's not starting", "error message %s", "formatted")
+//	require.NotRegexpf(t, "^start", "it's not starting", "error message %s", "formatted") // string is compiled
 func NotRegexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1961,8 +1969,12 @@ func Positivef(t TestingT, e interface{}, msg string, args ...interface{}) {
 
 // Regexp asserts that a specified regexp matches a string.
 //
+// The rx (expression) argument should be a *regexp.Regexp. For backward
+// compatibility, if rx is any other type, its value will be formatted with
+// %v and compiled using regexp.MustCompile.
+//
 //	require.Regexp(t, regexp.MustCompile("start"), "it's starting")
-//	require.Regexp(t, "start...$", "it's not starting")
+//	require.Regexp(t, "start...$", "it's not starting") // string is compiled
 func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1975,8 +1987,12 @@ func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface
 
 // Regexpf asserts that a specified regexp matches a string.
 //
+// The rx (expression) argument should be a *regexp.Regexp. For backward
+// compatibility, if rx is any other type, its value will be formatted with
+// %v and compiled using regexp.MustCompile.
+//
 //	require.Regexpf(t, regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
-//	require.Regexpf(t, "start...$", "it's not starting", "error message %s", "formatted")
+//	require.Regexpf(t, "start...$", "it's not starting", "error message %s", "formatted") // string is compiled
 func Regexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()

--- a/require/require.go
+++ b/require/require.go
@@ -34,9 +34,9 @@ func Conditionf(t TestingT, comp assert.Comparison, msg string, args ...interfac
 // Contains asserts that the specified string, list(array, slice...) or map contains the
 // specified substring or element.
 //
-// 	require.Contains(t, "Hello World", "World")
-// 	require.Contains(t, ["Hello", "World"], "World")
-// 	require.Contains(t, {"Hello": "World"}, "Hello")
+//	require.Contains(t, "Hello World", "World")
+//	require.Contains(t, ["Hello", "World"], "World")
+//	require.Contains(t, {"Hello": "World"}, "Hello")
 func Contains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -50,9 +50,9 @@ func Contains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...int
 // Containsf asserts that the specified string, list(array, slice...) or map contains the
 // specified substring or element.
 //
-// 	require.Containsf(t, "Hello World", "World", "error message %s", "formatted")
-// 	require.Containsf(t, ["Hello", "World"], "World", "error message %s", "formatted")
-// 	require.Containsf(t, {"Hello": "World"}, "Hello", "error message %s", "formatted")
+//	require.Containsf(t, "Hello World", "World", "error message %s", "formatted")
+//	require.Containsf(t, ["Hello", "World"], "World", "error message %s", "formatted")
+//	require.Containsf(t, {"Hello": "World"}, "Hello", "error message %s", "formatted")
 func Containsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -127,7 +127,7 @@ func ElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string
 //
 // Pointer values are "empty" if the pointer is nil or if the pointed value is "empty".
 //
-// 	require.Empty(t, obj)
+//	require.Empty(t, obj)
 //
 // [Zero values]: https://go.dev/ref/spec#The_zero_value
 func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
@@ -150,7 +150,7 @@ func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 //
 // Pointer values are "empty" if the pointer is nil or if the pointed value is "empty".
 //
-// 	require.Emptyf(t, obj, "error message %s", "formatted")
+//	require.Emptyf(t, obj, "error message %s", "formatted")
 //
 // [Zero values]: https://go.dev/ref/spec#The_zero_value
 func Emptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
@@ -165,7 +165,7 @@ func Emptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
 
 // Equal asserts that two objects are equal.
 //
-// 	require.Equal(t, 123, 123)
+//	require.Equal(t, 123, 123)
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses). Function equality
@@ -183,8 +183,8 @@ func Equal(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...i
 // EqualError asserts that a function returned a non-nil error (i.e. an error)
 // and that it is equal to the provided error.
 //
-// 	actualObj, err := SomeFunction()
-// 	require.EqualError(t, err,  expectedErrorString)
+//	actualObj, err := SomeFunction()
+//	require.EqualError(t, err,  expectedErrorString)
 func EqualError(t TestingT, theError error, errString string, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -198,8 +198,8 @@ func EqualError(t TestingT, theError error, errString string, msgAndArgs ...inte
 // EqualErrorf asserts that a function returned a non-nil error (i.e. an error)
 // and that it is equal to the provided error.
 //
-// 	actualObj, err := SomeFunction()
-// 	require.EqualErrorf(t, err,  expectedErrorString, "error message %s", "formatted")
+//	actualObj, err := SomeFunction()
+//	require.EqualErrorf(t, err,  expectedErrorString, "error message %s", "formatted")
 func EqualErrorf(t TestingT, theError error, errString string, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -214,12 +214,12 @@ func EqualErrorf(t TestingT, theError error, errString string, msg string, args 
 // fields are also equal. This is useful for comparing structs that have private fields
 // that could potentially differ.
 //
-// 	 type S struct {
-// 		Exported     	int
-// 		notExported   	int
-// 	 }
-// 	 require.EqualExportedValues(t, S{1, 2}, S{1, 3}) => true
-// 	 require.EqualExportedValues(t, S{1, 2}, S{2, 3}) => false
+//	 type S struct {
+//		Exported     	int
+//		notExported   	int
+//	 }
+//	 require.EqualExportedValues(t, S{1, 2}, S{1, 3}) => true
+//	 require.EqualExportedValues(t, S{1, 2}, S{2, 3}) => false
 func EqualExportedValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -234,12 +234,12 @@ func EqualExportedValues(t TestingT, expected interface{}, actual interface{}, m
 // fields are also equal. This is useful for comparing structs that have private fields
 // that could potentially differ.
 //
-// 	 type S struct {
-// 		Exported     	int
-// 		notExported   	int
-// 	 }
-// 	 require.EqualExportedValuesf(t, S{1, 2}, S{1, 3}, "error message %s", "formatted") => true
-// 	 require.EqualExportedValuesf(t, S{1, 2}, S{2, 3}, "error message %s", "formatted") => false
+//	 type S struct {
+//		Exported     	int
+//		notExported   	int
+//	 }
+//	 require.EqualExportedValuesf(t, S{1, 2}, S{1, 3}, "error message %s", "formatted") => true
+//	 require.EqualExportedValuesf(t, S{1, 2}, S{2, 3}, "error message %s", "formatted") => false
 func EqualExportedValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -253,7 +253,7 @@ func EqualExportedValuesf(t TestingT, expected interface{}, actual interface{}, 
 // EqualValues asserts that two objects are equal or convertible to the larger
 // type and equal.
 //
-// 	require.EqualValues(t, uint32(123), int32(123))
+//	require.EqualValues(t, uint32(123), int32(123))
 func EqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -267,7 +267,7 @@ func EqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArg
 // EqualValuesf asserts that two objects are equal or convertible to the larger
 // type and equal.
 //
-// 	require.EqualValuesf(t, uint32(123), int32(123), "error message %s", "formatted")
+//	require.EqualValuesf(t, uint32(123), int32(123), "error message %s", "formatted")
 func EqualValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -280,7 +280,7 @@ func EqualValuesf(t TestingT, expected interface{}, actual interface{}, msg stri
 
 // Equalf asserts that two objects are equal.
 //
-// 	require.Equalf(t, 123, 123, "error message %s", "formatted")
+//	require.Equalf(t, 123, 123, "error message %s", "formatted")
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses). Function equality
@@ -297,8 +297,8 @@ func Equalf(t TestingT, expected interface{}, actual interface{}, msg string, ar
 
 // Error asserts that a function returned a non-nil error (ie. an error).
 //
-// 	actualObj, err := SomeFunction()
-// 	require.Error(t, err)
+//	actualObj, err := SomeFunction()
+//	require.Error(t, err)
 func Error(t TestingT, err error, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -336,8 +336,8 @@ func ErrorAsf(t TestingT, err error, target interface{}, msg string, args ...int
 // ErrorContains asserts that a function returned a non-nil error (i.e. an
 // error) and that the error contains the specified substring.
 //
-// 	actualObj, err := SomeFunction()
-// 	require.ErrorContains(t, err,  expectedErrorSubString)
+//	actualObj, err := SomeFunction()
+//	require.ErrorContains(t, err,  expectedErrorSubString)
 func ErrorContains(t TestingT, theError error, contains string, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -351,8 +351,8 @@ func ErrorContains(t TestingT, theError error, contains string, msgAndArgs ...in
 // ErrorContainsf asserts that a function returned a non-nil error (i.e. an
 // error) and that the error contains the specified substring.
 //
-// 	actualObj, err := SomeFunction()
-// 	require.ErrorContainsf(t, err,  expectedErrorSubString, "error message %s", "formatted")
+//	actualObj, err := SomeFunction()
+//	require.ErrorContainsf(t, err,  expectedErrorSubString, "error message %s", "formatted")
 func ErrorContainsf(t TestingT, theError error, contains string, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -389,8 +389,8 @@ func ErrorIsf(t TestingT, err error, target error, msg string, args ...interface
 
 // Errorf asserts that a function returned a non-nil error (ie. an error).
 //
-// 	actualObj, err := SomeFunction()
-// 	require.Errorf(t, err, "error message %s", "formatted")
+//	actualObj, err := SomeFunction()
+//	require.Errorf(t, err, "error message %s", "formatted")
 func Errorf(t TestingT, err error, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -404,7 +404,7 @@ func Errorf(t TestingT, err error, msg string, args ...interface{}) {
 // Eventually asserts that given condition will be met in waitFor time,
 // periodically checking target function each tick.
 //
-// 	require.Eventually(t, func() bool { return true; }, time.Second, 10*time.Millisecond)
+//	require.Eventually(t, func() bool { return true; }, time.Second, 10*time.Millisecond)
 func Eventually(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -424,15 +424,15 @@ func Eventually(t TestingT, condition func() bool, waitFor time.Duration, tick t
 // If the condition is not met before waitFor, the collected errors of
 // the last tick are copied to t.
 //
-// 	externalValue := false
-// 	go func() {
-// 		time.Sleep(8*time.Second)
-// 		externalValue = true
-// 	}()
-// 	require.EventuallyWithT(t, func(c *require.CollectT) {
-// 		// add assertions as needed; any assertion failure will fail the current tick
-// 		require.True(c, externalValue, "expected 'externalValue' to be true")
-// 	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
+//	externalValue := false
+//	go func() {
+//		time.Sleep(8*time.Second)
+//		externalValue = true
+//	}()
+//	require.EventuallyWithT(t, func(c *require.CollectT) {
+//		// add assertions as needed; any assertion failure will fail the current tick
+//		require.True(c, externalValue, "expected 'externalValue' to be true")
+//	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
 func EventuallyWithT(t TestingT, condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -452,15 +452,15 @@ func EventuallyWithT(t TestingT, condition func(collect *assert.CollectT), waitF
 // If the condition is not met before waitFor, the collected errors of
 // the last tick are copied to t.
 //
-// 	externalValue := false
-// 	go func() {
-// 		time.Sleep(8*time.Second)
-// 		externalValue = true
-// 	}()
-// 	require.EventuallyWithTf(t, func(c *require.CollectT, "error message %s", "formatted") {
-// 		// add assertions as needed; any assertion failure will fail the current tick
-// 		require.True(c, externalValue, "expected 'externalValue' to be true")
-// 	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
+//	externalValue := false
+//	go func() {
+//		time.Sleep(8*time.Second)
+//		externalValue = true
+//	}()
+//	require.EventuallyWithTf(t, func(c *require.CollectT, "error message %s", "formatted") {
+//		// add assertions as needed; any assertion failure will fail the current tick
+//		require.True(c, externalValue, "expected 'externalValue' to be true")
+//	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
 func EventuallyWithTf(t TestingT, condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -474,7 +474,7 @@ func EventuallyWithTf(t TestingT, condition func(collect *assert.CollectT), wait
 // Eventuallyf asserts that given condition will be met in waitFor time,
 // periodically checking target function each tick.
 //
-// 	require.Eventuallyf(t, func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+//	require.Eventuallyf(t, func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
 func Eventuallyf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -487,7 +487,7 @@ func Eventuallyf(t TestingT, condition func() bool, waitFor time.Duration, tick 
 
 // Exactly asserts that two objects are equal in value and type.
 //
-// 	require.Exactly(t, int32(123), int64(123))
+//	require.Exactly(t, int32(123), int64(123))
 func Exactly(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -500,7 +500,7 @@ func Exactly(t TestingT, expected interface{}, actual interface{}, msgAndArgs ..
 
 // Exactlyf asserts that two objects are equal in value and type.
 //
-// 	require.Exactlyf(t, int32(123), int64(123), "error message %s", "formatted")
+//	require.Exactlyf(t, int32(123), int64(123), "error message %s", "formatted")
 func Exactlyf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -557,7 +557,7 @@ func Failf(t TestingT, failureMessage string, msg string, args ...interface{}) {
 
 // False asserts that the specified value is false.
 //
-// 	require.False(t, myBool)
+//	require.False(t, myBool)
 func False(t TestingT, value bool, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -570,7 +570,7 @@ func False(t TestingT, value bool, msgAndArgs ...interface{}) {
 
 // Falsef asserts that the specified value is false.
 //
-// 	require.Falsef(t, myBool, "error message %s", "formatted")
+//	require.Falsef(t, myBool, "error message %s", "formatted")
 func Falsef(t TestingT, value bool, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -607,9 +607,9 @@ func FileExistsf(t TestingT, path string, msg string, args ...interface{}) {
 
 // Greater asserts that the first element is greater than the second
 //
-// 	require.Greater(t, 2, 1)
-// 	require.Greater(t, float64(2), float64(1))
-// 	require.Greater(t, "b", "a")
+//	require.Greater(t, 2, 1)
+//	require.Greater(t, float64(2), float64(1))
+//	require.Greater(t, "b", "a")
 func Greater(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -622,10 +622,10 @@ func Greater(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface
 
 // GreaterOrEqual asserts that the first element is greater than or equal to the second
 //
-// 	require.GreaterOrEqual(t, 2, 1)
-// 	require.GreaterOrEqual(t, 2, 2)
-// 	require.GreaterOrEqual(t, "b", "a")
-// 	require.GreaterOrEqual(t, "b", "b")
+//	require.GreaterOrEqual(t, 2, 1)
+//	require.GreaterOrEqual(t, 2, 2)
+//	require.GreaterOrEqual(t, "b", "a")
+//	require.GreaterOrEqual(t, "b", "b")
 func GreaterOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -638,10 +638,10 @@ func GreaterOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...in
 
 // GreaterOrEqualf asserts that the first element is greater than or equal to the second
 //
-// 	require.GreaterOrEqualf(t, 2, 1, "error message %s", "formatted")
-// 	require.GreaterOrEqualf(t, 2, 2, "error message %s", "formatted")
-// 	require.GreaterOrEqualf(t, "b", "a", "error message %s", "formatted")
-// 	require.GreaterOrEqualf(t, "b", "b", "error message %s", "formatted")
+//	require.GreaterOrEqualf(t, 2, 1, "error message %s", "formatted")
+//	require.GreaterOrEqualf(t, 2, 2, "error message %s", "formatted")
+//	require.GreaterOrEqualf(t, "b", "a", "error message %s", "formatted")
+//	require.GreaterOrEqualf(t, "b", "b", "error message %s", "formatted")
 func GreaterOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -654,9 +654,9 @@ func GreaterOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, arg
 
 // Greaterf asserts that the first element is greater than the second
 //
-// 	require.Greaterf(t, 2, 1, "error message %s", "formatted")
-// 	require.Greaterf(t, float64(2), float64(1), "error message %s", "formatted")
-// 	require.Greaterf(t, "b", "a", "error message %s", "formatted")
+//	require.Greaterf(t, 2, 1, "error message %s", "formatted")
+//	require.Greaterf(t, float64(2), float64(1), "error message %s", "formatted")
+//	require.Greaterf(t, "b", "a", "error message %s", "formatted")
 func Greaterf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -670,7 +670,7 @@ func Greaterf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...in
 // HTTPBodyContains asserts that a specified handler returns a
 // body that contains a string.
 //
-// 	require.HTTPBodyContains(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
+//	require.HTTPBodyContains(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPBodyContains(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
@@ -686,7 +686,7 @@ func HTTPBodyContains(t TestingT, handler http.HandlerFunc, method string, url s
 // HTTPBodyContainsf asserts that a specified handler returns a
 // body that contains a string.
 //
-// 	require.HTTPBodyContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+//	require.HTTPBodyContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPBodyContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
@@ -702,7 +702,7 @@ func HTTPBodyContainsf(t TestingT, handler http.HandlerFunc, method string, url 
 // HTTPBodyNotContains asserts that a specified handler returns a
 // body that does not contain a string.
 //
-// 	require.HTTPBodyNotContains(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
+//	require.HTTPBodyNotContains(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPBodyNotContains(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
@@ -718,7 +718,7 @@ func HTTPBodyNotContains(t TestingT, handler http.HandlerFunc, method string, ur
 // HTTPBodyNotContainsf asserts that a specified handler returns a
 // body that does not contain a string.
 //
-// 	require.HTTPBodyNotContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+//	require.HTTPBodyNotContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPBodyNotContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
@@ -733,7 +733,7 @@ func HTTPBodyNotContainsf(t TestingT, handler http.HandlerFunc, method string, u
 
 // HTTPError asserts that a specified handler returns an error status code.
 //
-// 	require.HTTPError(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//	require.HTTPError(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPError(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
@@ -748,7 +748,7 @@ func HTTPError(t TestingT, handler http.HandlerFunc, method string, url string, 
 
 // HTTPErrorf asserts that a specified handler returns an error status code.
 //
-// 	require.HTTPErrorf(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//	require.HTTPErrorf(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPErrorf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
@@ -763,7 +763,7 @@ func HTTPErrorf(t TestingT, handler http.HandlerFunc, method string, url string,
 
 // HTTPRedirect asserts that a specified handler returns a redirect status code.
 //
-// 	require.HTTPRedirect(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//	require.HTTPRedirect(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPRedirect(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
@@ -778,7 +778,7 @@ func HTTPRedirect(t TestingT, handler http.HandlerFunc, method string, url strin
 
 // HTTPRedirectf asserts that a specified handler returns a redirect status code.
 //
-// 	require.HTTPRedirectf(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//	require.HTTPRedirectf(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPRedirectf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
@@ -793,7 +793,7 @@ func HTTPRedirectf(t TestingT, handler http.HandlerFunc, method string, url stri
 
 // HTTPStatusCode asserts that a specified handler returns a specified status code.
 //
-// 	require.HTTPStatusCode(t, myHandler, "GET", "/notImplemented", nil, 501)
+//	require.HTTPStatusCode(t, myHandler, "GET", "/notImplemented", nil, 501)
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPStatusCode(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msgAndArgs ...interface{}) {
@@ -808,7 +808,7 @@ func HTTPStatusCode(t TestingT, handler http.HandlerFunc, method string, url str
 
 // HTTPStatusCodef asserts that a specified handler returns a specified status code.
 //
-// 	require.HTTPStatusCodef(t, myHandler, "GET", "/notImplemented", nil, 501, "error message %s", "formatted")
+//	require.HTTPStatusCodef(t, myHandler, "GET", "/notImplemented", nil, 501, "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPStatusCodef(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msg string, args ...interface{}) {
@@ -823,7 +823,7 @@ func HTTPStatusCodef(t TestingT, handler http.HandlerFunc, method string, url st
 
 // HTTPSuccess asserts that a specified handler returns a success status code.
 //
-// 	require.HTTPSuccess(t, myHandler, "POST", "http://www.google.com", nil)
+//	require.HTTPSuccess(t, myHandler, "POST", "http://www.google.com", nil)
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPSuccess(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
@@ -838,7 +838,7 @@ func HTTPSuccess(t TestingT, handler http.HandlerFunc, method string, url string
 
 // HTTPSuccessf asserts that a specified handler returns a success status code.
 //
-// 	require.HTTPSuccessf(t, myHandler, "POST", "http://www.google.com", nil, "error message %s", "formatted")
+//	require.HTTPSuccessf(t, myHandler, "POST", "http://www.google.com", nil, "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPSuccessf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
@@ -853,7 +853,7 @@ func HTTPSuccessf(t TestingT, handler http.HandlerFunc, method string, url strin
 
 // Implements asserts that an object is implemented by the specified interface.
 //
-// 	require.Implements(t, (*MyInterface)(nil), new(MyObject))
+//	require.Implements(t, (*MyInterface)(nil), new(MyObject))
 func Implements(t TestingT, interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -866,7 +866,7 @@ func Implements(t TestingT, interfaceObject interface{}, object interface{}, msg
 
 // Implementsf asserts that an object is implemented by the specified interface.
 //
-// 	require.Implementsf(t, (*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
+//	require.Implementsf(t, (*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
 func Implementsf(t TestingT, interfaceObject interface{}, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -879,7 +879,7 @@ func Implementsf(t TestingT, interfaceObject interface{}, object interface{}, ms
 
 // InDelta asserts that the two numerals are within delta of each other.
 //
-// 	require.InDelta(t, math.Pi, 22/7.0, 0.01)
+//	require.InDelta(t, math.Pi, 22/7.0, 0.01)
 func InDelta(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -936,7 +936,7 @@ func InDeltaSlicef(t TestingT, expected interface{}, actual interface{}, delta f
 
 // InDeltaf asserts that the two numerals are within delta of each other.
 //
-// 	require.InDeltaf(t, math.Pi, 22/7.0, 0.01, "error message %s", "formatted")
+//	require.InDeltaf(t, math.Pi, 22/7.0, 0.01, "error message %s", "formatted")
 func InDeltaf(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -993,9 +993,9 @@ func InEpsilonf(t TestingT, expected interface{}, actual interface{}, epsilon fl
 
 // IsDecreasing asserts that the collection is decreasing
 //
-// 	require.IsDecreasing(t, []int{2, 1, 0})
-// 	require.IsDecreasing(t, []float{2, 1})
-// 	require.IsDecreasing(t, []string{"b", "a"})
+//	require.IsDecreasing(t, []int{2, 1, 0})
+//	require.IsDecreasing(t, []float{2, 1})
+//	require.IsDecreasing(t, []string{"b", "a"})
 func IsDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1008,9 +1008,9 @@ func IsDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 
 // IsDecreasingf asserts that the collection is decreasing
 //
-// 	require.IsDecreasingf(t, []int{2, 1, 0}, "error message %s", "formatted")
-// 	require.IsDecreasingf(t, []float{2, 1}, "error message %s", "formatted")
-// 	require.IsDecreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
+//	require.IsDecreasingf(t, []int{2, 1, 0}, "error message %s", "formatted")
+//	require.IsDecreasingf(t, []float{2, 1}, "error message %s", "formatted")
+//	require.IsDecreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
 func IsDecreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1023,9 +1023,9 @@ func IsDecreasingf(t TestingT, object interface{}, msg string, args ...interface
 
 // IsIncreasing asserts that the collection is increasing
 //
-// 	require.IsIncreasing(t, []int{1, 2, 3})
-// 	require.IsIncreasing(t, []float{1, 2})
-// 	require.IsIncreasing(t, []string{"a", "b"})
+//	require.IsIncreasing(t, []int{1, 2, 3})
+//	require.IsIncreasing(t, []float{1, 2})
+//	require.IsIncreasing(t, []string{"a", "b"})
 func IsIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1038,9 +1038,9 @@ func IsIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 
 // IsIncreasingf asserts that the collection is increasing
 //
-// 	require.IsIncreasingf(t, []int{1, 2, 3}, "error message %s", "formatted")
-// 	require.IsIncreasingf(t, []float{1, 2}, "error message %s", "formatted")
-// 	require.IsIncreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
+//	require.IsIncreasingf(t, []int{1, 2, 3}, "error message %s", "formatted")
+//	require.IsIncreasingf(t, []float{1, 2}, "error message %s", "formatted")
+//	require.IsIncreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
 func IsIncreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1053,9 +1053,9 @@ func IsIncreasingf(t TestingT, object interface{}, msg string, args ...interface
 
 // IsNonDecreasing asserts that the collection is not decreasing
 //
-// 	require.IsNonDecreasing(t, []int{1, 1, 2})
-// 	require.IsNonDecreasing(t, []float{1, 2})
-// 	require.IsNonDecreasing(t, []string{"a", "b"})
+//	require.IsNonDecreasing(t, []int{1, 1, 2})
+//	require.IsNonDecreasing(t, []float{1, 2})
+//	require.IsNonDecreasing(t, []string{"a", "b"})
 func IsNonDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1068,9 +1068,9 @@ func IsNonDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) 
 
 // IsNonDecreasingf asserts that the collection is not decreasing
 //
-// 	require.IsNonDecreasingf(t, []int{1, 1, 2}, "error message %s", "formatted")
-// 	require.IsNonDecreasingf(t, []float{1, 2}, "error message %s", "formatted")
-// 	require.IsNonDecreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
+//	require.IsNonDecreasingf(t, []int{1, 1, 2}, "error message %s", "formatted")
+//	require.IsNonDecreasingf(t, []float{1, 2}, "error message %s", "formatted")
+//	require.IsNonDecreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
 func IsNonDecreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1083,9 +1083,9 @@ func IsNonDecreasingf(t TestingT, object interface{}, msg string, args ...interf
 
 // IsNonIncreasing asserts that the collection is not increasing
 //
-// 	require.IsNonIncreasing(t, []int{2, 1, 1})
-// 	require.IsNonIncreasing(t, []float{2, 1})
-// 	require.IsNonIncreasing(t, []string{"b", "a"})
+//	require.IsNonIncreasing(t, []int{2, 1, 1})
+//	require.IsNonIncreasing(t, []float{2, 1})
+//	require.IsNonIncreasing(t, []string{"b", "a"})
 func IsNonIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1098,9 +1098,9 @@ func IsNonIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) 
 
 // IsNonIncreasingf asserts that the collection is not increasing
 //
-// 	require.IsNonIncreasingf(t, []int{2, 1, 1}, "error message %s", "formatted")
-// 	require.IsNonIncreasingf(t, []float{2, 1}, "error message %s", "formatted")
-// 	require.IsNonIncreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
+//	require.IsNonIncreasingf(t, []int{2, 1, 1}, "error message %s", "formatted")
+//	require.IsNonIncreasingf(t, []float{2, 1}, "error message %s", "formatted")
+//	require.IsNonIncreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
 func IsNonIncreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1113,7 +1113,7 @@ func IsNonIncreasingf(t TestingT, object interface{}, msg string, args ...interf
 
 // IsNotType asserts that the specified objects are not of the same type.
 //
-// 	require.IsNotType(t, &NotMyStruct{}, &MyStruct{})
+//	require.IsNotType(t, &NotMyStruct{}, &MyStruct{})
 func IsNotType(t TestingT, theType interface{}, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1126,7 +1126,7 @@ func IsNotType(t TestingT, theType interface{}, object interface{}, msgAndArgs .
 
 // IsNotTypef asserts that the specified objects are not of the same type.
 //
-// 	require.IsNotTypef(t, &NotMyStruct{}, &MyStruct{}, "error message %s", "formatted")
+//	require.IsNotTypef(t, &NotMyStruct{}, &MyStruct{}, "error message %s", "formatted")
 func IsNotTypef(t TestingT, theType interface{}, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1139,7 +1139,7 @@ func IsNotTypef(t TestingT, theType interface{}, object interface{}, msg string,
 
 // IsType asserts that the specified objects are of the same type.
 //
-// 	require.IsType(t, &MyStruct{}, &MyStruct{})
+//	require.IsType(t, &MyStruct{}, &MyStruct{})
 func IsType(t TestingT, expectedType interface{}, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1152,7 +1152,7 @@ func IsType(t TestingT, expectedType interface{}, object interface{}, msgAndArgs
 
 // IsTypef asserts that the specified objects are of the same type.
 //
-// 	require.IsTypef(t, &MyStruct{}, &MyStruct{}, "error message %s", "formatted")
+//	require.IsTypef(t, &MyStruct{}, &MyStruct{}, "error message %s", "formatted")
 func IsTypef(t TestingT, expectedType interface{}, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1165,7 +1165,7 @@ func IsTypef(t TestingT, expectedType interface{}, object interface{}, msg strin
 
 // JSONEq asserts that two JSON strings are equivalent.
 //
-// 	require.JSONEq(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
+//	require.JSONEq(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
 func JSONEq(t TestingT, expected string, actual string, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1178,7 +1178,7 @@ func JSONEq(t TestingT, expected string, actual string, msgAndArgs ...interface{
 
 // JSONEqf asserts that two JSON strings are equivalent.
 //
-// 	require.JSONEqf(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
+//	require.JSONEqf(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
 func JSONEqf(t TestingT, expected string, actual string, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1192,7 +1192,7 @@ func JSONEqf(t TestingT, expected string, actual string, msg string, args ...int
 // Len asserts that the specified object has specific length.
 // Len also fails if the object has a type that len() not accept.
 //
-// 	require.Len(t, mySlice, 3)
+//	require.Len(t, mySlice, 3)
 func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1206,7 +1206,7 @@ func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) 
 // Lenf asserts that the specified object has specific length.
 // Len also fails if the object has a type that len() not accept.
 //
-// 	require.Lenf(t, mySlice, 3, "error message %s", "formatted")
+//	require.Lenf(t, mySlice, 3, "error message %s", "formatted")
 func Lenf(t TestingT, object interface{}, length int, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1219,9 +1219,9 @@ func Lenf(t TestingT, object interface{}, length int, msg string, args ...interf
 
 // Less asserts that the first element is less than the second
 //
-// 	require.Less(t, 1, 2)
-// 	require.Less(t, float64(1), float64(2))
-// 	require.Less(t, "a", "b")
+//	require.Less(t, 1, 2)
+//	require.Less(t, float64(1), float64(2))
+//	require.Less(t, "a", "b")
 func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1234,10 +1234,10 @@ func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{})
 
 // LessOrEqual asserts that the first element is less than or equal to the second
 //
-// 	require.LessOrEqual(t, 1, 2)
-// 	require.LessOrEqual(t, 2, 2)
-// 	require.LessOrEqual(t, "a", "b")
-// 	require.LessOrEqual(t, "b", "b")
+//	require.LessOrEqual(t, 1, 2)
+//	require.LessOrEqual(t, 2, 2)
+//	require.LessOrEqual(t, "a", "b")
+//	require.LessOrEqual(t, "b", "b")
 func LessOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1250,10 +1250,10 @@ func LessOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...inter
 
 // LessOrEqualf asserts that the first element is less than or equal to the second
 //
-// 	require.LessOrEqualf(t, 1, 2, "error message %s", "formatted")
-// 	require.LessOrEqualf(t, 2, 2, "error message %s", "formatted")
-// 	require.LessOrEqualf(t, "a", "b", "error message %s", "formatted")
-// 	require.LessOrEqualf(t, "b", "b", "error message %s", "formatted")
+//	require.LessOrEqualf(t, 1, 2, "error message %s", "formatted")
+//	require.LessOrEqualf(t, 2, 2, "error message %s", "formatted")
+//	require.LessOrEqualf(t, "a", "b", "error message %s", "formatted")
+//	require.LessOrEqualf(t, "b", "b", "error message %s", "formatted")
 func LessOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1266,9 +1266,9 @@ func LessOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args .
 
 // Lessf asserts that the first element is less than the second
 //
-// 	require.Lessf(t, 1, 2, "error message %s", "formatted")
-// 	require.Lessf(t, float64(1), float64(2), "error message %s", "formatted")
-// 	require.Lessf(t, "a", "b", "error message %s", "formatted")
+//	require.Lessf(t, 1, 2, "error message %s", "formatted")
+//	require.Lessf(t, float64(1), float64(2), "error message %s", "formatted")
+//	require.Lessf(t, "a", "b", "error message %s", "formatted")
 func Lessf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1281,8 +1281,8 @@ func Lessf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...inter
 
 // Negative asserts that the specified element is negative
 //
-// 	require.Negative(t, -1)
-// 	require.Negative(t, -1.23)
+//	require.Negative(t, -1)
+//	require.Negative(t, -1.23)
 func Negative(t TestingT, e interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1295,8 +1295,8 @@ func Negative(t TestingT, e interface{}, msgAndArgs ...interface{}) {
 
 // Negativef asserts that the specified element is negative
 //
-// 	require.Negativef(t, -1, "error message %s", "formatted")
-// 	require.Negativef(t, -1.23, "error message %s", "formatted")
+//	require.Negativef(t, -1, "error message %s", "formatted")
+//	require.Negativef(t, -1.23, "error message %s", "formatted")
 func Negativef(t TestingT, e interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1310,7 +1310,7 @@ func Negativef(t TestingT, e interface{}, msg string, args ...interface{}) {
 // Never asserts that the given condition doesn't satisfy in waitFor time,
 // periodically checking the target function each tick.
 //
-// 	require.Never(t, func() bool { return false; }, time.Second, 10*time.Millisecond)
+//	require.Never(t, func() bool { return false; }, time.Second, 10*time.Millisecond)
 func Never(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1324,7 +1324,7 @@ func Never(t TestingT, condition func() bool, waitFor time.Duration, tick time.D
 // Neverf asserts that the given condition doesn't satisfy in waitFor time,
 // periodically checking the target function each tick.
 //
-// 	require.Neverf(t, func() bool { return false; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+//	require.Neverf(t, func() bool { return false; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
 func Neverf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1337,7 +1337,7 @@ func Neverf(t TestingT, condition func() bool, waitFor time.Duration, tick time.
 
 // Nil asserts that the specified object is nil.
 //
-// 	require.Nil(t, err)
+//	require.Nil(t, err)
 func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1350,7 +1350,7 @@ func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 
 // Nilf asserts that the specified object is nil.
 //
-// 	require.Nilf(t, err, "error message %s", "formatted")
+//	require.Nilf(t, err, "error message %s", "formatted")
 func Nilf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1387,10 +1387,10 @@ func NoDirExistsf(t TestingT, path string, msg string, args ...interface{}) {
 
 // NoError asserts that a function returned a nil error (ie. no error).
 //
-// 	  actualObj, err := SomeFunction()
-// 	  if require.NoError(t, err) {
-// 		   require.Equal(t, expectedObj, actualObj)
-// 	  }
+//	  actualObj, err := SomeFunction()
+//	  if require.NoError(t, err) {
+//		   require.Equal(t, expectedObj, actualObj)
+//	  }
 func NoError(t TestingT, err error, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1403,10 +1403,10 @@ func NoError(t TestingT, err error, msgAndArgs ...interface{}) {
 
 // NoErrorf asserts that a function returned a nil error (ie. no error).
 //
-// 	  actualObj, err := SomeFunction()
-// 	  if require.NoErrorf(t, err, "error message %s", "formatted") {
-// 		   require.Equal(t, expectedObj, actualObj)
-// 	  }
+//	  actualObj, err := SomeFunction()
+//	  if require.NoErrorf(t, err, "error message %s", "formatted") {
+//		   require.Equal(t, expectedObj, actualObj)
+//	  }
 func NoErrorf(t TestingT, err error, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1444,9 +1444,9 @@ func NoFileExistsf(t TestingT, path string, msg string, args ...interface{}) {
 // NotContains asserts that the specified string, list(array, slice...) or map does NOT contain the
 // specified substring or element.
 //
-// 	require.NotContains(t, "Hello World", "Earth")
-// 	require.NotContains(t, ["Hello", "World"], "Earth")
-// 	require.NotContains(t, {"Hello": "World"}, "Earth")
+//	require.NotContains(t, "Hello World", "Earth")
+//	require.NotContains(t, ["Hello", "World"], "Earth")
+//	require.NotContains(t, {"Hello": "World"}, "Earth")
 func NotContains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1460,9 +1460,9 @@ func NotContains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...
 // NotContainsf asserts that the specified string, list(array, slice...) or map does NOT contain the
 // specified substring or element.
 //
-// 	require.NotContainsf(t, "Hello World", "Earth", "error message %s", "formatted")
-// 	require.NotContainsf(t, ["Hello", "World"], "Earth", "error message %s", "formatted")
-// 	require.NotContainsf(t, {"Hello": "World"}, "Earth", "error message %s", "formatted")
+//	require.NotContainsf(t, "Hello World", "Earth", "error message %s", "formatted")
+//	require.NotContainsf(t, ["Hello", "World"], "Earth", "error message %s", "formatted")
+//	require.NotContainsf(t, {"Hello": "World"}, "Earth", "error message %s", "formatted")
 func NotContainsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1515,9 +1515,9 @@ func NotElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg str
 
 // NotEmpty asserts that the specified object is NOT [Empty].
 //
-// 	if require.NotEmpty(t, obj) {
-// 	  require.Equal(t, "two", obj[1])
-// 	}
+//	if require.NotEmpty(t, obj) {
+//	  require.Equal(t, "two", obj[1])
+//	}
 func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1530,9 +1530,9 @@ func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 
 // NotEmptyf asserts that the specified object is NOT [Empty].
 //
-// 	if require.NotEmptyf(t, obj, "error message %s", "formatted") {
-// 	  require.Equal(t, "two", obj[1])
-// 	}
+//	if require.NotEmptyf(t, obj, "error message %s", "formatted") {
+//	  require.Equal(t, "two", obj[1])
+//	}
 func NotEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1545,7 +1545,7 @@ func NotEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) 
 
 // NotEqual asserts that the specified values are NOT equal.
 //
-// 	require.NotEqual(t, obj1, obj2)
+//	require.NotEqual(t, obj1, obj2)
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
@@ -1561,7 +1561,7 @@ func NotEqual(t TestingT, expected interface{}, actual interface{}, msgAndArgs .
 
 // NotEqualValues asserts that two objects are not equal even when converted to the same type
 //
-// 	require.NotEqualValues(t, obj1, obj2)
+//	require.NotEqualValues(t, obj1, obj2)
 func NotEqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1574,7 +1574,7 @@ func NotEqualValues(t TestingT, expected interface{}, actual interface{}, msgAnd
 
 // NotEqualValuesf asserts that two objects are not equal even when converted to the same type
 //
-// 	require.NotEqualValuesf(t, obj1, obj2, "error message %s", "formatted")
+//	require.NotEqualValuesf(t, obj1, obj2, "error message %s", "formatted")
 func NotEqualValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1587,7 +1587,7 @@ func NotEqualValuesf(t TestingT, expected interface{}, actual interface{}, msg s
 
 // NotEqualf asserts that the specified values are NOT equal.
 //
-// 	require.NotEqualf(t, obj1, obj2, "error message %s", "formatted")
+//	require.NotEqualf(t, obj1, obj2, "error message %s", "formatted")
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
@@ -1651,7 +1651,7 @@ func NotErrorIsf(t TestingT, err error, target error, msg string, args ...interf
 
 // NotImplements asserts that an object does not implement the specified interface.
 //
-// 	require.NotImplements(t, (*MyInterface)(nil), new(MyObject))
+//	require.NotImplements(t, (*MyInterface)(nil), new(MyObject))
 func NotImplements(t TestingT, interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1664,7 +1664,7 @@ func NotImplements(t TestingT, interfaceObject interface{}, object interface{}, 
 
 // NotImplementsf asserts that an object does not implement the specified interface.
 //
-// 	require.NotImplementsf(t, (*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
+//	require.NotImplementsf(t, (*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
 func NotImplementsf(t TestingT, interfaceObject interface{}, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1677,7 +1677,7 @@ func NotImplementsf(t TestingT, interfaceObject interface{}, object interface{},
 
 // NotNil asserts that the specified object is not nil.
 //
-// 	require.NotNil(t, err)
+//	require.NotNil(t, err)
 func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1690,7 +1690,7 @@ func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 
 // NotNilf asserts that the specified object is not nil.
 //
-// 	require.NotNilf(t, err, "error message %s", "formatted")
+//	require.NotNilf(t, err, "error message %s", "formatted")
 func NotNilf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1703,7 +1703,7 @@ func NotNilf(t TestingT, object interface{}, msg string, args ...interface{}) {
 
 // NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
 //
-// 	require.NotPanics(t, func(){ RemainCalm() })
+//	require.NotPanics(t, func(){ RemainCalm() })
 func NotPanics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1716,7 +1716,7 @@ func NotPanics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 
 // NotPanicsf asserts that the code inside the specified PanicTestFunc does NOT panic.
 //
-// 	require.NotPanicsf(t, func(){ RemainCalm() }, "error message %s", "formatted")
+//	require.NotPanicsf(t, func(){ RemainCalm() }, "error message %s", "formatted")
 func NotPanicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1735,8 +1735,8 @@ func NotPanicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interfac
 //
 // Examples:
 //
-// 	require.NotRegexp(t, regexp.MustCompile("starts"), "it's starting")
-// 	require.NotRegexp(t, "^start", "it's not starting") // string is compiled
+//	require.NotRegexp(t, regexp.MustCompile("starts"), "it's starting")
+//	require.NotRegexp(t, "^start", "it's not starting") // string is compiled
 func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1755,8 +1755,8 @@ func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interf
 //
 // Examples:
 //
-// 	require.NotRegexpf(t, regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
-// 	require.NotRegexpf(t, "^start", "it's not starting", "error message %s", "formatted") // string is compiled
+//	require.NotRegexpf(t, regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
+//	require.NotRegexpf(t, "^start", "it's not starting", "error message %s", "formatted") // string is compiled
 func NotRegexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1769,7 +1769,7 @@ func NotRegexpf(t TestingT, rx interface{}, str interface{}, msg string, args ..
 
 // NotSame asserts that two pointers do not reference the same object.
 //
-// 	require.NotSame(t, ptr1, ptr2)
+//	require.NotSame(t, ptr1, ptr2)
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
@@ -1785,7 +1785,7 @@ func NotSame(t TestingT, expected interface{}, actual interface{}, msgAndArgs ..
 
 // NotSamef asserts that two pointers do not reference the same object.
 //
-// 	require.NotSamef(t, ptr1, ptr2, "error message %s", "formatted")
+//	require.NotSamef(t, ptr1, ptr2, "error message %s", "formatted")
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
@@ -1804,10 +1804,10 @@ func NotSamef(t TestingT, expected interface{}, actual interface{}, msg string, 
 // Map elements are key-value pairs unless compared with an array or slice where
 // only the map key is evaluated.
 //
-// 	require.NotSubset(t, [1, 3, 4], [1, 2])
-// 	require.NotSubset(t, {"x": 1, "y": 2}, {"z": 3})
-// 	require.NotSubset(t, [1, 3, 4], {1: "one", 2: "two"})
-// 	require.NotSubset(t, {"x": 1, "y": 2}, ["z"])
+//	require.NotSubset(t, [1, 3, 4], [1, 2])
+//	require.NotSubset(t, {"x": 1, "y": 2}, {"z": 3})
+//	require.NotSubset(t, [1, 3, 4], {1: "one", 2: "two"})
+//	require.NotSubset(t, {"x": 1, "y": 2}, ["z"])
 func NotSubset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1823,10 +1823,10 @@ func NotSubset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...i
 // Map elements are key-value pairs unless compared with an array or slice where
 // only the map key is evaluated.
 //
-// 	require.NotSubsetf(t, [1, 3, 4], [1, 2], "error message %s", "formatted")
-// 	require.NotSubsetf(t, {"x": 1, "y": 2}, {"z": 3}, "error message %s", "formatted")
-// 	require.NotSubsetf(t, [1, 3, 4], {1: "one", 2: "two"}, "error message %s", "formatted")
-// 	require.NotSubsetf(t, {"x": 1, "y": 2}, ["z"], "error message %s", "formatted")
+//	require.NotSubsetf(t, [1, 3, 4], [1, 2], "error message %s", "formatted")
+//	require.NotSubsetf(t, {"x": 1, "y": 2}, {"z": 3}, "error message %s", "formatted")
+//	require.NotSubsetf(t, [1, 3, 4], {1: "one", 2: "two"}, "error message %s", "formatted")
+//	require.NotSubsetf(t, {"x": 1, "y": 2}, ["z"], "error message %s", "formatted")
 func NotSubsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1861,7 +1861,7 @@ func NotZerof(t TestingT, i interface{}, msg string, args ...interface{}) {
 
 // Panics asserts that the code inside the specified PanicTestFunc panics.
 //
-// 	require.Panics(t, func(){ GoCrazy() })
+//	require.Panics(t, func(){ GoCrazy() })
 func Panics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1876,7 +1876,7 @@ func Panics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 // panics, and that the recovered panic value is an error that satisfies the
 // EqualError comparison.
 //
-// 	require.PanicsWithError(t, "crazy error", func(){ GoCrazy() })
+//	require.PanicsWithError(t, "crazy error", func(){ GoCrazy() })
 func PanicsWithError(t TestingT, errString string, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1891,7 +1891,7 @@ func PanicsWithError(t TestingT, errString string, f assert.PanicTestFunc, msgAn
 // panics, and that the recovered panic value is an error that satisfies the
 // EqualError comparison.
 //
-// 	require.PanicsWithErrorf(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+//	require.PanicsWithErrorf(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
 func PanicsWithErrorf(t TestingT, errString string, f assert.PanicTestFunc, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1905,7 +1905,7 @@ func PanicsWithErrorf(t TestingT, errString string, f assert.PanicTestFunc, msg 
 // PanicsWithValue asserts that the code inside the specified PanicTestFunc panics, and that
 // the recovered panic value equals the expected panic value.
 //
-// 	require.PanicsWithValue(t, "crazy error", func(){ GoCrazy() })
+//	require.PanicsWithValue(t, "crazy error", func(){ GoCrazy() })
 func PanicsWithValue(t TestingT, expected interface{}, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1919,7 +1919,7 @@ func PanicsWithValue(t TestingT, expected interface{}, f assert.PanicTestFunc, m
 // PanicsWithValuef asserts that the code inside the specified PanicTestFunc panics, and that
 // the recovered panic value equals the expected panic value.
 //
-// 	require.PanicsWithValuef(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+//	require.PanicsWithValuef(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
 func PanicsWithValuef(t TestingT, expected interface{}, f assert.PanicTestFunc, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1932,7 +1932,7 @@ func PanicsWithValuef(t TestingT, expected interface{}, f assert.PanicTestFunc, 
 
 // Panicsf asserts that the code inside the specified PanicTestFunc panics.
 //
-// 	require.Panicsf(t, func(){ GoCrazy() }, "error message %s", "formatted")
+//	require.Panicsf(t, func(){ GoCrazy() }, "error message %s", "formatted")
 func Panicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1945,8 +1945,8 @@ func Panicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}
 
 // Positive asserts that the specified element is positive
 //
-// 	require.Positive(t, 1)
-// 	require.Positive(t, 1.23)
+//	require.Positive(t, 1)
+//	require.Positive(t, 1.23)
 func Positive(t TestingT, e interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1959,8 +1959,8 @@ func Positive(t TestingT, e interface{}, msgAndArgs ...interface{}) {
 
 // Positivef asserts that the specified element is positive
 //
-// 	require.Positivef(t, 1, "error message %s", "formatted")
-// 	require.Positivef(t, 1.23, "error message %s", "formatted")
+//	require.Positivef(t, 1, "error message %s", "formatted")
+//	require.Positivef(t, 1.23, "error message %s", "formatted")
 func Positivef(t TestingT, e interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1979,8 +1979,8 @@ func Positivef(t TestingT, e interface{}, msg string, args ...interface{}) {
 //
 // Examples:
 //
-// 	require.Regexp(t, regexp.MustCompile("start"), "it's starting")
-// 	require.Regexp(t, "start...$", "it's not starting") // string is compiled
+//	require.Regexp(t, regexp.MustCompile("start"), "it's starting")
+//	require.Regexp(t, "start...$", "it's not starting") // string is compiled
 func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1999,8 +1999,8 @@ func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface
 //
 // Examples:
 //
-// 	require.Regexpf(t, regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
-// 	require.Regexpf(t, "start...$", "it's not starting", "error message %s", "formatted") // string is compiled
+//	require.Regexpf(t, regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
+//	require.Regexpf(t, "start...$", "it's not starting", "error message %s", "formatted") // string is compiled
 func Regexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2013,7 +2013,7 @@ func Regexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...in
 
 // Same asserts that two pointers reference the same object.
 //
-// 	require.Same(t, ptr1, ptr2)
+//	require.Same(t, ptr1, ptr2)
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
@@ -2029,7 +2029,7 @@ func Same(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...in
 
 // Samef asserts that two pointers reference the same object.
 //
-// 	require.Samef(t, ptr1, ptr2, "error message %s", "formatted")
+//	require.Samef(t, ptr1, ptr2, "error message %s", "formatted")
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
@@ -2048,10 +2048,10 @@ func Samef(t TestingT, expected interface{}, actual interface{}, msg string, arg
 // Map elements are key-value pairs unless compared with an array or slice where
 // only the map key is evaluated.
 //
-// 	require.Subset(t, [1, 2, 3], [1, 2])
-// 	require.Subset(t, {"x": 1, "y": 2}, {"x": 1})
-// 	require.Subset(t, [1, 2, 3], {1: "one", 2: "two"})
-// 	require.Subset(t, {"x": 1, "y": 2}, ["x"])
+//	require.Subset(t, [1, 2, 3], [1, 2])
+//	require.Subset(t, {"x": 1, "y": 2}, {"x": 1})
+//	require.Subset(t, [1, 2, 3], {1: "one", 2: "two"})
+//	require.Subset(t, {"x": 1, "y": 2}, ["x"])
 func Subset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2067,10 +2067,10 @@ func Subset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...inte
 // Map elements are key-value pairs unless compared with an array or slice where
 // only the map key is evaluated.
 //
-// 	require.Subsetf(t, [1, 2, 3], [1, 2], "error message %s", "formatted")
-// 	require.Subsetf(t, {"x": 1, "y": 2}, {"x": 1}, "error message %s", "formatted")
-// 	require.Subsetf(t, [1, 2, 3], {1: "one", 2: "two"}, "error message %s", "formatted")
-// 	require.Subsetf(t, {"x": 1, "y": 2}, ["x"], "error message %s", "formatted")
+//	require.Subsetf(t, [1, 2, 3], [1, 2], "error message %s", "formatted")
+//	require.Subsetf(t, {"x": 1, "y": 2}, {"x": 1}, "error message %s", "formatted")
+//	require.Subsetf(t, [1, 2, 3], {1: "one", 2: "two"}, "error message %s", "formatted")
+//	require.Subsetf(t, {"x": 1, "y": 2}, ["x"], "error message %s", "formatted")
 func Subsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2083,7 +2083,7 @@ func Subsetf(t TestingT, list interface{}, subset interface{}, msg string, args 
 
 // True asserts that the specified value is true.
 //
-// 	require.True(t, myBool)
+//	require.True(t, myBool)
 func True(t TestingT, value bool, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2096,7 +2096,7 @@ func True(t TestingT, value bool, msgAndArgs ...interface{}) {
 
 // Truef asserts that the specified value is true.
 //
-// 	require.Truef(t, myBool, "error message %s", "formatted")
+//	require.Truef(t, myBool, "error message %s", "formatted")
 func Truef(t TestingT, value bool, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2109,7 +2109,7 @@ func Truef(t TestingT, value bool, msg string, args ...interface{}) {
 
 // WithinDuration asserts that the two times are within duration delta of each other.
 //
-// 	require.WithinDuration(t, time.Now(), time.Now(), 10*time.Second)
+//	require.WithinDuration(t, time.Now(), time.Now(), 10*time.Second)
 func WithinDuration(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2122,7 +2122,7 @@ func WithinDuration(t TestingT, expected time.Time, actual time.Time, delta time
 
 // WithinDurationf asserts that the two times are within duration delta of each other.
 //
-// 	require.WithinDurationf(t, time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
+//	require.WithinDurationf(t, time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
 func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2135,7 +2135,7 @@ func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta tim
 
 // WithinRange asserts that a time is within a time range (inclusive).
 //
-// 	require.WithinRange(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second))
+//	require.WithinRange(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second))
 func WithinRange(t TestingT, actual time.Time, start time.Time, end time.Time, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2148,7 +2148,7 @@ func WithinRange(t TestingT, actual time.Time, start time.Time, end time.Time, m
 
 // WithinRangef asserts that a time is within a time range (inclusive).
 //
-// 	require.WithinRangef(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second), "error message %s", "formatted")
+//	require.WithinRangef(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second), "error message %s", "formatted")
 func WithinRangef(t TestingT, actual time.Time, start time.Time, end time.Time, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2161,17 +2161,17 @@ func WithinRangef(t TestingT, actual time.Time, start time.Time, end time.Time, 
 
 // YAMLEq asserts that the first documents in the two YAML strings are equivalent.
 //
-// 	expected := `---
-// 	key: value
-// 	---
-// 	key: this is a second document, it is not evaluated
-// 	`
-// 	actual := `---
-// 	key: value
-// 	---
-// 	key: this is a subsequent document, it is not evaluated
-// 	`
-// 	require.YAMLEq(t, expected, actual)
+//	expected := `---
+//	key: value
+//	---
+//	key: this is a second document, it is not evaluated
+//	`
+//	actual := `---
+//	key: value
+//	---
+//	key: this is a subsequent document, it is not evaluated
+//	`
+//	require.YAMLEq(t, expected, actual)
 func YAMLEq(t TestingT, expected string, actual string, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2184,17 +2184,17 @@ func YAMLEq(t TestingT, expected string, actual string, msgAndArgs ...interface{
 
 // YAMLEqf asserts that the first documents in the two YAML strings are equivalent.
 //
-// 	expected := `---
-// 	key: value
-// 	---
-// 	key: this is a second document, it is not evaluated
-// 	`
-// 	actual := `---
-// 	key: value
-// 	---
-// 	key: this is a subsequent document, it is not evaluated
-// 	`
-// 	require.YAMLEqf(t, expected, actual, "error message %s", "formatted")
+//	expected := `---
+//	key: value
+//	---
+//	key: this is a second document, it is not evaluated
+//	`
+//	actual := `---
+//	key: value
+//	---
+//	key: this is a subsequent document, it is not evaluated
+//	`
+//	require.YAMLEqf(t, expected, actual, "error message %s", "formatted")
 func YAMLEqf(t TestingT, expected string, actual string, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()

--- a/require/require.go
+++ b/require/require.go
@@ -1204,7 +1204,7 @@ func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) 
 }
 
 // Lenf asserts that the specified object has specific length.
-// Lenf also fails if the object has a type that len() not accept.
+// Len also fails if the object has a type that len() not accept.
 //
 // 	require.Lenf(t, mySlice, 3, "error message %s", "formatted")
 func Lenf(t TestingT, object interface{}, length int, msg string, args ...interface{}) {
@@ -1734,6 +1734,7 @@ func NotPanicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interfac
 // %v and compiled using regexp.Compile.
 //
 // Examples:
+//
 // 	require.NotRegexp(t, regexp.MustCompile("starts"), "it's starting")
 // 	require.NotRegexp(t, "^start", "it's not starting") // string is compiled
 func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
@@ -1753,6 +1754,7 @@ func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interf
 // %v and compiled using regexp.Compile.
 //
 // Examples:
+//
 // 	require.NotRegexpf(t, regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
 // 	require.NotRegexpf(t, "^start", "it's not starting", "error message %s", "formatted") // string is compiled
 func NotRegexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) {
@@ -1976,6 +1978,7 @@ func Positivef(t TestingT, e interface{}, msg string, args ...interface{}) {
 // %v and compiled using regexp.Compile.
 //
 // Examples:
+//
 // 	require.Regexp(t, regexp.MustCompile("start"), "it's starting")
 // 	require.Regexp(t, "start...$", "it's not starting") // string is compiled
 func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
@@ -1995,6 +1998,7 @@ func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface
 // %v and compiled using regexp.Compile.
 //
 // Examples:
+//
 // 	require.Regexpf(t, regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
 // 	require.Regexpf(t, "start...$", "it's not starting", "error message %s", "formatted") // string is compiled
 func Regexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) {

--- a/require/require.go
+++ b/require/require.go
@@ -34,9 +34,9 @@ func Conditionf(t TestingT, comp assert.Comparison, msg string, args ...interfac
 // Contains asserts that the specified string, list(array, slice...) or map contains the
 // specified substring or element.
 //
-//	require.Contains(t, "Hello World", "World")
-//	require.Contains(t, ["Hello", "World"], "World")
-//	require.Contains(t, {"Hello": "World"}, "Hello")
+// 	require.Contains(t, "Hello World", "World")
+// 	require.Contains(t, ["Hello", "World"], "World")
+// 	require.Contains(t, {"Hello": "World"}, "Hello")
 func Contains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -50,9 +50,9 @@ func Contains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...int
 // Containsf asserts that the specified string, list(array, slice...) or map contains the
 // specified substring or element.
 //
-//	require.Containsf(t, "Hello World", "World", "error message %s", "formatted")
-//	require.Containsf(t, ["Hello", "World"], "World", "error message %s", "formatted")
-//	require.Containsf(t, {"Hello": "World"}, "Hello", "error message %s", "formatted")
+// 	require.Containsf(t, "Hello World", "World", "error message %s", "formatted")
+// 	require.Containsf(t, ["Hello", "World"], "World", "error message %s", "formatted")
+// 	require.Containsf(t, {"Hello": "World"}, "Hello", "error message %s", "formatted")
 func Containsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -127,7 +127,7 @@ func ElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string
 //
 // Pointer values are "empty" if the pointer is nil or if the pointed value is "empty".
 //
-//	require.Empty(t, obj)
+// 	require.Empty(t, obj)
 //
 // [Zero values]: https://go.dev/ref/spec#The_zero_value
 func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
@@ -150,7 +150,7 @@ func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 //
 // Pointer values are "empty" if the pointer is nil or if the pointed value is "empty".
 //
-//	require.Emptyf(t, obj, "error message %s", "formatted")
+// 	require.Emptyf(t, obj, "error message %s", "formatted")
 //
 // [Zero values]: https://go.dev/ref/spec#The_zero_value
 func Emptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
@@ -165,7 +165,7 @@ func Emptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
 
 // Equal asserts that two objects are equal.
 //
-//	require.Equal(t, 123, 123)
+// 	require.Equal(t, 123, 123)
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses). Function equality
@@ -183,8 +183,8 @@ func Equal(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...i
 // EqualError asserts that a function returned a non-nil error (i.e. an error)
 // and that it is equal to the provided error.
 //
-//	actualObj, err := SomeFunction()
-//	require.EqualError(t, err,  expectedErrorString)
+// 	actualObj, err := SomeFunction()
+// 	require.EqualError(t, err,  expectedErrorString)
 func EqualError(t TestingT, theError error, errString string, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -198,8 +198,8 @@ func EqualError(t TestingT, theError error, errString string, msgAndArgs ...inte
 // EqualErrorf asserts that a function returned a non-nil error (i.e. an error)
 // and that it is equal to the provided error.
 //
-//	actualObj, err := SomeFunction()
-//	require.EqualErrorf(t, err,  expectedErrorString, "error message %s", "formatted")
+// 	actualObj, err := SomeFunction()
+// 	require.EqualErrorf(t, err,  expectedErrorString, "error message %s", "formatted")
 func EqualErrorf(t TestingT, theError error, errString string, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -214,12 +214,12 @@ func EqualErrorf(t TestingT, theError error, errString string, msg string, args 
 // fields are also equal. This is useful for comparing structs that have private fields
 // that could potentially differ.
 //
-//	 type S struct {
-//		Exported     	int
-//		notExported   	int
-//	 }
-//	 require.EqualExportedValues(t, S{1, 2}, S{1, 3}) => true
-//	 require.EqualExportedValues(t, S{1, 2}, S{2, 3}) => false
+// 	 type S struct {
+// 		Exported     	int
+// 		notExported   	int
+// 	 }
+// 	 require.EqualExportedValues(t, S{1, 2}, S{1, 3}) => true
+// 	 require.EqualExportedValues(t, S{1, 2}, S{2, 3}) => false
 func EqualExportedValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -234,12 +234,12 @@ func EqualExportedValues(t TestingT, expected interface{}, actual interface{}, m
 // fields are also equal. This is useful for comparing structs that have private fields
 // that could potentially differ.
 //
-//	 type S struct {
-//		Exported     	int
-//		notExported   	int
-//	 }
-//	 require.EqualExportedValuesf(t, S{1, 2}, S{1, 3}, "error message %s", "formatted") => true
-//	 require.EqualExportedValuesf(t, S{1, 2}, S{2, 3}, "error message %s", "formatted") => false
+// 	 type S struct {
+// 		Exported     	int
+// 		notExported   	int
+// 	 }
+// 	 require.EqualExportedValuesf(t, S{1, 2}, S{1, 3}, "error message %s", "formatted") => true
+// 	 require.EqualExportedValuesf(t, S{1, 2}, S{2, 3}, "error message %s", "formatted") => false
 func EqualExportedValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -253,7 +253,7 @@ func EqualExportedValuesf(t TestingT, expected interface{}, actual interface{}, 
 // EqualValues asserts that two objects are equal or convertible to the larger
 // type and equal.
 //
-//	require.EqualValues(t, uint32(123), int32(123))
+// 	require.EqualValues(t, uint32(123), int32(123))
 func EqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -267,7 +267,7 @@ func EqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArg
 // EqualValuesf asserts that two objects are equal or convertible to the larger
 // type and equal.
 //
-//	require.EqualValuesf(t, uint32(123), int32(123), "error message %s", "formatted")
+// 	require.EqualValuesf(t, uint32(123), int32(123), "error message %s", "formatted")
 func EqualValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -280,7 +280,7 @@ func EqualValuesf(t TestingT, expected interface{}, actual interface{}, msg stri
 
 // Equalf asserts that two objects are equal.
 //
-//	require.Equalf(t, 123, 123, "error message %s", "formatted")
+// 	require.Equalf(t, 123, 123, "error message %s", "formatted")
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses). Function equality
@@ -297,8 +297,8 @@ func Equalf(t TestingT, expected interface{}, actual interface{}, msg string, ar
 
 // Error asserts that a function returned a non-nil error (ie. an error).
 //
-//	actualObj, err := SomeFunction()
-//	require.Error(t, err)
+// 	actualObj, err := SomeFunction()
+// 	require.Error(t, err)
 func Error(t TestingT, err error, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -336,8 +336,8 @@ func ErrorAsf(t TestingT, err error, target interface{}, msg string, args ...int
 // ErrorContains asserts that a function returned a non-nil error (i.e. an
 // error) and that the error contains the specified substring.
 //
-//	actualObj, err := SomeFunction()
-//	require.ErrorContains(t, err,  expectedErrorSubString)
+// 	actualObj, err := SomeFunction()
+// 	require.ErrorContains(t, err,  expectedErrorSubString)
 func ErrorContains(t TestingT, theError error, contains string, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -351,8 +351,8 @@ func ErrorContains(t TestingT, theError error, contains string, msgAndArgs ...in
 // ErrorContainsf asserts that a function returned a non-nil error (i.e. an
 // error) and that the error contains the specified substring.
 //
-//	actualObj, err := SomeFunction()
-//	require.ErrorContainsf(t, err,  expectedErrorSubString, "error message %s", "formatted")
+// 	actualObj, err := SomeFunction()
+// 	require.ErrorContainsf(t, err,  expectedErrorSubString, "error message %s", "formatted")
 func ErrorContainsf(t TestingT, theError error, contains string, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -389,8 +389,8 @@ func ErrorIsf(t TestingT, err error, target error, msg string, args ...interface
 
 // Errorf asserts that a function returned a non-nil error (ie. an error).
 //
-//	actualObj, err := SomeFunction()
-//	require.Errorf(t, err, "error message %s", "formatted")
+// 	actualObj, err := SomeFunction()
+// 	require.Errorf(t, err, "error message %s", "formatted")
 func Errorf(t TestingT, err error, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -404,7 +404,7 @@ func Errorf(t TestingT, err error, msg string, args ...interface{}) {
 // Eventually asserts that given condition will be met in waitFor time,
 // periodically checking target function each tick.
 //
-//	require.Eventually(t, func() bool { return true; }, time.Second, 10*time.Millisecond)
+// 	require.Eventually(t, func() bool { return true; }, time.Second, 10*time.Millisecond)
 func Eventually(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -424,15 +424,15 @@ func Eventually(t TestingT, condition func() bool, waitFor time.Duration, tick t
 // If the condition is not met before waitFor, the collected errors of
 // the last tick are copied to t.
 //
-//	externalValue := false
-//	go func() {
-//		time.Sleep(8*time.Second)
-//		externalValue = true
-//	}()
-//	require.EventuallyWithT(t, func(c *require.CollectT) {
-//		// add assertions as needed; any assertion failure will fail the current tick
-//		require.True(c, externalValue, "expected 'externalValue' to be true")
-//	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
+// 	externalValue := false
+// 	go func() {
+// 		time.Sleep(8*time.Second)
+// 		externalValue = true
+// 	}()
+// 	require.EventuallyWithT(t, func(c *require.CollectT) {
+// 		// add assertions as needed; any assertion failure will fail the current tick
+// 		require.True(c, externalValue, "expected 'externalValue' to be true")
+// 	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
 func EventuallyWithT(t TestingT, condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -452,15 +452,15 @@ func EventuallyWithT(t TestingT, condition func(collect *assert.CollectT), waitF
 // If the condition is not met before waitFor, the collected errors of
 // the last tick are copied to t.
 //
-//	externalValue := false
-//	go func() {
-//		time.Sleep(8*time.Second)
-//		externalValue = true
-//	}()
-//	require.EventuallyWithTf(t, func(c *require.CollectT, "error message %s", "formatted") {
-//		// add assertions as needed; any assertion failure will fail the current tick
-//		require.True(c, externalValue, "expected 'externalValue' to be true")
-//	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
+// 	externalValue := false
+// 	go func() {
+// 		time.Sleep(8*time.Second)
+// 		externalValue = true
+// 	}()
+// 	require.EventuallyWithTf(t, func(c *require.CollectT, "error message %s", "formatted") {
+// 		// add assertions as needed; any assertion failure will fail the current tick
+// 		require.True(c, externalValue, "expected 'externalValue' to be true")
+// 	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
 func EventuallyWithTf(t TestingT, condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -474,7 +474,7 @@ func EventuallyWithTf(t TestingT, condition func(collect *assert.CollectT), wait
 // Eventuallyf asserts that given condition will be met in waitFor time,
 // periodically checking target function each tick.
 //
-//	require.Eventuallyf(t, func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+// 	require.Eventuallyf(t, func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
 func Eventuallyf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -487,7 +487,7 @@ func Eventuallyf(t TestingT, condition func() bool, waitFor time.Duration, tick 
 
 // Exactly asserts that two objects are equal in value and type.
 //
-//	require.Exactly(t, int32(123), int64(123))
+// 	require.Exactly(t, int32(123), int64(123))
 func Exactly(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -500,7 +500,7 @@ func Exactly(t TestingT, expected interface{}, actual interface{}, msgAndArgs ..
 
 // Exactlyf asserts that two objects are equal in value and type.
 //
-//	require.Exactlyf(t, int32(123), int64(123), "error message %s", "formatted")
+// 	require.Exactlyf(t, int32(123), int64(123), "error message %s", "formatted")
 func Exactlyf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -557,7 +557,7 @@ func Failf(t TestingT, failureMessage string, msg string, args ...interface{}) {
 
 // False asserts that the specified value is false.
 //
-//	require.False(t, myBool)
+// 	require.False(t, myBool)
 func False(t TestingT, value bool, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -570,7 +570,7 @@ func False(t TestingT, value bool, msgAndArgs ...interface{}) {
 
 // Falsef asserts that the specified value is false.
 //
-//	require.Falsef(t, myBool, "error message %s", "formatted")
+// 	require.Falsef(t, myBool, "error message %s", "formatted")
 func Falsef(t TestingT, value bool, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -607,9 +607,9 @@ func FileExistsf(t TestingT, path string, msg string, args ...interface{}) {
 
 // Greater asserts that the first element is greater than the second
 //
-//	require.Greater(t, 2, 1)
-//	require.Greater(t, float64(2), float64(1))
-//	require.Greater(t, "b", "a")
+// 	require.Greater(t, 2, 1)
+// 	require.Greater(t, float64(2), float64(1))
+// 	require.Greater(t, "b", "a")
 func Greater(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -622,10 +622,10 @@ func Greater(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface
 
 // GreaterOrEqual asserts that the first element is greater than or equal to the second
 //
-//	require.GreaterOrEqual(t, 2, 1)
-//	require.GreaterOrEqual(t, 2, 2)
-//	require.GreaterOrEqual(t, "b", "a")
-//	require.GreaterOrEqual(t, "b", "b")
+// 	require.GreaterOrEqual(t, 2, 1)
+// 	require.GreaterOrEqual(t, 2, 2)
+// 	require.GreaterOrEqual(t, "b", "a")
+// 	require.GreaterOrEqual(t, "b", "b")
 func GreaterOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -638,10 +638,10 @@ func GreaterOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...in
 
 // GreaterOrEqualf asserts that the first element is greater than or equal to the second
 //
-//	require.GreaterOrEqualf(t, 2, 1, "error message %s", "formatted")
-//	require.GreaterOrEqualf(t, 2, 2, "error message %s", "formatted")
-//	require.GreaterOrEqualf(t, "b", "a", "error message %s", "formatted")
-//	require.GreaterOrEqualf(t, "b", "b", "error message %s", "formatted")
+// 	require.GreaterOrEqualf(t, 2, 1, "error message %s", "formatted")
+// 	require.GreaterOrEqualf(t, 2, 2, "error message %s", "formatted")
+// 	require.GreaterOrEqualf(t, "b", "a", "error message %s", "formatted")
+// 	require.GreaterOrEqualf(t, "b", "b", "error message %s", "formatted")
 func GreaterOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -654,9 +654,9 @@ func GreaterOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, arg
 
 // Greaterf asserts that the first element is greater than the second
 //
-//	require.Greaterf(t, 2, 1, "error message %s", "formatted")
-//	require.Greaterf(t, float64(2), float64(1), "error message %s", "formatted")
-//	require.Greaterf(t, "b", "a", "error message %s", "formatted")
+// 	require.Greaterf(t, 2, 1, "error message %s", "formatted")
+// 	require.Greaterf(t, float64(2), float64(1), "error message %s", "formatted")
+// 	require.Greaterf(t, "b", "a", "error message %s", "formatted")
 func Greaterf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -670,7 +670,7 @@ func Greaterf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...in
 // HTTPBodyContains asserts that a specified handler returns a
 // body that contains a string.
 //
-//	require.HTTPBodyContains(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
+// 	require.HTTPBodyContains(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPBodyContains(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
@@ -686,7 +686,7 @@ func HTTPBodyContains(t TestingT, handler http.HandlerFunc, method string, url s
 // HTTPBodyContainsf asserts that a specified handler returns a
 // body that contains a string.
 //
-//	require.HTTPBodyContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+// 	require.HTTPBodyContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPBodyContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
@@ -702,7 +702,7 @@ func HTTPBodyContainsf(t TestingT, handler http.HandlerFunc, method string, url 
 // HTTPBodyNotContains asserts that a specified handler returns a
 // body that does not contain a string.
 //
-//	require.HTTPBodyNotContains(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
+// 	require.HTTPBodyNotContains(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPBodyNotContains(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
@@ -718,7 +718,7 @@ func HTTPBodyNotContains(t TestingT, handler http.HandlerFunc, method string, ur
 // HTTPBodyNotContainsf asserts that a specified handler returns a
 // body that does not contain a string.
 //
-//	require.HTTPBodyNotContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+// 	require.HTTPBodyNotContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPBodyNotContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
@@ -733,7 +733,7 @@ func HTTPBodyNotContainsf(t TestingT, handler http.HandlerFunc, method string, u
 
 // HTTPError asserts that a specified handler returns an error status code.
 //
-//	require.HTTPError(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+// 	require.HTTPError(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPError(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
@@ -748,7 +748,7 @@ func HTTPError(t TestingT, handler http.HandlerFunc, method string, url string, 
 
 // HTTPErrorf asserts that a specified handler returns an error status code.
 //
-//	require.HTTPErrorf(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+// 	require.HTTPErrorf(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPErrorf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
@@ -763,7 +763,7 @@ func HTTPErrorf(t TestingT, handler http.HandlerFunc, method string, url string,
 
 // HTTPRedirect asserts that a specified handler returns a redirect status code.
 //
-//	require.HTTPRedirect(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+// 	require.HTTPRedirect(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPRedirect(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
@@ -778,7 +778,7 @@ func HTTPRedirect(t TestingT, handler http.HandlerFunc, method string, url strin
 
 // HTTPRedirectf asserts that a specified handler returns a redirect status code.
 //
-//	require.HTTPRedirectf(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+// 	require.HTTPRedirectf(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPRedirectf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
@@ -793,7 +793,7 @@ func HTTPRedirectf(t TestingT, handler http.HandlerFunc, method string, url stri
 
 // HTTPStatusCode asserts that a specified handler returns a specified status code.
 //
-//	require.HTTPStatusCode(t, myHandler, "GET", "/notImplemented", nil, 501)
+// 	require.HTTPStatusCode(t, myHandler, "GET", "/notImplemented", nil, 501)
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPStatusCode(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msgAndArgs ...interface{}) {
@@ -808,7 +808,7 @@ func HTTPStatusCode(t TestingT, handler http.HandlerFunc, method string, url str
 
 // HTTPStatusCodef asserts that a specified handler returns a specified status code.
 //
-//	require.HTTPStatusCodef(t, myHandler, "GET", "/notImplemented", nil, 501, "error message %s", "formatted")
+// 	require.HTTPStatusCodef(t, myHandler, "GET", "/notImplemented", nil, 501, "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPStatusCodef(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msg string, args ...interface{}) {
@@ -823,7 +823,7 @@ func HTTPStatusCodef(t TestingT, handler http.HandlerFunc, method string, url st
 
 // HTTPSuccess asserts that a specified handler returns a success status code.
 //
-//	require.HTTPSuccess(t, myHandler, "POST", "http://www.google.com", nil)
+// 	require.HTTPSuccess(t, myHandler, "POST", "http://www.google.com", nil)
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPSuccess(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
@@ -838,7 +838,7 @@ func HTTPSuccess(t TestingT, handler http.HandlerFunc, method string, url string
 
 // HTTPSuccessf asserts that a specified handler returns a success status code.
 //
-//	require.HTTPSuccessf(t, myHandler, "POST", "http://www.google.com", nil, "error message %s", "formatted")
+// 	require.HTTPSuccessf(t, myHandler, "POST", "http://www.google.com", nil, "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func HTTPSuccessf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
@@ -853,7 +853,7 @@ func HTTPSuccessf(t TestingT, handler http.HandlerFunc, method string, url strin
 
 // Implements asserts that an object is implemented by the specified interface.
 //
-//	require.Implements(t, (*MyInterface)(nil), new(MyObject))
+// 	require.Implements(t, (*MyInterface)(nil), new(MyObject))
 func Implements(t TestingT, interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -866,7 +866,7 @@ func Implements(t TestingT, interfaceObject interface{}, object interface{}, msg
 
 // Implementsf asserts that an object is implemented by the specified interface.
 //
-//	require.Implementsf(t, (*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
+// 	require.Implementsf(t, (*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
 func Implementsf(t TestingT, interfaceObject interface{}, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -879,7 +879,7 @@ func Implementsf(t TestingT, interfaceObject interface{}, object interface{}, ms
 
 // InDelta asserts that the two numerals are within delta of each other.
 //
-//	require.InDelta(t, math.Pi, 22/7.0, 0.01)
+// 	require.InDelta(t, math.Pi, 22/7.0, 0.01)
 func InDelta(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -936,7 +936,7 @@ func InDeltaSlicef(t TestingT, expected interface{}, actual interface{}, delta f
 
 // InDeltaf asserts that the two numerals are within delta of each other.
 //
-//	require.InDeltaf(t, math.Pi, 22/7.0, 0.01, "error message %s", "formatted")
+// 	require.InDeltaf(t, math.Pi, 22/7.0, 0.01, "error message %s", "formatted")
 func InDeltaf(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -993,9 +993,9 @@ func InEpsilonf(t TestingT, expected interface{}, actual interface{}, epsilon fl
 
 // IsDecreasing asserts that the collection is decreasing
 //
-//	require.IsDecreasing(t, []int{2, 1, 0})
-//	require.IsDecreasing(t, []float{2, 1})
-//	require.IsDecreasing(t, []string{"b", "a"})
+// 	require.IsDecreasing(t, []int{2, 1, 0})
+// 	require.IsDecreasing(t, []float{2, 1})
+// 	require.IsDecreasing(t, []string{"b", "a"})
 func IsDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1008,9 +1008,9 @@ func IsDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 
 // IsDecreasingf asserts that the collection is decreasing
 //
-//	require.IsDecreasingf(t, []int{2, 1, 0}, "error message %s", "formatted")
-//	require.IsDecreasingf(t, []float{2, 1}, "error message %s", "formatted")
-//	require.IsDecreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
+// 	require.IsDecreasingf(t, []int{2, 1, 0}, "error message %s", "formatted")
+// 	require.IsDecreasingf(t, []float{2, 1}, "error message %s", "formatted")
+// 	require.IsDecreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
 func IsDecreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1023,9 +1023,9 @@ func IsDecreasingf(t TestingT, object interface{}, msg string, args ...interface
 
 // IsIncreasing asserts that the collection is increasing
 //
-//	require.IsIncreasing(t, []int{1, 2, 3})
-//	require.IsIncreasing(t, []float{1, 2})
-//	require.IsIncreasing(t, []string{"a", "b"})
+// 	require.IsIncreasing(t, []int{1, 2, 3})
+// 	require.IsIncreasing(t, []float{1, 2})
+// 	require.IsIncreasing(t, []string{"a", "b"})
 func IsIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1038,9 +1038,9 @@ func IsIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 
 // IsIncreasingf asserts that the collection is increasing
 //
-//	require.IsIncreasingf(t, []int{1, 2, 3}, "error message %s", "formatted")
-//	require.IsIncreasingf(t, []float{1, 2}, "error message %s", "formatted")
-//	require.IsIncreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
+// 	require.IsIncreasingf(t, []int{1, 2, 3}, "error message %s", "formatted")
+// 	require.IsIncreasingf(t, []float{1, 2}, "error message %s", "formatted")
+// 	require.IsIncreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
 func IsIncreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1053,9 +1053,9 @@ func IsIncreasingf(t TestingT, object interface{}, msg string, args ...interface
 
 // IsNonDecreasing asserts that the collection is not decreasing
 //
-//	require.IsNonDecreasing(t, []int{1, 1, 2})
-//	require.IsNonDecreasing(t, []float{1, 2})
-//	require.IsNonDecreasing(t, []string{"a", "b"})
+// 	require.IsNonDecreasing(t, []int{1, 1, 2})
+// 	require.IsNonDecreasing(t, []float{1, 2})
+// 	require.IsNonDecreasing(t, []string{"a", "b"})
 func IsNonDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1068,9 +1068,9 @@ func IsNonDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) 
 
 // IsNonDecreasingf asserts that the collection is not decreasing
 //
-//	require.IsNonDecreasingf(t, []int{1, 1, 2}, "error message %s", "formatted")
-//	require.IsNonDecreasingf(t, []float{1, 2}, "error message %s", "formatted")
-//	require.IsNonDecreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
+// 	require.IsNonDecreasingf(t, []int{1, 1, 2}, "error message %s", "formatted")
+// 	require.IsNonDecreasingf(t, []float{1, 2}, "error message %s", "formatted")
+// 	require.IsNonDecreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
 func IsNonDecreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1083,9 +1083,9 @@ func IsNonDecreasingf(t TestingT, object interface{}, msg string, args ...interf
 
 // IsNonIncreasing asserts that the collection is not increasing
 //
-//	require.IsNonIncreasing(t, []int{2, 1, 1})
-//	require.IsNonIncreasing(t, []float{2, 1})
-//	require.IsNonIncreasing(t, []string{"b", "a"})
+// 	require.IsNonIncreasing(t, []int{2, 1, 1})
+// 	require.IsNonIncreasing(t, []float{2, 1})
+// 	require.IsNonIncreasing(t, []string{"b", "a"})
 func IsNonIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1098,9 +1098,9 @@ func IsNonIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) 
 
 // IsNonIncreasingf asserts that the collection is not increasing
 //
-//	require.IsNonIncreasingf(t, []int{2, 1, 1}, "error message %s", "formatted")
-//	require.IsNonIncreasingf(t, []float{2, 1}, "error message %s", "formatted")
-//	require.IsNonIncreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
+// 	require.IsNonIncreasingf(t, []int{2, 1, 1}, "error message %s", "formatted")
+// 	require.IsNonIncreasingf(t, []float{2, 1}, "error message %s", "formatted")
+// 	require.IsNonIncreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
 func IsNonIncreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1113,7 +1113,7 @@ func IsNonIncreasingf(t TestingT, object interface{}, msg string, args ...interf
 
 // IsNotType asserts that the specified objects are not of the same type.
 //
-//	require.IsNotType(t, &NotMyStruct{}, &MyStruct{})
+// 	require.IsNotType(t, &NotMyStruct{}, &MyStruct{})
 func IsNotType(t TestingT, theType interface{}, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1126,7 +1126,7 @@ func IsNotType(t TestingT, theType interface{}, object interface{}, msgAndArgs .
 
 // IsNotTypef asserts that the specified objects are not of the same type.
 //
-//	require.IsNotTypef(t, &NotMyStruct{}, &MyStruct{}, "error message %s", "formatted")
+// 	require.IsNotTypef(t, &NotMyStruct{}, &MyStruct{}, "error message %s", "formatted")
 func IsNotTypef(t TestingT, theType interface{}, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1139,7 +1139,7 @@ func IsNotTypef(t TestingT, theType interface{}, object interface{}, msg string,
 
 // IsType asserts that the specified objects are of the same type.
 //
-//	require.IsType(t, &MyStruct{}, &MyStruct{})
+// 	require.IsType(t, &MyStruct{}, &MyStruct{})
 func IsType(t TestingT, expectedType interface{}, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1152,7 +1152,7 @@ func IsType(t TestingT, expectedType interface{}, object interface{}, msgAndArgs
 
 // IsTypef asserts that the specified objects are of the same type.
 //
-//	require.IsTypef(t, &MyStruct{}, &MyStruct{}, "error message %s", "formatted")
+// 	require.IsTypef(t, &MyStruct{}, &MyStruct{}, "error message %s", "formatted")
 func IsTypef(t TestingT, expectedType interface{}, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1165,7 +1165,7 @@ func IsTypef(t TestingT, expectedType interface{}, object interface{}, msg strin
 
 // JSONEq asserts that two JSON strings are equivalent.
 //
-//	require.JSONEq(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
+// 	require.JSONEq(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
 func JSONEq(t TestingT, expected string, actual string, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1178,7 +1178,7 @@ func JSONEq(t TestingT, expected string, actual string, msgAndArgs ...interface{
 
 // JSONEqf asserts that two JSON strings are equivalent.
 //
-//	require.JSONEqf(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
+// 	require.JSONEqf(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
 func JSONEqf(t TestingT, expected string, actual string, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1192,7 +1192,7 @@ func JSONEqf(t TestingT, expected string, actual string, msg string, args ...int
 // Len asserts that the specified object has specific length.
 // Len also fails if the object has a type that len() not accept.
 //
-//	require.Len(t, mySlice, 3)
+// 	require.Len(t, mySlice, 3)
 func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1206,7 +1206,7 @@ func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) 
 // Lenf asserts that the specified object has specific length.
 // Lenf also fails if the object has a type that len() not accept.
 //
-//	require.Lenf(t, mySlice, 3, "error message %s", "formatted")
+// 	require.Lenf(t, mySlice, 3, "error message %s", "formatted")
 func Lenf(t TestingT, object interface{}, length int, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1219,9 +1219,9 @@ func Lenf(t TestingT, object interface{}, length int, msg string, args ...interf
 
 // Less asserts that the first element is less than the second
 //
-//	require.Less(t, 1, 2)
-//	require.Less(t, float64(1), float64(2))
-//	require.Less(t, "a", "b")
+// 	require.Less(t, 1, 2)
+// 	require.Less(t, float64(1), float64(2))
+// 	require.Less(t, "a", "b")
 func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1234,10 +1234,10 @@ func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{})
 
 // LessOrEqual asserts that the first element is less than or equal to the second
 //
-//	require.LessOrEqual(t, 1, 2)
-//	require.LessOrEqual(t, 2, 2)
-//	require.LessOrEqual(t, "a", "b")
-//	require.LessOrEqual(t, "b", "b")
+// 	require.LessOrEqual(t, 1, 2)
+// 	require.LessOrEqual(t, 2, 2)
+// 	require.LessOrEqual(t, "a", "b")
+// 	require.LessOrEqual(t, "b", "b")
 func LessOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1250,10 +1250,10 @@ func LessOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...inter
 
 // LessOrEqualf asserts that the first element is less than or equal to the second
 //
-//	require.LessOrEqualf(t, 1, 2, "error message %s", "formatted")
-//	require.LessOrEqualf(t, 2, 2, "error message %s", "formatted")
-//	require.LessOrEqualf(t, "a", "b", "error message %s", "formatted")
-//	require.LessOrEqualf(t, "b", "b", "error message %s", "formatted")
+// 	require.LessOrEqualf(t, 1, 2, "error message %s", "formatted")
+// 	require.LessOrEqualf(t, 2, 2, "error message %s", "formatted")
+// 	require.LessOrEqualf(t, "a", "b", "error message %s", "formatted")
+// 	require.LessOrEqualf(t, "b", "b", "error message %s", "formatted")
 func LessOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1266,9 +1266,9 @@ func LessOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args .
 
 // Lessf asserts that the first element is less than the second
 //
-//	require.Lessf(t, 1, 2, "error message %s", "formatted")
-//	require.Lessf(t, float64(1), float64(2), "error message %s", "formatted")
-//	require.Lessf(t, "a", "b", "error message %s", "formatted")
+// 	require.Lessf(t, 1, 2, "error message %s", "formatted")
+// 	require.Lessf(t, float64(1), float64(2), "error message %s", "formatted")
+// 	require.Lessf(t, "a", "b", "error message %s", "formatted")
 func Lessf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1281,8 +1281,8 @@ func Lessf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...inter
 
 // Negative asserts that the specified element is negative
 //
-//	require.Negative(t, -1)
-//	require.Negative(t, -1.23)
+// 	require.Negative(t, -1)
+// 	require.Negative(t, -1.23)
 func Negative(t TestingT, e interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1295,8 +1295,8 @@ func Negative(t TestingT, e interface{}, msgAndArgs ...interface{}) {
 
 // Negativef asserts that the specified element is negative
 //
-//	require.Negativef(t, -1, "error message %s", "formatted")
-//	require.Negativef(t, -1.23, "error message %s", "formatted")
+// 	require.Negativef(t, -1, "error message %s", "formatted")
+// 	require.Negativef(t, -1.23, "error message %s", "formatted")
 func Negativef(t TestingT, e interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1310,7 +1310,7 @@ func Negativef(t TestingT, e interface{}, msg string, args ...interface{}) {
 // Never asserts that the given condition doesn't satisfy in waitFor time,
 // periodically checking the target function each tick.
 //
-//	require.Never(t, func() bool { return false; }, time.Second, 10*time.Millisecond)
+// 	require.Never(t, func() bool { return false; }, time.Second, 10*time.Millisecond)
 func Never(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1324,7 +1324,7 @@ func Never(t TestingT, condition func() bool, waitFor time.Duration, tick time.D
 // Neverf asserts that the given condition doesn't satisfy in waitFor time,
 // periodically checking the target function each tick.
 //
-//	require.Neverf(t, func() bool { return false; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+// 	require.Neverf(t, func() bool { return false; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
 func Neverf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1337,7 +1337,7 @@ func Neverf(t TestingT, condition func() bool, waitFor time.Duration, tick time.
 
 // Nil asserts that the specified object is nil.
 //
-//	require.Nil(t, err)
+// 	require.Nil(t, err)
 func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1350,7 +1350,7 @@ func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 
 // Nilf asserts that the specified object is nil.
 //
-//	require.Nilf(t, err, "error message %s", "formatted")
+// 	require.Nilf(t, err, "error message %s", "formatted")
 func Nilf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1387,10 +1387,10 @@ func NoDirExistsf(t TestingT, path string, msg string, args ...interface{}) {
 
 // NoError asserts that a function returned a nil error (ie. no error).
 //
-//	  actualObj, err := SomeFunction()
-//	  if require.NoError(t, err) {
-//		   require.Equal(t, expectedObj, actualObj)
-//	  }
+// 	  actualObj, err := SomeFunction()
+// 	  if require.NoError(t, err) {
+// 		   require.Equal(t, expectedObj, actualObj)
+// 	  }
 func NoError(t TestingT, err error, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1403,10 +1403,10 @@ func NoError(t TestingT, err error, msgAndArgs ...interface{}) {
 
 // NoErrorf asserts that a function returned a nil error (ie. no error).
 //
-//	  actualObj, err := SomeFunction()
-//	  if require.NoErrorf(t, err, "error message %s", "formatted") {
-//		   require.Equal(t, expectedObj, actualObj)
-//	  }
+// 	  actualObj, err := SomeFunction()
+// 	  if require.NoErrorf(t, err, "error message %s", "formatted") {
+// 		   require.Equal(t, expectedObj, actualObj)
+// 	  }
 func NoErrorf(t TestingT, err error, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1444,9 +1444,9 @@ func NoFileExistsf(t TestingT, path string, msg string, args ...interface{}) {
 // NotContains asserts that the specified string, list(array, slice...) or map does NOT contain the
 // specified substring or element.
 //
-//	require.NotContains(t, "Hello World", "Earth")
-//	require.NotContains(t, ["Hello", "World"], "Earth")
-//	require.NotContains(t, {"Hello": "World"}, "Earth")
+// 	require.NotContains(t, "Hello World", "Earth")
+// 	require.NotContains(t, ["Hello", "World"], "Earth")
+// 	require.NotContains(t, {"Hello": "World"}, "Earth")
 func NotContains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1460,9 +1460,9 @@ func NotContains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...
 // NotContainsf asserts that the specified string, list(array, slice...) or map does NOT contain the
 // specified substring or element.
 //
-//	require.NotContainsf(t, "Hello World", "Earth", "error message %s", "formatted")
-//	require.NotContainsf(t, ["Hello", "World"], "Earth", "error message %s", "formatted")
-//	require.NotContainsf(t, {"Hello": "World"}, "Earth", "error message %s", "formatted")
+// 	require.NotContainsf(t, "Hello World", "Earth", "error message %s", "formatted")
+// 	require.NotContainsf(t, ["Hello", "World"], "Earth", "error message %s", "formatted")
+// 	require.NotContainsf(t, {"Hello": "World"}, "Earth", "error message %s", "formatted")
 func NotContainsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1515,9 +1515,9 @@ func NotElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg str
 
 // NotEmpty asserts that the specified object is NOT [Empty].
 //
-//	if require.NotEmpty(t, obj) {
-//	  require.Equal(t, "two", obj[1])
-//	}
+// 	if require.NotEmpty(t, obj) {
+// 	  require.Equal(t, "two", obj[1])
+// 	}
 func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1530,9 +1530,9 @@ func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 
 // NotEmptyf asserts that the specified object is NOT [Empty].
 //
-//	if require.NotEmptyf(t, obj, "error message %s", "formatted") {
-//	  require.Equal(t, "two", obj[1])
-//	}
+// 	if require.NotEmptyf(t, obj, "error message %s", "formatted") {
+// 	  require.Equal(t, "two", obj[1])
+// 	}
 func NotEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1545,7 +1545,7 @@ func NotEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) 
 
 // NotEqual asserts that the specified values are NOT equal.
 //
-//	require.NotEqual(t, obj1, obj2)
+// 	require.NotEqual(t, obj1, obj2)
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
@@ -1561,7 +1561,7 @@ func NotEqual(t TestingT, expected interface{}, actual interface{}, msgAndArgs .
 
 // NotEqualValues asserts that two objects are not equal even when converted to the same type
 //
-//	require.NotEqualValues(t, obj1, obj2)
+// 	require.NotEqualValues(t, obj1, obj2)
 func NotEqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1574,7 +1574,7 @@ func NotEqualValues(t TestingT, expected interface{}, actual interface{}, msgAnd
 
 // NotEqualValuesf asserts that two objects are not equal even when converted to the same type
 //
-//	require.NotEqualValuesf(t, obj1, obj2, "error message %s", "formatted")
+// 	require.NotEqualValuesf(t, obj1, obj2, "error message %s", "formatted")
 func NotEqualValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1587,7 +1587,7 @@ func NotEqualValuesf(t TestingT, expected interface{}, actual interface{}, msg s
 
 // NotEqualf asserts that the specified values are NOT equal.
 //
-//	require.NotEqualf(t, obj1, obj2, "error message %s", "formatted")
+// 	require.NotEqualf(t, obj1, obj2, "error message %s", "formatted")
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
@@ -1651,7 +1651,7 @@ func NotErrorIsf(t TestingT, err error, target error, msg string, args ...interf
 
 // NotImplements asserts that an object does not implement the specified interface.
 //
-//	require.NotImplements(t, (*MyInterface)(nil), new(MyObject))
+// 	require.NotImplements(t, (*MyInterface)(nil), new(MyObject))
 func NotImplements(t TestingT, interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1664,7 +1664,7 @@ func NotImplements(t TestingT, interfaceObject interface{}, object interface{}, 
 
 // NotImplementsf asserts that an object does not implement the specified interface.
 //
-//	require.NotImplementsf(t, (*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
+// 	require.NotImplementsf(t, (*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
 func NotImplementsf(t TestingT, interfaceObject interface{}, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1677,7 +1677,7 @@ func NotImplementsf(t TestingT, interfaceObject interface{}, object interface{},
 
 // NotNil asserts that the specified object is not nil.
 //
-//	require.NotNil(t, err)
+// 	require.NotNil(t, err)
 func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1690,7 +1690,7 @@ func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 
 // NotNilf asserts that the specified object is not nil.
 //
-//	require.NotNilf(t, err, "error message %s", "formatted")
+// 	require.NotNilf(t, err, "error message %s", "formatted")
 func NotNilf(t TestingT, object interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1703,7 +1703,7 @@ func NotNilf(t TestingT, object interface{}, msg string, args ...interface{}) {
 
 // NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
 //
-//	require.NotPanics(t, func(){ RemainCalm() })
+// 	require.NotPanics(t, func(){ RemainCalm() })
 func NotPanics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1716,7 +1716,7 @@ func NotPanics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 
 // NotPanicsf asserts that the code inside the specified PanicTestFunc does NOT panic.
 //
-//	require.NotPanicsf(t, func(){ RemainCalm() }, "error message %s", "formatted")
+// 	require.NotPanicsf(t, func(){ RemainCalm() }, "error message %s", "formatted")
 func NotPanicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1731,10 +1731,11 @@ func NotPanicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interfac
 //
 // The rx (expression) argument should be a *regexp.Regexp. For backward
 // compatibility, if rx is any other type, its value will be formatted with
-// %v and compiled using regexp.MustCompile.
+// %v and compiled using regexp.Compile.
 //
-//	require.NotRegexp(t, regexp.MustCompile("starts"), "it's starting")
-//	require.NotRegexp(t, "^start", "it's not starting") // string is compiled
+// Examples:
+// 	require.NotRegexp(t, regexp.MustCompile("starts"), "it's starting")
+// 	require.NotRegexp(t, "^start", "it's not starting") // string is compiled
 func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1749,10 +1750,11 @@ func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interf
 //
 // The rx (expression) argument should be a *regexp.Regexp. For backward
 // compatibility, if rx is any other type, its value will be formatted with
-// %v and compiled using regexp.MustCompile.
+// %v and compiled using regexp.Compile.
 //
-//	require.NotRegexpf(t, regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
-//	require.NotRegexpf(t, "^start", "it's not starting", "error message %s", "formatted") // string is compiled
+// Examples:
+// 	require.NotRegexpf(t, regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
+// 	require.NotRegexpf(t, "^start", "it's not starting", "error message %s", "formatted") // string is compiled
 func NotRegexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1765,7 +1767,7 @@ func NotRegexpf(t TestingT, rx interface{}, str interface{}, msg string, args ..
 
 // NotSame asserts that two pointers do not reference the same object.
 //
-//	require.NotSame(t, ptr1, ptr2)
+// 	require.NotSame(t, ptr1, ptr2)
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
@@ -1781,7 +1783,7 @@ func NotSame(t TestingT, expected interface{}, actual interface{}, msgAndArgs ..
 
 // NotSamef asserts that two pointers do not reference the same object.
 //
-//	require.NotSamef(t, ptr1, ptr2, "error message %s", "formatted")
+// 	require.NotSamef(t, ptr1, ptr2, "error message %s", "formatted")
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
@@ -1800,10 +1802,10 @@ func NotSamef(t TestingT, expected interface{}, actual interface{}, msg string, 
 // Map elements are key-value pairs unless compared with an array or slice where
 // only the map key is evaluated.
 //
-//	require.NotSubset(t, [1, 3, 4], [1, 2])
-//	require.NotSubset(t, {"x": 1, "y": 2}, {"z": 3})
-//	require.NotSubset(t, [1, 3, 4], {1: "one", 2: "two"})
-//	require.NotSubset(t, {"x": 1, "y": 2}, ["z"])
+// 	require.NotSubset(t, [1, 3, 4], [1, 2])
+// 	require.NotSubset(t, {"x": 1, "y": 2}, {"z": 3})
+// 	require.NotSubset(t, [1, 3, 4], {1: "one", 2: "two"})
+// 	require.NotSubset(t, {"x": 1, "y": 2}, ["z"])
 func NotSubset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1819,10 +1821,10 @@ func NotSubset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...i
 // Map elements are key-value pairs unless compared with an array or slice where
 // only the map key is evaluated.
 //
-//	require.NotSubsetf(t, [1, 3, 4], [1, 2], "error message %s", "formatted")
-//	require.NotSubsetf(t, {"x": 1, "y": 2}, {"z": 3}, "error message %s", "formatted")
-//	require.NotSubsetf(t, [1, 3, 4], {1: "one", 2: "two"}, "error message %s", "formatted")
-//	require.NotSubsetf(t, {"x": 1, "y": 2}, ["z"], "error message %s", "formatted")
+// 	require.NotSubsetf(t, [1, 3, 4], [1, 2], "error message %s", "formatted")
+// 	require.NotSubsetf(t, {"x": 1, "y": 2}, {"z": 3}, "error message %s", "formatted")
+// 	require.NotSubsetf(t, [1, 3, 4], {1: "one", 2: "two"}, "error message %s", "formatted")
+// 	require.NotSubsetf(t, {"x": 1, "y": 2}, ["z"], "error message %s", "formatted")
 func NotSubsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1857,7 +1859,7 @@ func NotZerof(t TestingT, i interface{}, msg string, args ...interface{}) {
 
 // Panics asserts that the code inside the specified PanicTestFunc panics.
 //
-//	require.Panics(t, func(){ GoCrazy() })
+// 	require.Panics(t, func(){ GoCrazy() })
 func Panics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1872,7 +1874,7 @@ func Panics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 // panics, and that the recovered panic value is an error that satisfies the
 // EqualError comparison.
 //
-//	require.PanicsWithError(t, "crazy error", func(){ GoCrazy() })
+// 	require.PanicsWithError(t, "crazy error", func(){ GoCrazy() })
 func PanicsWithError(t TestingT, errString string, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1887,7 +1889,7 @@ func PanicsWithError(t TestingT, errString string, f assert.PanicTestFunc, msgAn
 // panics, and that the recovered panic value is an error that satisfies the
 // EqualError comparison.
 //
-//	require.PanicsWithErrorf(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+// 	require.PanicsWithErrorf(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
 func PanicsWithErrorf(t TestingT, errString string, f assert.PanicTestFunc, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1901,7 +1903,7 @@ func PanicsWithErrorf(t TestingT, errString string, f assert.PanicTestFunc, msg 
 // PanicsWithValue asserts that the code inside the specified PanicTestFunc panics, and that
 // the recovered panic value equals the expected panic value.
 //
-//	require.PanicsWithValue(t, "crazy error", func(){ GoCrazy() })
+// 	require.PanicsWithValue(t, "crazy error", func(){ GoCrazy() })
 func PanicsWithValue(t TestingT, expected interface{}, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1915,7 +1917,7 @@ func PanicsWithValue(t TestingT, expected interface{}, f assert.PanicTestFunc, m
 // PanicsWithValuef asserts that the code inside the specified PanicTestFunc panics, and that
 // the recovered panic value equals the expected panic value.
 //
-//	require.PanicsWithValuef(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+// 	require.PanicsWithValuef(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
 func PanicsWithValuef(t TestingT, expected interface{}, f assert.PanicTestFunc, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1928,7 +1930,7 @@ func PanicsWithValuef(t TestingT, expected interface{}, f assert.PanicTestFunc, 
 
 // Panicsf asserts that the code inside the specified PanicTestFunc panics.
 //
-//	require.Panicsf(t, func(){ GoCrazy() }, "error message %s", "formatted")
+// 	require.Panicsf(t, func(){ GoCrazy() }, "error message %s", "formatted")
 func Panicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1941,8 +1943,8 @@ func Panicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}
 
 // Positive asserts that the specified element is positive
 //
-//	require.Positive(t, 1)
-//	require.Positive(t, 1.23)
+// 	require.Positive(t, 1)
+// 	require.Positive(t, 1.23)
 func Positive(t TestingT, e interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1955,8 +1957,8 @@ func Positive(t TestingT, e interface{}, msgAndArgs ...interface{}) {
 
 // Positivef asserts that the specified element is positive
 //
-//	require.Positivef(t, 1, "error message %s", "formatted")
-//	require.Positivef(t, 1.23, "error message %s", "formatted")
+// 	require.Positivef(t, 1, "error message %s", "formatted")
+// 	require.Positivef(t, 1.23, "error message %s", "formatted")
 func Positivef(t TestingT, e interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1971,10 +1973,11 @@ func Positivef(t TestingT, e interface{}, msg string, args ...interface{}) {
 //
 // The rx (expression) argument should be a *regexp.Regexp. For backward
 // compatibility, if rx is any other type, its value will be formatted with
-// %v and compiled using regexp.MustCompile.
+// %v and compiled using regexp.Compile.
 //
-//	require.Regexp(t, regexp.MustCompile("start"), "it's starting")
-//	require.Regexp(t, "start...$", "it's not starting") // string is compiled
+// Examples:
+// 	require.Regexp(t, regexp.MustCompile("start"), "it's starting")
+// 	require.Regexp(t, "start...$", "it's not starting") // string is compiled
 func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -1989,10 +1992,11 @@ func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface
 //
 // The rx (expression) argument should be a *regexp.Regexp. For backward
 // compatibility, if rx is any other type, its value will be formatted with
-// %v and compiled using regexp.MustCompile.
+// %v and compiled using regexp.Compile.
 //
-//	require.Regexpf(t, regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
-//	require.Regexpf(t, "start...$", "it's not starting", "error message %s", "formatted") // string is compiled
+// Examples:
+// 	require.Regexpf(t, regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
+// 	require.Regexpf(t, "start...$", "it's not starting", "error message %s", "formatted") // string is compiled
 func Regexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2005,7 +2009,7 @@ func Regexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...in
 
 // Same asserts that two pointers reference the same object.
 //
-//	require.Same(t, ptr1, ptr2)
+// 	require.Same(t, ptr1, ptr2)
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
@@ -2021,7 +2025,7 @@ func Same(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...in
 
 // Samef asserts that two pointers reference the same object.
 //
-//	require.Samef(t, ptr1, ptr2, "error message %s", "formatted")
+// 	require.Samef(t, ptr1, ptr2, "error message %s", "formatted")
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
@@ -2040,10 +2044,10 @@ func Samef(t TestingT, expected interface{}, actual interface{}, msg string, arg
 // Map elements are key-value pairs unless compared with an array or slice where
 // only the map key is evaluated.
 //
-//	require.Subset(t, [1, 2, 3], [1, 2])
-//	require.Subset(t, {"x": 1, "y": 2}, {"x": 1})
-//	require.Subset(t, [1, 2, 3], {1: "one", 2: "two"})
-//	require.Subset(t, {"x": 1, "y": 2}, ["x"])
+// 	require.Subset(t, [1, 2, 3], [1, 2])
+// 	require.Subset(t, {"x": 1, "y": 2}, {"x": 1})
+// 	require.Subset(t, [1, 2, 3], {1: "one", 2: "two"})
+// 	require.Subset(t, {"x": 1, "y": 2}, ["x"])
 func Subset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2059,10 +2063,10 @@ func Subset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...inte
 // Map elements are key-value pairs unless compared with an array or slice where
 // only the map key is evaluated.
 //
-//	require.Subsetf(t, [1, 2, 3], [1, 2], "error message %s", "formatted")
-//	require.Subsetf(t, {"x": 1, "y": 2}, {"x": 1}, "error message %s", "formatted")
-//	require.Subsetf(t, [1, 2, 3], {1: "one", 2: "two"}, "error message %s", "formatted")
-//	require.Subsetf(t, {"x": 1, "y": 2}, ["x"], "error message %s", "formatted")
+// 	require.Subsetf(t, [1, 2, 3], [1, 2], "error message %s", "formatted")
+// 	require.Subsetf(t, {"x": 1, "y": 2}, {"x": 1}, "error message %s", "formatted")
+// 	require.Subsetf(t, [1, 2, 3], {1: "one", 2: "two"}, "error message %s", "formatted")
+// 	require.Subsetf(t, {"x": 1, "y": 2}, ["x"], "error message %s", "formatted")
 func Subsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2075,7 +2079,7 @@ func Subsetf(t TestingT, list interface{}, subset interface{}, msg string, args 
 
 // True asserts that the specified value is true.
 //
-//	require.True(t, myBool)
+// 	require.True(t, myBool)
 func True(t TestingT, value bool, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2088,7 +2092,7 @@ func True(t TestingT, value bool, msgAndArgs ...interface{}) {
 
 // Truef asserts that the specified value is true.
 //
-//	require.Truef(t, myBool, "error message %s", "formatted")
+// 	require.Truef(t, myBool, "error message %s", "formatted")
 func Truef(t TestingT, value bool, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2101,7 +2105,7 @@ func Truef(t TestingT, value bool, msg string, args ...interface{}) {
 
 // WithinDuration asserts that the two times are within duration delta of each other.
 //
-//	require.WithinDuration(t, time.Now(), time.Now(), 10*time.Second)
+// 	require.WithinDuration(t, time.Now(), time.Now(), 10*time.Second)
 func WithinDuration(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2114,7 +2118,7 @@ func WithinDuration(t TestingT, expected time.Time, actual time.Time, delta time
 
 // WithinDurationf asserts that the two times are within duration delta of each other.
 //
-//	require.WithinDurationf(t, time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
+// 	require.WithinDurationf(t, time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
 func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2127,7 +2131,7 @@ func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta tim
 
 // WithinRange asserts that a time is within a time range (inclusive).
 //
-//	require.WithinRange(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second))
+// 	require.WithinRange(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second))
 func WithinRange(t TestingT, actual time.Time, start time.Time, end time.Time, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2140,7 +2144,7 @@ func WithinRange(t TestingT, actual time.Time, start time.Time, end time.Time, m
 
 // WithinRangef asserts that a time is within a time range (inclusive).
 //
-//	require.WithinRangef(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second), "error message %s", "formatted")
+// 	require.WithinRangef(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second), "error message %s", "formatted")
 func WithinRangef(t TestingT, actual time.Time, start time.Time, end time.Time, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2153,17 +2157,17 @@ func WithinRangef(t TestingT, actual time.Time, start time.Time, end time.Time, 
 
 // YAMLEq asserts that the first documents in the two YAML strings are equivalent.
 //
-//	expected := `---
-//	key: value
-//	---
-//	key: this is a second document, it is not evaluated
-//	`
-//	actual := `---
-//	key: value
-//	---
-//	key: this is a subsequent document, it is not evaluated
-//	`
-//	require.YAMLEq(t, expected, actual)
+// 	expected := `---
+// 	key: value
+// 	---
+// 	key: this is a second document, it is not evaluated
+// 	`
+// 	actual := `---
+// 	key: value
+// 	---
+// 	key: this is a subsequent document, it is not evaluated
+// 	`
+// 	require.YAMLEq(t, expected, actual)
 func YAMLEq(t TestingT, expected string, actual string, msgAndArgs ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
@@ -2176,17 +2180,17 @@ func YAMLEq(t TestingT, expected string, actual string, msgAndArgs ...interface{
 
 // YAMLEqf asserts that the first documents in the two YAML strings are equivalent.
 //
-//	expected := `---
-//	key: value
-//	---
-//	key: this is a second document, it is not evaluated
-//	`
-//	actual := `---
-//	key: value
-//	---
-//	key: this is a subsequent document, it is not evaluated
-//	`
-//	require.YAMLEqf(t, expected, actual, "error message %s", "formatted")
+// 	expected := `---
+// 	key: value
+// 	---
+// 	key: this is a second document, it is not evaluated
+// 	`
+// 	actual := `---
+// 	key: value
+// 	---
+// 	key: this is a subsequent document, it is not evaluated
+// 	`
+// 	require.YAMLEqf(t, expected, actual, "error message %s", "formatted")
 func YAMLEqf(t TestingT, expected string, actual string, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()

--- a/require/require_forward.go
+++ b/require/require_forward.go
@@ -1369,8 +1369,12 @@ func (a *Assertions) NotPanicsf(f assert.PanicTestFunc, msg string, args ...inte
 
 // NotRegexp asserts that a specified regexp does not match a string.
 //
+// The rx (expression) argument should be a *regexp.Regexp. For backward
+// compatibility, if rx is any other type, its value will be formatted with
+// %v and compiled using regexp.MustCompile.
+//
 //	a.NotRegexp(regexp.MustCompile("starts"), "it's starting")
-//	a.NotRegexp("^start", "it's not starting")
+//	a.NotRegexp("^start", "it's not starting") // string is compiled
 func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1380,8 +1384,12 @@ func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...in
 
 // NotRegexpf asserts that a specified regexp does not match a string.
 //
+// The rx (expression) argument should be a *regexp.Regexp. For backward
+// compatibility, if rx is any other type, its value will be formatted with
+// %v and compiled using regexp.MustCompile.
+//
 //	a.NotRegexpf(regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
-//	a.NotRegexpf("^start", "it's not starting", "error message %s", "formatted")
+//	a.NotRegexpf("^start", "it's not starting", "error message %s", "formatted") // string is compiled
 func (a *Assertions) NotRegexpf(rx interface{}, str interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1553,8 +1561,12 @@ func (a *Assertions) Positivef(e interface{}, msg string, args ...interface{}) {
 
 // Regexp asserts that a specified regexp matches a string.
 //
+// The rx (expression) argument should be a *regexp.Regexp. For backward
+// compatibility, if rx is any other type, its value will be formatted with
+// %v and compiled using regexp.MustCompile.
+//
 //	a.Regexp(regexp.MustCompile("start"), "it's starting")
-//	a.Regexp("start...$", "it's not starting")
+//	a.Regexp("start...$", "it's not starting") // string is compiled
 func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1564,8 +1576,12 @@ func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...inter
 
 // Regexpf asserts that a specified regexp matches a string.
 //
+// The rx (expression) argument should be a *regexp.Regexp. For backward
+// compatibility, if rx is any other type, its value will be formatted with
+// %v and compiled using regexp.MustCompile.
+//
 //	a.Regexpf(regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
-//	a.Regexpf("start...$", "it's not starting", "error message %s", "formatted")
+//	a.Regexpf("start...$", "it's not starting", "error message %s", "formatted") // string is compiled
 func (a *Assertions) Regexpf(rx interface{}, str interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()

--- a/require/require_forward.go
+++ b/require/require_forward.go
@@ -28,9 +28,9 @@ func (a *Assertions) Conditionf(comp assert.Comparison, msg string, args ...inte
 // Contains asserts that the specified string, list(array, slice...) or map contains the
 // specified substring or element.
 //
-//	a.Contains("Hello World", "World")
-//	a.Contains(["Hello", "World"], "World")
-//	a.Contains({"Hello": "World"}, "Hello")
+// 	a.Contains("Hello World", "World")
+// 	a.Contains(["Hello", "World"], "World")
+// 	a.Contains({"Hello": "World"}, "Hello")
 func (a *Assertions) Contains(s interface{}, contains interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -41,9 +41,9 @@ func (a *Assertions) Contains(s interface{}, contains interface{}, msgAndArgs ..
 // Containsf asserts that the specified string, list(array, slice...) or map contains the
 // specified substring or element.
 //
-//	a.Containsf("Hello World", "World", "error message %s", "formatted")
-//	a.Containsf(["Hello", "World"], "World", "error message %s", "formatted")
-//	a.Containsf({"Hello": "World"}, "Hello", "error message %s", "formatted")
+// 	a.Containsf("Hello World", "World", "error message %s", "formatted")
+// 	a.Containsf(["Hello", "World"], "World", "error message %s", "formatted")
+// 	a.Containsf({"Hello": "World"}, "Hello", "error message %s", "formatted")
 func (a *Assertions) Containsf(s interface{}, contains interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -103,7 +103,7 @@ func (a *Assertions) ElementsMatchf(listA interface{}, listB interface{}, msg st
 //
 // Pointer values are "empty" if the pointer is nil or if the pointed value is "empty".
 //
-//	a.Empty(obj)
+// 	a.Empty(obj)
 //
 // [Zero values]: https://go.dev/ref/spec#The_zero_value
 func (a *Assertions) Empty(object interface{}, msgAndArgs ...interface{}) {
@@ -123,7 +123,7 @@ func (a *Assertions) Empty(object interface{}, msgAndArgs ...interface{}) {
 //
 // Pointer values are "empty" if the pointer is nil or if the pointed value is "empty".
 //
-//	a.Emptyf(obj, "error message %s", "formatted")
+// 	a.Emptyf(obj, "error message %s", "formatted")
 //
 // [Zero values]: https://go.dev/ref/spec#The_zero_value
 func (a *Assertions) Emptyf(object interface{}, msg string, args ...interface{}) {
@@ -135,7 +135,7 @@ func (a *Assertions) Emptyf(object interface{}, msg string, args ...interface{})
 
 // Equal asserts that two objects are equal.
 //
-//	a.Equal(123, 123)
+// 	a.Equal(123, 123)
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses). Function equality
@@ -150,8 +150,8 @@ func (a *Assertions) Equal(expected interface{}, actual interface{}, msgAndArgs 
 // EqualError asserts that a function returned a non-nil error (i.e. an error)
 // and that it is equal to the provided error.
 //
-//	actualObj, err := SomeFunction()
-//	a.EqualError(err,  expectedErrorString)
+// 	actualObj, err := SomeFunction()
+// 	a.EqualError(err,  expectedErrorString)
 func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -162,8 +162,8 @@ func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...
 // EqualErrorf asserts that a function returned a non-nil error (i.e. an error)
 // and that it is equal to the provided error.
 //
-//	actualObj, err := SomeFunction()
-//	a.EqualErrorf(err,  expectedErrorString, "error message %s", "formatted")
+// 	actualObj, err := SomeFunction()
+// 	a.EqualErrorf(err,  expectedErrorString, "error message %s", "formatted")
 func (a *Assertions) EqualErrorf(theError error, errString string, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -175,12 +175,12 @@ func (a *Assertions) EqualErrorf(theError error, errString string, msg string, a
 // fields are also equal. This is useful for comparing structs that have private fields
 // that could potentially differ.
 //
-//	 type S struct {
-//		Exported     	int
-//		notExported   	int
-//	 }
-//	 a.EqualExportedValues(S{1, 2}, S{1, 3}) => true
-//	 a.EqualExportedValues(S{1, 2}, S{2, 3}) => false
+// 	 type S struct {
+// 		Exported     	int
+// 		notExported   	int
+// 	 }
+// 	 a.EqualExportedValues(S{1, 2}, S{1, 3}) => true
+// 	 a.EqualExportedValues(S{1, 2}, S{2, 3}) => false
 func (a *Assertions) EqualExportedValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -192,12 +192,12 @@ func (a *Assertions) EqualExportedValues(expected interface{}, actual interface{
 // fields are also equal. This is useful for comparing structs that have private fields
 // that could potentially differ.
 //
-//	 type S struct {
-//		Exported     	int
-//		notExported   	int
-//	 }
-//	 a.EqualExportedValuesf(S{1, 2}, S{1, 3}, "error message %s", "formatted") => true
-//	 a.EqualExportedValuesf(S{1, 2}, S{2, 3}, "error message %s", "formatted") => false
+// 	 type S struct {
+// 		Exported     	int
+// 		notExported   	int
+// 	 }
+// 	 a.EqualExportedValuesf(S{1, 2}, S{1, 3}, "error message %s", "formatted") => true
+// 	 a.EqualExportedValuesf(S{1, 2}, S{2, 3}, "error message %s", "formatted") => false
 func (a *Assertions) EqualExportedValuesf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -208,7 +208,7 @@ func (a *Assertions) EqualExportedValuesf(expected interface{}, actual interface
 // EqualValues asserts that two objects are equal or convertible to the larger
 // type and equal.
 //
-//	a.EqualValues(uint32(123), int32(123))
+// 	a.EqualValues(uint32(123), int32(123))
 func (a *Assertions) EqualValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -219,7 +219,7 @@ func (a *Assertions) EqualValues(expected interface{}, actual interface{}, msgAn
 // EqualValuesf asserts that two objects are equal or convertible to the larger
 // type and equal.
 //
-//	a.EqualValuesf(uint32(123), int32(123), "error message %s", "formatted")
+// 	a.EqualValuesf(uint32(123), int32(123), "error message %s", "formatted")
 func (a *Assertions) EqualValuesf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -229,7 +229,7 @@ func (a *Assertions) EqualValuesf(expected interface{}, actual interface{}, msg 
 
 // Equalf asserts that two objects are equal.
 //
-//	a.Equalf(123, 123, "error message %s", "formatted")
+// 	a.Equalf(123, 123, "error message %s", "formatted")
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses). Function equality
@@ -243,8 +243,8 @@ func (a *Assertions) Equalf(expected interface{}, actual interface{}, msg string
 
 // Error asserts that a function returned a non-nil error (ie. an error).
 //
-//	actualObj, err := SomeFunction()
-//	a.Error(err)
+// 	actualObj, err := SomeFunction()
+// 	a.Error(err)
 func (a *Assertions) Error(err error, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -273,8 +273,8 @@ func (a *Assertions) ErrorAsf(err error, target interface{}, msg string, args ..
 // ErrorContains asserts that a function returned a non-nil error (i.e. an
 // error) and that the error contains the specified substring.
 //
-//	actualObj, err := SomeFunction()
-//	a.ErrorContains(err,  expectedErrorSubString)
+// 	actualObj, err := SomeFunction()
+// 	a.ErrorContains(err,  expectedErrorSubString)
 func (a *Assertions) ErrorContains(theError error, contains string, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -285,8 +285,8 @@ func (a *Assertions) ErrorContains(theError error, contains string, msgAndArgs .
 // ErrorContainsf asserts that a function returned a non-nil error (i.e. an
 // error) and that the error contains the specified substring.
 //
-//	actualObj, err := SomeFunction()
-//	a.ErrorContainsf(err,  expectedErrorSubString, "error message %s", "formatted")
+// 	actualObj, err := SomeFunction()
+// 	a.ErrorContainsf(err,  expectedErrorSubString, "error message %s", "formatted")
 func (a *Assertions) ErrorContainsf(theError error, contains string, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -314,8 +314,8 @@ func (a *Assertions) ErrorIsf(err error, target error, msg string, args ...inter
 
 // Errorf asserts that a function returned a non-nil error (ie. an error).
 //
-//	actualObj, err := SomeFunction()
-//	a.Errorf(err, "error message %s", "formatted")
+// 	actualObj, err := SomeFunction()
+// 	a.Errorf(err, "error message %s", "formatted")
 func (a *Assertions) Errorf(err error, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -326,7 +326,7 @@ func (a *Assertions) Errorf(err error, msg string, args ...interface{}) {
 // Eventually asserts that given condition will be met in waitFor time,
 // periodically checking target function each tick.
 //
-//	a.Eventually(func() bool { return true; }, time.Second, 10*time.Millisecond)
+// 	a.Eventually(func() bool { return true; }, time.Second, 10*time.Millisecond)
 func (a *Assertions) Eventually(condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -343,15 +343,15 @@ func (a *Assertions) Eventually(condition func() bool, waitFor time.Duration, ti
 // If the condition is not met before waitFor, the collected errors of
 // the last tick are copied to t.
 //
-//	externalValue := false
-//	go func() {
-//		time.Sleep(8*time.Second)
-//		externalValue = true
-//	}()
-//	a.EventuallyWithT(func(c *assert.CollectT) {
-//		// add assertions as needed; any assertion failure will fail the current tick
-//		assert.True(c, externalValue, "expected 'externalValue' to be true")
-//	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
+// 	externalValue := false
+// 	go func() {
+// 		time.Sleep(8*time.Second)
+// 		externalValue = true
+// 	}()
+// 	a.EventuallyWithT(func(c *assert.CollectT) {
+// 		// add assertions as needed; any assertion failure will fail the current tick
+// 		assert.True(c, externalValue, "expected 'externalValue' to be true")
+// 	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
 func (a *Assertions) EventuallyWithT(condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -368,15 +368,15 @@ func (a *Assertions) EventuallyWithT(condition func(collect *assert.CollectT), w
 // If the condition is not met before waitFor, the collected errors of
 // the last tick are copied to t.
 //
-//	externalValue := false
-//	go func() {
-//		time.Sleep(8*time.Second)
-//		externalValue = true
-//	}()
-//	a.EventuallyWithTf(func(c *assert.CollectT, "error message %s", "formatted") {
-//		// add assertions as needed; any assertion failure will fail the current tick
-//		assert.True(c, externalValue, "expected 'externalValue' to be true")
-//	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
+// 	externalValue := false
+// 	go func() {
+// 		time.Sleep(8*time.Second)
+// 		externalValue = true
+// 	}()
+// 	a.EventuallyWithTf(func(c *assert.CollectT, "error message %s", "formatted") {
+// 		// add assertions as needed; any assertion failure will fail the current tick
+// 		assert.True(c, externalValue, "expected 'externalValue' to be true")
+// 	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
 func (a *Assertions) EventuallyWithTf(condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -387,7 +387,7 @@ func (a *Assertions) EventuallyWithTf(condition func(collect *assert.CollectT), 
 // Eventuallyf asserts that given condition will be met in waitFor time,
 // periodically checking target function each tick.
 //
-//	a.Eventuallyf(func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+// 	a.Eventuallyf(func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
 func (a *Assertions) Eventuallyf(condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -397,7 +397,7 @@ func (a *Assertions) Eventuallyf(condition func() bool, waitFor time.Duration, t
 
 // Exactly asserts that two objects are equal in value and type.
 //
-//	a.Exactly(int32(123), int64(123))
+// 	a.Exactly(int32(123), int64(123))
 func (a *Assertions) Exactly(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -407,7 +407,7 @@ func (a *Assertions) Exactly(expected interface{}, actual interface{}, msgAndArg
 
 // Exactlyf asserts that two objects are equal in value and type.
 //
-//	a.Exactlyf(int32(123), int64(123), "error message %s", "formatted")
+// 	a.Exactlyf(int32(123), int64(123), "error message %s", "formatted")
 func (a *Assertions) Exactlyf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -449,7 +449,7 @@ func (a *Assertions) Failf(failureMessage string, msg string, args ...interface{
 
 // False asserts that the specified value is false.
 //
-//	a.False(myBool)
+// 	a.False(myBool)
 func (a *Assertions) False(value bool, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -459,7 +459,7 @@ func (a *Assertions) False(value bool, msgAndArgs ...interface{}) {
 
 // Falsef asserts that the specified value is false.
 //
-//	a.Falsef(myBool, "error message %s", "formatted")
+// 	a.Falsef(myBool, "error message %s", "formatted")
 func (a *Assertions) Falsef(value bool, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -487,9 +487,9 @@ func (a *Assertions) FileExistsf(path string, msg string, args ...interface{}) {
 
 // Greater asserts that the first element is greater than the second
 //
-//	a.Greater(2, 1)
-//	a.Greater(float64(2), float64(1))
-//	a.Greater("b", "a")
+// 	a.Greater(2, 1)
+// 	a.Greater(float64(2), float64(1))
+// 	a.Greater("b", "a")
 func (a *Assertions) Greater(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -499,10 +499,10 @@ func (a *Assertions) Greater(e1 interface{}, e2 interface{}, msgAndArgs ...inter
 
 // GreaterOrEqual asserts that the first element is greater than or equal to the second
 //
-//	a.GreaterOrEqual(2, 1)
-//	a.GreaterOrEqual(2, 2)
-//	a.GreaterOrEqual("b", "a")
-//	a.GreaterOrEqual("b", "b")
+// 	a.GreaterOrEqual(2, 1)
+// 	a.GreaterOrEqual(2, 2)
+// 	a.GreaterOrEqual("b", "a")
+// 	a.GreaterOrEqual("b", "b")
 func (a *Assertions) GreaterOrEqual(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -512,10 +512,10 @@ func (a *Assertions) GreaterOrEqual(e1 interface{}, e2 interface{}, msgAndArgs .
 
 // GreaterOrEqualf asserts that the first element is greater than or equal to the second
 //
-//	a.GreaterOrEqualf(2, 1, "error message %s", "formatted")
-//	a.GreaterOrEqualf(2, 2, "error message %s", "formatted")
-//	a.GreaterOrEqualf("b", "a", "error message %s", "formatted")
-//	a.GreaterOrEqualf("b", "b", "error message %s", "formatted")
+// 	a.GreaterOrEqualf(2, 1, "error message %s", "formatted")
+// 	a.GreaterOrEqualf(2, 2, "error message %s", "formatted")
+// 	a.GreaterOrEqualf("b", "a", "error message %s", "formatted")
+// 	a.GreaterOrEqualf("b", "b", "error message %s", "formatted")
 func (a *Assertions) GreaterOrEqualf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -525,9 +525,9 @@ func (a *Assertions) GreaterOrEqualf(e1 interface{}, e2 interface{}, msg string,
 
 // Greaterf asserts that the first element is greater than the second
 //
-//	a.Greaterf(2, 1, "error message %s", "formatted")
-//	a.Greaterf(float64(2), float64(1), "error message %s", "formatted")
-//	a.Greaterf("b", "a", "error message %s", "formatted")
+// 	a.Greaterf(2, 1, "error message %s", "formatted")
+// 	a.Greaterf(float64(2), float64(1), "error message %s", "formatted")
+// 	a.Greaterf("b", "a", "error message %s", "formatted")
 func (a *Assertions) Greaterf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -538,7 +538,7 @@ func (a *Assertions) Greaterf(e1 interface{}, e2 interface{}, msg string, args .
 // HTTPBodyContains asserts that a specified handler returns a
 // body that contains a string.
 //
-//	a.HTTPBodyContains(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
+// 	a.HTTPBodyContains(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPBodyContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
@@ -551,7 +551,7 @@ func (a *Assertions) HTTPBodyContains(handler http.HandlerFunc, method string, u
 // HTTPBodyContainsf asserts that a specified handler returns a
 // body that contains a string.
 //
-//	a.HTTPBodyContainsf(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+// 	a.HTTPBodyContainsf(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPBodyContainsf(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
@@ -564,7 +564,7 @@ func (a *Assertions) HTTPBodyContainsf(handler http.HandlerFunc, method string, 
 // HTTPBodyNotContains asserts that a specified handler returns a
 // body that does not contain a string.
 //
-//	a.HTTPBodyNotContains(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
+// 	a.HTTPBodyNotContains(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPBodyNotContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
@@ -577,7 +577,7 @@ func (a *Assertions) HTTPBodyNotContains(handler http.HandlerFunc, method string
 // HTTPBodyNotContainsf asserts that a specified handler returns a
 // body that does not contain a string.
 //
-//	a.HTTPBodyNotContainsf(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+// 	a.HTTPBodyNotContainsf(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPBodyNotContainsf(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
@@ -589,7 +589,7 @@ func (a *Assertions) HTTPBodyNotContainsf(handler http.HandlerFunc, method strin
 
 // HTTPError asserts that a specified handler returns an error status code.
 //
-//	a.HTTPError(myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+// 	a.HTTPError(myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPError(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
@@ -601,7 +601,7 @@ func (a *Assertions) HTTPError(handler http.HandlerFunc, method string, url stri
 
 // HTTPErrorf asserts that a specified handler returns an error status code.
 //
-//	a.HTTPErrorf(myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+// 	a.HTTPErrorf(myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPErrorf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
@@ -613,7 +613,7 @@ func (a *Assertions) HTTPErrorf(handler http.HandlerFunc, method string, url str
 
 // HTTPRedirect asserts that a specified handler returns a redirect status code.
 //
-//	a.HTTPRedirect(myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+// 	a.HTTPRedirect(myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPRedirect(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
@@ -625,7 +625,7 @@ func (a *Assertions) HTTPRedirect(handler http.HandlerFunc, method string, url s
 
 // HTTPRedirectf asserts that a specified handler returns a redirect status code.
 //
-//	a.HTTPRedirectf(myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+// 	a.HTTPRedirectf(myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPRedirectf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
@@ -637,7 +637,7 @@ func (a *Assertions) HTTPRedirectf(handler http.HandlerFunc, method string, url 
 
 // HTTPStatusCode asserts that a specified handler returns a specified status code.
 //
-//	a.HTTPStatusCode(myHandler, "GET", "/notImplemented", nil, 501)
+// 	a.HTTPStatusCode(myHandler, "GET", "/notImplemented", nil, 501)
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPStatusCode(handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msgAndArgs ...interface{}) {
@@ -649,7 +649,7 @@ func (a *Assertions) HTTPStatusCode(handler http.HandlerFunc, method string, url
 
 // HTTPStatusCodef asserts that a specified handler returns a specified status code.
 //
-//	a.HTTPStatusCodef(myHandler, "GET", "/notImplemented", nil, 501, "error message %s", "formatted")
+// 	a.HTTPStatusCodef(myHandler, "GET", "/notImplemented", nil, 501, "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPStatusCodef(handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msg string, args ...interface{}) {
@@ -661,7 +661,7 @@ func (a *Assertions) HTTPStatusCodef(handler http.HandlerFunc, method string, ur
 
 // HTTPSuccess asserts that a specified handler returns a success status code.
 //
-//	a.HTTPSuccess(myHandler, "POST", "http://www.google.com", nil)
+// 	a.HTTPSuccess(myHandler, "POST", "http://www.google.com", nil)
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPSuccess(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
@@ -673,7 +673,7 @@ func (a *Assertions) HTTPSuccess(handler http.HandlerFunc, method string, url st
 
 // HTTPSuccessf asserts that a specified handler returns a success status code.
 //
-//	a.HTTPSuccessf(myHandler, "POST", "http://www.google.com", nil, "error message %s", "formatted")
+// 	a.HTTPSuccessf(myHandler, "POST", "http://www.google.com", nil, "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPSuccessf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
@@ -685,7 +685,7 @@ func (a *Assertions) HTTPSuccessf(handler http.HandlerFunc, method string, url s
 
 // Implements asserts that an object is implemented by the specified interface.
 //
-//	a.Implements((*MyInterface)(nil), new(MyObject))
+// 	a.Implements((*MyInterface)(nil), new(MyObject))
 func (a *Assertions) Implements(interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -695,7 +695,7 @@ func (a *Assertions) Implements(interfaceObject interface{}, object interface{},
 
 // Implementsf asserts that an object is implemented by the specified interface.
 //
-//	a.Implementsf((*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
+// 	a.Implementsf((*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
 func (a *Assertions) Implementsf(interfaceObject interface{}, object interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -705,7 +705,7 @@ func (a *Assertions) Implementsf(interfaceObject interface{}, object interface{}
 
 // InDelta asserts that the two numerals are within delta of each other.
 //
-//	a.InDelta(math.Pi, 22/7.0, 0.01)
+// 	a.InDelta(math.Pi, 22/7.0, 0.01)
 func (a *Assertions) InDelta(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -747,7 +747,7 @@ func (a *Assertions) InDeltaSlicef(expected interface{}, actual interface{}, del
 
 // InDeltaf asserts that the two numerals are within delta of each other.
 //
-//	a.InDeltaf(math.Pi, 22/7.0, 0.01, "error message %s", "formatted")
+// 	a.InDeltaf(math.Pi, 22/7.0, 0.01, "error message %s", "formatted")
 func (a *Assertions) InDeltaf(expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -789,9 +789,9 @@ func (a *Assertions) InEpsilonf(expected interface{}, actual interface{}, epsilo
 
 // IsDecreasing asserts that the collection is decreasing
 //
-//	a.IsDecreasing([]int{2, 1, 0})
-//	a.IsDecreasing([]float{2, 1})
-//	a.IsDecreasing([]string{"b", "a"})
+// 	a.IsDecreasing([]int{2, 1, 0})
+// 	a.IsDecreasing([]float{2, 1})
+// 	a.IsDecreasing([]string{"b", "a"})
 func (a *Assertions) IsDecreasing(object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -801,9 +801,9 @@ func (a *Assertions) IsDecreasing(object interface{}, msgAndArgs ...interface{})
 
 // IsDecreasingf asserts that the collection is decreasing
 //
-//	a.IsDecreasingf([]int{2, 1, 0}, "error message %s", "formatted")
-//	a.IsDecreasingf([]float{2, 1}, "error message %s", "formatted")
-//	a.IsDecreasingf([]string{"b", "a"}, "error message %s", "formatted")
+// 	a.IsDecreasingf([]int{2, 1, 0}, "error message %s", "formatted")
+// 	a.IsDecreasingf([]float{2, 1}, "error message %s", "formatted")
+// 	a.IsDecreasingf([]string{"b", "a"}, "error message %s", "formatted")
 func (a *Assertions) IsDecreasingf(object interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -813,9 +813,9 @@ func (a *Assertions) IsDecreasingf(object interface{}, msg string, args ...inter
 
 // IsIncreasing asserts that the collection is increasing
 //
-//	a.IsIncreasing([]int{1, 2, 3})
-//	a.IsIncreasing([]float{1, 2})
-//	a.IsIncreasing([]string{"a", "b"})
+// 	a.IsIncreasing([]int{1, 2, 3})
+// 	a.IsIncreasing([]float{1, 2})
+// 	a.IsIncreasing([]string{"a", "b"})
 func (a *Assertions) IsIncreasing(object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -825,9 +825,9 @@ func (a *Assertions) IsIncreasing(object interface{}, msgAndArgs ...interface{})
 
 // IsIncreasingf asserts that the collection is increasing
 //
-//	a.IsIncreasingf([]int{1, 2, 3}, "error message %s", "formatted")
-//	a.IsIncreasingf([]float{1, 2}, "error message %s", "formatted")
-//	a.IsIncreasingf([]string{"a", "b"}, "error message %s", "formatted")
+// 	a.IsIncreasingf([]int{1, 2, 3}, "error message %s", "formatted")
+// 	a.IsIncreasingf([]float{1, 2}, "error message %s", "formatted")
+// 	a.IsIncreasingf([]string{"a", "b"}, "error message %s", "formatted")
 func (a *Assertions) IsIncreasingf(object interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -837,9 +837,9 @@ func (a *Assertions) IsIncreasingf(object interface{}, msg string, args ...inter
 
 // IsNonDecreasing asserts that the collection is not decreasing
 //
-//	a.IsNonDecreasing([]int{1, 1, 2})
-//	a.IsNonDecreasing([]float{1, 2})
-//	a.IsNonDecreasing([]string{"a", "b"})
+// 	a.IsNonDecreasing([]int{1, 1, 2})
+// 	a.IsNonDecreasing([]float{1, 2})
+// 	a.IsNonDecreasing([]string{"a", "b"})
 func (a *Assertions) IsNonDecreasing(object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -849,9 +849,9 @@ func (a *Assertions) IsNonDecreasing(object interface{}, msgAndArgs ...interface
 
 // IsNonDecreasingf asserts that the collection is not decreasing
 //
-//	a.IsNonDecreasingf([]int{1, 1, 2}, "error message %s", "formatted")
-//	a.IsNonDecreasingf([]float{1, 2}, "error message %s", "formatted")
-//	a.IsNonDecreasingf([]string{"a", "b"}, "error message %s", "formatted")
+// 	a.IsNonDecreasingf([]int{1, 1, 2}, "error message %s", "formatted")
+// 	a.IsNonDecreasingf([]float{1, 2}, "error message %s", "formatted")
+// 	a.IsNonDecreasingf([]string{"a", "b"}, "error message %s", "formatted")
 func (a *Assertions) IsNonDecreasingf(object interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -861,9 +861,9 @@ func (a *Assertions) IsNonDecreasingf(object interface{}, msg string, args ...in
 
 // IsNonIncreasing asserts that the collection is not increasing
 //
-//	a.IsNonIncreasing([]int{2, 1, 1})
-//	a.IsNonIncreasing([]float{2, 1})
-//	a.IsNonIncreasing([]string{"b", "a"})
+// 	a.IsNonIncreasing([]int{2, 1, 1})
+// 	a.IsNonIncreasing([]float{2, 1})
+// 	a.IsNonIncreasing([]string{"b", "a"})
 func (a *Assertions) IsNonIncreasing(object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -873,9 +873,9 @@ func (a *Assertions) IsNonIncreasing(object interface{}, msgAndArgs ...interface
 
 // IsNonIncreasingf asserts that the collection is not increasing
 //
-//	a.IsNonIncreasingf([]int{2, 1, 1}, "error message %s", "formatted")
-//	a.IsNonIncreasingf([]float{2, 1}, "error message %s", "formatted")
-//	a.IsNonIncreasingf([]string{"b", "a"}, "error message %s", "formatted")
+// 	a.IsNonIncreasingf([]int{2, 1, 1}, "error message %s", "formatted")
+// 	a.IsNonIncreasingf([]float{2, 1}, "error message %s", "formatted")
+// 	a.IsNonIncreasingf([]string{"b", "a"}, "error message %s", "formatted")
 func (a *Assertions) IsNonIncreasingf(object interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -885,7 +885,7 @@ func (a *Assertions) IsNonIncreasingf(object interface{}, msg string, args ...in
 
 // IsNotType asserts that the specified objects are not of the same type.
 //
-//	a.IsNotType(&NotMyStruct{}, &MyStruct{})
+// 	a.IsNotType(&NotMyStruct{}, &MyStruct{})
 func (a *Assertions) IsNotType(theType interface{}, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -895,7 +895,7 @@ func (a *Assertions) IsNotType(theType interface{}, object interface{}, msgAndAr
 
 // IsNotTypef asserts that the specified objects are not of the same type.
 //
-//	a.IsNotTypef(&NotMyStruct{}, &MyStruct{}, "error message %s", "formatted")
+// 	a.IsNotTypef(&NotMyStruct{}, &MyStruct{}, "error message %s", "formatted")
 func (a *Assertions) IsNotTypef(theType interface{}, object interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -905,7 +905,7 @@ func (a *Assertions) IsNotTypef(theType interface{}, object interface{}, msg str
 
 // IsType asserts that the specified objects are of the same type.
 //
-//	a.IsType(&MyStruct{}, &MyStruct{})
+// 	a.IsType(&MyStruct{}, &MyStruct{})
 func (a *Assertions) IsType(expectedType interface{}, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -915,7 +915,7 @@ func (a *Assertions) IsType(expectedType interface{}, object interface{}, msgAnd
 
 // IsTypef asserts that the specified objects are of the same type.
 //
-//	a.IsTypef(&MyStruct{}, &MyStruct{}, "error message %s", "formatted")
+// 	a.IsTypef(&MyStruct{}, &MyStruct{}, "error message %s", "formatted")
 func (a *Assertions) IsTypef(expectedType interface{}, object interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -925,7 +925,7 @@ func (a *Assertions) IsTypef(expectedType interface{}, object interface{}, msg s
 
 // JSONEq asserts that two JSON strings are equivalent.
 //
-//	a.JSONEq(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
+// 	a.JSONEq(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
 func (a *Assertions) JSONEq(expected string, actual string, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -935,7 +935,7 @@ func (a *Assertions) JSONEq(expected string, actual string, msgAndArgs ...interf
 
 // JSONEqf asserts that two JSON strings are equivalent.
 //
-//	a.JSONEqf(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
+// 	a.JSONEqf(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
 func (a *Assertions) JSONEqf(expected string, actual string, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -946,7 +946,7 @@ func (a *Assertions) JSONEqf(expected string, actual string, msg string, args ..
 // Len asserts that the specified object has specific length.
 // Len also fails if the object has a type that len() not accept.
 //
-//	a.Len(mySlice, 3)
+// 	a.Len(mySlice, 3)
 func (a *Assertions) Len(object interface{}, length int, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -957,7 +957,7 @@ func (a *Assertions) Len(object interface{}, length int, msgAndArgs ...interface
 // Lenf asserts that the specified object has specific length.
 // Lenf also fails if the object has a type that len() not accept.
 //
-//	a.Lenf(mySlice, 3, "error message %s", "formatted")
+// 	a.Lenf(mySlice, 3, "error message %s", "formatted")
 func (a *Assertions) Lenf(object interface{}, length int, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -967,9 +967,9 @@ func (a *Assertions) Lenf(object interface{}, length int, msg string, args ...in
 
 // Less asserts that the first element is less than the second
 //
-//	a.Less(1, 2)
-//	a.Less(float64(1), float64(2))
-//	a.Less("a", "b")
+// 	a.Less(1, 2)
+// 	a.Less(float64(1), float64(2))
+// 	a.Less("a", "b")
 func (a *Assertions) Less(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -979,10 +979,10 @@ func (a *Assertions) Less(e1 interface{}, e2 interface{}, msgAndArgs ...interfac
 
 // LessOrEqual asserts that the first element is less than or equal to the second
 //
-//	a.LessOrEqual(1, 2)
-//	a.LessOrEqual(2, 2)
-//	a.LessOrEqual("a", "b")
-//	a.LessOrEqual("b", "b")
+// 	a.LessOrEqual(1, 2)
+// 	a.LessOrEqual(2, 2)
+// 	a.LessOrEqual("a", "b")
+// 	a.LessOrEqual("b", "b")
 func (a *Assertions) LessOrEqual(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -992,10 +992,10 @@ func (a *Assertions) LessOrEqual(e1 interface{}, e2 interface{}, msgAndArgs ...i
 
 // LessOrEqualf asserts that the first element is less than or equal to the second
 //
-//	a.LessOrEqualf(1, 2, "error message %s", "formatted")
-//	a.LessOrEqualf(2, 2, "error message %s", "formatted")
-//	a.LessOrEqualf("a", "b", "error message %s", "formatted")
-//	a.LessOrEqualf("b", "b", "error message %s", "formatted")
+// 	a.LessOrEqualf(1, 2, "error message %s", "formatted")
+// 	a.LessOrEqualf(2, 2, "error message %s", "formatted")
+// 	a.LessOrEqualf("a", "b", "error message %s", "formatted")
+// 	a.LessOrEqualf("b", "b", "error message %s", "formatted")
 func (a *Assertions) LessOrEqualf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1005,9 +1005,9 @@ func (a *Assertions) LessOrEqualf(e1 interface{}, e2 interface{}, msg string, ar
 
 // Lessf asserts that the first element is less than the second
 //
-//	a.Lessf(1, 2, "error message %s", "formatted")
-//	a.Lessf(float64(1), float64(2), "error message %s", "formatted")
-//	a.Lessf("a", "b", "error message %s", "formatted")
+// 	a.Lessf(1, 2, "error message %s", "formatted")
+// 	a.Lessf(float64(1), float64(2), "error message %s", "formatted")
+// 	a.Lessf("a", "b", "error message %s", "formatted")
 func (a *Assertions) Lessf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1017,8 +1017,8 @@ func (a *Assertions) Lessf(e1 interface{}, e2 interface{}, msg string, args ...i
 
 // Negative asserts that the specified element is negative
 //
-//	a.Negative(-1)
-//	a.Negative(-1.23)
+// 	a.Negative(-1)
+// 	a.Negative(-1.23)
 func (a *Assertions) Negative(e interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1028,8 +1028,8 @@ func (a *Assertions) Negative(e interface{}, msgAndArgs ...interface{}) {
 
 // Negativef asserts that the specified element is negative
 //
-//	a.Negativef(-1, "error message %s", "formatted")
-//	a.Negativef(-1.23, "error message %s", "formatted")
+// 	a.Negativef(-1, "error message %s", "formatted")
+// 	a.Negativef(-1.23, "error message %s", "formatted")
 func (a *Assertions) Negativef(e interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1040,7 +1040,7 @@ func (a *Assertions) Negativef(e interface{}, msg string, args ...interface{}) {
 // Never asserts that the given condition doesn't satisfy in waitFor time,
 // periodically checking the target function each tick.
 //
-//	a.Never(func() bool { return false; }, time.Second, 10*time.Millisecond)
+// 	a.Never(func() bool { return false; }, time.Second, 10*time.Millisecond)
 func (a *Assertions) Never(condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1051,7 +1051,7 @@ func (a *Assertions) Never(condition func() bool, waitFor time.Duration, tick ti
 // Neverf asserts that the given condition doesn't satisfy in waitFor time,
 // periodically checking the target function each tick.
 //
-//	a.Neverf(func() bool { return false; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+// 	a.Neverf(func() bool { return false; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
 func (a *Assertions) Neverf(condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1061,7 +1061,7 @@ func (a *Assertions) Neverf(condition func() bool, waitFor time.Duration, tick t
 
 // Nil asserts that the specified object is nil.
 //
-//	a.Nil(err)
+// 	a.Nil(err)
 func (a *Assertions) Nil(object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1071,7 +1071,7 @@ func (a *Assertions) Nil(object interface{}, msgAndArgs ...interface{}) {
 
 // Nilf asserts that the specified object is nil.
 //
-//	a.Nilf(err, "error message %s", "formatted")
+// 	a.Nilf(err, "error message %s", "formatted")
 func (a *Assertions) Nilf(object interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1099,10 +1099,10 @@ func (a *Assertions) NoDirExistsf(path string, msg string, args ...interface{}) 
 
 // NoError asserts that a function returned a nil error (ie. no error).
 //
-//	  actualObj, err := SomeFunction()
-//	  if a.NoError(err) {
-//		   assert.Equal(t, expectedObj, actualObj)
-//	  }
+// 	  actualObj, err := SomeFunction()
+// 	  if a.NoError(err) {
+// 		   assert.Equal(t, expectedObj, actualObj)
+// 	  }
 func (a *Assertions) NoError(err error, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1112,10 +1112,10 @@ func (a *Assertions) NoError(err error, msgAndArgs ...interface{}) {
 
 // NoErrorf asserts that a function returned a nil error (ie. no error).
 //
-//	  actualObj, err := SomeFunction()
-//	  if a.NoErrorf(err, "error message %s", "formatted") {
-//		   assert.Equal(t, expectedObj, actualObj)
-//	  }
+// 	  actualObj, err := SomeFunction()
+// 	  if a.NoErrorf(err, "error message %s", "formatted") {
+// 		   assert.Equal(t, expectedObj, actualObj)
+// 	  }
 func (a *Assertions) NoErrorf(err error, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1144,9 +1144,9 @@ func (a *Assertions) NoFileExistsf(path string, msg string, args ...interface{})
 // NotContains asserts that the specified string, list(array, slice...) or map does NOT contain the
 // specified substring or element.
 //
-//	a.NotContains("Hello World", "Earth")
-//	a.NotContains(["Hello", "World"], "Earth")
-//	a.NotContains({"Hello": "World"}, "Earth")
+// 	a.NotContains("Hello World", "Earth")
+// 	a.NotContains(["Hello", "World"], "Earth")
+// 	a.NotContains({"Hello": "World"}, "Earth")
 func (a *Assertions) NotContains(s interface{}, contains interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1157,9 +1157,9 @@ func (a *Assertions) NotContains(s interface{}, contains interface{}, msgAndArgs
 // NotContainsf asserts that the specified string, list(array, slice...) or map does NOT contain the
 // specified substring or element.
 //
-//	a.NotContainsf("Hello World", "Earth", "error message %s", "formatted")
-//	a.NotContainsf(["Hello", "World"], "Earth", "error message %s", "formatted")
-//	a.NotContainsf({"Hello": "World"}, "Earth", "error message %s", "formatted")
+// 	a.NotContainsf("Hello World", "Earth", "error message %s", "formatted")
+// 	a.NotContainsf(["Hello", "World"], "Earth", "error message %s", "formatted")
+// 	a.NotContainsf({"Hello": "World"}, "Earth", "error message %s", "formatted")
 func (a *Assertions) NotContainsf(s interface{}, contains interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1203,9 +1203,9 @@ func (a *Assertions) NotElementsMatchf(listA interface{}, listB interface{}, msg
 
 // NotEmpty asserts that the specified object is NOT [Empty].
 //
-//	if a.NotEmpty(obj) {
-//	  assert.Equal(t, "two", obj[1])
-//	}
+// 	if a.NotEmpty(obj) {
+// 	  assert.Equal(t, "two", obj[1])
+// 	}
 func (a *Assertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1215,9 +1215,9 @@ func (a *Assertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) {
 
 // NotEmptyf asserts that the specified object is NOT [Empty].
 //
-//	if a.NotEmptyf(obj, "error message %s", "formatted") {
-//	  assert.Equal(t, "two", obj[1])
-//	}
+// 	if a.NotEmptyf(obj, "error message %s", "formatted") {
+// 	  assert.Equal(t, "two", obj[1])
+// 	}
 func (a *Assertions) NotEmptyf(object interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1227,7 +1227,7 @@ func (a *Assertions) NotEmptyf(object interface{}, msg string, args ...interface
 
 // NotEqual asserts that the specified values are NOT equal.
 //
-//	a.NotEqual(obj1, obj2)
+// 	a.NotEqual(obj1, obj2)
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
@@ -1240,7 +1240,7 @@ func (a *Assertions) NotEqual(expected interface{}, actual interface{}, msgAndAr
 
 // NotEqualValues asserts that two objects are not equal even when converted to the same type
 //
-//	a.NotEqualValues(obj1, obj2)
+// 	a.NotEqualValues(obj1, obj2)
 func (a *Assertions) NotEqualValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1250,7 +1250,7 @@ func (a *Assertions) NotEqualValues(expected interface{}, actual interface{}, ms
 
 // NotEqualValuesf asserts that two objects are not equal even when converted to the same type
 //
-//	a.NotEqualValuesf(obj1, obj2, "error message %s", "formatted")
+// 	a.NotEqualValuesf(obj1, obj2, "error message %s", "formatted")
 func (a *Assertions) NotEqualValuesf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1260,7 +1260,7 @@ func (a *Assertions) NotEqualValuesf(expected interface{}, actual interface{}, m
 
 // NotEqualf asserts that the specified values are NOT equal.
 //
-//	a.NotEqualf(obj1, obj2, "error message %s", "formatted")
+// 	a.NotEqualf(obj1, obj2, "error message %s", "formatted")
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
@@ -1309,7 +1309,7 @@ func (a *Assertions) NotErrorIsf(err error, target error, msg string, args ...in
 
 // NotImplements asserts that an object does not implement the specified interface.
 //
-//	a.NotImplements((*MyInterface)(nil), new(MyObject))
+// 	a.NotImplements((*MyInterface)(nil), new(MyObject))
 func (a *Assertions) NotImplements(interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1319,7 +1319,7 @@ func (a *Assertions) NotImplements(interfaceObject interface{}, object interface
 
 // NotImplementsf asserts that an object does not implement the specified interface.
 //
-//	a.NotImplementsf((*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
+// 	a.NotImplementsf((*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
 func (a *Assertions) NotImplementsf(interfaceObject interface{}, object interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1329,7 +1329,7 @@ func (a *Assertions) NotImplementsf(interfaceObject interface{}, object interfac
 
 // NotNil asserts that the specified object is not nil.
 //
-//	a.NotNil(err)
+// 	a.NotNil(err)
 func (a *Assertions) NotNil(object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1339,7 +1339,7 @@ func (a *Assertions) NotNil(object interface{}, msgAndArgs ...interface{}) {
 
 // NotNilf asserts that the specified object is not nil.
 //
-//	a.NotNilf(err, "error message %s", "formatted")
+// 	a.NotNilf(err, "error message %s", "formatted")
 func (a *Assertions) NotNilf(object interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1349,7 +1349,7 @@ func (a *Assertions) NotNilf(object interface{}, msg string, args ...interface{}
 
 // NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
 //
-//	a.NotPanics(func(){ RemainCalm() })
+// 	a.NotPanics(func(){ RemainCalm() })
 func (a *Assertions) NotPanics(f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1359,7 +1359,7 @@ func (a *Assertions) NotPanics(f assert.PanicTestFunc, msgAndArgs ...interface{}
 
 // NotPanicsf asserts that the code inside the specified PanicTestFunc does NOT panic.
 //
-//	a.NotPanicsf(func(){ RemainCalm() }, "error message %s", "formatted")
+// 	a.NotPanicsf(func(){ RemainCalm() }, "error message %s", "formatted")
 func (a *Assertions) NotPanicsf(f assert.PanicTestFunc, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1371,10 +1371,11 @@ func (a *Assertions) NotPanicsf(f assert.PanicTestFunc, msg string, args ...inte
 //
 // The rx (expression) argument should be a *regexp.Regexp. For backward
 // compatibility, if rx is any other type, its value will be formatted with
-// %v and compiled using regexp.MustCompile.
+// %v and compiled using regexp.Compile.
 //
-//	a.NotRegexp(regexp.MustCompile("starts"), "it's starting")
-//	a.NotRegexp("^start", "it's not starting") // string is compiled
+// Examples:
+// 	a.NotRegexp(regexp.MustCompile("starts"), "it's starting")
+// 	a.NotRegexp("^start", "it's not starting") // string is compiled
 func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1386,10 +1387,11 @@ func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...in
 //
 // The rx (expression) argument should be a *regexp.Regexp. For backward
 // compatibility, if rx is any other type, its value will be formatted with
-// %v and compiled using regexp.MustCompile.
+// %v and compiled using regexp.Compile.
 //
-//	a.NotRegexpf(regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
-//	a.NotRegexpf("^start", "it's not starting", "error message %s", "formatted") // string is compiled
+// Examples:
+// 	a.NotRegexpf(regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
+// 	a.NotRegexpf("^start", "it's not starting", "error message %s", "formatted") // string is compiled
 func (a *Assertions) NotRegexpf(rx interface{}, str interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1399,7 +1401,7 @@ func (a *Assertions) NotRegexpf(rx interface{}, str interface{}, msg string, arg
 
 // NotSame asserts that two pointers do not reference the same object.
 //
-//	a.NotSame(ptr1, ptr2)
+// 	a.NotSame(ptr1, ptr2)
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
@@ -1412,7 +1414,7 @@ func (a *Assertions) NotSame(expected interface{}, actual interface{}, msgAndArg
 
 // NotSamef asserts that two pointers do not reference the same object.
 //
-//	a.NotSamef(ptr1, ptr2, "error message %s", "formatted")
+// 	a.NotSamef(ptr1, ptr2, "error message %s", "formatted")
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
@@ -1428,10 +1430,10 @@ func (a *Assertions) NotSamef(expected interface{}, actual interface{}, msg stri
 // Map elements are key-value pairs unless compared with an array or slice where
 // only the map key is evaluated.
 //
-//	a.NotSubset([1, 3, 4], [1, 2])
-//	a.NotSubset({"x": 1, "y": 2}, {"z": 3})
-//	a.NotSubset([1, 3, 4], {1: "one", 2: "two"})
-//	a.NotSubset({"x": 1, "y": 2}, ["z"])
+// 	a.NotSubset([1, 3, 4], [1, 2])
+// 	a.NotSubset({"x": 1, "y": 2}, {"z": 3})
+// 	a.NotSubset([1, 3, 4], {1: "one", 2: "two"})
+// 	a.NotSubset({"x": 1, "y": 2}, ["z"])
 func (a *Assertions) NotSubset(list interface{}, subset interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1444,10 +1446,10 @@ func (a *Assertions) NotSubset(list interface{}, subset interface{}, msgAndArgs 
 // Map elements are key-value pairs unless compared with an array or slice where
 // only the map key is evaluated.
 //
-//	a.NotSubsetf([1, 3, 4], [1, 2], "error message %s", "formatted")
-//	a.NotSubsetf({"x": 1, "y": 2}, {"z": 3}, "error message %s", "formatted")
-//	a.NotSubsetf([1, 3, 4], {1: "one", 2: "two"}, "error message %s", "formatted")
-//	a.NotSubsetf({"x": 1, "y": 2}, ["z"], "error message %s", "formatted")
+// 	a.NotSubsetf([1, 3, 4], [1, 2], "error message %s", "formatted")
+// 	a.NotSubsetf({"x": 1, "y": 2}, {"z": 3}, "error message %s", "formatted")
+// 	a.NotSubsetf([1, 3, 4], {1: "one", 2: "two"}, "error message %s", "formatted")
+// 	a.NotSubsetf({"x": 1, "y": 2}, ["z"], "error message %s", "formatted")
 func (a *Assertions) NotSubsetf(list interface{}, subset interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1473,7 +1475,7 @@ func (a *Assertions) NotZerof(i interface{}, msg string, args ...interface{}) {
 
 // Panics asserts that the code inside the specified PanicTestFunc panics.
 //
-//	a.Panics(func(){ GoCrazy() })
+// 	a.Panics(func(){ GoCrazy() })
 func (a *Assertions) Panics(f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1485,7 +1487,7 @@ func (a *Assertions) Panics(f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 // panics, and that the recovered panic value is an error that satisfies the
 // EqualError comparison.
 //
-//	a.PanicsWithError("crazy error", func(){ GoCrazy() })
+// 	a.PanicsWithError("crazy error", func(){ GoCrazy() })
 func (a *Assertions) PanicsWithError(errString string, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1497,7 +1499,7 @@ func (a *Assertions) PanicsWithError(errString string, f assert.PanicTestFunc, m
 // panics, and that the recovered panic value is an error that satisfies the
 // EqualError comparison.
 //
-//	a.PanicsWithErrorf("crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+// 	a.PanicsWithErrorf("crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
 func (a *Assertions) PanicsWithErrorf(errString string, f assert.PanicTestFunc, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1508,7 +1510,7 @@ func (a *Assertions) PanicsWithErrorf(errString string, f assert.PanicTestFunc, 
 // PanicsWithValue asserts that the code inside the specified PanicTestFunc panics, and that
 // the recovered panic value equals the expected panic value.
 //
-//	a.PanicsWithValue("crazy error", func(){ GoCrazy() })
+// 	a.PanicsWithValue("crazy error", func(){ GoCrazy() })
 func (a *Assertions) PanicsWithValue(expected interface{}, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1519,7 +1521,7 @@ func (a *Assertions) PanicsWithValue(expected interface{}, f assert.PanicTestFun
 // PanicsWithValuef asserts that the code inside the specified PanicTestFunc panics, and that
 // the recovered panic value equals the expected panic value.
 //
-//	a.PanicsWithValuef("crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+// 	a.PanicsWithValuef("crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
 func (a *Assertions) PanicsWithValuef(expected interface{}, f assert.PanicTestFunc, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1529,7 +1531,7 @@ func (a *Assertions) PanicsWithValuef(expected interface{}, f assert.PanicTestFu
 
 // Panicsf asserts that the code inside the specified PanicTestFunc panics.
 //
-//	a.Panicsf(func(){ GoCrazy() }, "error message %s", "formatted")
+// 	a.Panicsf(func(){ GoCrazy() }, "error message %s", "formatted")
 func (a *Assertions) Panicsf(f assert.PanicTestFunc, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1539,8 +1541,8 @@ func (a *Assertions) Panicsf(f assert.PanicTestFunc, msg string, args ...interfa
 
 // Positive asserts that the specified element is positive
 //
-//	a.Positive(1)
-//	a.Positive(1.23)
+// 	a.Positive(1)
+// 	a.Positive(1.23)
 func (a *Assertions) Positive(e interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1550,8 +1552,8 @@ func (a *Assertions) Positive(e interface{}, msgAndArgs ...interface{}) {
 
 // Positivef asserts that the specified element is positive
 //
-//	a.Positivef(1, "error message %s", "formatted")
-//	a.Positivef(1.23, "error message %s", "formatted")
+// 	a.Positivef(1, "error message %s", "formatted")
+// 	a.Positivef(1.23, "error message %s", "formatted")
 func (a *Assertions) Positivef(e interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1563,10 +1565,11 @@ func (a *Assertions) Positivef(e interface{}, msg string, args ...interface{}) {
 //
 // The rx (expression) argument should be a *regexp.Regexp. For backward
 // compatibility, if rx is any other type, its value will be formatted with
-// %v and compiled using regexp.MustCompile.
+// %v and compiled using regexp.Compile.
 //
-//	a.Regexp(regexp.MustCompile("start"), "it's starting")
-//	a.Regexp("start...$", "it's not starting") // string is compiled
+// Examples:
+// 	a.Regexp(regexp.MustCompile("start"), "it's starting")
+// 	a.Regexp("start...$", "it's not starting") // string is compiled
 func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1578,10 +1581,11 @@ func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...inter
 //
 // The rx (expression) argument should be a *regexp.Regexp. For backward
 // compatibility, if rx is any other type, its value will be formatted with
-// %v and compiled using regexp.MustCompile.
+// %v and compiled using regexp.Compile.
 //
-//	a.Regexpf(regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
-//	a.Regexpf("start...$", "it's not starting", "error message %s", "formatted") // string is compiled
+// Examples:
+// 	a.Regexpf(regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
+// 	a.Regexpf("start...$", "it's not starting", "error message %s", "formatted") // string is compiled
 func (a *Assertions) Regexpf(rx interface{}, str interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1591,7 +1595,7 @@ func (a *Assertions) Regexpf(rx interface{}, str interface{}, msg string, args .
 
 // Same asserts that two pointers reference the same object.
 //
-//	a.Same(ptr1, ptr2)
+// 	a.Same(ptr1, ptr2)
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
@@ -1604,7 +1608,7 @@ func (a *Assertions) Same(expected interface{}, actual interface{}, msgAndArgs .
 
 // Samef asserts that two pointers reference the same object.
 //
-//	a.Samef(ptr1, ptr2, "error message %s", "formatted")
+// 	a.Samef(ptr1, ptr2, "error message %s", "formatted")
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
@@ -1620,10 +1624,10 @@ func (a *Assertions) Samef(expected interface{}, actual interface{}, msg string,
 // Map elements are key-value pairs unless compared with an array or slice where
 // only the map key is evaluated.
 //
-//	a.Subset([1, 2, 3], [1, 2])
-//	a.Subset({"x": 1, "y": 2}, {"x": 1})
-//	a.Subset([1, 2, 3], {1: "one", 2: "two"})
-//	a.Subset({"x": 1, "y": 2}, ["x"])
+// 	a.Subset([1, 2, 3], [1, 2])
+// 	a.Subset({"x": 1, "y": 2}, {"x": 1})
+// 	a.Subset([1, 2, 3], {1: "one", 2: "two"})
+// 	a.Subset({"x": 1, "y": 2}, ["x"])
 func (a *Assertions) Subset(list interface{}, subset interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1636,10 +1640,10 @@ func (a *Assertions) Subset(list interface{}, subset interface{}, msgAndArgs ...
 // Map elements are key-value pairs unless compared with an array or slice where
 // only the map key is evaluated.
 //
-//	a.Subsetf([1, 2, 3], [1, 2], "error message %s", "formatted")
-//	a.Subsetf({"x": 1, "y": 2}, {"x": 1}, "error message %s", "formatted")
-//	a.Subsetf([1, 2, 3], {1: "one", 2: "two"}, "error message %s", "formatted")
-//	a.Subsetf({"x": 1, "y": 2}, ["x"], "error message %s", "formatted")
+// 	a.Subsetf([1, 2, 3], [1, 2], "error message %s", "formatted")
+// 	a.Subsetf({"x": 1, "y": 2}, {"x": 1}, "error message %s", "formatted")
+// 	a.Subsetf([1, 2, 3], {1: "one", 2: "two"}, "error message %s", "formatted")
+// 	a.Subsetf({"x": 1, "y": 2}, ["x"], "error message %s", "formatted")
 func (a *Assertions) Subsetf(list interface{}, subset interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1649,7 +1653,7 @@ func (a *Assertions) Subsetf(list interface{}, subset interface{}, msg string, a
 
 // True asserts that the specified value is true.
 //
-//	a.True(myBool)
+// 	a.True(myBool)
 func (a *Assertions) True(value bool, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1659,7 +1663,7 @@ func (a *Assertions) True(value bool, msgAndArgs ...interface{}) {
 
 // Truef asserts that the specified value is true.
 //
-//	a.Truef(myBool, "error message %s", "formatted")
+// 	a.Truef(myBool, "error message %s", "formatted")
 func (a *Assertions) Truef(value bool, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1669,7 +1673,7 @@ func (a *Assertions) Truef(value bool, msg string, args ...interface{}) {
 
 // WithinDuration asserts that the two times are within duration delta of each other.
 //
-//	a.WithinDuration(time.Now(), time.Now(), 10*time.Second)
+// 	a.WithinDuration(time.Now(), time.Now(), 10*time.Second)
 func (a *Assertions) WithinDuration(expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1679,7 +1683,7 @@ func (a *Assertions) WithinDuration(expected time.Time, actual time.Time, delta 
 
 // WithinDurationf asserts that the two times are within duration delta of each other.
 //
-//	a.WithinDurationf(time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
+// 	a.WithinDurationf(time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
 func (a *Assertions) WithinDurationf(expected time.Time, actual time.Time, delta time.Duration, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1689,7 +1693,7 @@ func (a *Assertions) WithinDurationf(expected time.Time, actual time.Time, delta
 
 // WithinRange asserts that a time is within a time range (inclusive).
 //
-//	a.WithinRange(time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second))
+// 	a.WithinRange(time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second))
 func (a *Assertions) WithinRange(actual time.Time, start time.Time, end time.Time, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1699,7 +1703,7 @@ func (a *Assertions) WithinRange(actual time.Time, start time.Time, end time.Tim
 
 // WithinRangef asserts that a time is within a time range (inclusive).
 //
-//	a.WithinRangef(time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second), "error message %s", "formatted")
+// 	a.WithinRangef(time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second), "error message %s", "formatted")
 func (a *Assertions) WithinRangef(actual time.Time, start time.Time, end time.Time, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1709,17 +1713,17 @@ func (a *Assertions) WithinRangef(actual time.Time, start time.Time, end time.Ti
 
 // YAMLEq asserts that the first documents in the two YAML strings are equivalent.
 //
-//	expected := `---
-//	key: value
-//	---
-//	key: this is a second document, it is not evaluated
-//	`
-//	actual := `---
-//	key: value
-//	---
-//	key: this is a subsequent document, it is not evaluated
-//	`
-//	a.YAMLEq(expected, actual)
+// 	expected := `---
+// 	key: value
+// 	---
+// 	key: this is a second document, it is not evaluated
+// 	`
+// 	actual := `---
+// 	key: value
+// 	---
+// 	key: this is a subsequent document, it is not evaluated
+// 	`
+// 	a.YAMLEq(expected, actual)
 func (a *Assertions) YAMLEq(expected string, actual string, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1729,17 +1733,17 @@ func (a *Assertions) YAMLEq(expected string, actual string, msgAndArgs ...interf
 
 // YAMLEqf asserts that the first documents in the two YAML strings are equivalent.
 //
-//	expected := `---
-//	key: value
-//	---
-//	key: this is a second document, it is not evaluated
-//	`
-//	actual := `---
-//	key: value
-//	---
-//	key: this is a subsequent document, it is not evaluated
-//	`
-//	a.YAMLEqf(expected, actual, "error message %s", "formatted")
+// 	expected := `---
+// 	key: value
+// 	---
+// 	key: this is a second document, it is not evaluated
+// 	`
+// 	actual := `---
+// 	key: value
+// 	---
+// 	key: this is a subsequent document, it is not evaluated
+// 	`
+// 	a.YAMLEqf(expected, actual, "error message %s", "formatted")
 func (a *Assertions) YAMLEqf(expected string, actual string, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()

--- a/require/require_forward.go
+++ b/require/require_forward.go
@@ -28,9 +28,9 @@ func (a *Assertions) Conditionf(comp assert.Comparison, msg string, args ...inte
 // Contains asserts that the specified string, list(array, slice...) or map contains the
 // specified substring or element.
 //
-// 	a.Contains("Hello World", "World")
-// 	a.Contains(["Hello", "World"], "World")
-// 	a.Contains({"Hello": "World"}, "Hello")
+//	a.Contains("Hello World", "World")
+//	a.Contains(["Hello", "World"], "World")
+//	a.Contains({"Hello": "World"}, "Hello")
 func (a *Assertions) Contains(s interface{}, contains interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -41,9 +41,9 @@ func (a *Assertions) Contains(s interface{}, contains interface{}, msgAndArgs ..
 // Containsf asserts that the specified string, list(array, slice...) or map contains the
 // specified substring or element.
 //
-// 	a.Containsf("Hello World", "World", "error message %s", "formatted")
-// 	a.Containsf(["Hello", "World"], "World", "error message %s", "formatted")
-// 	a.Containsf({"Hello": "World"}, "Hello", "error message %s", "formatted")
+//	a.Containsf("Hello World", "World", "error message %s", "formatted")
+//	a.Containsf(["Hello", "World"], "World", "error message %s", "formatted")
+//	a.Containsf({"Hello": "World"}, "Hello", "error message %s", "formatted")
 func (a *Assertions) Containsf(s interface{}, contains interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -103,7 +103,7 @@ func (a *Assertions) ElementsMatchf(listA interface{}, listB interface{}, msg st
 //
 // Pointer values are "empty" if the pointer is nil or if the pointed value is "empty".
 //
-// 	a.Empty(obj)
+//	a.Empty(obj)
 //
 // [Zero values]: https://go.dev/ref/spec#The_zero_value
 func (a *Assertions) Empty(object interface{}, msgAndArgs ...interface{}) {
@@ -123,7 +123,7 @@ func (a *Assertions) Empty(object interface{}, msgAndArgs ...interface{}) {
 //
 // Pointer values are "empty" if the pointer is nil or if the pointed value is "empty".
 //
-// 	a.Emptyf(obj, "error message %s", "formatted")
+//	a.Emptyf(obj, "error message %s", "formatted")
 //
 // [Zero values]: https://go.dev/ref/spec#The_zero_value
 func (a *Assertions) Emptyf(object interface{}, msg string, args ...interface{}) {
@@ -135,7 +135,7 @@ func (a *Assertions) Emptyf(object interface{}, msg string, args ...interface{})
 
 // Equal asserts that two objects are equal.
 //
-// 	a.Equal(123, 123)
+//	a.Equal(123, 123)
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses). Function equality
@@ -150,8 +150,8 @@ func (a *Assertions) Equal(expected interface{}, actual interface{}, msgAndArgs 
 // EqualError asserts that a function returned a non-nil error (i.e. an error)
 // and that it is equal to the provided error.
 //
-// 	actualObj, err := SomeFunction()
-// 	a.EqualError(err,  expectedErrorString)
+//	actualObj, err := SomeFunction()
+//	a.EqualError(err,  expectedErrorString)
 func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -162,8 +162,8 @@ func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...
 // EqualErrorf asserts that a function returned a non-nil error (i.e. an error)
 // and that it is equal to the provided error.
 //
-// 	actualObj, err := SomeFunction()
-// 	a.EqualErrorf(err,  expectedErrorString, "error message %s", "formatted")
+//	actualObj, err := SomeFunction()
+//	a.EqualErrorf(err,  expectedErrorString, "error message %s", "formatted")
 func (a *Assertions) EqualErrorf(theError error, errString string, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -175,12 +175,12 @@ func (a *Assertions) EqualErrorf(theError error, errString string, msg string, a
 // fields are also equal. This is useful for comparing structs that have private fields
 // that could potentially differ.
 //
-// 	 type S struct {
-// 		Exported     	int
-// 		notExported   	int
-// 	 }
-// 	 a.EqualExportedValues(S{1, 2}, S{1, 3}) => true
-// 	 a.EqualExportedValues(S{1, 2}, S{2, 3}) => false
+//	 type S struct {
+//		Exported     	int
+//		notExported   	int
+//	 }
+//	 a.EqualExportedValues(S{1, 2}, S{1, 3}) => true
+//	 a.EqualExportedValues(S{1, 2}, S{2, 3}) => false
 func (a *Assertions) EqualExportedValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -192,12 +192,12 @@ func (a *Assertions) EqualExportedValues(expected interface{}, actual interface{
 // fields are also equal. This is useful for comparing structs that have private fields
 // that could potentially differ.
 //
-// 	 type S struct {
-// 		Exported     	int
-// 		notExported   	int
-// 	 }
-// 	 a.EqualExportedValuesf(S{1, 2}, S{1, 3}, "error message %s", "formatted") => true
-// 	 a.EqualExportedValuesf(S{1, 2}, S{2, 3}, "error message %s", "formatted") => false
+//	 type S struct {
+//		Exported     	int
+//		notExported   	int
+//	 }
+//	 a.EqualExportedValuesf(S{1, 2}, S{1, 3}, "error message %s", "formatted") => true
+//	 a.EqualExportedValuesf(S{1, 2}, S{2, 3}, "error message %s", "formatted") => false
 func (a *Assertions) EqualExportedValuesf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -208,7 +208,7 @@ func (a *Assertions) EqualExportedValuesf(expected interface{}, actual interface
 // EqualValues asserts that two objects are equal or convertible to the larger
 // type and equal.
 //
-// 	a.EqualValues(uint32(123), int32(123))
+//	a.EqualValues(uint32(123), int32(123))
 func (a *Assertions) EqualValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -219,7 +219,7 @@ func (a *Assertions) EqualValues(expected interface{}, actual interface{}, msgAn
 // EqualValuesf asserts that two objects are equal or convertible to the larger
 // type and equal.
 //
-// 	a.EqualValuesf(uint32(123), int32(123), "error message %s", "formatted")
+//	a.EqualValuesf(uint32(123), int32(123), "error message %s", "formatted")
 func (a *Assertions) EqualValuesf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -229,7 +229,7 @@ func (a *Assertions) EqualValuesf(expected interface{}, actual interface{}, msg 
 
 // Equalf asserts that two objects are equal.
 //
-// 	a.Equalf(123, 123, "error message %s", "formatted")
+//	a.Equalf(123, 123, "error message %s", "formatted")
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses). Function equality
@@ -243,8 +243,8 @@ func (a *Assertions) Equalf(expected interface{}, actual interface{}, msg string
 
 // Error asserts that a function returned a non-nil error (ie. an error).
 //
-// 	actualObj, err := SomeFunction()
-// 	a.Error(err)
+//	actualObj, err := SomeFunction()
+//	a.Error(err)
 func (a *Assertions) Error(err error, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -273,8 +273,8 @@ func (a *Assertions) ErrorAsf(err error, target interface{}, msg string, args ..
 // ErrorContains asserts that a function returned a non-nil error (i.e. an
 // error) and that the error contains the specified substring.
 //
-// 	actualObj, err := SomeFunction()
-// 	a.ErrorContains(err,  expectedErrorSubString)
+//	actualObj, err := SomeFunction()
+//	a.ErrorContains(err,  expectedErrorSubString)
 func (a *Assertions) ErrorContains(theError error, contains string, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -285,8 +285,8 @@ func (a *Assertions) ErrorContains(theError error, contains string, msgAndArgs .
 // ErrorContainsf asserts that a function returned a non-nil error (i.e. an
 // error) and that the error contains the specified substring.
 //
-// 	actualObj, err := SomeFunction()
-// 	a.ErrorContainsf(err,  expectedErrorSubString, "error message %s", "formatted")
+//	actualObj, err := SomeFunction()
+//	a.ErrorContainsf(err,  expectedErrorSubString, "error message %s", "formatted")
 func (a *Assertions) ErrorContainsf(theError error, contains string, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -314,8 +314,8 @@ func (a *Assertions) ErrorIsf(err error, target error, msg string, args ...inter
 
 // Errorf asserts that a function returned a non-nil error (ie. an error).
 //
-// 	actualObj, err := SomeFunction()
-// 	a.Errorf(err, "error message %s", "formatted")
+//	actualObj, err := SomeFunction()
+//	a.Errorf(err, "error message %s", "formatted")
 func (a *Assertions) Errorf(err error, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -326,7 +326,7 @@ func (a *Assertions) Errorf(err error, msg string, args ...interface{}) {
 // Eventually asserts that given condition will be met in waitFor time,
 // periodically checking target function each tick.
 //
-// 	a.Eventually(func() bool { return true; }, time.Second, 10*time.Millisecond)
+//	a.Eventually(func() bool { return true; }, time.Second, 10*time.Millisecond)
 func (a *Assertions) Eventually(condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -343,15 +343,15 @@ func (a *Assertions) Eventually(condition func() bool, waitFor time.Duration, ti
 // If the condition is not met before waitFor, the collected errors of
 // the last tick are copied to t.
 //
-// 	externalValue := false
-// 	go func() {
-// 		time.Sleep(8*time.Second)
-// 		externalValue = true
-// 	}()
-// 	a.EventuallyWithT(func(c *assert.CollectT) {
-// 		// add assertions as needed; any assertion failure will fail the current tick
-// 		assert.True(c, externalValue, "expected 'externalValue' to be true")
-// 	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
+//	externalValue := false
+//	go func() {
+//		time.Sleep(8*time.Second)
+//		externalValue = true
+//	}()
+//	a.EventuallyWithT(func(c *assert.CollectT) {
+//		// add assertions as needed; any assertion failure will fail the current tick
+//		assert.True(c, externalValue, "expected 'externalValue' to be true")
+//	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
 func (a *Assertions) EventuallyWithT(condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -368,15 +368,15 @@ func (a *Assertions) EventuallyWithT(condition func(collect *assert.CollectT), w
 // If the condition is not met before waitFor, the collected errors of
 // the last tick are copied to t.
 //
-// 	externalValue := false
-// 	go func() {
-// 		time.Sleep(8*time.Second)
-// 		externalValue = true
-// 	}()
-// 	a.EventuallyWithTf(func(c *assert.CollectT, "error message %s", "formatted") {
-// 		// add assertions as needed; any assertion failure will fail the current tick
-// 		assert.True(c, externalValue, "expected 'externalValue' to be true")
-// 	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
+//	externalValue := false
+//	go func() {
+//		time.Sleep(8*time.Second)
+//		externalValue = true
+//	}()
+//	a.EventuallyWithTf(func(c *assert.CollectT, "error message %s", "formatted") {
+//		// add assertions as needed; any assertion failure will fail the current tick
+//		assert.True(c, externalValue, "expected 'externalValue' to be true")
+//	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
 func (a *Assertions) EventuallyWithTf(condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -387,7 +387,7 @@ func (a *Assertions) EventuallyWithTf(condition func(collect *assert.CollectT), 
 // Eventuallyf asserts that given condition will be met in waitFor time,
 // periodically checking target function each tick.
 //
-// 	a.Eventuallyf(func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+//	a.Eventuallyf(func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
 func (a *Assertions) Eventuallyf(condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -397,7 +397,7 @@ func (a *Assertions) Eventuallyf(condition func() bool, waitFor time.Duration, t
 
 // Exactly asserts that two objects are equal in value and type.
 //
-// 	a.Exactly(int32(123), int64(123))
+//	a.Exactly(int32(123), int64(123))
 func (a *Assertions) Exactly(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -407,7 +407,7 @@ func (a *Assertions) Exactly(expected interface{}, actual interface{}, msgAndArg
 
 // Exactlyf asserts that two objects are equal in value and type.
 //
-// 	a.Exactlyf(int32(123), int64(123), "error message %s", "formatted")
+//	a.Exactlyf(int32(123), int64(123), "error message %s", "formatted")
 func (a *Assertions) Exactlyf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -449,7 +449,7 @@ func (a *Assertions) Failf(failureMessage string, msg string, args ...interface{
 
 // False asserts that the specified value is false.
 //
-// 	a.False(myBool)
+//	a.False(myBool)
 func (a *Assertions) False(value bool, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -459,7 +459,7 @@ func (a *Assertions) False(value bool, msgAndArgs ...interface{}) {
 
 // Falsef asserts that the specified value is false.
 //
-// 	a.Falsef(myBool, "error message %s", "formatted")
+//	a.Falsef(myBool, "error message %s", "formatted")
 func (a *Assertions) Falsef(value bool, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -487,9 +487,9 @@ func (a *Assertions) FileExistsf(path string, msg string, args ...interface{}) {
 
 // Greater asserts that the first element is greater than the second
 //
-// 	a.Greater(2, 1)
-// 	a.Greater(float64(2), float64(1))
-// 	a.Greater("b", "a")
+//	a.Greater(2, 1)
+//	a.Greater(float64(2), float64(1))
+//	a.Greater("b", "a")
 func (a *Assertions) Greater(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -499,10 +499,10 @@ func (a *Assertions) Greater(e1 interface{}, e2 interface{}, msgAndArgs ...inter
 
 // GreaterOrEqual asserts that the first element is greater than or equal to the second
 //
-// 	a.GreaterOrEqual(2, 1)
-// 	a.GreaterOrEqual(2, 2)
-// 	a.GreaterOrEqual("b", "a")
-// 	a.GreaterOrEqual("b", "b")
+//	a.GreaterOrEqual(2, 1)
+//	a.GreaterOrEqual(2, 2)
+//	a.GreaterOrEqual("b", "a")
+//	a.GreaterOrEqual("b", "b")
 func (a *Assertions) GreaterOrEqual(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -512,10 +512,10 @@ func (a *Assertions) GreaterOrEqual(e1 interface{}, e2 interface{}, msgAndArgs .
 
 // GreaterOrEqualf asserts that the first element is greater than or equal to the second
 //
-// 	a.GreaterOrEqualf(2, 1, "error message %s", "formatted")
-// 	a.GreaterOrEqualf(2, 2, "error message %s", "formatted")
-// 	a.GreaterOrEqualf("b", "a", "error message %s", "formatted")
-// 	a.GreaterOrEqualf("b", "b", "error message %s", "formatted")
+//	a.GreaterOrEqualf(2, 1, "error message %s", "formatted")
+//	a.GreaterOrEqualf(2, 2, "error message %s", "formatted")
+//	a.GreaterOrEqualf("b", "a", "error message %s", "formatted")
+//	a.GreaterOrEqualf("b", "b", "error message %s", "formatted")
 func (a *Assertions) GreaterOrEqualf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -525,9 +525,9 @@ func (a *Assertions) GreaterOrEqualf(e1 interface{}, e2 interface{}, msg string,
 
 // Greaterf asserts that the first element is greater than the second
 //
-// 	a.Greaterf(2, 1, "error message %s", "formatted")
-// 	a.Greaterf(float64(2), float64(1), "error message %s", "formatted")
-// 	a.Greaterf("b", "a", "error message %s", "formatted")
+//	a.Greaterf(2, 1, "error message %s", "formatted")
+//	a.Greaterf(float64(2), float64(1), "error message %s", "formatted")
+//	a.Greaterf("b", "a", "error message %s", "formatted")
 func (a *Assertions) Greaterf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -538,7 +538,7 @@ func (a *Assertions) Greaterf(e1 interface{}, e2 interface{}, msg string, args .
 // HTTPBodyContains asserts that a specified handler returns a
 // body that contains a string.
 //
-// 	a.HTTPBodyContains(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
+//	a.HTTPBodyContains(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPBodyContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
@@ -551,7 +551,7 @@ func (a *Assertions) HTTPBodyContains(handler http.HandlerFunc, method string, u
 // HTTPBodyContainsf asserts that a specified handler returns a
 // body that contains a string.
 //
-// 	a.HTTPBodyContainsf(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+//	a.HTTPBodyContainsf(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPBodyContainsf(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
@@ -564,7 +564,7 @@ func (a *Assertions) HTTPBodyContainsf(handler http.HandlerFunc, method string, 
 // HTTPBodyNotContains asserts that a specified handler returns a
 // body that does not contain a string.
 //
-// 	a.HTTPBodyNotContains(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
+//	a.HTTPBodyNotContains(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPBodyNotContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
@@ -577,7 +577,7 @@ func (a *Assertions) HTTPBodyNotContains(handler http.HandlerFunc, method string
 // HTTPBodyNotContainsf asserts that a specified handler returns a
 // body that does not contain a string.
 //
-// 	a.HTTPBodyNotContainsf(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+//	a.HTTPBodyNotContainsf(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPBodyNotContainsf(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
@@ -589,7 +589,7 @@ func (a *Assertions) HTTPBodyNotContainsf(handler http.HandlerFunc, method strin
 
 // HTTPError asserts that a specified handler returns an error status code.
 //
-// 	a.HTTPError(myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//	a.HTTPError(myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPError(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
@@ -601,7 +601,7 @@ func (a *Assertions) HTTPError(handler http.HandlerFunc, method string, url stri
 
 // HTTPErrorf asserts that a specified handler returns an error status code.
 //
-// 	a.HTTPErrorf(myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//	a.HTTPErrorf(myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPErrorf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
@@ -613,7 +613,7 @@ func (a *Assertions) HTTPErrorf(handler http.HandlerFunc, method string, url str
 
 // HTTPRedirect asserts that a specified handler returns a redirect status code.
 //
-// 	a.HTTPRedirect(myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//	a.HTTPRedirect(myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPRedirect(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
@@ -625,7 +625,7 @@ func (a *Assertions) HTTPRedirect(handler http.HandlerFunc, method string, url s
 
 // HTTPRedirectf asserts that a specified handler returns a redirect status code.
 //
-// 	a.HTTPRedirectf(myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//	a.HTTPRedirectf(myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPRedirectf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
@@ -637,7 +637,7 @@ func (a *Assertions) HTTPRedirectf(handler http.HandlerFunc, method string, url 
 
 // HTTPStatusCode asserts that a specified handler returns a specified status code.
 //
-// 	a.HTTPStatusCode(myHandler, "GET", "/notImplemented", nil, 501)
+//	a.HTTPStatusCode(myHandler, "GET", "/notImplemented", nil, 501)
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPStatusCode(handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msgAndArgs ...interface{}) {
@@ -649,7 +649,7 @@ func (a *Assertions) HTTPStatusCode(handler http.HandlerFunc, method string, url
 
 // HTTPStatusCodef asserts that a specified handler returns a specified status code.
 //
-// 	a.HTTPStatusCodef(myHandler, "GET", "/notImplemented", nil, 501, "error message %s", "formatted")
+//	a.HTTPStatusCodef(myHandler, "GET", "/notImplemented", nil, 501, "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPStatusCodef(handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msg string, args ...interface{}) {
@@ -661,7 +661,7 @@ func (a *Assertions) HTTPStatusCodef(handler http.HandlerFunc, method string, ur
 
 // HTTPSuccess asserts that a specified handler returns a success status code.
 //
-// 	a.HTTPSuccess(myHandler, "POST", "http://www.google.com", nil)
+//	a.HTTPSuccess(myHandler, "POST", "http://www.google.com", nil)
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPSuccess(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
@@ -673,7 +673,7 @@ func (a *Assertions) HTTPSuccess(handler http.HandlerFunc, method string, url st
 
 // HTTPSuccessf asserts that a specified handler returns a success status code.
 //
-// 	a.HTTPSuccessf(myHandler, "POST", "http://www.google.com", nil, "error message %s", "formatted")
+//	a.HTTPSuccessf(myHandler, "POST", "http://www.google.com", nil, "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
 func (a *Assertions) HTTPSuccessf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
@@ -685,7 +685,7 @@ func (a *Assertions) HTTPSuccessf(handler http.HandlerFunc, method string, url s
 
 // Implements asserts that an object is implemented by the specified interface.
 //
-// 	a.Implements((*MyInterface)(nil), new(MyObject))
+//	a.Implements((*MyInterface)(nil), new(MyObject))
 func (a *Assertions) Implements(interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -695,7 +695,7 @@ func (a *Assertions) Implements(interfaceObject interface{}, object interface{},
 
 // Implementsf asserts that an object is implemented by the specified interface.
 //
-// 	a.Implementsf((*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
+//	a.Implementsf((*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
 func (a *Assertions) Implementsf(interfaceObject interface{}, object interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -705,7 +705,7 @@ func (a *Assertions) Implementsf(interfaceObject interface{}, object interface{}
 
 // InDelta asserts that the two numerals are within delta of each other.
 //
-// 	a.InDelta(math.Pi, 22/7.0, 0.01)
+//	a.InDelta(math.Pi, 22/7.0, 0.01)
 func (a *Assertions) InDelta(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -747,7 +747,7 @@ func (a *Assertions) InDeltaSlicef(expected interface{}, actual interface{}, del
 
 // InDeltaf asserts that the two numerals are within delta of each other.
 //
-// 	a.InDeltaf(math.Pi, 22/7.0, 0.01, "error message %s", "formatted")
+//	a.InDeltaf(math.Pi, 22/7.0, 0.01, "error message %s", "formatted")
 func (a *Assertions) InDeltaf(expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -789,9 +789,9 @@ func (a *Assertions) InEpsilonf(expected interface{}, actual interface{}, epsilo
 
 // IsDecreasing asserts that the collection is decreasing
 //
-// 	a.IsDecreasing([]int{2, 1, 0})
-// 	a.IsDecreasing([]float{2, 1})
-// 	a.IsDecreasing([]string{"b", "a"})
+//	a.IsDecreasing([]int{2, 1, 0})
+//	a.IsDecreasing([]float{2, 1})
+//	a.IsDecreasing([]string{"b", "a"})
 func (a *Assertions) IsDecreasing(object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -801,9 +801,9 @@ func (a *Assertions) IsDecreasing(object interface{}, msgAndArgs ...interface{})
 
 // IsDecreasingf asserts that the collection is decreasing
 //
-// 	a.IsDecreasingf([]int{2, 1, 0}, "error message %s", "formatted")
-// 	a.IsDecreasingf([]float{2, 1}, "error message %s", "formatted")
-// 	a.IsDecreasingf([]string{"b", "a"}, "error message %s", "formatted")
+//	a.IsDecreasingf([]int{2, 1, 0}, "error message %s", "formatted")
+//	a.IsDecreasingf([]float{2, 1}, "error message %s", "formatted")
+//	a.IsDecreasingf([]string{"b", "a"}, "error message %s", "formatted")
 func (a *Assertions) IsDecreasingf(object interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -813,9 +813,9 @@ func (a *Assertions) IsDecreasingf(object interface{}, msg string, args ...inter
 
 // IsIncreasing asserts that the collection is increasing
 //
-// 	a.IsIncreasing([]int{1, 2, 3})
-// 	a.IsIncreasing([]float{1, 2})
-// 	a.IsIncreasing([]string{"a", "b"})
+//	a.IsIncreasing([]int{1, 2, 3})
+//	a.IsIncreasing([]float{1, 2})
+//	a.IsIncreasing([]string{"a", "b"})
 func (a *Assertions) IsIncreasing(object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -825,9 +825,9 @@ func (a *Assertions) IsIncreasing(object interface{}, msgAndArgs ...interface{})
 
 // IsIncreasingf asserts that the collection is increasing
 //
-// 	a.IsIncreasingf([]int{1, 2, 3}, "error message %s", "formatted")
-// 	a.IsIncreasingf([]float{1, 2}, "error message %s", "formatted")
-// 	a.IsIncreasingf([]string{"a", "b"}, "error message %s", "formatted")
+//	a.IsIncreasingf([]int{1, 2, 3}, "error message %s", "formatted")
+//	a.IsIncreasingf([]float{1, 2}, "error message %s", "formatted")
+//	a.IsIncreasingf([]string{"a", "b"}, "error message %s", "formatted")
 func (a *Assertions) IsIncreasingf(object interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -837,9 +837,9 @@ func (a *Assertions) IsIncreasingf(object interface{}, msg string, args ...inter
 
 // IsNonDecreasing asserts that the collection is not decreasing
 //
-// 	a.IsNonDecreasing([]int{1, 1, 2})
-// 	a.IsNonDecreasing([]float{1, 2})
-// 	a.IsNonDecreasing([]string{"a", "b"})
+//	a.IsNonDecreasing([]int{1, 1, 2})
+//	a.IsNonDecreasing([]float{1, 2})
+//	a.IsNonDecreasing([]string{"a", "b"})
 func (a *Assertions) IsNonDecreasing(object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -849,9 +849,9 @@ func (a *Assertions) IsNonDecreasing(object interface{}, msgAndArgs ...interface
 
 // IsNonDecreasingf asserts that the collection is not decreasing
 //
-// 	a.IsNonDecreasingf([]int{1, 1, 2}, "error message %s", "formatted")
-// 	a.IsNonDecreasingf([]float{1, 2}, "error message %s", "formatted")
-// 	a.IsNonDecreasingf([]string{"a", "b"}, "error message %s", "formatted")
+//	a.IsNonDecreasingf([]int{1, 1, 2}, "error message %s", "formatted")
+//	a.IsNonDecreasingf([]float{1, 2}, "error message %s", "formatted")
+//	a.IsNonDecreasingf([]string{"a", "b"}, "error message %s", "formatted")
 func (a *Assertions) IsNonDecreasingf(object interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -861,9 +861,9 @@ func (a *Assertions) IsNonDecreasingf(object interface{}, msg string, args ...in
 
 // IsNonIncreasing asserts that the collection is not increasing
 //
-// 	a.IsNonIncreasing([]int{2, 1, 1})
-// 	a.IsNonIncreasing([]float{2, 1})
-// 	a.IsNonIncreasing([]string{"b", "a"})
+//	a.IsNonIncreasing([]int{2, 1, 1})
+//	a.IsNonIncreasing([]float{2, 1})
+//	a.IsNonIncreasing([]string{"b", "a"})
 func (a *Assertions) IsNonIncreasing(object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -873,9 +873,9 @@ func (a *Assertions) IsNonIncreasing(object interface{}, msgAndArgs ...interface
 
 // IsNonIncreasingf asserts that the collection is not increasing
 //
-// 	a.IsNonIncreasingf([]int{2, 1, 1}, "error message %s", "formatted")
-// 	a.IsNonIncreasingf([]float{2, 1}, "error message %s", "formatted")
-// 	a.IsNonIncreasingf([]string{"b", "a"}, "error message %s", "formatted")
+//	a.IsNonIncreasingf([]int{2, 1, 1}, "error message %s", "formatted")
+//	a.IsNonIncreasingf([]float{2, 1}, "error message %s", "formatted")
+//	a.IsNonIncreasingf([]string{"b", "a"}, "error message %s", "formatted")
 func (a *Assertions) IsNonIncreasingf(object interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -885,7 +885,7 @@ func (a *Assertions) IsNonIncreasingf(object interface{}, msg string, args ...in
 
 // IsNotType asserts that the specified objects are not of the same type.
 //
-// 	a.IsNotType(&NotMyStruct{}, &MyStruct{})
+//	a.IsNotType(&NotMyStruct{}, &MyStruct{})
 func (a *Assertions) IsNotType(theType interface{}, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -895,7 +895,7 @@ func (a *Assertions) IsNotType(theType interface{}, object interface{}, msgAndAr
 
 // IsNotTypef asserts that the specified objects are not of the same type.
 //
-// 	a.IsNotTypef(&NotMyStruct{}, &MyStruct{}, "error message %s", "formatted")
+//	a.IsNotTypef(&NotMyStruct{}, &MyStruct{}, "error message %s", "formatted")
 func (a *Assertions) IsNotTypef(theType interface{}, object interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -905,7 +905,7 @@ func (a *Assertions) IsNotTypef(theType interface{}, object interface{}, msg str
 
 // IsType asserts that the specified objects are of the same type.
 //
-// 	a.IsType(&MyStruct{}, &MyStruct{})
+//	a.IsType(&MyStruct{}, &MyStruct{})
 func (a *Assertions) IsType(expectedType interface{}, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -915,7 +915,7 @@ func (a *Assertions) IsType(expectedType interface{}, object interface{}, msgAnd
 
 // IsTypef asserts that the specified objects are of the same type.
 //
-// 	a.IsTypef(&MyStruct{}, &MyStruct{}, "error message %s", "formatted")
+//	a.IsTypef(&MyStruct{}, &MyStruct{}, "error message %s", "formatted")
 func (a *Assertions) IsTypef(expectedType interface{}, object interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -925,7 +925,7 @@ func (a *Assertions) IsTypef(expectedType interface{}, object interface{}, msg s
 
 // JSONEq asserts that two JSON strings are equivalent.
 //
-// 	a.JSONEq(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
+//	a.JSONEq(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
 func (a *Assertions) JSONEq(expected string, actual string, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -935,7 +935,7 @@ func (a *Assertions) JSONEq(expected string, actual string, msgAndArgs ...interf
 
 // JSONEqf asserts that two JSON strings are equivalent.
 //
-// 	a.JSONEqf(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
+//	a.JSONEqf(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
 func (a *Assertions) JSONEqf(expected string, actual string, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -946,7 +946,7 @@ func (a *Assertions) JSONEqf(expected string, actual string, msg string, args ..
 // Len asserts that the specified object has specific length.
 // Len also fails if the object has a type that len() not accept.
 //
-// 	a.Len(mySlice, 3)
+//	a.Len(mySlice, 3)
 func (a *Assertions) Len(object interface{}, length int, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -957,7 +957,7 @@ func (a *Assertions) Len(object interface{}, length int, msgAndArgs ...interface
 // Lenf asserts that the specified object has specific length.
 // Len also fails if the object has a type that len() not accept.
 //
-// 	a.Lenf(mySlice, 3, "error message %s", "formatted")
+//	a.Lenf(mySlice, 3, "error message %s", "formatted")
 func (a *Assertions) Lenf(object interface{}, length int, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -967,9 +967,9 @@ func (a *Assertions) Lenf(object interface{}, length int, msg string, args ...in
 
 // Less asserts that the first element is less than the second
 //
-// 	a.Less(1, 2)
-// 	a.Less(float64(1), float64(2))
-// 	a.Less("a", "b")
+//	a.Less(1, 2)
+//	a.Less(float64(1), float64(2))
+//	a.Less("a", "b")
 func (a *Assertions) Less(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -979,10 +979,10 @@ func (a *Assertions) Less(e1 interface{}, e2 interface{}, msgAndArgs ...interfac
 
 // LessOrEqual asserts that the first element is less than or equal to the second
 //
-// 	a.LessOrEqual(1, 2)
-// 	a.LessOrEqual(2, 2)
-// 	a.LessOrEqual("a", "b")
-// 	a.LessOrEqual("b", "b")
+//	a.LessOrEqual(1, 2)
+//	a.LessOrEqual(2, 2)
+//	a.LessOrEqual("a", "b")
+//	a.LessOrEqual("b", "b")
 func (a *Assertions) LessOrEqual(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -992,10 +992,10 @@ func (a *Assertions) LessOrEqual(e1 interface{}, e2 interface{}, msgAndArgs ...i
 
 // LessOrEqualf asserts that the first element is less than or equal to the second
 //
-// 	a.LessOrEqualf(1, 2, "error message %s", "formatted")
-// 	a.LessOrEqualf(2, 2, "error message %s", "formatted")
-// 	a.LessOrEqualf("a", "b", "error message %s", "formatted")
-// 	a.LessOrEqualf("b", "b", "error message %s", "formatted")
+//	a.LessOrEqualf(1, 2, "error message %s", "formatted")
+//	a.LessOrEqualf(2, 2, "error message %s", "formatted")
+//	a.LessOrEqualf("a", "b", "error message %s", "formatted")
+//	a.LessOrEqualf("b", "b", "error message %s", "formatted")
 func (a *Assertions) LessOrEqualf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1005,9 +1005,9 @@ func (a *Assertions) LessOrEqualf(e1 interface{}, e2 interface{}, msg string, ar
 
 // Lessf asserts that the first element is less than the second
 //
-// 	a.Lessf(1, 2, "error message %s", "formatted")
-// 	a.Lessf(float64(1), float64(2), "error message %s", "formatted")
-// 	a.Lessf("a", "b", "error message %s", "formatted")
+//	a.Lessf(1, 2, "error message %s", "formatted")
+//	a.Lessf(float64(1), float64(2), "error message %s", "formatted")
+//	a.Lessf("a", "b", "error message %s", "formatted")
 func (a *Assertions) Lessf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1017,8 +1017,8 @@ func (a *Assertions) Lessf(e1 interface{}, e2 interface{}, msg string, args ...i
 
 // Negative asserts that the specified element is negative
 //
-// 	a.Negative(-1)
-// 	a.Negative(-1.23)
+//	a.Negative(-1)
+//	a.Negative(-1.23)
 func (a *Assertions) Negative(e interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1028,8 +1028,8 @@ func (a *Assertions) Negative(e interface{}, msgAndArgs ...interface{}) {
 
 // Negativef asserts that the specified element is negative
 //
-// 	a.Negativef(-1, "error message %s", "formatted")
-// 	a.Negativef(-1.23, "error message %s", "formatted")
+//	a.Negativef(-1, "error message %s", "formatted")
+//	a.Negativef(-1.23, "error message %s", "formatted")
 func (a *Assertions) Negativef(e interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1040,7 +1040,7 @@ func (a *Assertions) Negativef(e interface{}, msg string, args ...interface{}) {
 // Never asserts that the given condition doesn't satisfy in waitFor time,
 // periodically checking the target function each tick.
 //
-// 	a.Never(func() bool { return false; }, time.Second, 10*time.Millisecond)
+//	a.Never(func() bool { return false; }, time.Second, 10*time.Millisecond)
 func (a *Assertions) Never(condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1051,7 +1051,7 @@ func (a *Assertions) Never(condition func() bool, waitFor time.Duration, tick ti
 // Neverf asserts that the given condition doesn't satisfy in waitFor time,
 // periodically checking the target function each tick.
 //
-// 	a.Neverf(func() bool { return false; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+//	a.Neverf(func() bool { return false; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
 func (a *Assertions) Neverf(condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1061,7 +1061,7 @@ func (a *Assertions) Neverf(condition func() bool, waitFor time.Duration, tick t
 
 // Nil asserts that the specified object is nil.
 //
-// 	a.Nil(err)
+//	a.Nil(err)
 func (a *Assertions) Nil(object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1071,7 +1071,7 @@ func (a *Assertions) Nil(object interface{}, msgAndArgs ...interface{}) {
 
 // Nilf asserts that the specified object is nil.
 //
-// 	a.Nilf(err, "error message %s", "formatted")
+//	a.Nilf(err, "error message %s", "formatted")
 func (a *Assertions) Nilf(object interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1099,10 +1099,10 @@ func (a *Assertions) NoDirExistsf(path string, msg string, args ...interface{}) 
 
 // NoError asserts that a function returned a nil error (ie. no error).
 //
-// 	  actualObj, err := SomeFunction()
-// 	  if a.NoError(err) {
-// 		   assert.Equal(t, expectedObj, actualObj)
-// 	  }
+//	  actualObj, err := SomeFunction()
+//	  if a.NoError(err) {
+//		   assert.Equal(t, expectedObj, actualObj)
+//	  }
 func (a *Assertions) NoError(err error, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1112,10 +1112,10 @@ func (a *Assertions) NoError(err error, msgAndArgs ...interface{}) {
 
 // NoErrorf asserts that a function returned a nil error (ie. no error).
 //
-// 	  actualObj, err := SomeFunction()
-// 	  if a.NoErrorf(err, "error message %s", "formatted") {
-// 		   assert.Equal(t, expectedObj, actualObj)
-// 	  }
+//	  actualObj, err := SomeFunction()
+//	  if a.NoErrorf(err, "error message %s", "formatted") {
+//		   assert.Equal(t, expectedObj, actualObj)
+//	  }
 func (a *Assertions) NoErrorf(err error, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1144,9 +1144,9 @@ func (a *Assertions) NoFileExistsf(path string, msg string, args ...interface{})
 // NotContains asserts that the specified string, list(array, slice...) or map does NOT contain the
 // specified substring or element.
 //
-// 	a.NotContains("Hello World", "Earth")
-// 	a.NotContains(["Hello", "World"], "Earth")
-// 	a.NotContains({"Hello": "World"}, "Earth")
+//	a.NotContains("Hello World", "Earth")
+//	a.NotContains(["Hello", "World"], "Earth")
+//	a.NotContains({"Hello": "World"}, "Earth")
 func (a *Assertions) NotContains(s interface{}, contains interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1157,9 +1157,9 @@ func (a *Assertions) NotContains(s interface{}, contains interface{}, msgAndArgs
 // NotContainsf asserts that the specified string, list(array, slice...) or map does NOT contain the
 // specified substring or element.
 //
-// 	a.NotContainsf("Hello World", "Earth", "error message %s", "formatted")
-// 	a.NotContainsf(["Hello", "World"], "Earth", "error message %s", "formatted")
-// 	a.NotContainsf({"Hello": "World"}, "Earth", "error message %s", "formatted")
+//	a.NotContainsf("Hello World", "Earth", "error message %s", "formatted")
+//	a.NotContainsf(["Hello", "World"], "Earth", "error message %s", "formatted")
+//	a.NotContainsf({"Hello": "World"}, "Earth", "error message %s", "formatted")
 func (a *Assertions) NotContainsf(s interface{}, contains interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1203,9 +1203,9 @@ func (a *Assertions) NotElementsMatchf(listA interface{}, listB interface{}, msg
 
 // NotEmpty asserts that the specified object is NOT [Empty].
 //
-// 	if a.NotEmpty(obj) {
-// 	  assert.Equal(t, "two", obj[1])
-// 	}
+//	if a.NotEmpty(obj) {
+//	  assert.Equal(t, "two", obj[1])
+//	}
 func (a *Assertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1215,9 +1215,9 @@ func (a *Assertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) {
 
 // NotEmptyf asserts that the specified object is NOT [Empty].
 //
-// 	if a.NotEmptyf(obj, "error message %s", "formatted") {
-// 	  assert.Equal(t, "two", obj[1])
-// 	}
+//	if a.NotEmptyf(obj, "error message %s", "formatted") {
+//	  assert.Equal(t, "two", obj[1])
+//	}
 func (a *Assertions) NotEmptyf(object interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1227,7 +1227,7 @@ func (a *Assertions) NotEmptyf(object interface{}, msg string, args ...interface
 
 // NotEqual asserts that the specified values are NOT equal.
 //
-// 	a.NotEqual(obj1, obj2)
+//	a.NotEqual(obj1, obj2)
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
@@ -1240,7 +1240,7 @@ func (a *Assertions) NotEqual(expected interface{}, actual interface{}, msgAndAr
 
 // NotEqualValues asserts that two objects are not equal even when converted to the same type
 //
-// 	a.NotEqualValues(obj1, obj2)
+//	a.NotEqualValues(obj1, obj2)
 func (a *Assertions) NotEqualValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1250,7 +1250,7 @@ func (a *Assertions) NotEqualValues(expected interface{}, actual interface{}, ms
 
 // NotEqualValuesf asserts that two objects are not equal even when converted to the same type
 //
-// 	a.NotEqualValuesf(obj1, obj2, "error message %s", "formatted")
+//	a.NotEqualValuesf(obj1, obj2, "error message %s", "formatted")
 func (a *Assertions) NotEqualValuesf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1260,7 +1260,7 @@ func (a *Assertions) NotEqualValuesf(expected interface{}, actual interface{}, m
 
 // NotEqualf asserts that the specified values are NOT equal.
 //
-// 	a.NotEqualf(obj1, obj2, "error message %s", "formatted")
+//	a.NotEqualf(obj1, obj2, "error message %s", "formatted")
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
@@ -1309,7 +1309,7 @@ func (a *Assertions) NotErrorIsf(err error, target error, msg string, args ...in
 
 // NotImplements asserts that an object does not implement the specified interface.
 //
-// 	a.NotImplements((*MyInterface)(nil), new(MyObject))
+//	a.NotImplements((*MyInterface)(nil), new(MyObject))
 func (a *Assertions) NotImplements(interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1319,7 +1319,7 @@ func (a *Assertions) NotImplements(interfaceObject interface{}, object interface
 
 // NotImplementsf asserts that an object does not implement the specified interface.
 //
-// 	a.NotImplementsf((*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
+//	a.NotImplementsf((*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
 func (a *Assertions) NotImplementsf(interfaceObject interface{}, object interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1329,7 +1329,7 @@ func (a *Assertions) NotImplementsf(interfaceObject interface{}, object interfac
 
 // NotNil asserts that the specified object is not nil.
 //
-// 	a.NotNil(err)
+//	a.NotNil(err)
 func (a *Assertions) NotNil(object interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1339,7 +1339,7 @@ func (a *Assertions) NotNil(object interface{}, msgAndArgs ...interface{}) {
 
 // NotNilf asserts that the specified object is not nil.
 //
-// 	a.NotNilf(err, "error message %s", "formatted")
+//	a.NotNilf(err, "error message %s", "formatted")
 func (a *Assertions) NotNilf(object interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1349,7 +1349,7 @@ func (a *Assertions) NotNilf(object interface{}, msg string, args ...interface{}
 
 // NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
 //
-// 	a.NotPanics(func(){ RemainCalm() })
+//	a.NotPanics(func(){ RemainCalm() })
 func (a *Assertions) NotPanics(f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1359,7 +1359,7 @@ func (a *Assertions) NotPanics(f assert.PanicTestFunc, msgAndArgs ...interface{}
 
 // NotPanicsf asserts that the code inside the specified PanicTestFunc does NOT panic.
 //
-// 	a.NotPanicsf(func(){ RemainCalm() }, "error message %s", "formatted")
+//	a.NotPanicsf(func(){ RemainCalm() }, "error message %s", "formatted")
 func (a *Assertions) NotPanicsf(f assert.PanicTestFunc, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1375,8 +1375,8 @@ func (a *Assertions) NotPanicsf(f assert.PanicTestFunc, msg string, args ...inte
 //
 // Examples:
 //
-// 	a.NotRegexp(regexp.MustCompile("starts"), "it's starting")
-// 	a.NotRegexp("^start", "it's not starting") // string is compiled
+//	a.NotRegexp(regexp.MustCompile("starts"), "it's starting")
+//	a.NotRegexp("^start", "it's not starting") // string is compiled
 func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1392,8 +1392,8 @@ func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...in
 //
 // Examples:
 //
-// 	a.NotRegexpf(regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
-// 	a.NotRegexpf("^start", "it's not starting", "error message %s", "formatted") // string is compiled
+//	a.NotRegexpf(regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
+//	a.NotRegexpf("^start", "it's not starting", "error message %s", "formatted") // string is compiled
 func (a *Assertions) NotRegexpf(rx interface{}, str interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1403,7 +1403,7 @@ func (a *Assertions) NotRegexpf(rx interface{}, str interface{}, msg string, arg
 
 // NotSame asserts that two pointers do not reference the same object.
 //
-// 	a.NotSame(ptr1, ptr2)
+//	a.NotSame(ptr1, ptr2)
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
@@ -1416,7 +1416,7 @@ func (a *Assertions) NotSame(expected interface{}, actual interface{}, msgAndArg
 
 // NotSamef asserts that two pointers do not reference the same object.
 //
-// 	a.NotSamef(ptr1, ptr2, "error message %s", "formatted")
+//	a.NotSamef(ptr1, ptr2, "error message %s", "formatted")
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
@@ -1432,10 +1432,10 @@ func (a *Assertions) NotSamef(expected interface{}, actual interface{}, msg stri
 // Map elements are key-value pairs unless compared with an array or slice where
 // only the map key is evaluated.
 //
-// 	a.NotSubset([1, 3, 4], [1, 2])
-// 	a.NotSubset({"x": 1, "y": 2}, {"z": 3})
-// 	a.NotSubset([1, 3, 4], {1: "one", 2: "two"})
-// 	a.NotSubset({"x": 1, "y": 2}, ["z"])
+//	a.NotSubset([1, 3, 4], [1, 2])
+//	a.NotSubset({"x": 1, "y": 2}, {"z": 3})
+//	a.NotSubset([1, 3, 4], {1: "one", 2: "two"})
+//	a.NotSubset({"x": 1, "y": 2}, ["z"])
 func (a *Assertions) NotSubset(list interface{}, subset interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1448,10 +1448,10 @@ func (a *Assertions) NotSubset(list interface{}, subset interface{}, msgAndArgs 
 // Map elements are key-value pairs unless compared with an array or slice where
 // only the map key is evaluated.
 //
-// 	a.NotSubsetf([1, 3, 4], [1, 2], "error message %s", "formatted")
-// 	a.NotSubsetf({"x": 1, "y": 2}, {"z": 3}, "error message %s", "formatted")
-// 	a.NotSubsetf([1, 3, 4], {1: "one", 2: "two"}, "error message %s", "formatted")
-// 	a.NotSubsetf({"x": 1, "y": 2}, ["z"], "error message %s", "formatted")
+//	a.NotSubsetf([1, 3, 4], [1, 2], "error message %s", "formatted")
+//	a.NotSubsetf({"x": 1, "y": 2}, {"z": 3}, "error message %s", "formatted")
+//	a.NotSubsetf([1, 3, 4], {1: "one", 2: "two"}, "error message %s", "formatted")
+//	a.NotSubsetf({"x": 1, "y": 2}, ["z"], "error message %s", "formatted")
 func (a *Assertions) NotSubsetf(list interface{}, subset interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1477,7 +1477,7 @@ func (a *Assertions) NotZerof(i interface{}, msg string, args ...interface{}) {
 
 // Panics asserts that the code inside the specified PanicTestFunc panics.
 //
-// 	a.Panics(func(){ GoCrazy() })
+//	a.Panics(func(){ GoCrazy() })
 func (a *Assertions) Panics(f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1489,7 +1489,7 @@ func (a *Assertions) Panics(f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 // panics, and that the recovered panic value is an error that satisfies the
 // EqualError comparison.
 //
-// 	a.PanicsWithError("crazy error", func(){ GoCrazy() })
+//	a.PanicsWithError("crazy error", func(){ GoCrazy() })
 func (a *Assertions) PanicsWithError(errString string, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1501,7 +1501,7 @@ func (a *Assertions) PanicsWithError(errString string, f assert.PanicTestFunc, m
 // panics, and that the recovered panic value is an error that satisfies the
 // EqualError comparison.
 //
-// 	a.PanicsWithErrorf("crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+//	a.PanicsWithErrorf("crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
 func (a *Assertions) PanicsWithErrorf(errString string, f assert.PanicTestFunc, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1512,7 +1512,7 @@ func (a *Assertions) PanicsWithErrorf(errString string, f assert.PanicTestFunc, 
 // PanicsWithValue asserts that the code inside the specified PanicTestFunc panics, and that
 // the recovered panic value equals the expected panic value.
 //
-// 	a.PanicsWithValue("crazy error", func(){ GoCrazy() })
+//	a.PanicsWithValue("crazy error", func(){ GoCrazy() })
 func (a *Assertions) PanicsWithValue(expected interface{}, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1523,7 +1523,7 @@ func (a *Assertions) PanicsWithValue(expected interface{}, f assert.PanicTestFun
 // PanicsWithValuef asserts that the code inside the specified PanicTestFunc panics, and that
 // the recovered panic value equals the expected panic value.
 //
-// 	a.PanicsWithValuef("crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+//	a.PanicsWithValuef("crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
 func (a *Assertions) PanicsWithValuef(expected interface{}, f assert.PanicTestFunc, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1533,7 +1533,7 @@ func (a *Assertions) PanicsWithValuef(expected interface{}, f assert.PanicTestFu
 
 // Panicsf asserts that the code inside the specified PanicTestFunc panics.
 //
-// 	a.Panicsf(func(){ GoCrazy() }, "error message %s", "formatted")
+//	a.Panicsf(func(){ GoCrazy() }, "error message %s", "formatted")
 func (a *Assertions) Panicsf(f assert.PanicTestFunc, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1543,8 +1543,8 @@ func (a *Assertions) Panicsf(f assert.PanicTestFunc, msg string, args ...interfa
 
 // Positive asserts that the specified element is positive
 //
-// 	a.Positive(1)
-// 	a.Positive(1.23)
+//	a.Positive(1)
+//	a.Positive(1.23)
 func (a *Assertions) Positive(e interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1554,8 +1554,8 @@ func (a *Assertions) Positive(e interface{}, msgAndArgs ...interface{}) {
 
 // Positivef asserts that the specified element is positive
 //
-// 	a.Positivef(1, "error message %s", "formatted")
-// 	a.Positivef(1.23, "error message %s", "formatted")
+//	a.Positivef(1, "error message %s", "formatted")
+//	a.Positivef(1.23, "error message %s", "formatted")
 func (a *Assertions) Positivef(e interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1571,8 +1571,8 @@ func (a *Assertions) Positivef(e interface{}, msg string, args ...interface{}) {
 //
 // Examples:
 //
-// 	a.Regexp(regexp.MustCompile("start"), "it's starting")
-// 	a.Regexp("start...$", "it's not starting") // string is compiled
+//	a.Regexp(regexp.MustCompile("start"), "it's starting")
+//	a.Regexp("start...$", "it's not starting") // string is compiled
 func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1588,8 +1588,8 @@ func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...inter
 //
 // Examples:
 //
-// 	a.Regexpf(regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
-// 	a.Regexpf("start...$", "it's not starting", "error message %s", "formatted") // string is compiled
+//	a.Regexpf(regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
+//	a.Regexpf("start...$", "it's not starting", "error message %s", "formatted") // string is compiled
 func (a *Assertions) Regexpf(rx interface{}, str interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1599,7 +1599,7 @@ func (a *Assertions) Regexpf(rx interface{}, str interface{}, msg string, args .
 
 // Same asserts that two pointers reference the same object.
 //
-// 	a.Same(ptr1, ptr2)
+//	a.Same(ptr1, ptr2)
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
@@ -1612,7 +1612,7 @@ func (a *Assertions) Same(expected interface{}, actual interface{}, msgAndArgs .
 
 // Samef asserts that two pointers reference the same object.
 //
-// 	a.Samef(ptr1, ptr2, "error message %s", "formatted")
+//	a.Samef(ptr1, ptr2, "error message %s", "formatted")
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
@@ -1628,10 +1628,10 @@ func (a *Assertions) Samef(expected interface{}, actual interface{}, msg string,
 // Map elements are key-value pairs unless compared with an array or slice where
 // only the map key is evaluated.
 //
-// 	a.Subset([1, 2, 3], [1, 2])
-// 	a.Subset({"x": 1, "y": 2}, {"x": 1})
-// 	a.Subset([1, 2, 3], {1: "one", 2: "two"})
-// 	a.Subset({"x": 1, "y": 2}, ["x"])
+//	a.Subset([1, 2, 3], [1, 2])
+//	a.Subset({"x": 1, "y": 2}, {"x": 1})
+//	a.Subset([1, 2, 3], {1: "one", 2: "two"})
+//	a.Subset({"x": 1, "y": 2}, ["x"])
 func (a *Assertions) Subset(list interface{}, subset interface{}, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1644,10 +1644,10 @@ func (a *Assertions) Subset(list interface{}, subset interface{}, msgAndArgs ...
 // Map elements are key-value pairs unless compared with an array or slice where
 // only the map key is evaluated.
 //
-// 	a.Subsetf([1, 2, 3], [1, 2], "error message %s", "formatted")
-// 	a.Subsetf({"x": 1, "y": 2}, {"x": 1}, "error message %s", "formatted")
-// 	a.Subsetf([1, 2, 3], {1: "one", 2: "two"}, "error message %s", "formatted")
-// 	a.Subsetf({"x": 1, "y": 2}, ["x"], "error message %s", "formatted")
+//	a.Subsetf([1, 2, 3], [1, 2], "error message %s", "formatted")
+//	a.Subsetf({"x": 1, "y": 2}, {"x": 1}, "error message %s", "formatted")
+//	a.Subsetf([1, 2, 3], {1: "one", 2: "two"}, "error message %s", "formatted")
+//	a.Subsetf({"x": 1, "y": 2}, ["x"], "error message %s", "formatted")
 func (a *Assertions) Subsetf(list interface{}, subset interface{}, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1657,7 +1657,7 @@ func (a *Assertions) Subsetf(list interface{}, subset interface{}, msg string, a
 
 // True asserts that the specified value is true.
 //
-// 	a.True(myBool)
+//	a.True(myBool)
 func (a *Assertions) True(value bool, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1667,7 +1667,7 @@ func (a *Assertions) True(value bool, msgAndArgs ...interface{}) {
 
 // Truef asserts that the specified value is true.
 //
-// 	a.Truef(myBool, "error message %s", "formatted")
+//	a.Truef(myBool, "error message %s", "formatted")
 func (a *Assertions) Truef(value bool, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1677,7 +1677,7 @@ func (a *Assertions) Truef(value bool, msg string, args ...interface{}) {
 
 // WithinDuration asserts that the two times are within duration delta of each other.
 //
-// 	a.WithinDuration(time.Now(), time.Now(), 10*time.Second)
+//	a.WithinDuration(time.Now(), time.Now(), 10*time.Second)
 func (a *Assertions) WithinDuration(expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1687,7 +1687,7 @@ func (a *Assertions) WithinDuration(expected time.Time, actual time.Time, delta 
 
 // WithinDurationf asserts that the two times are within duration delta of each other.
 //
-// 	a.WithinDurationf(time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
+//	a.WithinDurationf(time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
 func (a *Assertions) WithinDurationf(expected time.Time, actual time.Time, delta time.Duration, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1697,7 +1697,7 @@ func (a *Assertions) WithinDurationf(expected time.Time, actual time.Time, delta
 
 // WithinRange asserts that a time is within a time range (inclusive).
 //
-// 	a.WithinRange(time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second))
+//	a.WithinRange(time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second))
 func (a *Assertions) WithinRange(actual time.Time, start time.Time, end time.Time, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1707,7 +1707,7 @@ func (a *Assertions) WithinRange(actual time.Time, start time.Time, end time.Tim
 
 // WithinRangef asserts that a time is within a time range (inclusive).
 //
-// 	a.WithinRangef(time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second), "error message %s", "formatted")
+//	a.WithinRangef(time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second), "error message %s", "formatted")
 func (a *Assertions) WithinRangef(actual time.Time, start time.Time, end time.Time, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1717,17 +1717,17 @@ func (a *Assertions) WithinRangef(actual time.Time, start time.Time, end time.Ti
 
 // YAMLEq asserts that the first documents in the two YAML strings are equivalent.
 //
-// 	expected := `---
-// 	key: value
-// 	---
-// 	key: this is a second document, it is not evaluated
-// 	`
-// 	actual := `---
-// 	key: value
-// 	---
-// 	key: this is a subsequent document, it is not evaluated
-// 	`
-// 	a.YAMLEq(expected, actual)
+//	expected := `---
+//	key: value
+//	---
+//	key: this is a second document, it is not evaluated
+//	`
+//	actual := `---
+//	key: value
+//	---
+//	key: this is a subsequent document, it is not evaluated
+//	`
+//	a.YAMLEq(expected, actual)
 func (a *Assertions) YAMLEq(expected string, actual string, msgAndArgs ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
@@ -1737,17 +1737,17 @@ func (a *Assertions) YAMLEq(expected string, actual string, msgAndArgs ...interf
 
 // YAMLEqf asserts that the first documents in the two YAML strings are equivalent.
 //
-// 	expected := `---
-// 	key: value
-// 	---
-// 	key: this is a second document, it is not evaluated
-// 	`
-// 	actual := `---
-// 	key: value
-// 	---
-// 	key: this is a subsequent document, it is not evaluated
-// 	`
-// 	a.YAMLEqf(expected, actual, "error message %s", "formatted")
+//	expected := `---
+//	key: value
+//	---
+//	key: this is a second document, it is not evaluated
+//	`
+//	actual := `---
+//	key: value
+//	---
+//	key: this is a subsequent document, it is not evaluated
+//	`
+//	a.YAMLEqf(expected, actual, "error message %s", "formatted")
 func (a *Assertions) YAMLEqf(expected string, actual string, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()

--- a/require/require_forward.go
+++ b/require/require_forward.go
@@ -955,7 +955,7 @@ func (a *Assertions) Len(object interface{}, length int, msgAndArgs ...interface
 }
 
 // Lenf asserts that the specified object has specific length.
-// Lenf also fails if the object has a type that len() not accept.
+// Len also fails if the object has a type that len() not accept.
 //
 // 	a.Lenf(mySlice, 3, "error message %s", "formatted")
 func (a *Assertions) Lenf(object interface{}, length int, msg string, args ...interface{}) {
@@ -1374,6 +1374,7 @@ func (a *Assertions) NotPanicsf(f assert.PanicTestFunc, msg string, args ...inte
 // %v and compiled using regexp.Compile.
 //
 // Examples:
+//
 // 	a.NotRegexp(regexp.MustCompile("starts"), "it's starting")
 // 	a.NotRegexp("^start", "it's not starting") // string is compiled
 func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) {
@@ -1390,6 +1391,7 @@ func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...in
 // %v and compiled using regexp.Compile.
 //
 // Examples:
+//
 // 	a.NotRegexpf(regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
 // 	a.NotRegexpf("^start", "it's not starting", "error message %s", "formatted") // string is compiled
 func (a *Assertions) NotRegexpf(rx interface{}, str interface{}, msg string, args ...interface{}) {
@@ -1568,6 +1570,7 @@ func (a *Assertions) Positivef(e interface{}, msg string, args ...interface{}) {
 // %v and compiled using regexp.Compile.
 //
 // Examples:
+//
 // 	a.Regexp(regexp.MustCompile("start"), "it's starting")
 // 	a.Regexp("start...$", "it's not starting") // string is compiled
 func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) {
@@ -1584,6 +1587,7 @@ func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...inter
 // %v and compiled using regexp.Compile.
 //
 // Examples:
+//
 // 	a.Regexpf(regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
 // 	a.Regexpf("start...$", "it's not starting", "error message %s", "formatted") // string is compiled
 func (a *Assertions) Regexpf(rx interface{}, str interface{}, msg string, args ...interface{}) {


### PR DESCRIPTION
docs(assert/require): clarify allowed rx values for Regexp/NotRegexp (#268, #1793)
Summary
Clarify the allowed types and runtime behavior of the rx argument for assert.Regexp, assert.NotRegexp and their require and *f variants. This is a documentation-only change.
Changes
Updated function comments in:
assert/assertions.go
assert/assertion_format.go
assert/assertion_forward.go
require/require.go
require/require_forward.go
The comments now:
State that the preferred rx value is a *regexp.Regexp.
Explain that non-*regexp.Regexp values are stringified and compiled (historical behavior preserved).
Motivation
Users were unclear about which types are accepted for the rx parameter and whether passing a plain string or other value was supported. The code historically accepts interface{} and falls back to stringifying and compiling the value; documenting this explicitly reduces confusion and helps callers choose the safest/most efficient usage (passing a compiled *regexp.Regexp when possible).
Related issues
#1793 
Behavior / Tests
Behavior: No runtime or API behavior changes were made. The implementation still stringifies non-*regexp.Regexp values and compiles them with regexp.MustCompile (same as before). This PR is documentation-only.
Tests: I ran package tests for the changed packages locally:
go test ./assert ./require — passed.
Note: Running go test [d:](http://_vscodecontentref_/0). on Windows may show failures in suite due to environment-specific tests (panic/restart tests and -race subprocess builds needing a C toolchain). Those failures are unrelated to this docs-only change.