### PR TITLE
fix: panic in spew when dealing with unexported fields

### DIFF
--- a/internal/spew/common.go
+++ b/internal/spew/common.go
@@ -312,6 +312,12 @@ func valueSortLess(a, b reflect.Value) bool {
 		for i := 0; i < l; i++ {
 			av := a.Index(i)
 			bv := b.Index(i)
+
+			if !av.CanInterface() || !bv.CanInterface() {
+				// Unexported fields would panic on Interface() call.
+				continue
+			}
+
 			if av.Interface() == bv.Interface() {
 				continue
 			}


### PR DESCRIPTION
## Summary

Fix panic that happens when spew tries to sort unexported fields

## Changes

Fix the panic raised by [Interface()](https://pkg.go.dev/reflect#Value.Interface) on unexported fields

[CanInterface()](https://pkg.go.dev/reflect#Value.CanInterface) is the solution

## Motivation

Now, go-spew is vendored, we can fix old issues we had
## Related issues

- Related to #1826
- Closes #480
- Closes #1813
- Closes #1816
- Supersedes #1824