### PR TITLE
assert.EqualValues: fix float32 and float64 comparisions

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -187,11 +187,24 @@ func ObjectsAreEqualValues(expected, actual interface{}) bool {
 	// If BOTH values are numeric, there are chances of false positives due
 	// to overflow or underflow. So, we need to make sure to always convert
 	// the smaller type to a larger type before comparing.
-	if expectedType.Size() >= actualType.Size() {
-		return actualValue.Convert(expectedType).Interface() == expected
+	fromType := actualType
+	toType := expectedType
+	fromValue := actualValue
+	toValue := expectedValue
+	if expectedType.Size() < actualType.Size() {
+		fromType = expectedType
+		toType = actualType
+		fromValue = expectedValue
+		toValue = actualValue
 	}
 
-	return expectedValue.Convert(actualType).Interface() == actual
+	newValue := fromValue.Convert(toType).Interface()
+	if fromType.Kind() == reflect.Float32 && toType.Kind() == reflect.Float64 {
+		scale := math.Pow(10, 6)
+		newValue = math.Round(newValue.(float64)*scale) / scale
+	}
+
+	return newValue == toValue.Interface()
 }
 
 // isNumericType returns true if the type is one of:

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -198,6 +198,11 @@ func ObjectsAreEqualValues(expected, actual interface{}) bool {
 		toValue = actualValue
 	}
 
+	// If we are converting from float32 to float64, the converted value will
+	// have trailing non zero decimals due to binary representation differences
+	// For example: float64(float32(10.1)) = 10.100000381469727
+	// To remove the trailing decimals we can round the 64-bit value to
+	// expected precision of 32-bit which is 6 decimal places
 	newValue := fromValue.Convert(toType).Interface()
 	if fromType.Kind() == reflect.Float32 && toType.Kind() == reflect.Float64 {
 		scale := math.Pow(10, 6)

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -177,39 +177,53 @@ func ObjectsAreEqualValues(expected, actual interface{}) bool {
 		return false
 	}
 
+	convertedExpectedValue := expectedValue.Convert(actualType).Interface()
+
 	if !isNumericType(expectedType) || !isNumericType(actualType) {
 		// Attempt comparison after type conversion
-		return reflect.DeepEqual(
-			expectedValue.Convert(actualType).Interface(), actual,
-		)
+		return reflect.DeepEqual(convertedExpectedValue, actual)
 	}
 
 	// If BOTH values are numeric, there are chances of false positives due
 	// to overflow or underflow. So, we need to make sure to always convert
 	// the smaller type to a larger type before comparing.
-	fromType := actualType
-	toType := expectedType
-	fromValue := actualValue
-	toValue := expectedValue
-	if expectedType.Size() < actualType.Size() {
-		fromType = expectedType
-		toType = actualType
-		fromValue = expectedValue
-		toValue = actualValue
+	// Assume smaller is expected value and larger is actual value
+	smallerTypeValue, largerTypeValue := expectedValue, actualValue
+	smallerValueCmp, largerValueCmp := convertedExpectedValue, actual
+
+	// Actual value is smaller than expected value, converting actual value to expected value type
+	if actualType.Size() < expectedType.Size() {
+		smallerTypeValue, largerTypeValue = actualValue, expectedValue
+
+		if !actualType.ConvertibleTo(expectedType) {
+			return false
+		}
+		smallerValueCmp = actualValue.Convert(expectedType).Interface()
+		largerValueCmp = expected
 	}
 
-	// If we are converting from float32 to float64, the converted value will
-	// have trailing non zero decimals due to binary representation differences
+	// Quick comparison after type conversion to see if overflow or underflow is resolved
+	if smallerValueCmp == largerValueCmp {
+		return true
+	}
+
+	// We want to allow comparison between float32(10.1) and float64(10.1).
+	// The problem here is when converting from float32 to float64, the converted
+	// value will have trailing non zero decimals due to binary representation differences
 	// For example: float64(float32(10.1)) = 10.100000381469727
 	// To remove the trailing decimals we can round the 64-bit value to
 	// expected precision of 32-bit which is 6 decimal places
-	newValue := fromValue.Convert(toType).Interface()
-	if fromType.Kind() == reflect.Float32 && toType.Kind() == reflect.Float64 {
+	if smallerTypeValue.Kind() == reflect.Float32 && largerTypeValue.Kind() == reflect.Float64 {
+		float := smallerValueCmp.(float64)
+		integerPart := math.Floor(float)
+		decimalPart := float - integerPart
+
 		scale := math.Pow(10, 6)
-		newValue = math.Round(newValue.(float64)*scale) / scale
+		decimalPart = math.Round(decimalPart*scale) / scale
+		smallerValueCmp = integerPart + decimalPart
 	}
 
-	return newValue == toValue.Interface()
+	return smallerValueCmp == largerValueCmp
 }
 
 // isNumericType returns true if the type is one of:

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -165,6 +165,7 @@ func TestObjectsAreEqualValues(t *testing.T) {
 		{float64(10.1), float32(10.1), true},
 		{float32(10.123456), float64(10.12345600), true},
 		{float32(10.123456), float64(10.12345678), false},
+		{float32(1.0 / 3.0), float64(1.0 / 3.0), false},
 	}
 
 	for _, c := range cases {

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -123,6 +123,11 @@ func TestObjectsAreEqual(t *testing.T) {
 		{time.Now, time.Now, false},
 		{func() {}, func() {}, false},
 		{uint32(10), int32(10), false},
+		{math.NaN(), math.NaN(), false},
+		{math.Inf(1), math.Inf(1), true},
+		{math.Inf(-1), math.Inf(-1), true},
+		{math.Inf(1), math.Inf(-1), false},
+		{math.Copysign(0, -1), 0.0, true}, // -0 should compare equal to 0
 	}
 
 	for _, c := range cases {
@@ -131,6 +136,10 @@ func TestObjectsAreEqual(t *testing.T) {
 
 			if res != c.result {
 				t.Errorf("ObjectsAreEqual(%#v, %#v) should return %#v", c.expected, c.actual, c.result)
+			}
+
+			if ObjectsAreEqual(c.actual, c.expected) != res {
+				t.Errorf("ObjectsAreEqual should be symmetric: ObjectsAreEqual(%#v, %#v) should return the same as ObjectsAreEqual(%#v, %#v)", c.expected, c.actual, c.actual, c.expected)
 			}
 		})
 	}
@@ -148,24 +157,36 @@ func TestObjectsAreEqualValues(t *testing.T) {
 	}{
 		{uint32(10), int32(10), true},
 		{0, nil, false},
-		{nil, 0, false},
 		{now, now.In(time.Local), false}, // should not be time zone independent
 		{int(270), int8(14), false},      // should handle overflow/underflow
-		{int8(14), int(270), false},
 		{[]int{270, 270}, []int8{14, 14}, false},
 		{complex128(1e+100 + 1e+100i), complex64(complex(math.Inf(0), math.Inf(0))), false},
 		{complex64(complex(math.Inf(0), math.Inf(0))), complex128(1e+100 + 1e+100i), false},
 		{complex128(1e+100 + 1e+100i), 270, false},
 		{270, complex128(1e+100 + 1e+100i), false},
 		{complex128(1e+100 + 1e+100i), 3.14, false},
-		{3.14, complex128(1e+100 + 1e+100i), false},
 		{complex128(1e+10 + 1e+10i), complex64(1e+10 + 1e+10i), true},
-		{complex64(1e+10 + 1e+10i), complex128(1e+10 + 1e+10i), true},
-		{float32(10.1), float64(10.1), true},
 		{float64(10.1), float32(10.1), true},
 		{float32(10.123456), float64(10.12345600), true},
 		{float32(10.123456), float64(10.12345678), false},
 		{float32(1.0 / 3.0), float64(1.0 / 3.0), false},
+
+		// Something near overflow should work
+		{float32(math.MaxFloat32), float64(math.MaxFloat32), true},
+
+		// NaN should remain unequal, even across float32/float64.
+		{float32(math.NaN()), float64(math.NaN()), false},
+
+		// Infinity should compare like ordinary equality.
+		{float32(math.Inf(1)), float64(math.Inf(1)), true},
+		{float32(math.Inf(-1)), float64(math.Inf(-1)), true},
+		{float64(math.Inf(1)), float32(math.Inf(-1)), false},
+
+		// zero should not lead to division by zero error
+		{float32(0), float64(0), true},
+
+		// Signed zero should still compare equal.
+		{float32(math.Copysign(0, -1)), float64(0), true},
 	}
 
 	for _, c := range cases {
@@ -174,6 +195,10 @@ func TestObjectsAreEqualValues(t *testing.T) {
 
 			if res != c.result {
 				t.Errorf("ObjectsAreEqualValues(%#v, %#v) should return %#v", c.expected, c.actual, c.result)
+			}
+
+			if ObjectsAreEqualValues(c.actual, c.expected) != res {
+				t.Errorf("ObjectsAreEqualValues should be symmetric: ObjectsAreEqualValues(%#v, %#v) should return the same as ObjectsAreEqualValues(%#v, %#v)", c.expected, c.actual, c.actual, c.expected)
 			}
 		})
 	}

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -161,6 +161,10 @@ func TestObjectsAreEqualValues(t *testing.T) {
 		{3.14, complex128(1e+100 + 1e+100i), false},
 		{complex128(1e+10 + 1e+10i), complex64(1e+10 + 1e+10i), true},
 		{complex64(1e+10 + 1e+10i), complex128(1e+10 + 1e+10i), true},
+		{float32(10.1), float64(10.1), true},
+		{float64(10.1), float32(10.1), true},
+		{float32(10.123456), float64(10.12345600), true},
+		{float32(10.123456), float64(10.12345678), false},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
## Summary
This PR attempts to provide a solution to #1576 where converting `float32` to `float64` for comparison will fail due to differences in binary representation. Where 
```golang
fmt.Println(float32(10.1))          // 10.1
fmt.Println(float64(10.1))          // 10.1
fmt.Println(float64(float32(10.1))) //10.100000381469727
```
This solution only allows comparison when `float64` value has just as many decimal digits defined as `float32`. For example
```golang
fmt.Println(float32(10.123456))      // 10.123456
fmt.Println(float64(10.12345600000)) // 10.123456
```

But for `1.0 / 3.0`, these are very different values for both `float32` and `float64`.
```golang
fmt.Println(float32(1.0 / 3.0)) // 0.33333334
fmt.Println(float64(1.0 / 3.0)) // 0.3333333333333333
```
Because the `float64` value has more decimal places defined than `float32`, they are not equal anyway.

[playground](https://go.dev/play/p/iyq8V_1o2Qb)
## Changes
* Added rounding logic for converted `float32` value to remove the trailing non zero decimals after the 6th decimal place. 
* Added some variables to simplify logic which variable to convert and round

## Motivation
When converting to `float64`, zeros are added the binary representation losing the accuracy of the original value. When we are comparing the `float32` we only care about the digits that are accurate, which is why we remove the trailing digits. The choice to round to 6 digits was aligning to what I found in golang playground, `float32` seems to round to 6 digits.
```golang
fmt.Println(float32(10.123456))  // 10.123456
fmt.Println(float32(10.1234567)) // 10.123457
```
[playground](https://go.dev/play/p/GUt2b2hqnwD)

## Related issues
Closes #1576 
