### PR TITLE
suite: prevent panic when SetupTest skips with HandleStats

### DIFF
--- a/suite/suite.go
+++ b/suite/suite.go
@@ -200,14 +200,14 @@ func Run(t *testing.T, suite TestingSuite) {
 					failOnPanic(t, r)
 				}()
 
+				stats.start(method.Name)
+
 				if setupTestSuite, ok := suite.(SetupTestSuite); ok {
 					setupTestSuite.SetupTest()
 				}
 				if beforeTestSuite, ok := suite.(BeforeTest); ok {
 					beforeTestSuite.BeforeTest(methodFinder.Elem().Name(), method.Name)
 				}
-
-				stats.start(method.Name)
 
 				method.Func.Call([]reflect.Value{reflect.ValueOf(suite)})
 			},

--- a/suite/suite_test.go
+++ b/suite/suite_test.go
@@ -583,6 +583,42 @@ func TestSuiteWithStats(t *testing.T) {
 	assert.False(t, testStats["TestPanic"].Passed)
 }
 
+type suiteWithSkipInSetupAndStats struct {
+	Suite
+	wasCalled bool
+	stats     *SuiteInformation
+}
+
+func (s *suiteWithSkipInSetupAndStats) SetupTest() {
+	s.T().Skip("skip in setup")
+}
+
+func (s *suiteWithSkipInSetupAndStats) HandleStats(_ string, stats *SuiteInformation) {
+	s.wasCalled = true
+	s.stats = stats
+}
+
+func (s *suiteWithSkipInSetupAndStats) TestSomething() {
+	s.Fail("should not run")
+}
+
+func TestSuiteWithSkipInSetupAndStats(t *testing.T) {
+	skipSuite := new(suiteWithSkipInSetupAndStats)
+
+	testing.RunTests(allTestsFilter, []testing.InternalTest{
+		{
+			Name: t.Name() + "/skipSuite",
+			F: func(t *testing.T) {
+				Run(t, skipSuite)
+			},
+		},
+	})
+
+	assert.True(t, skipSuite.wasCalled, "HandleStats should have been called")
+	assert.NotNil(t, skipSuite.stats, "stats should not be nil")
+	assert.NotNil(t, skipSuite.stats.TestStats["TestSomething"], "test stats entry should exist even when skipped in SetupTest")
+}
+
 // FailfastSuite will test the behavior when running with the failfast flag
 // It logs calls in the callOrder slice which we then use to assert the correct calls were made
 type FailfastSuite struct {


### PR DESCRIPTION
## Motivation

When a suite implements `HandleStats` (the [`WithStats`](https://pkg.go.dev/github.com/stretchr/testify/suite#WithStats) interface) and `SetupTest()` calls `t.Skip()`, the suite panics with a nil pointer dereference. This is a bug, not expected behavior.

## The bug

`stats.start()` was registered *after* `SetupTest()` in the test runner. When `SetupTest()` calls `t.Skip()`, Go's `runtime.Goexit()` fires, skipping `stats.start()` entirely. The deferred `stats.end()` then accesses `s.TestStats[testName]` which is nil because `start()` never created the map entry.

## The fix

Move `stats.start()` before `SetupTest()` so the `TestStats` entry always exists when `end()` runs, regardless of whether setup skips, fails, or panics. This also makes timing more accurate since setup duration is now included.

One line moved, one test added. All 8 packages pass.

Fixes #1722