### PR TITLE
Catch panic when using go-spew

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1948,19 +1948,28 @@ func diff(expected interface{}, actual interface{}) string {
 
 	var e, a string
 
-	switch et {
-	case reflect.TypeOf(""):
-		e = reflect.ValueOf(expected).String()
-		a = reflect.ValueOf(actual).String()
-	case reflect.TypeOf(time.Time{}):
-		e = spewConfigStringerEnabled.Sdump(expected)
-		a = spewConfigStringerEnabled.Sdump(actual)
-	default:
-		e = spewConfig.Sdump(expected)
-		a = spewConfig.Sdump(actual)
+	// Use spew to create string representations of the objects
+	// We have to guard against panics in spew.
+	// See https://github.com/stretchr/testify/issues/480
+	panicked, _, _ := didPanic(func() {
+		switch et {
+		case reflect.TypeOf(""):
+			e = reflect.ValueOf(expected).String()
+			a = reflect.ValueOf(actual).String()
+		case reflect.TypeOf(time.Time{}):
+			e = spewConfigStringerEnabled.Sdump(expected)
+			a = spewConfigStringerEnabled.Sdump(actual)
+		default:
+			e = spewConfig.Sdump(expected)
+			a = spewConfig.Sdump(actual)
+		}
+	})
+	if panicked {
+		// silently ignore diff if we panic during spew, the library is no longer maintained
+		return ""
 	}
 
-	diff, _ := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
+	diff, err := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
 		A:        difflib.SplitLines(e),
 		B:        difflib.SplitLines(a),
 		FromFile: "Expected",
@@ -1969,6 +1978,11 @@ func diff(expected interface{}, actual interface{}) string {
 		ToDate:   "",
 		Context:  1,
 	})
+
+	if err != nil {
+		// silently ignore diff if the external library fails to compute it
+		return ""
+	}
 
 	return "\n\nDiff:\n" + diff
 }


### PR DESCRIPTION
## Summary

Avoid panic on go-spew errors


## Changes

wrap the calls to go-spew into a call to `didPanic`


## Motivation

go-spew can panic when trying to diff certain types of values, there are open issues about this on their GitHub repository.

go-spew is unfortunately unmaintained, we cannot expect a fix any time soon. Also, because of go-spew's design, there are multiple causes for a panic, and fixing all of them would be a huge undertaking.

We already return an empty diff when the types are not comparable, or when the values are not from types that can be easily diffed by go-spew.

Let's hide the panic by recovering from it, and returning an empty diff instead. This is not ideal, but at least it prevents the entire program from crashing. The expected/actual values will still be printed, just without the diff.

## Related issues

Closes #480

- #480

Related to 

- #1816 It provides a different approach but #1816 could be still be considered cc @HaraldNordgren
- #1813 Provide a solution for the panic issues without changing the diff lib cc @olitez


