### PR TITLE
suite: add SyncTest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,7 @@ jobs:
           - "1.21"
           - "1.22"
           - "1.23"
+          - "1.25"
     steps:
       - uses: actions/checkout@v5
       - name: Setup Go

--- a/suite/synctest.go
+++ b/suite/synctest.go
@@ -1,0 +1,18 @@
+//go:build go1.25
+
+package suite
+
+import (
+	"testing"
+	"testing/synctest"
+)
+
+// SyncTest executes f in a new [synctest] bubble.
+func (suite *Suite) SyncTest(f func()) {
+	oldT := suite.T()
+	synctest.Test(oldT, func(t *testing.T) {
+		suite.SetT(t)
+		defer suite.SetT(oldT)
+		f()
+	})
+}

--- a/suite/synctest_test.go
+++ b/suite/synctest_test.go
@@ -1,0 +1,28 @@
+//go:build go1.25
+
+package suite
+
+import (
+	"testing"
+	"testing/synctest"
+)
+
+type SyncTestSuite struct {
+	Suite
+}
+
+func TestSyncTest(t *testing.T) {
+	t.Setenv("GODEBUG", "asynctimerchan=0") // since our go.mod says `go 1.17`
+	Run(t, new(SyncTestSuite))
+}
+
+func (s *SyncTestSuite) TestSyncTest() {
+	s.SyncTest(func() {
+		synctest.Wait()
+	})
+	s.Run("subtest", func() {
+		s.SyncTest(func() {
+			synctest.Wait()
+		})
+	})
+}


### PR DESCRIPTION
Introduces `(*Suite).SyncTest` which is to `synctest.Run` like `(*Suite).Run` is to `(*testing.T).Run`.

Its role is to maintain `s.T()` (so it points to synctest bubble's `t`).

synctest was introduced in go 1.25, so this is built conditionally.