### PR TITLE
chore: use mdsf action and stable schema

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,8 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ matrix.go_version }}
-      - run: npm install -g mdsf-cli
+      - name: Setup mdsf
+        uses: hougesen/mdsf@v0.12.0
       - run: ./.ci.gogenerate.sh
       - run: ./.ci.gofmt.sh
       - run: ./.ci.readme.fmt.sh

--- a/.mdsf.json
+++ b/.mdsf.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/hougesen/mdsf/main/schemas/v0.8.2/mdsf.schema.json",
+  "$schema": "https://raw.githubusercontent.com/hougesen/mdsf/main/schemas/stable/mdsf.schema.json",
   "format_finished_document": false,
   "languages": {
     "go": [


### PR DESCRIPTION
## Summary

Use `mdsf` action instead of installing via `npm`.
Use the latest available schema for mdsf (see https://github.com/hougesen/mdsf/issues/1524).

## Changes

- Replace `npm install -g mdsf-cli` with `hougesen/mdsf@v0.12.0`.
- Update `$schema` in `mdsf.json`.

## Motivation

Because of supply chain security concerns.

This allows referencing a stable URL schema without needing to update it every time a new version is released.

## Related issues

#1687