### PR TITLE
Fix regression introduced in 1.11.x

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -2018,12 +2018,7 @@ func Eventually(t TestingT, condition func() bool, waitFor time.Duration, tick t
 	ticker := time.NewTicker(tick)
 	defer ticker.Stop()
 
-	var tickC <-chan time.Time
-
-	// Check the condition once first on the initial call.
-	go checkCond()
-
-	for {
+	for tickC := ticker.C; ; {
 		select {
 		case <-timer.C:
 			return Fail(t, "Condition never satisfied", msgAndArgs...)
@@ -2121,12 +2116,7 @@ func EventuallyWithT(t TestingT, condition func(collect *CollectT), waitFor time
 	ticker := time.NewTicker(tick)
 	defer ticker.Stop()
 
-	var tickC <-chan time.Time
-
-	// Check the condition once first on the initial call.
-	go checkCond()
-
-	for {
+	for tickC := ticker.C; ; {
 		select {
 		case <-timer.C:
 			for _, err := range lastFinishedTickErrs {
@@ -2165,12 +2155,7 @@ func Never(t TestingT, condition func() bool, waitFor time.Duration, tick time.D
 	ticker := time.NewTicker(tick)
 	defer ticker.Stop()
 
-	var tickC <-chan time.Time
-
-	// Check the condition once first on the initial call.
-	go checkCond()
-
-	for {
+	for tickC := ticker.C; ; {
 		select {
 		case <-timer.C:
 			return true

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -14,6 +14,7 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -3491,6 +3492,54 @@ func TestEventuallyWithTTrue(t *testing.T) {
 	Equal(t, 2, counter, "Condition is expected to be called 2 times")
 }
 
+func TestEventuallyWithT_AvoidsPanic_NilDeref(t *testing.T) {
+	t.Parallel()
+
+	var p atomic.Value
+	go func() {
+		time.Sleep(5 * time.Millisecond)
+		value := 1
+		p.Store(&value)
+	}()
+
+	// If the condition runs before the first tick, this panics on *p.Load()
+	True(t, EventuallyWithT(t, func(c *CollectT) {
+		Equal(c, 1, *p.Load().(*int))
+	}, 200*time.Millisecond, 50*time.Millisecond))
+}
+
+func TestEventually_AvoidsPanic_NilDeref(t *testing.T) {
+	t.Parallel()
+
+	var p atomic.Value
+	go func() {
+		time.Sleep(5 * time.Millisecond)
+		value := 1
+		p.Store(&value)
+	}()
+
+	// If the condition runs before the first tick, this panics on *p.Load()
+	True(t, Eventually(t, func() bool {
+		return *p.Load().(*int) == 1
+	}, 200*time.Millisecond, 50*time.Millisecond))
+}
+
+func TestNever_AvoidsPanic_NilDeref(t *testing.T) {
+	t.Parallel()
+
+	var p atomic.Value
+	go func() {
+		time.Sleep(5 * time.Millisecond)
+		value := 0
+		p.Store(&value)
+	}()
+
+	// If the condition runs before the first tick, this panics on *p.Load()
+	True(t, Never(t, func() bool {
+		return *p.Load().(*int) == 1 // set to 0 above, so this should never == 1
+	}, 200*time.Millisecond, 50*time.Millisecond))
+}
+
 func TestEventuallyWithT_ConcurrencySafe(t *testing.T) {
 	t.Parallel()
 
@@ -3568,28 +3617,26 @@ func TestEventuallyTimeout(t *testing.T) {
 	})
 }
 
-func TestEventuallySucceedQuickly(t *testing.T) {
+func TestEventually_NoImmediateCheckBeforeFirstTick(t *testing.T) {
 	t.Parallel()
 
 	mockT := new(testing.T)
 
 	condition := func() bool { return true }
 
-	// By making the tick longer than the total duration, we expect that this test would fail if
-	// we didn't check the condition before the first tick elapses.
-	True(t, Eventually(mockT, condition, 100*time.Millisecond, time.Second))
+	// By making the tick longer than the total duration, the condition should not be checked.
+	False(t, Eventually(mockT, condition, 100*time.Millisecond, time.Second))
 }
 
-func TestEventuallyWithTSucceedQuickly(t *testing.T) {
+func TestEventuallyWithT_NoImmediateCheckBeforeFirstTick(t *testing.T) {
 	t.Parallel()
 
 	mockT := new(testing.T)
 
 	condition := func(t *CollectT) {}
 
-	// By making the tick longer than the total duration, we expect that this test would fail if
-	// we didn't check the condition before the first tick elapses.
-	True(t, EventuallyWithT(mockT, condition, 100*time.Millisecond, time.Second))
+	// By making the tick longer than the total duration, the condition should not be checked.
+	False(t, EventuallyWithT(mockT, condition, 100*time.Millisecond, time.Second))
 }
 
 func TestNeverFalse(t *testing.T) {
@@ -3623,15 +3670,14 @@ func TestNeverTrue(t *testing.T) {
 	False(t, Never(mockT, condition, 100*time.Millisecond, 20*time.Millisecond))
 }
 
-func TestNeverFailQuickly(t *testing.T) {
+func TestNever_NoImmediateCheckBeforeFirstTick(t *testing.T) {
 	t.Parallel()
 
 	mockT := new(testing.T)
 
-	// By making the tick longer than the total duration, we expect that this test would fail if
-	// we didn't check the condition before the first tick elapses.
+	// By making the tick longer than the total duration, the condition should not be checked.
 	condition := func() bool { return true }
-	False(t, Never(mockT, condition, 100*time.Millisecond, time.Second))
+	True(t, Never(mockT, condition, 100*time.Millisecond, time.Second))
 }
 
 func Test_validateEqualArgs(t *testing.T) {


### PR DESCRIPTION
## Summary
Revert the check early behavior introduced in [this PR](https://github.com/stretchr/testify/pull/1427/changes). Add tests to ensure there are no panics due to nil derefs. Restores v1.10 behavior for [Never()](https://github.com/stretchr/testify/blob/v1.10.0/assert/assertions.go#L2074), [Eventually()](https://github.com/stretchr/testify/blob/v1.10.0/assert/assertions.go#L1943), [EventuallyWithT()](https://github.com/stretchr/testify/blob/v1.10.0/assert/assertions.go#L1943)

## Motivation
We hit nil deref panics in our dapr/dapr unit tests after upgrading to v1.11.x here in [this PR](https://github.com/dapr/dapr/pull/9345) ([see panic here](https://github.com/dapr/dapr/actions/runs/21289530220/job/61312418538#step:4:846)) because `EventuallyWithT` now runs the condition immediately on entry. You can see where I pinned back to 1.10 to resolve the issue in [this PR as a test to confirm the regression](https://github.com/dapr/dapr/pull/9352) and after confirming merged the pinned version [in this PR](https://github.com/dapr/dapr/pull/9345). The test from the linked CI failure is [here](https://github.com/dapr/dapr/blob/master/pkg/scheduler/server/internal/pool/loops/stream/stream_test.go#L240) for easy reference where we use atomic ptr, hence why I added a very similar test to your test suite.

## Related issues
<!-- Put `Closes #XXXX` for each issue number this PR fixes/closes -->
