### PR TITLE
quote string values in empty assertion failures

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -757,6 +757,15 @@ func isEmpty(object interface{}) bool {
 	return isEmptyValue(reflect.ValueOf(object))
 }
 
+func formatEmptyMessageValue(object interface{}) string {
+	value := reflect.ValueOf(object)
+	if value.IsValid() && value.Kind() == reflect.String {
+		return truncatingFormat("%q", object)
+	}
+
+	return truncatingFormat("%v", object)
+}
+
 // isEmptyValue gets whether the specified reflect.Value is considered empty or not.
 func isEmptyValue(objValue reflect.Value) bool {
 	if objValue.IsZero() {
@@ -794,7 +803,7 @@ func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
 		if h, ok := t.(tHelper); ok {
 			h.Helper()
 		}
-		Fail(t, fmt.Sprintf("Should be empty, but was %s", truncatingFormat("%v", object)), msgAndArgs...)
+		Fail(t, fmt.Sprintf("Should be empty, but was %s", formatEmptyMessageValue(object)), msgAndArgs...)
 	}
 
 	return pass
@@ -811,7 +820,7 @@ func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
 		if h, ok := t.(tHelper); ok {
 			h.Helper()
 		}
-		Fail(t, fmt.Sprintf("Should NOT be empty, but was %v", object), msgAndArgs...)
+		Fail(t, fmt.Sprintf("Should NOT be empty, but was %s", formatEmptyMessageValue(object)), msgAndArgs...)
 	}
 
 	return pass

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -1952,7 +1952,7 @@ func TestEmpty(t *testing.T) {
 			name:           "Non Empty string is not empty",
 			value:          "something",
 			expectedResult: false,
-			expectedErrMsg: "Should be empty, but was something\n",
+			expectedErrMsg: "Should be empty, but was \"something\"\n",
 		},
 		{
 			name:           "Non nil object is not empty",
@@ -1994,7 +1994,7 @@ func TestEmpty(t *testing.T) {
 			name:           "non-empty aliased string is empty",
 			value:          TString("abc"),
 			expectedResult: false,
-			expectedErrMsg: "Should be empty, but was abc\n",
+			expectedErrMsg: "Should be empty, but was \"abc\"\n",
 		},
 		{
 			name:           "ptr to non-nil value is not empty",
@@ -2014,49 +2014,38 @@ func TestEmpty(t *testing.T) {
 			name:           "string with only spaces is not empty",
 			value:          "   ",
 			expectedResult: false,
-			expectedErrMsg: "Should be empty, but was    \n", // TODO FIX THIS strange error message
+			expectedErrMsg: "Should be empty, but was \"   \"\n",
 		},
 		{
 			name:           "string with a line feed is not empty",
 			value:          "\n",
 			expectedResult: false,
-			// TODO This is the exact same error message as for an empty string
-			expectedErrMsg: "Should be empty, but was \n", // TODO FIX THIS strange error message
+			expectedErrMsg: "Should be empty, but was \"\\n\"\n",
 		},
 		{
 			name:           "string with only tabulation and lines feed is not empty",
 			value:          "\n\t\n",
 			expectedResult: false,
-			// TODO The line feeds and tab are not helping to spot what is expected
-			expectedErrMsg: "" + // this syntax is used to show how errors are reported.
-				"Should be empty, but was \n" +
-				"\t\n",
+			expectedErrMsg: "Should be empty, but was \"\\n\\t\\n\"\n",
 		},
 		{
 			name:           "string with trailing lines feed is not empty",
 			value:          "foo\n\n",
 			expectedResult: false,
-			// TODO it's not clear if one or two lines feed are expected
-			expectedErrMsg: "Should be empty, but was foo\n\n",
+			expectedErrMsg: "Should be empty, but was \"foo\\n\\n\"\n",
 		},
 		{
 			name:           "string with leading and trailing tabulation and lines feed is not empty",
 			value:          "\n\nfoo\t\n\t\n",
 			expectedResult: false,
-			// TODO The line feeds and tab are not helping to figure what is expected
-			expectedErrMsg: "" +
-				"Should be empty, but was \n" +
-				"\n" +
-				"foo\t\n" +
-				"\t\n",
+			expectedErrMsg: "Should be empty, but was \"\\n\\nfoo\\t\\n\\t\\n\"\n",
 		},
 
 		{
 			name:           "non-printable character is not empty",
 			value:          "\u00a0", // NO-BREAK SPACE UNICODE CHARACTER
 			expectedResult: false,
-			// TODO here you cannot figure out what is expected
-			expectedErrMsg: "Should be empty, but was \u00a0\n",
+			expectedErrMsg: "Should be empty, but was \"\\u00a0\"\n",
 		},
 
 		// Here we are testing there is no error message on success
@@ -2112,7 +2101,7 @@ func TestNotEmpty(t *testing.T) {
 			name:           "Empty string is empty",
 			value:          "",
 			expectedResult: false,
-			expectedErrMsg: `Should NOT be empty, but was ` + "\n", // TODO FIX THIS strange error message
+			expectedErrMsg: "Should NOT be empty, but was \"\"\n",
 		},
 		{
 			name:           "Nil is empty",


### PR DESCRIPTION

**Repo:** stretchr/testify (⭐ 23000)
**Type:** bugfix
**Files changed:** 2
**Lines:** +20/-22

## What
This change updates `assert.Empty` and `assert.NotEmpty` to quote string values in failure messages, including aliased string types. The related `assert` package tests were updated so whitespace-only, newline-containing, and empty-string cases now assert against explicit, readable output like `"\\n"` and `""` instead of visually ambiguous raw text.

## Why
Current failure output for string values uses `%v`, which makes empty strings and whitespace-heavy strings hard to distinguish from formatting noise. That weakens assertion diagnostics in exactly the cases where users need clarity. Quoting string values keeps behavior unchanged while making failures immediately understandable and resolves the existing TODO-marked test expectations around these messages.

## Testing
Ran `GOCACHE=$(pwd)/.gocache go test ./assert -run 'Test(Empty|NotEmpty)$'` from the repo root. The targeted tests passed.

## Risk
Low / Message formatting only changes for string values in `Empty` and `NotEmpty`; assertion semantics are unchanged.
