### PR TITLE
Ensure deterministic order when diffing maps

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1985,6 +1985,7 @@ var spewConfig = spew.ConfigState{
 	DisablePointerAddresses: true,
 	DisableCapacities:       true,
 	SortKeys:                true,
+	SpewKeys:                true,
 	DisableMethods:          true,
 	MaxDepth:                10,
 }
@@ -1994,6 +1995,7 @@ var spewConfigStringerEnabled = spew.ConfigState{
 	DisablePointerAddresses: true,
 	DisableCapacities:       true,
 	SortKeys:                true,
+	SpewKeys:                true,
 	MaxDepth:                10,
 }
 

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -2989,6 +2989,28 @@ Diff:
 Diff:
 --- Expected
 +++ Actual
+@@ -12,3 +12,3 @@
+   x: (int) 4
+- }: (int) 4
++ }: (int) 999
+ }
+`
+
+	type Key struct {
+		x int
+	}
+
+	actual = diff(
+		map[Key]int{Key{1}: 1, Key{2}: 2, Key{3}: 3, Key{4}: 4},
+		map[Key]int{Key{1}: 1, Key{2}: 2, Key{3}: 3, Key{4}: 999},
+	)
+	Equal(t, expected, actual)
+
+	expected = `
+
+Diff:
+--- Expected
++++ Actual
 @@ -1,3 +1,3 @@
  (*errors.errorString)({
 - s: (string) (len=19) "some expected error"


### PR DESCRIPTION
## Summary

Ensure deterministic order when diffing maps to make the diffs readable.

## Changes

Enable the [`SpewKeys` setting in `spew.ConfigState`](https://pkg.go.dev/github.com/davecgh/go-spew/spew#ConfigState).

## Motivation

When generating the diff for two maps where the map key is not a basic type, the order is non-deterministic which makes the diffs unreadable.

By enabling the `SpewKeys` setting, the map keys will be spewed to strings for the purpose of sorting them. This results in a deterministic order and makes the diffs readable.

For the test case added in this PR, the old config that has `SpewKeys` disabled would look like this:

```diff
--- Expected
+++ Actual
@@ -1,5 +1,2 @@
 (map[assert.Key]int) (len=4) {
- (assert.Key) {
-  x: (int) 4
- }: (int) 4,
  (assert.Key) {
@@ -12,3 +9,6 @@
   x: (int) 3
- }: (int) 3
+ }: (int) 3,
+ (assert.Key) {
+  x: (int) 4
+ }: (int) 999
 }
```

After enabling `SpewKeys`, we get the simpler diff that we would expect:

```diff
--- Expected
+++ Actual
@@ -12,3 +12,3 @@
   x: (int) 4
- }: (int) 4
+ }: (int) 999
 }
```
