### PR TITLE
docs: Fix EventuallyWithTf documentation with proper placement of formatting arguments

### DIFF
--- a/_codegen/main.go
+++ b/_codegen/main.go
@@ -283,10 +283,15 @@ func (f *testFunc) Comment() string {
 }
 
 func (f *testFunc) CommentFormat() string {
-	search := fmt.Sprintf("%s", f.DocInfo.Name)
+	search := f.DocInfo.Name
 	replace := fmt.Sprintf("%sf", f.DocInfo.Name)
-	comment := strings.Replace(f.Comment(), search, replace, -1)
-	exp := regexp.MustCompile(replace + `\(((\(\)|[^\n])+)\)`)
+	comment := strings.ReplaceAll(f.Comment(), search, replace)
+
+	// NOTE: Some functions have msgAndArgs at the end. It needs to be omitted. (currently only EventuallyWithT)
+	// Change here if the original comment changed.
+	comment = strings.Replace(comment, `, "external state has not changed to 'true'; still false"`, "", 1)
+
+	exp := regexp.MustCompile(replace + `\((([^()]*|\([^()]*\))*)\)`)
 	return exp.ReplaceAllString(comment, replace+`($1, "error message %s", "formatted")`)
 }
 

--- a/assert/assertion_format.go
+++ b/assert/assertion_format.go
@@ -190,10 +190,10 @@ func Eventuallyf(t TestingT, condition func() bool, waitFor time.Duration, tick 
 //		time.Sleep(8*time.Second)
 //		externalValue = true
 //	}()
-//	assert.EventuallyWithTf(t, func(c *assert.CollectT, "error message %s", "formatted") {
+//	assert.EventuallyWithTf(t, func(c *assert.CollectT) {
 //		// add assertions as needed; any assertion failure will fail the current tick
 //		assert.True(c, externalValue, "expected 'externalValue' to be true")
-//	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
+//	}, 10*time.Second, 1*time.Second, "error message %s", "formatted")
 func EventuallyWithTf(t TestingT, condition func(collect *CollectT), waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()

--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -372,10 +372,10 @@ func (a *Assertions) EventuallyWithT(condition func(collect *CollectT), waitFor 
 //		time.Sleep(8*time.Second)
 //		externalValue = true
 //	}()
-//	a.EventuallyWithTf(func(c *assert.CollectT, "error message %s", "formatted") {
+//	a.EventuallyWithTf(func(c *assert.CollectT) {
 //		// add assertions as needed; any assertion failure will fail the current tick
 //		assert.True(c, externalValue, "expected 'externalValue' to be true")
-//	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
+//	}, 10*time.Second, 1*time.Second, "error message %s", "formatted")
 func (a *Assertions) EventuallyWithTf(condition func(collect *CollectT), waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()

--- a/require/require.go
+++ b/require/require.go
@@ -457,10 +457,10 @@ func EventuallyWithT(t TestingT, condition func(collect *assert.CollectT), waitF
 //		time.Sleep(8*time.Second)
 //		externalValue = true
 //	}()
-//	require.EventuallyWithTf(t, func(c *assert.CollectT, "error message %s", "formatted") {
+//	require.EventuallyWithTf(t, func(c *assert.CollectT) {
 //		// add assertions as needed; any assertion failure will fail the current tick
 //		require.True(c, externalValue, "expected 'externalValue' to be true")
-//	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
+//	}, 10*time.Second, 1*time.Second, "error message %s", "formatted")
 func EventuallyWithTf(t TestingT, condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()

--- a/require/require_forward.go
+++ b/require/require_forward.go
@@ -373,10 +373,10 @@ func (a *Assertions) EventuallyWithT(condition func(collect *assert.CollectT), w
 //		time.Sleep(8*time.Second)
 //		externalValue = true
 //	}()
-//	a.EventuallyWithTf(func(c *assert.CollectT, "error message %s", "formatted") {
+//	a.EventuallyWithTf(func(c *assert.CollectT) {
 //		// add assertions as needed; any assertion failure will fail the current tick
 //		assert.True(c, externalValue, "expected 'externalValue' to be true")
-//	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
+//	}, 10*time.Second, 1*time.Second, "error message %s", "formatted")
 func (a *Assertions) EventuallyWithTf(condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()


### PR DESCRIPTION
## Summary
<!-- High-level, one sentence summary of what this PR accomplishes -->
Fixed the regexp for `CommentFormat()` code-generation function such that it properly captures the outer most closing parenthesis of a function call in code comment.
https://github.com/stretchr/testify/blob/65697cefca1d61fba40e001c90d2166be5c8df7f/_codegen/main.go#L291

## Changes
<!-- * Description of change 1 -->
<!-- * Description of change 2 -->
<!-- ... -->

- Changed regexp. It got much more of complexity but regexp is hard so what can I say...
- Minor refactoring such as removing a formating of a string which in reality does nothing.
- The original `EventuallyWithT` has `msgAndArgs` as the last argument, which needs to be replaced by two separate `msg` and `args` in `EventuallyWithTf`. I've implemented with very naive approach which might need to be improved.

## Motivation
<!-- Why were the changes necessary. -->
Misleading documentation

<!-- ## Example usage (if applicable) -->

## Related issues
<!-- Put `Closes #XXXX` for each issue number this PR fixes/closes -->
Closes #1833