### PR TITLE
fix(assert): stabilize relative error calculation in InEpsilon

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1570,7 +1570,8 @@ func calcRelativeError(expected, actual interface{}) (float64, error) {
 		return 0, errors.New("actual value must not be NaN")
 	}
 
-	return math.Abs(af-bf) / math.Abs(af), nil
+	denom := math.Max(math.Abs(af), math.Abs(bf))
+	return math.Abs(af-bf) / denom, nil
 }
 
 // InEpsilon asserts that expected and actual have a relative error less than epsilon

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -2459,6 +2459,7 @@ func TestInEpsilon(t *testing.T) {
 		{uint64(100), uint8(101), 0.01},
 		{0.1, -0.1, 2},
 		{0.1, 0, 2},
+		{0.1, 0.14, 0.4},
 		{math.NaN(), math.NaN(), 1},
 		{time.Second, time.Second + time.Millisecond, 0.002},
 	}


### PR DESCRIPTION
Fix relative error calculation for small expected values in InEpsilon.

The previous implementation normalized only by the expected value, which could
inflate relative error when expected was small. This change normalizes by the
maximum absolute value, improving numerical stability without changing the
semantics of the base code.

For the tests, i used the below values:
{0.1, 0.14, 0.4}