### PR TITLE
docs(require): correct example usage to use assert.CollectT (require.CollectT does not exist)

### DIFF
--- a/_codegen/main.go
+++ b/_codegen/main.go
@@ -106,9 +106,7 @@ func parseTemplates() (*template.Template, *template.Template, error) {
 		}
 		funcTemplate = string(f)
 	}
-	tmpl, err := template.New("function").Funcs(template.FuncMap{
-		"replace": strings.ReplaceAll,
-	}).Parse(funcTemplate)
+	tmpl, err := template.New("function").Parse(funcTemplate)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -331,6 +329,8 @@ func requireComment(comment string) string {
 
 func (f *testFunc) CommentRequire() string {
 	comment := strings.ReplaceAll(f.DocInfo.Doc, "assert.", "require.")
+	// Preserve assert.CollectT, even in package 'require'
+	comment = strings.ReplaceAll(comment, "require.CollectT", "assert.CollectT")
 	return requireComment(comment)
 }
 

--- a/require/require.go
+++ b/require/require.go
@@ -429,7 +429,7 @@ func Eventually(t TestingT, condition func() bool, waitFor time.Duration, tick t
 //		time.Sleep(8*time.Second)
 //		externalValue = true
 //	}()
-//	require.EventuallyWithT(t, func(c *require.CollectT) {
+//	require.EventuallyWithT(t, func(c *assert.CollectT) {
 //		// add assertions as needed; any assertion failure will fail the current tick
 //		require.True(c, externalValue, "expected 'externalValue' to be true")
 //	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
@@ -457,7 +457,7 @@ func EventuallyWithT(t TestingT, condition func(collect *assert.CollectT), waitF
 //		time.Sleep(8*time.Second)
 //		externalValue = true
 //	}()
-//	require.EventuallyWithTf(t, func(c *require.CollectT, "error message %s", "formatted") {
+//	require.EventuallyWithTf(t, func(c *assert.CollectT, "error message %s", "formatted") {
 //		// add assertions as needed; any assertion failure will fail the current tick
 //		require.True(c, externalValue, "expected 'externalValue' to be true")
 //	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")


### PR DESCRIPTION
## Summary
<!-- High-level, one sentence summary of what this PR accomplishes -->

Update documentation comments in `require.go` to use `assert.CollectT` instead of non-existing `require.CollectT` in `EventuallyWithT` and `EventuallyWithTf` examples. This clarifies the intended usage and prevents confusion for users.

## Changes
<!-- * Description of change 1 -->
<!-- * Description of change 2 -->
<!-- ... -->
- Created wrapper function for strings.ReplaceAll which preserve certain identifiers. So far we only need to preserve `assert.CollectT`.

## Motivation
<!-- Why were the changes necessary. -->

The documentation was confusing since it uses non-existent type.

<!-- ## Example usage (if applicable) -->

## Related issues
<!-- Put `Closes #XXXX` for each issue number this PR fixes/closes -->
Closes #1843