### PR TITLE
chore: migrate from gopkg.in/yaml.v3 to go.yaml.in/yaml/v3

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -17,7 +17,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
-	// Wrapper around gopkg.in/yaml.v3
+	// Wrapper around go.yaml.in/yaml/v3
 	"github.com/stretchr/testify/assert/yaml"
 	"github.com/stretchr/testify/internal/difflib"
 	"github.com/stretchr/testify/internal/spew"

--- a/assert/yaml/yaml_custom.go
+++ b/assert/yaml/yaml_custom.go
@@ -7,7 +7,7 @@
 //	go test -tags testify_yaml_custom
 //
 // This implementation can be used at build time to replace the default implementation
-// to avoid linking with [gopkg.in/yaml.v3].
+// to avoid linking with [go.yaml.in/yaml/v3].
 //
 // In your test package:
 //

--- a/assert/yaml/yaml_default.go
+++ b/assert/yaml/yaml_default.go
@@ -6,7 +6,7 @@
 // indirection with an alternative implementation of this package that uses
 // another implementation of YAML deserialization. This allows to not either not
 // use YAML deserialization at all, or to use another implementation than
-// [gopkg.in/yaml.v3] (for example for license compatibility reasons, see [PR #1120]).
+// [go.yaml.in/yaml/v3] (for example for license compatibility reasons, see [PR #1120]).
 //
 // Alternative implementations are selected using build tags:
 //
@@ -28,9 +28,9 @@
 // [PR #1120]: https://github.com/stretchr/testify/pull/1120
 package yaml
 
-import goyaml "gopkg.in/yaml.v3"
+import goyaml "go.yaml.in/yaml/v3"
 
-// Unmarshal is just a wrapper of [gopkg.in/yaml.v3.Unmarshal].
+// Unmarshal is just a wrapper of [go.yaml.in/yaml/v3.Unmarshal].
 func Unmarshal(in []byte, out interface{}) error {
 	return goyaml.Unmarshal(in, out)
 }

--- a/assert/yaml/yaml_fail.go
+++ b/assert/yaml/yaml_fail.go
@@ -3,7 +3,7 @@
 // Package yaml is an implementation of YAML functions that always fail.
 //
 // This implementation can be used at build time to replace the default implementation
-// to avoid linking with [gopkg.in/yaml.v3]:
+// to avoid linking with [go.yaml.in/yaml/v3]:
 //
 //	go test -tags testify_yaml_fail
 package yaml

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ go 1.17
 
 require (
 	github.com/stretchr/objx v0.5.2 // To avoid a cycle the version of testify used by objx should be excluded below
-	gopkg.in/yaml.v3 v3.0.1
+	go.yaml.in/yaml/v3 v3.0.4
 )
 
 // Break dependency cycle with objx.

--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
The original gopkg.in/yaml.v3 was marked unmaintained (April 2025). 

go.yaml.in/yaml/v3 is now maintained by the official YAML organization and is a drop-in replacement with an identical API.

## Summary
Drop an unmaintained dependency for yaml with a newer supported API

## Changes
```
  | File                        | Change                                              |
  |-----------------------------|-----------------------------------------------------|
  | go.mod                      | gopkg.in/yaml.v3 v3.0.1 → go.yaml.in/yaml/v3 v3.0.4 |
  | go.sum                      | Updated checksums for new package                   |
  | assert/yaml/yaml_default.go | Updated import and doc comments                     |
  | assert/yaml/yaml_custom.go  | Updated doc comment                                 |
  | assert/yaml/yaml_fail.go    | Updated doc comment                                 |
  | assert/assertions.go        | Updated comment on line 20                          |
```

## Motivation
If you see https://github.com/go-yaml/yaml, you will see the archival notice
```
This repository was archived by the owner on Apr 1, 2025. It is now read-only.
```

## Related issues
<!-- Put `Closes #XXXX` for each issue number this PR fixes/closes -->
