### PR TITLE
deps: bump objx to v0.5.3 and remove dependency cycle issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,6 @@ module github.com/stretchr/testify
 go 1.17
 
 require (
-	github.com/stretchr/objx v0.5.2 // To avoid a cycle the version of testify used by objx should be excluded below
+	github.com/stretchr/objx v0.5.3
 	gopkg.in/yaml.v3 v3.0.1
 )
-
-// Break dependency cycle with objx.
-// See https://github.com/stretchr/objx/pull/140
-exclude github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
-github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
+github.com/stretchr/objx v0.5.3 h1:jmXUvGomnU1o3W/V5h2VEradbpJDwGrzugQQvL0POH4=
+github.com/stretchr/objx v0.5.3/go.mod h1:rDQraq+vQZU7Fde9LOZLr8Tax6zZvy4kuNKF+QYS+U0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
## Changes

Bump the objx dependency, clean up the go.mod

## Motivation

The latest version objx no longer uses testify as a test suite.

Thanks to @emilien-puget work with https://github.com/stretchr/objx/pull/159

- https://github.com/stretchr/objx/pull/159

It resolves an old issue of cyclic dependencies that had been to address multiple times.

- #1453 
- #1567 

## Related issues

Closes #1807 

Related to 

- https://github.com/stretchr/objx/issues/124
- https://github.com/stretchr/testify/issues/1752