### PR TITLE
CI: test also with Go 1.24

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,7 @@ jobs:
           - "1.21"
           - "1.22"
           - "1.23"
+          - "1.24"
     steps:
       - uses: actions/checkout@v5
       - name: Setup Go


### PR DESCRIPTION
## Summary

Add "1.24" to CI.

## Changes

- Add "1.24" to `strategy.matrix.go_version` list in `.github/workflows/main.yml`

## Motivation

Now that Go 1.26.0 is released, Go 1.24 must be explicitly mentioned for testing, as it was previously "oldstable".
