### PR TITLE
Modernize Go

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,9 +10,9 @@ jobs:
           - stable
           - oldstable
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ matrix.go_version }}
       - run: npm install -g mdsf-cli
@@ -26,7 +26,6 @@ jobs:
     strategy:
       matrix:
         go_version:
-          - "1.17"
           - "1.18"
           - "1.19"
           - "1.20"
@@ -34,10 +33,12 @@ jobs:
           - "1.22"
           - "1.23"
           - "1.24"
+          - "1.25"
+          - "1.26"
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ matrix.go_version }}
       - run: go test -v -race ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,9 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Create GitHub release from tag
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ To update Testify to the latest version, use `go get -u github.com/stretchr/test
 Supported go versions
 ==================
 
-We currently support the most recent major Go versions from 1.19 onward.
+We currently support the most recent major Go versions from 1.18 onward.
 
 ------
 

--- a/assert/assertion_compare.go
+++ b/assert/assertion_compare.go
@@ -42,7 +42,7 @@ var (
 	bytesType = reflect.TypeOf([]byte{})
 )
 
-func compare(obj1, obj2 interface{}, kind reflect.Kind) (compareResult, bool) {
+func compare(obj1, obj2 any, kind reflect.Kind) (compareResult, bool) {
 	obj1Value := reflect.ValueOf(obj1)
 	obj2Value := reflect.ValueOf(obj2)
 
@@ -386,7 +386,7 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (compareResult, bool) {
 //	assert.Greater(t, 2, 1)
 //	assert.Greater(t, float64(2), float64(1))
 //	assert.Greater(t, "b", "a")
-func Greater(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
+func Greater(t TestingT, e1 any, e2 any, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -400,7 +400,7 @@ func Greater(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface
 //	assert.GreaterOrEqual(t, 2, 2)
 //	assert.GreaterOrEqual(t, "b", "a")
 //	assert.GreaterOrEqual(t, "b", "b")
-func GreaterOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
+func GreaterOrEqual(t TestingT, e1 any, e2 any, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -413,7 +413,7 @@ func GreaterOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...in
 //	assert.Less(t, 1, 2)
 //	assert.Less(t, float64(1), float64(2))
 //	assert.Less(t, "a", "b")
-func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
+func Less(t TestingT, e1 any, e2 any, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -427,7 +427,7 @@ func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{})
 //	assert.LessOrEqual(t, 2, 2)
 //	assert.LessOrEqual(t, "a", "b")
 //	assert.LessOrEqual(t, "b", "b")
-func LessOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
+func LessOrEqual(t TestingT, e1 any, e2 any, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -439,7 +439,7 @@ func LessOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...inter
 //
 //	assert.Positive(t, 1)
 //	assert.Positive(t, 1.23)
-func Positive(t TestingT, e interface{}, msgAndArgs ...interface{}) bool {
+func Positive(t TestingT, e any, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -452,7 +452,7 @@ func Positive(t TestingT, e interface{}, msgAndArgs ...interface{}) bool {
 //
 //	assert.Negative(t, -1)
 //	assert.Negative(t, -1.23)
-func Negative(t TestingT, e interface{}, msgAndArgs ...interface{}) bool {
+func Negative(t TestingT, e any, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -461,7 +461,7 @@ func Negative(t TestingT, e interface{}, msgAndArgs ...interface{}) bool {
 	return compareTwoValues(t, e, zero.Interface(), []compareResult{compareLess}, failMessage, msgAndArgs...)
 }
 
-func compareTwoValues(t TestingT, e1 interface{}, e2 interface{}, allowedComparesResults []compareResult, failMessage string, msgAndArgs ...interface{}) bool {
+func compareTwoValues(t TestingT, e1 any, e2 any, allowedComparesResults []compareResult, failMessage string, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}

--- a/assert/assertion_compare_test.go
+++ b/assert/assertion_compare_test.go
@@ -29,8 +29,8 @@ func TestCompare(t *testing.T) {
 	type customTime time.Time
 	type customBytes []byte
 	for _, currCase := range []struct {
-		less    interface{}
-		greater interface{}
+		less    any
+		greater any
 		cType   string
 	}{
 		{less: customString("a"), greater: customString("b"), cType: "string"},
@@ -102,7 +102,7 @@ type outputT struct {
 }
 
 // Implements TestingT
-func (t *outputT) Errorf(format string, args ...interface{}) {
+func (t *outputT) Errorf(format string, args ...any) {
 	s := fmt.Sprintf(format, args...)
 	t.buf.WriteString(s)
 }
@@ -147,8 +147,8 @@ func TestGreater(t *testing.T) {
 
 	// Check error report
 	for _, currCase := range []struct {
-		less    interface{}
-		greater interface{}
+		less    any
+		greater any
 		msg     string
 	}{
 		{less: "a", greater: "b", msg: `"a" is not greater than "b"`},
@@ -193,8 +193,8 @@ func TestGreaterOrEqual(t *testing.T) {
 
 	// Check error report
 	for _, currCase := range []struct {
-		less    interface{}
-		greater interface{}
+		less    any
+		greater any
 		msg     string
 	}{
 		{less: "a", greater: "b", msg: `"a" is not greater than or equal to "b"`},
@@ -239,8 +239,8 @@ func TestLess(t *testing.T) {
 
 	// Check error report
 	for _, currCase := range []struct {
-		less    interface{}
-		greater interface{}
+		less    any
+		greater any
 		msg     string
 	}{
 		{less: "a", greater: "b", msg: `"b" is not less than "a"`},
@@ -285,8 +285,8 @@ func TestLessOrEqual(t *testing.T) {
 
 	// Check error report
 	for _, currCase := range []struct {
-		less    interface{}
-		greater interface{}
+		less    any
+		greater any
 		msg     string
 	}{
 		{less: "a", greater: "b", msg: `"b" is not less than or equal to "a"`},
@@ -335,7 +335,7 @@ func TestPositive(t *testing.T) {
 
 	// Check error report
 	for _, currCase := range []struct {
-		e   interface{}
+		e   any
 		msg string
 	}{
 		{e: int(-1), msg: `"-1" is not positive`},
@@ -376,7 +376,7 @@ func TestNegative(t *testing.T) {
 
 	// Check error report
 	for _, currCase := range []struct {
-		e   interface{}
+		e   any
 		msg string
 	}{
 		{e: int(1), msg: `"1" is not negative`},
@@ -400,8 +400,8 @@ func Test_compareTwoValuesDifferentValuesTypes(t *testing.T) {
 	mockT := new(testing.T)
 
 	for _, currCase := range []struct {
-		v1            interface{}
-		v2            interface{}
+		v1            any
+		v2            any
 		compareResult bool
 	}{
 		{v1: 123, v2: "abc"},
@@ -423,8 +423,8 @@ func Test_compareTwoValuesNotComparableValues(t *testing.T) {
 	}
 
 	for _, currCase := range []struct {
-		v1 interface{}
-		v2 interface{}
+		v1 any
+		v2 any
 	}{
 		{v1: CompareStruct{}, v2: CompareStruct{}},
 		{v1: map[string]int{}, v2: map[string]int{}},
@@ -441,8 +441,8 @@ func Test_compareTwoValuesCorrectCompareResult(t *testing.T) {
 	mockT := new(testing.T)
 
 	for _, currCase := range []struct {
-		v1             interface{}
-		v2             interface{}
+		v1             any
+		v2             any
 		allowedResults []compareResult
 	}{
 		{v1: 1, v2: 2, allowedResults: []compareResult{compareLess}},
@@ -476,7 +476,7 @@ func Test_containsValue(t *testing.T) {
 }
 
 func TestComparingMsgAndArgsForwarding(t *testing.T) {
-	msgAndArgs := []interface{}{"format %s %x", "this", 0xc001}
+	msgAndArgs := []any{"format %s %x", "this", 0xc001}
 	expectedOutput := "format this c001\n"
 	funcs := []func(t TestingT){
 		func(t TestingT) { Greater(t, 1, 2, msgAndArgs...) },

--- a/assert/assertion_format.go
+++ b/assert/assertion_format.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Conditionf uses a Comparison to assert a complex condition.
-func Conditionf(t TestingT, comp Comparison, msg string, args ...interface{}) bool {
+func Conditionf(t TestingT, comp Comparison, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -22,7 +22,7 @@ func Conditionf(t TestingT, comp Comparison, msg string, args ...interface{}) bo
 //	assert.Containsf(t, "Hello World", "World", "error message %s", "formatted")
 //	assert.Containsf(t, ["Hello", "World"], "World", "error message %s", "formatted")
 //	assert.Containsf(t, {"Hello": "World"}, "Hello", "error message %s", "formatted")
-func Containsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) bool {
+func Containsf(t TestingT, s any, contains any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -31,7 +31,7 @@ func Containsf(t TestingT, s interface{}, contains interface{}, msg string, args
 
 // DirExistsf checks whether a directory exists in the given path. It also fails
 // if the path is a file rather a directory or there is an error checking whether it exists.
-func DirExistsf(t TestingT, path string, msg string, args ...interface{}) bool {
+func DirExistsf(t TestingT, path string, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -43,7 +43,7 @@ func DirExistsf(t TestingT, path string, msg string, args ...interface{}) bool {
 // the number of appearances of each of them in both lists should match.
 //
 // assert.ElementsMatchf(t, [1, 3, 2, 3], [1, 3, 3, 2], "error message %s", "formatted")
-func ElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string, args ...interface{}) bool {
+func ElementsMatchf(t TestingT, listA any, listB any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -63,7 +63,7 @@ func ElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string
 //	assert.Emptyf(t, obj, "error message %s", "formatted")
 //
 // [Zero values]: https://go.dev/ref/spec#The_zero_value
-func Emptyf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
+func Emptyf(t TestingT, object any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -77,7 +77,7 @@ func Emptyf(t TestingT, object interface{}, msg string, args ...interface{}) boo
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses). Function equality
 // cannot be determined and will always fail.
-func Equalf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+func Equalf(t TestingT, expected any, actual any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -89,7 +89,7 @@ func Equalf(t TestingT, expected interface{}, actual interface{}, msg string, ar
 //
 //	actualObj, err := SomeFunction()
 //	assert.EqualErrorf(t, err,  expectedErrorString, "error message %s", "formatted")
-func EqualErrorf(t TestingT, theError error, errString string, msg string, args ...interface{}) bool {
+func EqualErrorf(t TestingT, theError error, errString string, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -106,7 +106,7 @@ func EqualErrorf(t TestingT, theError error, errString string, msg string, args 
 //	 }
 //	 assert.EqualExportedValuesf(t, S{1, 2}, S{1, 3}, "error message %s", "formatted") => true
 //	 assert.EqualExportedValuesf(t, S{1, 2}, S{2, 3}, "error message %s", "formatted") => false
-func EqualExportedValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+func EqualExportedValuesf(t TestingT, expected any, actual any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -117,7 +117,7 @@ func EqualExportedValuesf(t TestingT, expected interface{}, actual interface{}, 
 // type and equal.
 //
 //	assert.EqualValuesf(t, uint32(123), int32(123), "error message %s", "formatted")
-func EqualValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+func EqualValuesf(t TestingT, expected any, actual any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -128,7 +128,7 @@ func EqualValuesf(t TestingT, expected interface{}, actual interface{}, msg stri
 //
 //	actualObj, err := SomeFunction()
 //	assert.Errorf(t, err, "error message %s", "formatted")
-func Errorf(t TestingT, err error, msg string, args ...interface{}) bool {
+func Errorf(t TestingT, err error, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -137,7 +137,7 @@ func Errorf(t TestingT, err error, msg string, args ...interface{}) bool {
 
 // ErrorAsf asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
 // This is a wrapper for errors.As.
-func ErrorAsf(t TestingT, err error, target interface{}, msg string, args ...interface{}) bool {
+func ErrorAsf(t TestingT, err error, target any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -149,7 +149,7 @@ func ErrorAsf(t TestingT, err error, target interface{}, msg string, args ...int
 //
 //	actualObj, err := SomeFunction()
 //	assert.ErrorContainsf(t, err,  expectedErrorSubString, "error message %s", "formatted")
-func ErrorContainsf(t TestingT, theError error, contains string, msg string, args ...interface{}) bool {
+func ErrorContainsf(t TestingT, theError error, contains string, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -158,7 +158,7 @@ func ErrorContainsf(t TestingT, theError error, contains string, msg string, arg
 
 // ErrorIsf asserts that at least one of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
-func ErrorIsf(t TestingT, err error, target error, msg string, args ...interface{}) bool {
+func ErrorIsf(t TestingT, err error, target error, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -169,7 +169,7 @@ func ErrorIsf(t TestingT, err error, target error, msg string, args ...interface
 // periodically checking target function each tick.
 //
 //	assert.Eventuallyf(t, func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
-func Eventuallyf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) bool {
+func Eventuallyf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -194,7 +194,7 @@ func Eventuallyf(t TestingT, condition func() bool, waitFor time.Duration, tick 
 //		// add assertions as needed; any assertion failure will fail the current tick
 //		assert.True(c, externalValue, "expected 'externalValue' to be true")
 //	}, 10*time.Second, 1*time.Second, "error message %s", "formatted")
-func EventuallyWithTf(t TestingT, condition func(collect *CollectT), waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) bool {
+func EventuallyWithTf(t TestingT, condition func(collect *CollectT), waitFor time.Duration, tick time.Duration, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -204,7 +204,7 @@ func EventuallyWithTf(t TestingT, condition func(collect *CollectT), waitFor tim
 // Exactlyf asserts that two objects are equal in value and type.
 //
 //	assert.Exactlyf(t, int32(123), int64(123), "error message %s", "formatted")
-func Exactlyf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+func Exactlyf(t TestingT, expected any, actual any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -212,7 +212,7 @@ func Exactlyf(t TestingT, expected interface{}, actual interface{}, msg string, 
 }
 
 // Failf reports a failure through
-func Failf(t TestingT, failureMessage string, msg string, args ...interface{}) bool {
+func Failf(t TestingT, failureMessage string, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -220,7 +220,7 @@ func Failf(t TestingT, failureMessage string, msg string, args ...interface{}) b
 }
 
 // FailNowf fails test
-func FailNowf(t TestingT, failureMessage string, msg string, args ...interface{}) bool {
+func FailNowf(t TestingT, failureMessage string, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -230,7 +230,7 @@ func FailNowf(t TestingT, failureMessage string, msg string, args ...interface{}
 // Falsef asserts that the specified value is false.
 //
 //	assert.Falsef(t, myBool, "error message %s", "formatted")
-func Falsef(t TestingT, value bool, msg string, args ...interface{}) bool {
+func Falsef(t TestingT, value bool, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -239,7 +239,7 @@ func Falsef(t TestingT, value bool, msg string, args ...interface{}) bool {
 
 // FileExistsf checks whether a file exists in the given path. It also fails if
 // the path points to a directory or there is an error when trying to check the file.
-func FileExistsf(t TestingT, path string, msg string, args ...interface{}) bool {
+func FileExistsf(t TestingT, path string, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -251,7 +251,7 @@ func FileExistsf(t TestingT, path string, msg string, args ...interface{}) bool 
 //	assert.Greaterf(t, 2, 1, "error message %s", "formatted")
 //	assert.Greaterf(t, float64(2), float64(1), "error message %s", "formatted")
 //	assert.Greaterf(t, "b", "a", "error message %s", "formatted")
-func Greaterf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
+func Greaterf(t TestingT, e1 any, e2 any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -264,7 +264,7 @@ func Greaterf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...in
 //	assert.GreaterOrEqualf(t, 2, 2, "error message %s", "formatted")
 //	assert.GreaterOrEqualf(t, "b", "a", "error message %s", "formatted")
 //	assert.GreaterOrEqualf(t, "b", "b", "error message %s", "formatted")
-func GreaterOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
+func GreaterOrEqualf(t TestingT, e1 any, e2 any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -277,7 +277,7 @@ func GreaterOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, arg
 //	assert.HTTPBodyContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
-func HTTPBodyContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) bool {
+func HTTPBodyContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -290,7 +290,7 @@ func HTTPBodyContainsf(t TestingT, handler http.HandlerFunc, method string, url 
 //	assert.HTTPBodyNotContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
-func HTTPBodyNotContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) bool {
+func HTTPBodyNotContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -302,7 +302,7 @@ func HTTPBodyNotContainsf(t TestingT, handler http.HandlerFunc, method string, u
 //	assert.HTTPErrorf(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
-func HTTPErrorf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) bool {
+func HTTPErrorf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -314,7 +314,7 @@ func HTTPErrorf(t TestingT, handler http.HandlerFunc, method string, url string,
 //	assert.HTTPRedirectf(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
-func HTTPRedirectf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) bool {
+func HTTPRedirectf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -326,7 +326,7 @@ func HTTPRedirectf(t TestingT, handler http.HandlerFunc, method string, url stri
 //	assert.HTTPStatusCodef(t, myHandler, "GET", "/notImplemented", nil, 501, "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
-func HTTPStatusCodef(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msg string, args ...interface{}) bool {
+func HTTPStatusCodef(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -338,7 +338,7 @@ func HTTPStatusCodef(t TestingT, handler http.HandlerFunc, method string, url st
 //	assert.HTTPSuccessf(t, myHandler, "POST", "http://www.google.com", nil, "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
-func HTTPSuccessf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) bool {
+func HTTPSuccessf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -348,7 +348,7 @@ func HTTPSuccessf(t TestingT, handler http.HandlerFunc, method string, url strin
 // Implementsf asserts that an object is implemented by the specified interface.
 //
 //	assert.Implementsf(t, (*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
-func Implementsf(t TestingT, interfaceObject interface{}, object interface{}, msg string, args ...interface{}) bool {
+func Implementsf(t TestingT, interfaceObject any, object any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -358,7 +358,7 @@ func Implementsf(t TestingT, interfaceObject interface{}, object interface{}, ms
 // InDeltaf asserts that the two numerals are within delta of each other.
 //
 //	assert.InDeltaf(t, math.Pi, 22/7.0, 0.01, "error message %s", "formatted")
-func InDeltaf(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) bool {
+func InDeltaf(t TestingT, expected any, actual any, delta float64, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -366,7 +366,7 @@ func InDeltaf(t TestingT, expected interface{}, actual interface{}, delta float6
 }
 
 // InDeltaMapValuesf is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
-func InDeltaMapValuesf(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) bool {
+func InDeltaMapValuesf(t TestingT, expected any, actual any, delta float64, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -374,7 +374,7 @@ func InDeltaMapValuesf(t TestingT, expected interface{}, actual interface{}, del
 }
 
 // InDeltaSlicef is the same as InDelta, except it compares two slices.
-func InDeltaSlicef(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) bool {
+func InDeltaSlicef(t TestingT, expected any, actual any, delta float64, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -382,7 +382,7 @@ func InDeltaSlicef(t TestingT, expected interface{}, actual interface{}, delta f
 }
 
 // InEpsilonf asserts that expected and actual have a relative error less than epsilon
-func InEpsilonf(t TestingT, expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) bool {
+func InEpsilonf(t TestingT, expected any, actual any, epsilon float64, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -390,7 +390,7 @@ func InEpsilonf(t TestingT, expected interface{}, actual interface{}, epsilon fl
 }
 
 // InEpsilonSlicef is the same as InEpsilon, except it compares each value from two slices.
-func InEpsilonSlicef(t TestingT, expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) bool {
+func InEpsilonSlicef(t TestingT, expected any, actual any, epsilon float64, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -402,7 +402,7 @@ func InEpsilonSlicef(t TestingT, expected interface{}, actual interface{}, epsil
 //	assert.IsDecreasingf(t, []int{2, 1, 0}, "error message %s", "formatted")
 //	assert.IsDecreasingf(t, []float{2, 1}, "error message %s", "formatted")
 //	assert.IsDecreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
-func IsDecreasingf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
+func IsDecreasingf(t TestingT, object any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -414,7 +414,7 @@ func IsDecreasingf(t TestingT, object interface{}, msg string, args ...interface
 //	assert.IsIncreasingf(t, []int{1, 2, 3}, "error message %s", "formatted")
 //	assert.IsIncreasingf(t, []float{1, 2}, "error message %s", "formatted")
 //	assert.IsIncreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
-func IsIncreasingf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
+func IsIncreasingf(t TestingT, object any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -426,7 +426,7 @@ func IsIncreasingf(t TestingT, object interface{}, msg string, args ...interface
 //	assert.IsNonDecreasingf(t, []int{1, 1, 2}, "error message %s", "formatted")
 //	assert.IsNonDecreasingf(t, []float{1, 2}, "error message %s", "formatted")
 //	assert.IsNonDecreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
-func IsNonDecreasingf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
+func IsNonDecreasingf(t TestingT, object any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -438,7 +438,7 @@ func IsNonDecreasingf(t TestingT, object interface{}, msg string, args ...interf
 //	assert.IsNonIncreasingf(t, []int{2, 1, 1}, "error message %s", "formatted")
 //	assert.IsNonIncreasingf(t, []float{2, 1}, "error message %s", "formatted")
 //	assert.IsNonIncreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
-func IsNonIncreasingf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
+func IsNonIncreasingf(t TestingT, object any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -448,7 +448,7 @@ func IsNonIncreasingf(t TestingT, object interface{}, msg string, args ...interf
 // IsNotTypef asserts that the specified objects are not of the same type.
 //
 //	assert.IsNotTypef(t, &NotMyStruct{}, &MyStruct{}, "error message %s", "formatted")
-func IsNotTypef(t TestingT, theType interface{}, object interface{}, msg string, args ...interface{}) bool {
+func IsNotTypef(t TestingT, theType any, object any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -458,7 +458,7 @@ func IsNotTypef(t TestingT, theType interface{}, object interface{}, msg string,
 // IsTypef asserts that the specified objects are of the same type.
 //
 //	assert.IsTypef(t, &MyStruct{}, &MyStruct{}, "error message %s", "formatted")
-func IsTypef(t TestingT, expectedType interface{}, object interface{}, msg string, args ...interface{}) bool {
+func IsTypef(t TestingT, expectedType any, object any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -468,7 +468,7 @@ func IsTypef(t TestingT, expectedType interface{}, object interface{}, msg strin
 // JSONEqf asserts that two JSON strings are equivalent.
 //
 //	assert.JSONEqf(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
-func JSONEqf(t TestingT, expected string, actual string, msg string, args ...interface{}) bool {
+func JSONEqf(t TestingT, expected string, actual string, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -479,7 +479,7 @@ func JSONEqf(t TestingT, expected string, actual string, msg string, args ...int
 // Lenf also fails if the object has a type that len() not accept.
 //
 //	assert.Lenf(t, mySlice, 3, "error message %s", "formatted")
-func Lenf(t TestingT, object interface{}, length int, msg string, args ...interface{}) bool {
+func Lenf(t TestingT, object any, length int, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -491,7 +491,7 @@ func Lenf(t TestingT, object interface{}, length int, msg string, args ...interf
 //	assert.Lessf(t, 1, 2, "error message %s", "formatted")
 //	assert.Lessf(t, float64(1), float64(2), "error message %s", "formatted")
 //	assert.Lessf(t, "a", "b", "error message %s", "formatted")
-func Lessf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
+func Lessf(t TestingT, e1 any, e2 any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -504,7 +504,7 @@ func Lessf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...inter
 //	assert.LessOrEqualf(t, 2, 2, "error message %s", "formatted")
 //	assert.LessOrEqualf(t, "a", "b", "error message %s", "formatted")
 //	assert.LessOrEqualf(t, "b", "b", "error message %s", "formatted")
-func LessOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
+func LessOrEqualf(t TestingT, e1 any, e2 any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -515,7 +515,7 @@ func LessOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args .
 //
 //	assert.Negativef(t, -1, "error message %s", "formatted")
 //	assert.Negativef(t, -1.23, "error message %s", "formatted")
-func Negativef(t TestingT, e interface{}, msg string, args ...interface{}) bool {
+func Negativef(t TestingT, e any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -526,7 +526,7 @@ func Negativef(t TestingT, e interface{}, msg string, args ...interface{}) bool 
 // periodically checking the target function each tick.
 //
 //	assert.Neverf(t, func() bool { return false; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
-func Neverf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) bool {
+func Neverf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -536,7 +536,7 @@ func Neverf(t TestingT, condition func() bool, waitFor time.Duration, tick time.
 // Nilf asserts that the specified object is nil.
 //
 //	assert.Nilf(t, err, "error message %s", "formatted")
-func Nilf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
+func Nilf(t TestingT, object any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -545,7 +545,7 @@ func Nilf(t TestingT, object interface{}, msg string, args ...interface{}) bool 
 
 // NoDirExistsf checks whether a directory does not exist in the given path.
 // It fails if the path points to an existing _directory_ only.
-func NoDirExistsf(t TestingT, path string, msg string, args ...interface{}) bool {
+func NoDirExistsf(t TestingT, path string, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -558,7 +558,7 @@ func NoDirExistsf(t TestingT, path string, msg string, args ...interface{}) bool
 //	  if assert.NoErrorf(t, err, "error message %s", "formatted") {
 //		   assert.Equal(t, expectedObj, actualObj)
 //	  }
-func NoErrorf(t TestingT, err error, msg string, args ...interface{}) bool {
+func NoErrorf(t TestingT, err error, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -567,7 +567,7 @@ func NoErrorf(t TestingT, err error, msg string, args ...interface{}) bool {
 
 // NoFileExistsf checks whether a file does not exist in a given path. It fails
 // if the path points to an existing _file_ only.
-func NoFileExistsf(t TestingT, path string, msg string, args ...interface{}) bool {
+func NoFileExistsf(t TestingT, path string, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -580,7 +580,7 @@ func NoFileExistsf(t TestingT, path string, msg string, args ...interface{}) boo
 //	assert.NotContainsf(t, "Hello World", "Earth", "error message %s", "formatted")
 //	assert.NotContainsf(t, ["Hello", "World"], "Earth", "error message %s", "formatted")
 //	assert.NotContainsf(t, {"Hello": "World"}, "Earth", "error message %s", "formatted")
-func NotContainsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) bool {
+func NotContainsf(t TestingT, s any, contains any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -597,7 +597,7 @@ func NotContainsf(t TestingT, s interface{}, contains interface{}, msg string, a
 // assert.NotElementsMatchf(t, [1, 1, 2, 3], [1, 2, 3], "error message %s", "formatted") -> true
 //
 // assert.NotElementsMatchf(t, [1, 2, 3], [1, 2, 4], "error message %s", "formatted") -> true
-func NotElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string, args ...interface{}) bool {
+func NotElementsMatchf(t TestingT, listA any, listB any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -609,7 +609,7 @@ func NotElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg str
 //	if assert.NotEmptyf(t, obj, "error message %s", "formatted") {
 //	  assert.Equal(t, "two", obj[1])
 //	}
-func NotEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
+func NotEmptyf(t TestingT, object any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -622,7 +622,7 @@ func NotEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) 
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
-func NotEqualf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+func NotEqualf(t TestingT, expected any, actual any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -632,7 +632,7 @@ func NotEqualf(t TestingT, expected interface{}, actual interface{}, msg string,
 // NotEqualValuesf asserts that two objects are not equal even when converted to the same type
 //
 //	assert.NotEqualValuesf(t, obj1, obj2, "error message %s", "formatted")
-func NotEqualValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+func NotEqualValuesf(t TestingT, expected any, actual any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -641,7 +641,7 @@ func NotEqualValuesf(t TestingT, expected interface{}, actual interface{}, msg s
 
 // NotErrorAsf asserts that none of the errors in err's chain matches target,
 // but if so, sets target to that error value.
-func NotErrorAsf(t TestingT, err error, target interface{}, msg string, args ...interface{}) bool {
+func NotErrorAsf(t TestingT, err error, target any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -650,7 +650,7 @@ func NotErrorAsf(t TestingT, err error, target interface{}, msg string, args ...
 
 // NotErrorIsf asserts that none of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
-func NotErrorIsf(t TestingT, err error, target error, msg string, args ...interface{}) bool {
+func NotErrorIsf(t TestingT, err error, target error, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -660,7 +660,7 @@ func NotErrorIsf(t TestingT, err error, target error, msg string, args ...interf
 // NotImplementsf asserts that an object does not implement the specified interface.
 //
 //	assert.NotImplementsf(t, (*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
-func NotImplementsf(t TestingT, interfaceObject interface{}, object interface{}, msg string, args ...interface{}) bool {
+func NotImplementsf(t TestingT, interfaceObject any, object any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -670,7 +670,7 @@ func NotImplementsf(t TestingT, interfaceObject interface{}, object interface{},
 // NotNilf asserts that the specified object is not nil.
 //
 //	assert.NotNilf(t, err, "error message %s", "formatted")
-func NotNilf(t TestingT, object interface{}, msg string, args ...interface{}) bool {
+func NotNilf(t TestingT, object any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -680,7 +680,7 @@ func NotNilf(t TestingT, object interface{}, msg string, args ...interface{}) bo
 // NotPanicsf asserts that the code inside the specified PanicTestFunc does NOT panic.
 //
 //	assert.NotPanicsf(t, func(){ RemainCalm() }, "error message %s", "formatted")
-func NotPanicsf(t TestingT, f PanicTestFunc, msg string, args ...interface{}) bool {
+func NotPanicsf(t TestingT, f PanicTestFunc, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -691,7 +691,7 @@ func NotPanicsf(t TestingT, f PanicTestFunc, msg string, args ...interface{}) bo
 //
 //	assert.NotRegexpf(t, regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
 //	assert.NotRegexpf(t, "^start", "it's not starting", "error message %s", "formatted")
-func NotRegexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) bool {
+func NotRegexpf(t TestingT, rx any, str any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -704,7 +704,7 @@ func NotRegexpf(t TestingT, rx interface{}, str interface{}, msg string, args ..
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
-func NotSamef(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+func NotSamef(t TestingT, expected any, actual any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -720,7 +720,7 @@ func NotSamef(t TestingT, expected interface{}, actual interface{}, msg string, 
 //	assert.NotSubsetf(t, {"x": 1, "y": 2}, {"z": 3}, "error message %s", "formatted")
 //	assert.NotSubsetf(t, [1, 3, 4], {1: "one", 2: "two"}, "error message %s", "formatted")
 //	assert.NotSubsetf(t, {"x": 1, "y": 2}, ["z"], "error message %s", "formatted")
-func NotSubsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) bool {
+func NotSubsetf(t TestingT, list any, subset any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -728,7 +728,7 @@ func NotSubsetf(t TestingT, list interface{}, subset interface{}, msg string, ar
 }
 
 // NotZerof asserts that i is not the zero value for its type.
-func NotZerof(t TestingT, i interface{}, msg string, args ...interface{}) bool {
+func NotZerof(t TestingT, i any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -738,7 +738,7 @@ func NotZerof(t TestingT, i interface{}, msg string, args ...interface{}) bool {
 // Panicsf asserts that the code inside the specified PanicTestFunc panics.
 //
 //	assert.Panicsf(t, func(){ GoCrazy() }, "error message %s", "formatted")
-func Panicsf(t TestingT, f PanicTestFunc, msg string, args ...interface{}) bool {
+func Panicsf(t TestingT, f PanicTestFunc, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -750,7 +750,7 @@ func Panicsf(t TestingT, f PanicTestFunc, msg string, args ...interface{}) bool 
 // EqualError comparison.
 //
 //	assert.PanicsWithErrorf(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
-func PanicsWithErrorf(t TestingT, errString string, f PanicTestFunc, msg string, args ...interface{}) bool {
+func PanicsWithErrorf(t TestingT, errString string, f PanicTestFunc, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -761,7 +761,7 @@ func PanicsWithErrorf(t TestingT, errString string, f PanicTestFunc, msg string,
 // the recovered panic value equals the expected panic value.
 //
 //	assert.PanicsWithValuef(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
-func PanicsWithValuef(t TestingT, expected interface{}, f PanicTestFunc, msg string, args ...interface{}) bool {
+func PanicsWithValuef(t TestingT, expected any, f PanicTestFunc, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -772,7 +772,7 @@ func PanicsWithValuef(t TestingT, expected interface{}, f PanicTestFunc, msg str
 //
 //	assert.Positivef(t, 1, "error message %s", "formatted")
 //	assert.Positivef(t, 1.23, "error message %s", "formatted")
-func Positivef(t TestingT, e interface{}, msg string, args ...interface{}) bool {
+func Positivef(t TestingT, e any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -783,7 +783,7 @@ func Positivef(t TestingT, e interface{}, msg string, args ...interface{}) bool 
 //
 //	assert.Regexpf(t, regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
 //	assert.Regexpf(t, "start...$", "it's not starting", "error message %s", "formatted")
-func Regexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) bool {
+func Regexpf(t TestingT, rx any, str any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -796,7 +796,7 @@ func Regexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...in
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
-func Samef(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+func Samef(t TestingT, expected any, actual any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -812,7 +812,7 @@ func Samef(t TestingT, expected interface{}, actual interface{}, msg string, arg
 //	assert.Subsetf(t, {"x": 1, "y": 2}, {"x": 1}, "error message %s", "formatted")
 //	assert.Subsetf(t, [1, 2, 3], {1: "one", 2: "two"}, "error message %s", "formatted")
 //	assert.Subsetf(t, {"x": 1, "y": 2}, ["x"], "error message %s", "formatted")
-func Subsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) bool {
+func Subsetf(t TestingT, list any, subset any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -822,7 +822,7 @@ func Subsetf(t TestingT, list interface{}, subset interface{}, msg string, args 
 // Truef asserts that the specified value is true.
 //
 //	assert.Truef(t, myBool, "error message %s", "formatted")
-func Truef(t TestingT, value bool, msg string, args ...interface{}) bool {
+func Truef(t TestingT, value bool, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -832,7 +832,7 @@ func Truef(t TestingT, value bool, msg string, args ...interface{}) bool {
 // WithinDurationf asserts that the two times are within duration delta of each other.
 //
 //	assert.WithinDurationf(t, time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
-func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msg string, args ...interface{}) bool {
+func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -842,7 +842,7 @@ func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta tim
 // WithinRangef asserts that a time is within a time range (inclusive).
 //
 //	assert.WithinRangef(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second), "error message %s", "formatted")
-func WithinRangef(t TestingT, actual time.Time, start time.Time, end time.Time, msg string, args ...interface{}) bool {
+func WithinRangef(t TestingT, actual time.Time, start time.Time, end time.Time, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -862,7 +862,7 @@ func WithinRangef(t TestingT, actual time.Time, start time.Time, end time.Time, 
 //	key: this is a subsequent document, it is not evaluated
 //	`
 //	assert.YAMLEqf(t, expected, actual, "error message %s", "formatted")
-func YAMLEqf(t TestingT, expected string, actual string, msg string, args ...interface{}) bool {
+func YAMLEqf(t TestingT, expected string, actual string, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -870,7 +870,7 @@ func YAMLEqf(t TestingT, expected string, actual string, msg string, args ...int
 }
 
 // Zerof asserts that i is the zero value for its type.
-func Zerof(t TestingT, i interface{}, msg string, args ...interface{}) bool {
+func Zerof(t TestingT, i any, msg string, args ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}

--- a/assert/assertion_forward.go
+++ b/assert/assertion_forward.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Condition uses a Comparison to assert a complex condition.
-func (a *Assertions) Condition(comp Comparison, msgAndArgs ...interface{}) bool {
+func (a *Assertions) Condition(comp Comparison, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -17,7 +17,7 @@ func (a *Assertions) Condition(comp Comparison, msgAndArgs ...interface{}) bool 
 }
 
 // Conditionf uses a Comparison to assert a complex condition.
-func (a *Assertions) Conditionf(comp Comparison, msg string, args ...interface{}) bool {
+func (a *Assertions) Conditionf(comp Comparison, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -30,7 +30,7 @@ func (a *Assertions) Conditionf(comp Comparison, msg string, args ...interface{}
 //	a.Contains("Hello World", "World")
 //	a.Contains(["Hello", "World"], "World")
 //	a.Contains({"Hello": "World"}, "Hello")
-func (a *Assertions) Contains(s interface{}, contains interface{}, msgAndArgs ...interface{}) bool {
+func (a *Assertions) Contains(s any, contains any, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -43,7 +43,7 @@ func (a *Assertions) Contains(s interface{}, contains interface{}, msgAndArgs ..
 //	a.Containsf("Hello World", "World", "error message %s", "formatted")
 //	a.Containsf(["Hello", "World"], "World", "error message %s", "formatted")
 //	a.Containsf({"Hello": "World"}, "Hello", "error message %s", "formatted")
-func (a *Assertions) Containsf(s interface{}, contains interface{}, msg string, args ...interface{}) bool {
+func (a *Assertions) Containsf(s any, contains any, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -52,7 +52,7 @@ func (a *Assertions) Containsf(s interface{}, contains interface{}, msg string, 
 
 // DirExists checks whether a directory exists in the given path. It also fails
 // if the path is a file rather a directory or there is an error checking whether it exists.
-func (a *Assertions) DirExists(path string, msgAndArgs ...interface{}) bool {
+func (a *Assertions) DirExists(path string, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -61,7 +61,7 @@ func (a *Assertions) DirExists(path string, msgAndArgs ...interface{}) bool {
 
 // DirExistsf checks whether a directory exists in the given path. It also fails
 // if the path is a file rather a directory or there is an error checking whether it exists.
-func (a *Assertions) DirExistsf(path string, msg string, args ...interface{}) bool {
+func (a *Assertions) DirExistsf(path string, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -73,7 +73,7 @@ func (a *Assertions) DirExistsf(path string, msg string, args ...interface{}) bo
 // the number of appearances of each of them in both lists should match.
 //
 // a.ElementsMatch([1, 3, 2, 3], [1, 3, 3, 2])
-func (a *Assertions) ElementsMatch(listA interface{}, listB interface{}, msgAndArgs ...interface{}) bool {
+func (a *Assertions) ElementsMatch(listA any, listB any, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -85,7 +85,7 @@ func (a *Assertions) ElementsMatch(listA interface{}, listB interface{}, msgAndA
 // the number of appearances of each of them in both lists should match.
 //
 // a.ElementsMatchf([1, 3, 2, 3], [1, 3, 3, 2], "error message %s", "formatted")
-func (a *Assertions) ElementsMatchf(listA interface{}, listB interface{}, msg string, args ...interface{}) bool {
+func (a *Assertions) ElementsMatchf(listA any, listB any, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -105,7 +105,7 @@ func (a *Assertions) ElementsMatchf(listA interface{}, listB interface{}, msg st
 //	a.Empty(obj)
 //
 // [Zero values]: https://go.dev/ref/spec#The_zero_value
-func (a *Assertions) Empty(object interface{}, msgAndArgs ...interface{}) bool {
+func (a *Assertions) Empty(object any, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -125,7 +125,7 @@ func (a *Assertions) Empty(object interface{}, msgAndArgs ...interface{}) bool {
 //	a.Emptyf(obj, "error message %s", "formatted")
 //
 // [Zero values]: https://go.dev/ref/spec#The_zero_value
-func (a *Assertions) Emptyf(object interface{}, msg string, args ...interface{}) bool {
+func (a *Assertions) Emptyf(object any, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -139,7 +139,7 @@ func (a *Assertions) Emptyf(object interface{}, msg string, args ...interface{})
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses). Function equality
 // cannot be determined and will always fail.
-func (a *Assertions) Equal(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
+func (a *Assertions) Equal(expected any, actual any, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -151,7 +151,7 @@ func (a *Assertions) Equal(expected interface{}, actual interface{}, msgAndArgs 
 //
 //	actualObj, err := SomeFunction()
 //	a.EqualError(err,  expectedErrorString)
-func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...interface{}) bool {
+func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -163,7 +163,7 @@ func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...
 //
 //	actualObj, err := SomeFunction()
 //	a.EqualErrorf(err,  expectedErrorString, "error message %s", "formatted")
-func (a *Assertions) EqualErrorf(theError error, errString string, msg string, args ...interface{}) bool {
+func (a *Assertions) EqualErrorf(theError error, errString string, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -180,7 +180,7 @@ func (a *Assertions) EqualErrorf(theError error, errString string, msg string, a
 //	 }
 //	 a.EqualExportedValues(S{1, 2}, S{1, 3}) => true
 //	 a.EqualExportedValues(S{1, 2}, S{2, 3}) => false
-func (a *Assertions) EqualExportedValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
+func (a *Assertions) EqualExportedValues(expected any, actual any, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -197,7 +197,7 @@ func (a *Assertions) EqualExportedValues(expected interface{}, actual interface{
 //	 }
 //	 a.EqualExportedValuesf(S{1, 2}, S{1, 3}, "error message %s", "formatted") => true
 //	 a.EqualExportedValuesf(S{1, 2}, S{2, 3}, "error message %s", "formatted") => false
-func (a *Assertions) EqualExportedValuesf(expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+func (a *Assertions) EqualExportedValuesf(expected any, actual any, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -208,7 +208,7 @@ func (a *Assertions) EqualExportedValuesf(expected interface{}, actual interface
 // type and equal.
 //
 //	a.EqualValues(uint32(123), int32(123))
-func (a *Assertions) EqualValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
+func (a *Assertions) EqualValues(expected any, actual any, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -219,7 +219,7 @@ func (a *Assertions) EqualValues(expected interface{}, actual interface{}, msgAn
 // type and equal.
 //
 //	a.EqualValuesf(uint32(123), int32(123), "error message %s", "formatted")
-func (a *Assertions) EqualValuesf(expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+func (a *Assertions) EqualValuesf(expected any, actual any, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -233,7 +233,7 @@ func (a *Assertions) EqualValuesf(expected interface{}, actual interface{}, msg 
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses). Function equality
 // cannot be determined and will always fail.
-func (a *Assertions) Equalf(expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+func (a *Assertions) Equalf(expected any, actual any, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -244,7 +244,7 @@ func (a *Assertions) Equalf(expected interface{}, actual interface{}, msg string
 //
 //	actualObj, err := SomeFunction()
 //	a.Error(err)
-func (a *Assertions) Error(err error, msgAndArgs ...interface{}) bool {
+func (a *Assertions) Error(err error, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -253,7 +253,7 @@ func (a *Assertions) Error(err error, msgAndArgs ...interface{}) bool {
 
 // ErrorAs asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
 // This is a wrapper for errors.As.
-func (a *Assertions) ErrorAs(err error, target interface{}, msgAndArgs ...interface{}) bool {
+func (a *Assertions) ErrorAs(err error, target any, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -262,7 +262,7 @@ func (a *Assertions) ErrorAs(err error, target interface{}, msgAndArgs ...interf
 
 // ErrorAsf asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
 // This is a wrapper for errors.As.
-func (a *Assertions) ErrorAsf(err error, target interface{}, msg string, args ...interface{}) bool {
+func (a *Assertions) ErrorAsf(err error, target any, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -274,7 +274,7 @@ func (a *Assertions) ErrorAsf(err error, target interface{}, msg string, args ..
 //
 //	actualObj, err := SomeFunction()
 //	a.ErrorContains(err,  expectedErrorSubString)
-func (a *Assertions) ErrorContains(theError error, contains string, msgAndArgs ...interface{}) bool {
+func (a *Assertions) ErrorContains(theError error, contains string, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -286,7 +286,7 @@ func (a *Assertions) ErrorContains(theError error, contains string, msgAndArgs .
 //
 //	actualObj, err := SomeFunction()
 //	a.ErrorContainsf(err,  expectedErrorSubString, "error message %s", "formatted")
-func (a *Assertions) ErrorContainsf(theError error, contains string, msg string, args ...interface{}) bool {
+func (a *Assertions) ErrorContainsf(theError error, contains string, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -295,7 +295,7 @@ func (a *Assertions) ErrorContainsf(theError error, contains string, msg string,
 
 // ErrorIs asserts that at least one of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
-func (a *Assertions) ErrorIs(err error, target error, msgAndArgs ...interface{}) bool {
+func (a *Assertions) ErrorIs(err error, target error, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -304,7 +304,7 @@ func (a *Assertions) ErrorIs(err error, target error, msgAndArgs ...interface{})
 
 // ErrorIsf asserts that at least one of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
-func (a *Assertions) ErrorIsf(err error, target error, msg string, args ...interface{}) bool {
+func (a *Assertions) ErrorIsf(err error, target error, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -315,7 +315,7 @@ func (a *Assertions) ErrorIsf(err error, target error, msg string, args ...inter
 //
 //	actualObj, err := SomeFunction()
 //	a.Errorf(err, "error message %s", "formatted")
-func (a *Assertions) Errorf(err error, msg string, args ...interface{}) bool {
+func (a *Assertions) Errorf(err error, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -326,7 +326,7 @@ func (a *Assertions) Errorf(err error, msg string, args ...interface{}) bool {
 // periodically checking target function each tick.
 //
 //	a.Eventually(func() bool { return true; }, time.Second, 10*time.Millisecond)
-func (a *Assertions) Eventually(condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) bool {
+func (a *Assertions) Eventually(condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -351,7 +351,7 @@ func (a *Assertions) Eventually(condition func() bool, waitFor time.Duration, ti
 //		// add assertions as needed; any assertion failure will fail the current tick
 //		assert.True(c, externalValue, "expected 'externalValue' to be true")
 //	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
-func (a *Assertions) EventuallyWithT(condition func(collect *CollectT), waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) bool {
+func (a *Assertions) EventuallyWithT(condition func(collect *CollectT), waitFor time.Duration, tick time.Duration, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -376,7 +376,7 @@ func (a *Assertions) EventuallyWithT(condition func(collect *CollectT), waitFor 
 //		// add assertions as needed; any assertion failure will fail the current tick
 //		assert.True(c, externalValue, "expected 'externalValue' to be true")
 //	}, 10*time.Second, 1*time.Second, "error message %s", "formatted")
-func (a *Assertions) EventuallyWithTf(condition func(collect *CollectT), waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) bool {
+func (a *Assertions) EventuallyWithTf(condition func(collect *CollectT), waitFor time.Duration, tick time.Duration, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -387,7 +387,7 @@ func (a *Assertions) EventuallyWithTf(condition func(collect *CollectT), waitFor
 // periodically checking target function each tick.
 //
 //	a.Eventuallyf(func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
-func (a *Assertions) Eventuallyf(condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) bool {
+func (a *Assertions) Eventuallyf(condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -397,7 +397,7 @@ func (a *Assertions) Eventuallyf(condition func() bool, waitFor time.Duration, t
 // Exactly asserts that two objects are equal in value and type.
 //
 //	a.Exactly(int32(123), int64(123))
-func (a *Assertions) Exactly(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
+func (a *Assertions) Exactly(expected any, actual any, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -407,7 +407,7 @@ func (a *Assertions) Exactly(expected interface{}, actual interface{}, msgAndArg
 // Exactlyf asserts that two objects are equal in value and type.
 //
 //	a.Exactlyf(int32(123), int64(123), "error message %s", "formatted")
-func (a *Assertions) Exactlyf(expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+func (a *Assertions) Exactlyf(expected any, actual any, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -415,7 +415,7 @@ func (a *Assertions) Exactlyf(expected interface{}, actual interface{}, msg stri
 }
 
 // Fail reports a failure through
-func (a *Assertions) Fail(failureMessage string, msgAndArgs ...interface{}) bool {
+func (a *Assertions) Fail(failureMessage string, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -423,7 +423,7 @@ func (a *Assertions) Fail(failureMessage string, msgAndArgs ...interface{}) bool
 }
 
 // FailNow fails test
-func (a *Assertions) FailNow(failureMessage string, msgAndArgs ...interface{}) bool {
+func (a *Assertions) FailNow(failureMessage string, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -431,7 +431,7 @@ func (a *Assertions) FailNow(failureMessage string, msgAndArgs ...interface{}) b
 }
 
 // FailNowf fails test
-func (a *Assertions) FailNowf(failureMessage string, msg string, args ...interface{}) bool {
+func (a *Assertions) FailNowf(failureMessage string, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -439,7 +439,7 @@ func (a *Assertions) FailNowf(failureMessage string, msg string, args ...interfa
 }
 
 // Failf reports a failure through
-func (a *Assertions) Failf(failureMessage string, msg string, args ...interface{}) bool {
+func (a *Assertions) Failf(failureMessage string, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -449,7 +449,7 @@ func (a *Assertions) Failf(failureMessage string, msg string, args ...interface{
 // False asserts that the specified value is false.
 //
 //	a.False(myBool)
-func (a *Assertions) False(value bool, msgAndArgs ...interface{}) bool {
+func (a *Assertions) False(value bool, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -459,7 +459,7 @@ func (a *Assertions) False(value bool, msgAndArgs ...interface{}) bool {
 // Falsef asserts that the specified value is false.
 //
 //	a.Falsef(myBool, "error message %s", "formatted")
-func (a *Assertions) Falsef(value bool, msg string, args ...interface{}) bool {
+func (a *Assertions) Falsef(value bool, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -468,7 +468,7 @@ func (a *Assertions) Falsef(value bool, msg string, args ...interface{}) bool {
 
 // FileExists checks whether a file exists in the given path. It also fails if
 // the path points to a directory or there is an error when trying to check the file.
-func (a *Assertions) FileExists(path string, msgAndArgs ...interface{}) bool {
+func (a *Assertions) FileExists(path string, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -477,7 +477,7 @@ func (a *Assertions) FileExists(path string, msgAndArgs ...interface{}) bool {
 
 // FileExistsf checks whether a file exists in the given path. It also fails if
 // the path points to a directory or there is an error when trying to check the file.
-func (a *Assertions) FileExistsf(path string, msg string, args ...interface{}) bool {
+func (a *Assertions) FileExistsf(path string, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -489,7 +489,7 @@ func (a *Assertions) FileExistsf(path string, msg string, args ...interface{}) b
 //	a.Greater(2, 1)
 //	a.Greater(float64(2), float64(1))
 //	a.Greater("b", "a")
-func (a *Assertions) Greater(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
+func (a *Assertions) Greater(e1 any, e2 any, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -502,7 +502,7 @@ func (a *Assertions) Greater(e1 interface{}, e2 interface{}, msgAndArgs ...inter
 //	a.GreaterOrEqual(2, 2)
 //	a.GreaterOrEqual("b", "a")
 //	a.GreaterOrEqual("b", "b")
-func (a *Assertions) GreaterOrEqual(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
+func (a *Assertions) GreaterOrEqual(e1 any, e2 any, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -515,7 +515,7 @@ func (a *Assertions) GreaterOrEqual(e1 interface{}, e2 interface{}, msgAndArgs .
 //	a.GreaterOrEqualf(2, 2, "error message %s", "formatted")
 //	a.GreaterOrEqualf("b", "a", "error message %s", "formatted")
 //	a.GreaterOrEqualf("b", "b", "error message %s", "formatted")
-func (a *Assertions) GreaterOrEqualf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
+func (a *Assertions) GreaterOrEqualf(e1 any, e2 any, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -527,7 +527,7 @@ func (a *Assertions) GreaterOrEqualf(e1 interface{}, e2 interface{}, msg string,
 //	a.Greaterf(2, 1, "error message %s", "formatted")
 //	a.Greaterf(float64(2), float64(1), "error message %s", "formatted")
 //	a.Greaterf("b", "a", "error message %s", "formatted")
-func (a *Assertions) Greaterf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
+func (a *Assertions) Greaterf(e1 any, e2 any, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -540,7 +540,7 @@ func (a *Assertions) Greaterf(e1 interface{}, e2 interface{}, msg string, args .
 //	a.HTTPBodyContains(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
 //
 // Returns whether the assertion was successful (true) or not (false).
-func (a *Assertions) HTTPBodyContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) bool {
+func (a *Assertions) HTTPBodyContains(handler http.HandlerFunc, method string, url string, values url.Values, str any, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -553,7 +553,7 @@ func (a *Assertions) HTTPBodyContains(handler http.HandlerFunc, method string, u
 //	a.HTTPBodyContainsf(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
-func (a *Assertions) HTTPBodyContainsf(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) bool {
+func (a *Assertions) HTTPBodyContainsf(handler http.HandlerFunc, method string, url string, values url.Values, str any, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -566,7 +566,7 @@ func (a *Assertions) HTTPBodyContainsf(handler http.HandlerFunc, method string, 
 //	a.HTTPBodyNotContains(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
 //
 // Returns whether the assertion was successful (true) or not (false).
-func (a *Assertions) HTTPBodyNotContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) bool {
+func (a *Assertions) HTTPBodyNotContains(handler http.HandlerFunc, method string, url string, values url.Values, str any, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -579,7 +579,7 @@ func (a *Assertions) HTTPBodyNotContains(handler http.HandlerFunc, method string
 //	a.HTTPBodyNotContainsf(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
-func (a *Assertions) HTTPBodyNotContainsf(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) bool {
+func (a *Assertions) HTTPBodyNotContainsf(handler http.HandlerFunc, method string, url string, values url.Values, str any, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -591,7 +591,7 @@ func (a *Assertions) HTTPBodyNotContainsf(handler http.HandlerFunc, method strin
 //	a.HTTPError(myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
-func (a *Assertions) HTTPError(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) bool {
+func (a *Assertions) HTTPError(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -603,7 +603,7 @@ func (a *Assertions) HTTPError(handler http.HandlerFunc, method string, url stri
 //	a.HTTPErrorf(myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
-func (a *Assertions) HTTPErrorf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) bool {
+func (a *Assertions) HTTPErrorf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -615,7 +615,7 @@ func (a *Assertions) HTTPErrorf(handler http.HandlerFunc, method string, url str
 //	a.HTTPRedirect(myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
-func (a *Assertions) HTTPRedirect(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) bool {
+func (a *Assertions) HTTPRedirect(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -627,7 +627,7 @@ func (a *Assertions) HTTPRedirect(handler http.HandlerFunc, method string, url s
 //	a.HTTPRedirectf(myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
-func (a *Assertions) HTTPRedirectf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) bool {
+func (a *Assertions) HTTPRedirectf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -639,7 +639,7 @@ func (a *Assertions) HTTPRedirectf(handler http.HandlerFunc, method string, url 
 //	a.HTTPStatusCode(myHandler, "GET", "/notImplemented", nil, 501)
 //
 // Returns whether the assertion was successful (true) or not (false).
-func (a *Assertions) HTTPStatusCode(handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msgAndArgs ...interface{}) bool {
+func (a *Assertions) HTTPStatusCode(handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -651,7 +651,7 @@ func (a *Assertions) HTTPStatusCode(handler http.HandlerFunc, method string, url
 //	a.HTTPStatusCodef(myHandler, "GET", "/notImplemented", nil, 501, "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
-func (a *Assertions) HTTPStatusCodef(handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msg string, args ...interface{}) bool {
+func (a *Assertions) HTTPStatusCodef(handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -663,7 +663,7 @@ func (a *Assertions) HTTPStatusCodef(handler http.HandlerFunc, method string, ur
 //	a.HTTPSuccess(myHandler, "POST", "http://www.google.com", nil)
 //
 // Returns whether the assertion was successful (true) or not (false).
-func (a *Assertions) HTTPSuccess(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) bool {
+func (a *Assertions) HTTPSuccess(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -675,7 +675,7 @@ func (a *Assertions) HTTPSuccess(handler http.HandlerFunc, method string, url st
 //	a.HTTPSuccessf(myHandler, "POST", "http://www.google.com", nil, "error message %s", "formatted")
 //
 // Returns whether the assertion was successful (true) or not (false).
-func (a *Assertions) HTTPSuccessf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) bool {
+func (a *Assertions) HTTPSuccessf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -685,7 +685,7 @@ func (a *Assertions) HTTPSuccessf(handler http.HandlerFunc, method string, url s
 // Implements asserts that an object is implemented by the specified interface.
 //
 //	a.Implements((*MyInterface)(nil), new(MyObject))
-func (a *Assertions) Implements(interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) bool {
+func (a *Assertions) Implements(interfaceObject any, object any, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -695,7 +695,7 @@ func (a *Assertions) Implements(interfaceObject interface{}, object interface{},
 // Implementsf asserts that an object is implemented by the specified interface.
 //
 //	a.Implementsf((*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
-func (a *Assertions) Implementsf(interfaceObject interface{}, object interface{}, msg string, args ...interface{}) bool {
+func (a *Assertions) Implementsf(interfaceObject any, object any, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -705,7 +705,7 @@ func (a *Assertions) Implementsf(interfaceObject interface{}, object interface{}
 // InDelta asserts that the two numerals are within delta of each other.
 //
 //	a.InDelta(math.Pi, 22/7.0, 0.01)
-func (a *Assertions) InDelta(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) bool {
+func (a *Assertions) InDelta(expected any, actual any, delta float64, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -713,7 +713,7 @@ func (a *Assertions) InDelta(expected interface{}, actual interface{}, delta flo
 }
 
 // InDeltaMapValues is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
-func (a *Assertions) InDeltaMapValues(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) bool {
+func (a *Assertions) InDeltaMapValues(expected any, actual any, delta float64, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -721,7 +721,7 @@ func (a *Assertions) InDeltaMapValues(expected interface{}, actual interface{}, 
 }
 
 // InDeltaMapValuesf is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
-func (a *Assertions) InDeltaMapValuesf(expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) bool {
+func (a *Assertions) InDeltaMapValuesf(expected any, actual any, delta float64, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -729,7 +729,7 @@ func (a *Assertions) InDeltaMapValuesf(expected interface{}, actual interface{},
 }
 
 // InDeltaSlice is the same as InDelta, except it compares two slices.
-func (a *Assertions) InDeltaSlice(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) bool {
+func (a *Assertions) InDeltaSlice(expected any, actual any, delta float64, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -737,7 +737,7 @@ func (a *Assertions) InDeltaSlice(expected interface{}, actual interface{}, delt
 }
 
 // InDeltaSlicef is the same as InDelta, except it compares two slices.
-func (a *Assertions) InDeltaSlicef(expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) bool {
+func (a *Assertions) InDeltaSlicef(expected any, actual any, delta float64, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -747,7 +747,7 @@ func (a *Assertions) InDeltaSlicef(expected interface{}, actual interface{}, del
 // InDeltaf asserts that the two numerals are within delta of each other.
 //
 //	a.InDeltaf(math.Pi, 22/7.0, 0.01, "error message %s", "formatted")
-func (a *Assertions) InDeltaf(expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) bool {
+func (a *Assertions) InDeltaf(expected any, actual any, delta float64, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -755,7 +755,7 @@ func (a *Assertions) InDeltaf(expected interface{}, actual interface{}, delta fl
 }
 
 // InEpsilon asserts that expected and actual have a relative error less than epsilon
-func (a *Assertions) InEpsilon(expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) bool {
+func (a *Assertions) InEpsilon(expected any, actual any, epsilon float64, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -763,7 +763,7 @@ func (a *Assertions) InEpsilon(expected interface{}, actual interface{}, epsilon
 }
 
 // InEpsilonSlice is the same as InEpsilon, except it compares each value from two slices.
-func (a *Assertions) InEpsilonSlice(expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) bool {
+func (a *Assertions) InEpsilonSlice(expected any, actual any, epsilon float64, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -771,7 +771,7 @@ func (a *Assertions) InEpsilonSlice(expected interface{}, actual interface{}, ep
 }
 
 // InEpsilonSlicef is the same as InEpsilon, except it compares each value from two slices.
-func (a *Assertions) InEpsilonSlicef(expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) bool {
+func (a *Assertions) InEpsilonSlicef(expected any, actual any, epsilon float64, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -779,7 +779,7 @@ func (a *Assertions) InEpsilonSlicef(expected interface{}, actual interface{}, e
 }
 
 // InEpsilonf asserts that expected and actual have a relative error less than epsilon
-func (a *Assertions) InEpsilonf(expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) bool {
+func (a *Assertions) InEpsilonf(expected any, actual any, epsilon float64, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -791,7 +791,7 @@ func (a *Assertions) InEpsilonf(expected interface{}, actual interface{}, epsilo
 //	a.IsDecreasing([]int{2, 1, 0})
 //	a.IsDecreasing([]float{2, 1})
 //	a.IsDecreasing([]string{"b", "a"})
-func (a *Assertions) IsDecreasing(object interface{}, msgAndArgs ...interface{}) bool {
+func (a *Assertions) IsDecreasing(object any, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -803,7 +803,7 @@ func (a *Assertions) IsDecreasing(object interface{}, msgAndArgs ...interface{})
 //	a.IsDecreasingf([]int{2, 1, 0}, "error message %s", "formatted")
 //	a.IsDecreasingf([]float{2, 1}, "error message %s", "formatted")
 //	a.IsDecreasingf([]string{"b", "a"}, "error message %s", "formatted")
-func (a *Assertions) IsDecreasingf(object interface{}, msg string, args ...interface{}) bool {
+func (a *Assertions) IsDecreasingf(object any, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -815,7 +815,7 @@ func (a *Assertions) IsDecreasingf(object interface{}, msg string, args ...inter
 //	a.IsIncreasing([]int{1, 2, 3})
 //	a.IsIncreasing([]float{1, 2})
 //	a.IsIncreasing([]string{"a", "b"})
-func (a *Assertions) IsIncreasing(object interface{}, msgAndArgs ...interface{}) bool {
+func (a *Assertions) IsIncreasing(object any, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -827,7 +827,7 @@ func (a *Assertions) IsIncreasing(object interface{}, msgAndArgs ...interface{})
 //	a.IsIncreasingf([]int{1, 2, 3}, "error message %s", "formatted")
 //	a.IsIncreasingf([]float{1, 2}, "error message %s", "formatted")
 //	a.IsIncreasingf([]string{"a", "b"}, "error message %s", "formatted")
-func (a *Assertions) IsIncreasingf(object interface{}, msg string, args ...interface{}) bool {
+func (a *Assertions) IsIncreasingf(object any, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -839,7 +839,7 @@ func (a *Assertions) IsIncreasingf(object interface{}, msg string, args ...inter
 //	a.IsNonDecreasing([]int{1, 1, 2})
 //	a.IsNonDecreasing([]float{1, 2})
 //	a.IsNonDecreasing([]string{"a", "b"})
-func (a *Assertions) IsNonDecreasing(object interface{}, msgAndArgs ...interface{}) bool {
+func (a *Assertions) IsNonDecreasing(object any, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -851,7 +851,7 @@ func (a *Assertions) IsNonDecreasing(object interface{}, msgAndArgs ...interface
 //	a.IsNonDecreasingf([]int{1, 1, 2}, "error message %s", "formatted")
 //	a.IsNonDecreasingf([]float{1, 2}, "error message %s", "formatted")
 //	a.IsNonDecreasingf([]string{"a", "b"}, "error message %s", "formatted")
-func (a *Assertions) IsNonDecreasingf(object interface{}, msg string, args ...interface{}) bool {
+func (a *Assertions) IsNonDecreasingf(object any, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -863,7 +863,7 @@ func (a *Assertions) IsNonDecreasingf(object interface{}, msg string, args ...in
 //	a.IsNonIncreasing([]int{2, 1, 1})
 //	a.IsNonIncreasing([]float{2, 1})
 //	a.IsNonIncreasing([]string{"b", "a"})
-func (a *Assertions) IsNonIncreasing(object interface{}, msgAndArgs ...interface{}) bool {
+func (a *Assertions) IsNonIncreasing(object any, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -875,7 +875,7 @@ func (a *Assertions) IsNonIncreasing(object interface{}, msgAndArgs ...interface
 //	a.IsNonIncreasingf([]int{2, 1, 1}, "error message %s", "formatted")
 //	a.IsNonIncreasingf([]float{2, 1}, "error message %s", "formatted")
 //	a.IsNonIncreasingf([]string{"b", "a"}, "error message %s", "formatted")
-func (a *Assertions) IsNonIncreasingf(object interface{}, msg string, args ...interface{}) bool {
+func (a *Assertions) IsNonIncreasingf(object any, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -885,7 +885,7 @@ func (a *Assertions) IsNonIncreasingf(object interface{}, msg string, args ...in
 // IsNotType asserts that the specified objects are not of the same type.
 //
 //	a.IsNotType(&NotMyStruct{}, &MyStruct{})
-func (a *Assertions) IsNotType(theType interface{}, object interface{}, msgAndArgs ...interface{}) bool {
+func (a *Assertions) IsNotType(theType any, object any, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -895,7 +895,7 @@ func (a *Assertions) IsNotType(theType interface{}, object interface{}, msgAndAr
 // IsNotTypef asserts that the specified objects are not of the same type.
 //
 //	a.IsNotTypef(&NotMyStruct{}, &MyStruct{}, "error message %s", "formatted")
-func (a *Assertions) IsNotTypef(theType interface{}, object interface{}, msg string, args ...interface{}) bool {
+func (a *Assertions) IsNotTypef(theType any, object any, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -905,7 +905,7 @@ func (a *Assertions) IsNotTypef(theType interface{}, object interface{}, msg str
 // IsType asserts that the specified objects are of the same type.
 //
 //	a.IsType(&MyStruct{}, &MyStruct{})
-func (a *Assertions) IsType(expectedType interface{}, object interface{}, msgAndArgs ...interface{}) bool {
+func (a *Assertions) IsType(expectedType any, object any, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -915,7 +915,7 @@ func (a *Assertions) IsType(expectedType interface{}, object interface{}, msgAnd
 // IsTypef asserts that the specified objects are of the same type.
 //
 //	a.IsTypef(&MyStruct{}, &MyStruct{}, "error message %s", "formatted")
-func (a *Assertions) IsTypef(expectedType interface{}, object interface{}, msg string, args ...interface{}) bool {
+func (a *Assertions) IsTypef(expectedType any, object any, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -925,7 +925,7 @@ func (a *Assertions) IsTypef(expectedType interface{}, object interface{}, msg s
 // JSONEq asserts that two JSON strings are equivalent.
 //
 //	a.JSONEq(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
-func (a *Assertions) JSONEq(expected string, actual string, msgAndArgs ...interface{}) bool {
+func (a *Assertions) JSONEq(expected string, actual string, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -935,7 +935,7 @@ func (a *Assertions) JSONEq(expected string, actual string, msgAndArgs ...interf
 // JSONEqf asserts that two JSON strings are equivalent.
 //
 //	a.JSONEqf(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
-func (a *Assertions) JSONEqf(expected string, actual string, msg string, args ...interface{}) bool {
+func (a *Assertions) JSONEqf(expected string, actual string, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -946,7 +946,7 @@ func (a *Assertions) JSONEqf(expected string, actual string, msg string, args ..
 // Len also fails if the object has a type that len() not accept.
 //
 //	a.Len(mySlice, 3)
-func (a *Assertions) Len(object interface{}, length int, msgAndArgs ...interface{}) bool {
+func (a *Assertions) Len(object any, length int, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -957,7 +957,7 @@ func (a *Assertions) Len(object interface{}, length int, msgAndArgs ...interface
 // Lenf also fails if the object has a type that len() not accept.
 //
 //	a.Lenf(mySlice, 3, "error message %s", "formatted")
-func (a *Assertions) Lenf(object interface{}, length int, msg string, args ...interface{}) bool {
+func (a *Assertions) Lenf(object any, length int, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -969,7 +969,7 @@ func (a *Assertions) Lenf(object interface{}, length int, msg string, args ...in
 //	a.Less(1, 2)
 //	a.Less(float64(1), float64(2))
 //	a.Less("a", "b")
-func (a *Assertions) Less(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
+func (a *Assertions) Less(e1 any, e2 any, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -982,7 +982,7 @@ func (a *Assertions) Less(e1 interface{}, e2 interface{}, msgAndArgs ...interfac
 //	a.LessOrEqual(2, 2)
 //	a.LessOrEqual("a", "b")
 //	a.LessOrEqual("b", "b")
-func (a *Assertions) LessOrEqual(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
+func (a *Assertions) LessOrEqual(e1 any, e2 any, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -995,7 +995,7 @@ func (a *Assertions) LessOrEqual(e1 interface{}, e2 interface{}, msgAndArgs ...i
 //	a.LessOrEqualf(2, 2, "error message %s", "formatted")
 //	a.LessOrEqualf("a", "b", "error message %s", "formatted")
 //	a.LessOrEqualf("b", "b", "error message %s", "formatted")
-func (a *Assertions) LessOrEqualf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
+func (a *Assertions) LessOrEqualf(e1 any, e2 any, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1007,7 +1007,7 @@ func (a *Assertions) LessOrEqualf(e1 interface{}, e2 interface{}, msg string, ar
 //	a.Lessf(1, 2, "error message %s", "formatted")
 //	a.Lessf(float64(1), float64(2), "error message %s", "formatted")
 //	a.Lessf("a", "b", "error message %s", "formatted")
-func (a *Assertions) Lessf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) bool {
+func (a *Assertions) Lessf(e1 any, e2 any, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1018,7 +1018,7 @@ func (a *Assertions) Lessf(e1 interface{}, e2 interface{}, msg string, args ...i
 //
 //	a.Negative(-1)
 //	a.Negative(-1.23)
-func (a *Assertions) Negative(e interface{}, msgAndArgs ...interface{}) bool {
+func (a *Assertions) Negative(e any, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1029,7 +1029,7 @@ func (a *Assertions) Negative(e interface{}, msgAndArgs ...interface{}) bool {
 //
 //	a.Negativef(-1, "error message %s", "formatted")
 //	a.Negativef(-1.23, "error message %s", "formatted")
-func (a *Assertions) Negativef(e interface{}, msg string, args ...interface{}) bool {
+func (a *Assertions) Negativef(e any, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1040,7 +1040,7 @@ func (a *Assertions) Negativef(e interface{}, msg string, args ...interface{}) b
 // periodically checking the target function each tick.
 //
 //	a.Never(func() bool { return false; }, time.Second, 10*time.Millisecond)
-func (a *Assertions) Never(condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) bool {
+func (a *Assertions) Never(condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1051,7 +1051,7 @@ func (a *Assertions) Never(condition func() bool, waitFor time.Duration, tick ti
 // periodically checking the target function each tick.
 //
 //	a.Neverf(func() bool { return false; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
-func (a *Assertions) Neverf(condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) bool {
+func (a *Assertions) Neverf(condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1061,7 +1061,7 @@ func (a *Assertions) Neverf(condition func() bool, waitFor time.Duration, tick t
 // Nil asserts that the specified object is nil.
 //
 //	a.Nil(err)
-func (a *Assertions) Nil(object interface{}, msgAndArgs ...interface{}) bool {
+func (a *Assertions) Nil(object any, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1071,7 +1071,7 @@ func (a *Assertions) Nil(object interface{}, msgAndArgs ...interface{}) bool {
 // Nilf asserts that the specified object is nil.
 //
 //	a.Nilf(err, "error message %s", "formatted")
-func (a *Assertions) Nilf(object interface{}, msg string, args ...interface{}) bool {
+func (a *Assertions) Nilf(object any, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1080,7 +1080,7 @@ func (a *Assertions) Nilf(object interface{}, msg string, args ...interface{}) b
 
 // NoDirExists checks whether a directory does not exist in the given path.
 // It fails if the path points to an existing _directory_ only.
-func (a *Assertions) NoDirExists(path string, msgAndArgs ...interface{}) bool {
+func (a *Assertions) NoDirExists(path string, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1089,7 +1089,7 @@ func (a *Assertions) NoDirExists(path string, msgAndArgs ...interface{}) bool {
 
 // NoDirExistsf checks whether a directory does not exist in the given path.
 // It fails if the path points to an existing _directory_ only.
-func (a *Assertions) NoDirExistsf(path string, msg string, args ...interface{}) bool {
+func (a *Assertions) NoDirExistsf(path string, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1102,7 +1102,7 @@ func (a *Assertions) NoDirExistsf(path string, msg string, args ...interface{}) 
 //	  if a.NoError(err) {
 //		   assert.Equal(t, expectedObj, actualObj)
 //	  }
-func (a *Assertions) NoError(err error, msgAndArgs ...interface{}) bool {
+func (a *Assertions) NoError(err error, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1115,7 +1115,7 @@ func (a *Assertions) NoError(err error, msgAndArgs ...interface{}) bool {
 //	  if a.NoErrorf(err, "error message %s", "formatted") {
 //		   assert.Equal(t, expectedObj, actualObj)
 //	  }
-func (a *Assertions) NoErrorf(err error, msg string, args ...interface{}) bool {
+func (a *Assertions) NoErrorf(err error, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1124,7 +1124,7 @@ func (a *Assertions) NoErrorf(err error, msg string, args ...interface{}) bool {
 
 // NoFileExists checks whether a file does not exist in a given path. It fails
 // if the path points to an existing _file_ only.
-func (a *Assertions) NoFileExists(path string, msgAndArgs ...interface{}) bool {
+func (a *Assertions) NoFileExists(path string, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1133,7 +1133,7 @@ func (a *Assertions) NoFileExists(path string, msgAndArgs ...interface{}) bool {
 
 // NoFileExistsf checks whether a file does not exist in a given path. It fails
 // if the path points to an existing _file_ only.
-func (a *Assertions) NoFileExistsf(path string, msg string, args ...interface{}) bool {
+func (a *Assertions) NoFileExistsf(path string, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1146,7 +1146,7 @@ func (a *Assertions) NoFileExistsf(path string, msg string, args ...interface{})
 //	a.NotContains("Hello World", "Earth")
 //	a.NotContains(["Hello", "World"], "Earth")
 //	a.NotContains({"Hello": "World"}, "Earth")
-func (a *Assertions) NotContains(s interface{}, contains interface{}, msgAndArgs ...interface{}) bool {
+func (a *Assertions) NotContains(s any, contains any, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1159,7 +1159,7 @@ func (a *Assertions) NotContains(s interface{}, contains interface{}, msgAndArgs
 //	a.NotContainsf("Hello World", "Earth", "error message %s", "formatted")
 //	a.NotContainsf(["Hello", "World"], "Earth", "error message %s", "formatted")
 //	a.NotContainsf({"Hello": "World"}, "Earth", "error message %s", "formatted")
-func (a *Assertions) NotContainsf(s interface{}, contains interface{}, msg string, args ...interface{}) bool {
+func (a *Assertions) NotContainsf(s any, contains any, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1176,7 +1176,7 @@ func (a *Assertions) NotContainsf(s interface{}, contains interface{}, msg strin
 // a.NotElementsMatch([1, 1, 2, 3], [1, 2, 3]) -> true
 //
 // a.NotElementsMatch([1, 2, 3], [1, 2, 4]) -> true
-func (a *Assertions) NotElementsMatch(listA interface{}, listB interface{}, msgAndArgs ...interface{}) bool {
+func (a *Assertions) NotElementsMatch(listA any, listB any, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1193,7 +1193,7 @@ func (a *Assertions) NotElementsMatch(listA interface{}, listB interface{}, msgA
 // a.NotElementsMatchf([1, 1, 2, 3], [1, 2, 3], "error message %s", "formatted") -> true
 //
 // a.NotElementsMatchf([1, 2, 3], [1, 2, 4], "error message %s", "formatted") -> true
-func (a *Assertions) NotElementsMatchf(listA interface{}, listB interface{}, msg string, args ...interface{}) bool {
+func (a *Assertions) NotElementsMatchf(listA any, listB any, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1205,7 +1205,7 @@ func (a *Assertions) NotElementsMatchf(listA interface{}, listB interface{}, msg
 //	if a.NotEmpty(obj) {
 //	  assert.Equal(t, "two", obj[1])
 //	}
-func (a *Assertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) bool {
+func (a *Assertions) NotEmpty(object any, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1217,7 +1217,7 @@ func (a *Assertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) boo
 //	if a.NotEmptyf(obj, "error message %s", "formatted") {
 //	  assert.Equal(t, "two", obj[1])
 //	}
-func (a *Assertions) NotEmptyf(object interface{}, msg string, args ...interface{}) bool {
+func (a *Assertions) NotEmptyf(object any, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1230,7 +1230,7 @@ func (a *Assertions) NotEmptyf(object interface{}, msg string, args ...interface
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
-func (a *Assertions) NotEqual(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
+func (a *Assertions) NotEqual(expected any, actual any, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1240,7 +1240,7 @@ func (a *Assertions) NotEqual(expected interface{}, actual interface{}, msgAndAr
 // NotEqualValues asserts that two objects are not equal even when converted to the same type
 //
 //	a.NotEqualValues(obj1, obj2)
-func (a *Assertions) NotEqualValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
+func (a *Assertions) NotEqualValues(expected any, actual any, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1250,7 +1250,7 @@ func (a *Assertions) NotEqualValues(expected interface{}, actual interface{}, ms
 // NotEqualValuesf asserts that two objects are not equal even when converted to the same type
 //
 //	a.NotEqualValuesf(obj1, obj2, "error message %s", "formatted")
-func (a *Assertions) NotEqualValuesf(expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+func (a *Assertions) NotEqualValuesf(expected any, actual any, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1263,7 +1263,7 @@ func (a *Assertions) NotEqualValuesf(expected interface{}, actual interface{}, m
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
-func (a *Assertions) NotEqualf(expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+func (a *Assertions) NotEqualf(expected any, actual any, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1272,7 +1272,7 @@ func (a *Assertions) NotEqualf(expected interface{}, actual interface{}, msg str
 
 // NotErrorAs asserts that none of the errors in err's chain matches target,
 // but if so, sets target to that error value.
-func (a *Assertions) NotErrorAs(err error, target interface{}, msgAndArgs ...interface{}) bool {
+func (a *Assertions) NotErrorAs(err error, target any, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1281,7 +1281,7 @@ func (a *Assertions) NotErrorAs(err error, target interface{}, msgAndArgs ...int
 
 // NotErrorAsf asserts that none of the errors in err's chain matches target,
 // but if so, sets target to that error value.
-func (a *Assertions) NotErrorAsf(err error, target interface{}, msg string, args ...interface{}) bool {
+func (a *Assertions) NotErrorAsf(err error, target any, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1290,7 +1290,7 @@ func (a *Assertions) NotErrorAsf(err error, target interface{}, msg string, args
 
 // NotErrorIs asserts that none of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
-func (a *Assertions) NotErrorIs(err error, target error, msgAndArgs ...interface{}) bool {
+func (a *Assertions) NotErrorIs(err error, target error, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1299,7 +1299,7 @@ func (a *Assertions) NotErrorIs(err error, target error, msgAndArgs ...interface
 
 // NotErrorIsf asserts that none of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
-func (a *Assertions) NotErrorIsf(err error, target error, msg string, args ...interface{}) bool {
+func (a *Assertions) NotErrorIsf(err error, target error, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1309,7 +1309,7 @@ func (a *Assertions) NotErrorIsf(err error, target error, msg string, args ...in
 // NotImplements asserts that an object does not implement the specified interface.
 //
 //	a.NotImplements((*MyInterface)(nil), new(MyObject))
-func (a *Assertions) NotImplements(interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) bool {
+func (a *Assertions) NotImplements(interfaceObject any, object any, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1319,7 +1319,7 @@ func (a *Assertions) NotImplements(interfaceObject interface{}, object interface
 // NotImplementsf asserts that an object does not implement the specified interface.
 //
 //	a.NotImplementsf((*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
-func (a *Assertions) NotImplementsf(interfaceObject interface{}, object interface{}, msg string, args ...interface{}) bool {
+func (a *Assertions) NotImplementsf(interfaceObject any, object any, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1329,7 +1329,7 @@ func (a *Assertions) NotImplementsf(interfaceObject interface{}, object interfac
 // NotNil asserts that the specified object is not nil.
 //
 //	a.NotNil(err)
-func (a *Assertions) NotNil(object interface{}, msgAndArgs ...interface{}) bool {
+func (a *Assertions) NotNil(object any, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1339,7 +1339,7 @@ func (a *Assertions) NotNil(object interface{}, msgAndArgs ...interface{}) bool 
 // NotNilf asserts that the specified object is not nil.
 //
 //	a.NotNilf(err, "error message %s", "formatted")
-func (a *Assertions) NotNilf(object interface{}, msg string, args ...interface{}) bool {
+func (a *Assertions) NotNilf(object any, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1349,7 +1349,7 @@ func (a *Assertions) NotNilf(object interface{}, msg string, args ...interface{}
 // NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
 //
 //	a.NotPanics(func(){ RemainCalm() })
-func (a *Assertions) NotPanics(f PanicTestFunc, msgAndArgs ...interface{}) bool {
+func (a *Assertions) NotPanics(f PanicTestFunc, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1359,7 +1359,7 @@ func (a *Assertions) NotPanics(f PanicTestFunc, msgAndArgs ...interface{}) bool 
 // NotPanicsf asserts that the code inside the specified PanicTestFunc does NOT panic.
 //
 //	a.NotPanicsf(func(){ RemainCalm() }, "error message %s", "formatted")
-func (a *Assertions) NotPanicsf(f PanicTestFunc, msg string, args ...interface{}) bool {
+func (a *Assertions) NotPanicsf(f PanicTestFunc, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1370,7 +1370,7 @@ func (a *Assertions) NotPanicsf(f PanicTestFunc, msg string, args ...interface{}
 //
 //	a.NotRegexp(regexp.MustCompile("starts"), "it's starting")
 //	a.NotRegexp("^start", "it's not starting")
-func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) bool {
+func (a *Assertions) NotRegexp(rx any, str any, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1381,7 +1381,7 @@ func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...in
 //
 //	a.NotRegexpf(regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
 //	a.NotRegexpf("^start", "it's not starting", "error message %s", "formatted")
-func (a *Assertions) NotRegexpf(rx interface{}, str interface{}, msg string, args ...interface{}) bool {
+func (a *Assertions) NotRegexpf(rx any, str any, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1394,7 +1394,7 @@ func (a *Assertions) NotRegexpf(rx interface{}, str interface{}, msg string, arg
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
-func (a *Assertions) NotSame(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
+func (a *Assertions) NotSame(expected any, actual any, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1407,7 +1407,7 @@ func (a *Assertions) NotSame(expected interface{}, actual interface{}, msgAndArg
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
-func (a *Assertions) NotSamef(expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+func (a *Assertions) NotSamef(expected any, actual any, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1423,7 +1423,7 @@ func (a *Assertions) NotSamef(expected interface{}, actual interface{}, msg stri
 //	a.NotSubset({"x": 1, "y": 2}, {"z": 3})
 //	a.NotSubset([1, 3, 4], {1: "one", 2: "two"})
 //	a.NotSubset({"x": 1, "y": 2}, ["z"])
-func (a *Assertions) NotSubset(list interface{}, subset interface{}, msgAndArgs ...interface{}) bool {
+func (a *Assertions) NotSubset(list any, subset any, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1439,7 +1439,7 @@ func (a *Assertions) NotSubset(list interface{}, subset interface{}, msgAndArgs 
 //	a.NotSubsetf({"x": 1, "y": 2}, {"z": 3}, "error message %s", "formatted")
 //	a.NotSubsetf([1, 3, 4], {1: "one", 2: "two"}, "error message %s", "formatted")
 //	a.NotSubsetf({"x": 1, "y": 2}, ["z"], "error message %s", "formatted")
-func (a *Assertions) NotSubsetf(list interface{}, subset interface{}, msg string, args ...interface{}) bool {
+func (a *Assertions) NotSubsetf(list any, subset any, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1447,7 +1447,7 @@ func (a *Assertions) NotSubsetf(list interface{}, subset interface{}, msg string
 }
 
 // NotZero asserts that i is not the zero value for its type.
-func (a *Assertions) NotZero(i interface{}, msgAndArgs ...interface{}) bool {
+func (a *Assertions) NotZero(i any, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1455,7 +1455,7 @@ func (a *Assertions) NotZero(i interface{}, msgAndArgs ...interface{}) bool {
 }
 
 // NotZerof asserts that i is not the zero value for its type.
-func (a *Assertions) NotZerof(i interface{}, msg string, args ...interface{}) bool {
+func (a *Assertions) NotZerof(i any, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1465,7 +1465,7 @@ func (a *Assertions) NotZerof(i interface{}, msg string, args ...interface{}) bo
 // Panics asserts that the code inside the specified PanicTestFunc panics.
 //
 //	a.Panics(func(){ GoCrazy() })
-func (a *Assertions) Panics(f PanicTestFunc, msgAndArgs ...interface{}) bool {
+func (a *Assertions) Panics(f PanicTestFunc, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1477,7 +1477,7 @@ func (a *Assertions) Panics(f PanicTestFunc, msgAndArgs ...interface{}) bool {
 // EqualError comparison.
 //
 //	a.PanicsWithError("crazy error", func(){ GoCrazy() })
-func (a *Assertions) PanicsWithError(errString string, f PanicTestFunc, msgAndArgs ...interface{}) bool {
+func (a *Assertions) PanicsWithError(errString string, f PanicTestFunc, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1489,7 +1489,7 @@ func (a *Assertions) PanicsWithError(errString string, f PanicTestFunc, msgAndAr
 // EqualError comparison.
 //
 //	a.PanicsWithErrorf("crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
-func (a *Assertions) PanicsWithErrorf(errString string, f PanicTestFunc, msg string, args ...interface{}) bool {
+func (a *Assertions) PanicsWithErrorf(errString string, f PanicTestFunc, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1500,7 +1500,7 @@ func (a *Assertions) PanicsWithErrorf(errString string, f PanicTestFunc, msg str
 // the recovered panic value equals the expected panic value.
 //
 //	a.PanicsWithValue("crazy error", func(){ GoCrazy() })
-func (a *Assertions) PanicsWithValue(expected interface{}, f PanicTestFunc, msgAndArgs ...interface{}) bool {
+func (a *Assertions) PanicsWithValue(expected any, f PanicTestFunc, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1511,7 +1511,7 @@ func (a *Assertions) PanicsWithValue(expected interface{}, f PanicTestFunc, msgA
 // the recovered panic value equals the expected panic value.
 //
 //	a.PanicsWithValuef("crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
-func (a *Assertions) PanicsWithValuef(expected interface{}, f PanicTestFunc, msg string, args ...interface{}) bool {
+func (a *Assertions) PanicsWithValuef(expected any, f PanicTestFunc, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1521,7 +1521,7 @@ func (a *Assertions) PanicsWithValuef(expected interface{}, f PanicTestFunc, msg
 // Panicsf asserts that the code inside the specified PanicTestFunc panics.
 //
 //	a.Panicsf(func(){ GoCrazy() }, "error message %s", "formatted")
-func (a *Assertions) Panicsf(f PanicTestFunc, msg string, args ...interface{}) bool {
+func (a *Assertions) Panicsf(f PanicTestFunc, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1532,7 +1532,7 @@ func (a *Assertions) Panicsf(f PanicTestFunc, msg string, args ...interface{}) b
 //
 //	a.Positive(1)
 //	a.Positive(1.23)
-func (a *Assertions) Positive(e interface{}, msgAndArgs ...interface{}) bool {
+func (a *Assertions) Positive(e any, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1543,7 +1543,7 @@ func (a *Assertions) Positive(e interface{}, msgAndArgs ...interface{}) bool {
 //
 //	a.Positivef(1, "error message %s", "formatted")
 //	a.Positivef(1.23, "error message %s", "formatted")
-func (a *Assertions) Positivef(e interface{}, msg string, args ...interface{}) bool {
+func (a *Assertions) Positivef(e any, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1554,7 +1554,7 @@ func (a *Assertions) Positivef(e interface{}, msg string, args ...interface{}) b
 //
 //	a.Regexp(regexp.MustCompile("start"), "it's starting")
 //	a.Regexp("start...$", "it's not starting")
-func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) bool {
+func (a *Assertions) Regexp(rx any, str any, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1565,7 +1565,7 @@ func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...inter
 //
 //	a.Regexpf(regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
 //	a.Regexpf("start...$", "it's not starting", "error message %s", "formatted")
-func (a *Assertions) Regexpf(rx interface{}, str interface{}, msg string, args ...interface{}) bool {
+func (a *Assertions) Regexpf(rx any, str any, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1578,7 +1578,7 @@ func (a *Assertions) Regexpf(rx interface{}, str interface{}, msg string, args .
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
-func (a *Assertions) Same(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
+func (a *Assertions) Same(expected any, actual any, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1591,7 +1591,7 @@ func (a *Assertions) Same(expected interface{}, actual interface{}, msgAndArgs .
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
-func (a *Assertions) Samef(expected interface{}, actual interface{}, msg string, args ...interface{}) bool {
+func (a *Assertions) Samef(expected any, actual any, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1607,7 +1607,7 @@ func (a *Assertions) Samef(expected interface{}, actual interface{}, msg string,
 //	a.Subset({"x": 1, "y": 2}, {"x": 1})
 //	a.Subset([1, 2, 3], {1: "one", 2: "two"})
 //	a.Subset({"x": 1, "y": 2}, ["x"])
-func (a *Assertions) Subset(list interface{}, subset interface{}, msgAndArgs ...interface{}) bool {
+func (a *Assertions) Subset(list any, subset any, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1623,7 +1623,7 @@ func (a *Assertions) Subset(list interface{}, subset interface{}, msgAndArgs ...
 //	a.Subsetf({"x": 1, "y": 2}, {"x": 1}, "error message %s", "formatted")
 //	a.Subsetf([1, 2, 3], {1: "one", 2: "two"}, "error message %s", "formatted")
 //	a.Subsetf({"x": 1, "y": 2}, ["x"], "error message %s", "formatted")
-func (a *Assertions) Subsetf(list interface{}, subset interface{}, msg string, args ...interface{}) bool {
+func (a *Assertions) Subsetf(list any, subset any, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1633,7 +1633,7 @@ func (a *Assertions) Subsetf(list interface{}, subset interface{}, msg string, a
 // True asserts that the specified value is true.
 //
 //	a.True(myBool)
-func (a *Assertions) True(value bool, msgAndArgs ...interface{}) bool {
+func (a *Assertions) True(value bool, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1643,7 +1643,7 @@ func (a *Assertions) True(value bool, msgAndArgs ...interface{}) bool {
 // Truef asserts that the specified value is true.
 //
 //	a.Truef(myBool, "error message %s", "formatted")
-func (a *Assertions) Truef(value bool, msg string, args ...interface{}) bool {
+func (a *Assertions) Truef(value bool, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1653,7 +1653,7 @@ func (a *Assertions) Truef(value bool, msg string, args ...interface{}) bool {
 // WithinDuration asserts that the two times are within duration delta of each other.
 //
 //	a.WithinDuration(time.Now(), time.Now(), 10*time.Second)
-func (a *Assertions) WithinDuration(expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) bool {
+func (a *Assertions) WithinDuration(expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1663,7 +1663,7 @@ func (a *Assertions) WithinDuration(expected time.Time, actual time.Time, delta 
 // WithinDurationf asserts that the two times are within duration delta of each other.
 //
 //	a.WithinDurationf(time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
-func (a *Assertions) WithinDurationf(expected time.Time, actual time.Time, delta time.Duration, msg string, args ...interface{}) bool {
+func (a *Assertions) WithinDurationf(expected time.Time, actual time.Time, delta time.Duration, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1673,7 +1673,7 @@ func (a *Assertions) WithinDurationf(expected time.Time, actual time.Time, delta
 // WithinRange asserts that a time is within a time range (inclusive).
 //
 //	a.WithinRange(time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second))
-func (a *Assertions) WithinRange(actual time.Time, start time.Time, end time.Time, msgAndArgs ...interface{}) bool {
+func (a *Assertions) WithinRange(actual time.Time, start time.Time, end time.Time, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1683,7 +1683,7 @@ func (a *Assertions) WithinRange(actual time.Time, start time.Time, end time.Tim
 // WithinRangef asserts that a time is within a time range (inclusive).
 //
 //	a.WithinRangef(time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second), "error message %s", "formatted")
-func (a *Assertions) WithinRangef(actual time.Time, start time.Time, end time.Time, msg string, args ...interface{}) bool {
+func (a *Assertions) WithinRangef(actual time.Time, start time.Time, end time.Time, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1703,7 +1703,7 @@ func (a *Assertions) WithinRangef(actual time.Time, start time.Time, end time.Ti
 //	key: this is a subsequent document, it is not evaluated
 //	`
 //	a.YAMLEq(expected, actual)
-func (a *Assertions) YAMLEq(expected string, actual string, msgAndArgs ...interface{}) bool {
+func (a *Assertions) YAMLEq(expected string, actual string, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1723,7 +1723,7 @@ func (a *Assertions) YAMLEq(expected string, actual string, msgAndArgs ...interf
 //	key: this is a subsequent document, it is not evaluated
 //	`
 //	a.YAMLEqf(expected, actual, "error message %s", "formatted")
-func (a *Assertions) YAMLEqf(expected string, actual string, msg string, args ...interface{}) bool {
+func (a *Assertions) YAMLEqf(expected string, actual string, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1731,7 +1731,7 @@ func (a *Assertions) YAMLEqf(expected string, actual string, msg string, args ..
 }
 
 // Zero asserts that i is the zero value for its type.
-func (a *Assertions) Zero(i interface{}, msgAndArgs ...interface{}) bool {
+func (a *Assertions) Zero(i any, msgAndArgs ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1739,7 +1739,7 @@ func (a *Assertions) Zero(i interface{}, msgAndArgs ...interface{}) bool {
 }
 
 // Zerof asserts that i is the zero value for its type.
-func (a *Assertions) Zerof(i interface{}, msg string, args ...interface{}) bool {
+func (a *Assertions) Zerof(i any, msg string, args ...any) bool {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}

--- a/assert/assertion_order.go
+++ b/assert/assertion_order.go
@@ -6,7 +6,7 @@ import (
 )
 
 // isOrdered checks that collection contains orderable elements.
-func isOrdered(t TestingT, object interface{}, allowedComparesResults []compareResult, failMessage string, msgAndArgs ...interface{}) bool {
+func isOrdered(t TestingT, object any, allowedComparesResults []compareResult, failMessage string, msgAndArgs ...any) bool {
 	objKind := reflect.TypeOf(object).Kind()
 	if objKind != reflect.Slice && objKind != reflect.Array {
 		return Fail(t, fmt.Sprintf("object %T is not an ordered collection", object), msgAndArgs...)
@@ -49,7 +49,7 @@ func isOrdered(t TestingT, object interface{}, allowedComparesResults []compareR
 //	assert.IsIncreasing(t, []int{1, 2, 3})
 //	assert.IsIncreasing(t, []float{1, 2})
 //	assert.IsIncreasing(t, []string{"a", "b"})
-func IsIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
+func IsIncreasing(t TestingT, object any, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -61,7 +61,7 @@ func IsIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) boo
 //	assert.IsNonIncreasing(t, []int{2, 1, 1})
 //	assert.IsNonIncreasing(t, []float{2, 1})
 //	assert.IsNonIncreasing(t, []string{"b", "a"})
-func IsNonIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
+func IsNonIncreasing(t TestingT, object any, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -73,7 +73,7 @@ func IsNonIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) 
 //	assert.IsDecreasing(t, []int{2, 1, 0})
 //	assert.IsDecreasing(t, []float{2, 1})
 //	assert.IsDecreasing(t, []string{"b", "a"})
-func IsDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
+func IsDecreasing(t TestingT, object any, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -85,7 +85,7 @@ func IsDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) boo
 //	assert.IsNonDecreasing(t, []int{1, 1, 2})
 //	assert.IsNonDecreasing(t, []float{1, 2})
 //	assert.IsNonDecreasing(t, []string{"a", "b"})
-func IsNonDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
+func IsNonDecreasing(t TestingT, object any, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}

--- a/assert/assertion_order_test.go
+++ b/assert/assertion_order_test.go
@@ -29,7 +29,7 @@ func TestIsIncreasing(t *testing.T) {
 
 	// Check error report
 	for _, currCase := range []struct {
-		collection interface{}
+		collection any
 		msg        string
 	}{
 		{collection: []string{"b", "a"}, msg: `"b" is not less than "a"`},
@@ -79,7 +79,7 @@ func TestIsNonIncreasing(t *testing.T) {
 
 	// Check error report
 	for _, currCase := range []struct {
-		collection interface{}
+		collection any
 		msg        string
 	}{
 		{collection: []string{"a", "b"}, msg: `"a" is not greater than or equal to "b"`},
@@ -129,7 +129,7 @@ func TestIsDecreasing(t *testing.T) {
 
 	// Check error report
 	for _, currCase := range []struct {
-		collection interface{}
+		collection any
 		msg        string
 	}{
 		{collection: []string{"a", "b"}, msg: `"a" is not greater than "b"`},
@@ -179,7 +179,7 @@ func TestIsNonDecreasing(t *testing.T) {
 
 	// Check error report
 	for _, currCase := range []struct {
-		collection interface{}
+		collection any
 		msg        string
 	}{
 		{collection: []string{"b", "a"}, msg: `"b" is not less than or equal to "a"`},
@@ -209,7 +209,7 @@ func TestIsNonDecreasing(t *testing.T) {
 func TestOrderingMsgAndArgsForwarding(t *testing.T) {
 	t.Parallel()
 
-	msgAndArgs := []interface{}{"format %s %x", "this", 0xc001}
+	msgAndArgs := []any{"format %s %x", "this", 0xc001}
 	expectedOutput := "format this c001\n"
 	collection := []int{1, 2, 1}
 	funcs := []func(t TestingT){

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -27,28 +27,28 @@ import (
 
 // TestingT is an interface wrapper around *testing.T
 type TestingT interface {
-	Errorf(format string, args ...interface{})
+	Errorf(format string, args ...any)
 }
 
 // ComparisonAssertionFunc is a common function prototype when comparing two values.  Can be useful
 // for table driven tests.
-type ComparisonAssertionFunc func(TestingT, interface{}, interface{}, ...interface{}) bool
+type ComparisonAssertionFunc func(TestingT, any, any, ...any) bool
 
 // ValueAssertionFunc is a common function prototype when validating a single value.  Can be useful
 // for table driven tests.
-type ValueAssertionFunc func(TestingT, interface{}, ...interface{}) bool
+type ValueAssertionFunc func(TestingT, any, ...any) bool
 
 // BoolAssertionFunc is a common function prototype when validating a bool value.  Can be useful
 // for table driven tests.
-type BoolAssertionFunc func(TestingT, bool, ...interface{}) bool
+type BoolAssertionFunc func(TestingT, bool, ...any) bool
 
 // ErrorAssertionFunc is a common function prototype when validating an error value.  Can be useful
 // for table driven tests.
-type ErrorAssertionFunc func(TestingT, error, ...interface{}) bool
+type ErrorAssertionFunc func(TestingT, error, ...any) bool
 
 // PanicAssertionFunc is a common function prototype when validating a panic value.  Can be useful
 // for table driven tests.
-type PanicAssertionFunc = func(t TestingT, f PanicTestFunc, msgAndArgs ...interface{}) bool
+type PanicAssertionFunc = func(t TestingT, f PanicTestFunc, msgAndArgs ...any) bool
 
 // Comparison is a custom function that returns true on success and false on failure
 type Comparison func() (success bool)
@@ -60,7 +60,7 @@ type Comparison func() (success bool)
 // ObjectsAreEqual determines if two objects are considered equal.
 //
 // This function does no assertion of any kind.
-func ObjectsAreEqual(expected, actual interface{}) bool {
+func ObjectsAreEqual(expected, actual any) bool {
 	if expected == nil || actual == nil {
 		return expected == actual
 	}
@@ -82,7 +82,7 @@ func ObjectsAreEqual(expected, actual interface{}) bool {
 
 // copyExportedFields iterates downward through nested data structures and creates a copy
 // that only contains the exported struct fields.
-func copyExportedFields(expected interface{}) interface{} {
+func copyExportedFields(expected any) any {
 	if isNil(expected) {
 		return expected
 	}
@@ -152,7 +152,7 @@ func copyExportedFields(expected interface{}) interface{} {
 // This function does no assertion of any kind.
 //
 // Deprecated: Use [EqualExportedValues] instead.
-func ObjectsExportedFieldsAreEqual(expected, actual interface{}) bool {
+func ObjectsExportedFieldsAreEqual(expected, actual any) bool {
 	expectedCleaned := copyExportedFields(expected)
 	actualCleaned := copyExportedFields(actual)
 	return ObjectsAreEqualValues(expectedCleaned, actualCleaned)
@@ -160,7 +160,7 @@ func ObjectsExportedFieldsAreEqual(expected, actual interface{}) bool {
 
 // ObjectsAreEqualValues gets whether two objects are equal, or if their
 // values are equal.
-func ObjectsAreEqualValues(expected, actual interface{}) bool {
+func ObjectsAreEqualValues(expected, actual any) bool {
 	if ObjectsAreEqual(expected, actual) {
 		return true
 	}
@@ -300,7 +300,7 @@ func isTest(name, prefix string) bool {
 	return !unicode.IsLower(r)
 }
 
-func messageFromMsgAndArgs(msgAndArgs ...interface{}) string {
+func messageFromMsgAndArgs(msgAndArgs ...any) string {
 	if len(msgAndArgs) == 0 || msgAndArgs == nil {
 		return ""
 	}
@@ -343,7 +343,7 @@ type failNower interface {
 }
 
 // FailNow fails test
-func FailNow(t TestingT, failureMessage string, msgAndArgs ...interface{}) bool {
+func FailNow(t TestingT, failureMessage string, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -364,7 +364,7 @@ func FailNow(t TestingT, failureMessage string, msgAndArgs ...interface{}) bool 
 }
 
 // Fail reports a failure through
-func Fail(t TestingT, failureMessage string, msgAndArgs ...interface{}) bool {
+func Fail(t TestingT, failureMessage string, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -421,7 +421,7 @@ func labeledOutput(content ...labeledContent) string {
 // Implements asserts that an object is implemented by the specified interface.
 //
 //	assert.Implements(t, (*MyInterface)(nil), new(MyObject))
-func Implements(t TestingT, interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) bool {
+func Implements(t TestingT, interfaceObject any, object any, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -440,7 +440,7 @@ func Implements(t TestingT, interfaceObject interface{}, object interface{}, msg
 // NotImplements asserts that an object does not implement the specified interface.
 //
 //	assert.NotImplements(t, (*MyInterface)(nil), new(MyObject))
-func NotImplements(t TestingT, interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) bool {
+func NotImplements(t TestingT, interfaceObject any, object any, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -456,14 +456,14 @@ func NotImplements(t TestingT, interfaceObject interface{}, object interface{}, 
 	return true
 }
 
-func isType(expectedType, object interface{}) bool {
+func isType(expectedType, object any) bool {
 	return ObjectsAreEqual(reflect.TypeOf(object), reflect.TypeOf(expectedType))
 }
 
 // IsType asserts that the specified objects are of the same type.
 //
 //	assert.IsType(t, &MyStruct{}, &MyStruct{})
-func IsType(t TestingT, expectedType, object interface{}, msgAndArgs ...interface{}) bool {
+func IsType(t TestingT, expectedType, object any, msgAndArgs ...any) bool {
 	if isType(expectedType, object) {
 		return true
 	}
@@ -476,7 +476,7 @@ func IsType(t TestingT, expectedType, object interface{}, msgAndArgs ...interfac
 // IsNotType asserts that the specified objects are not of the same type.
 //
 //	assert.IsNotType(t, &NotMyStruct{}, &MyStruct{})
-func IsNotType(t TestingT, theType, object interface{}, msgAndArgs ...interface{}) bool {
+func IsNotType(t TestingT, theType, object any, msgAndArgs ...any) bool {
 	if !isType(theType, object) {
 		return true
 	}
@@ -493,7 +493,7 @@ func IsNotType(t TestingT, theType, object interface{}, msgAndArgs ...interface{
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses). Function equality
 // cannot be determined and will always fail.
-func Equal(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool {
+func Equal(t TestingT, expected, actual any, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -515,7 +515,7 @@ func Equal(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) 
 
 // validateEqualArgs checks whether provided arguments can be safely used in the
 // Equal/NotEqual functions.
-func validateEqualArgs(expected, actual interface{}) error {
+func validateEqualArgs(expected, actual any) error {
 	if expected == nil && actual == nil {
 		return nil
 	}
@@ -532,7 +532,7 @@ func validateEqualArgs(expected, actual interface{}) error {
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
-func Same(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool {
+func Same(t TestingT, expected, actual any, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -558,7 +558,7 @@ func Same(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) b
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
-func NotSame(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool {
+func NotSame(t TestingT, expected, actual any, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -581,7 +581,7 @@ func NotSame(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}
 // type pointing to the same object. It returns two values: same indicating if
 // they are the same type and point to the same object, and ok indicating that
 // both inputs are pointers.
-func samePointers(first, second interface{}) (same bool, ok bool) {
+func samePointers(first, second any) (same bool, ok bool) {
 	firstPtr, secondPtr := reflect.ValueOf(first), reflect.ValueOf(second)
 	if firstPtr.Kind() != reflect.Ptr || secondPtr.Kind() != reflect.Ptr {
 		return false, false // not both are pointers
@@ -602,7 +602,7 @@ func samePointers(first, second interface{}) (same bool, ok bool) {
 // If the values are not of like type, the returned strings will be prefixed
 // with the type name, and the value will be enclosed in parentheses similar
 // to a type conversion in the Go grammar.
-func formatUnequalValues(expected, actual interface{}) (e string, a string) {
+func formatUnequalValues(expected, actual any) (e string, a string) {
 	if reflect.TypeOf(expected) != reflect.TypeOf(actual) {
 		return fmt.Sprintf("%T(%s)", expected, truncatingFormat("%#v", expected)),
 			fmt.Sprintf("%T(%s)", actual, truncatingFormat("%#v", actual))
@@ -618,7 +618,7 @@ func formatUnequalValues(expected, actual interface{}) (e string, a string) {
 //
 // This helps keep formatted error messages lines from exceeding the
 // bufio.MaxScanTokenSize max line length that the go testing framework imposes.
-func truncatingFormat(format string, data interface{}) string {
+func truncatingFormat(format string, data any) string {
 	value := fmt.Sprintf(format, data)
 	// Give us space for two truncated objects and the surrounding sentence.
 	maxMessageSize := bufio.MaxScanTokenSize/2 - 100
@@ -632,7 +632,7 @@ func truncatingFormat(format string, data interface{}) string {
 // type and equal.
 //
 //	assert.EqualValues(t, uint32(123), int32(123))
-func EqualValues(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool {
+func EqualValues(t TestingT, expected, actual any, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -658,7 +658,7 @@ func EqualValues(t TestingT, expected, actual interface{}, msgAndArgs ...interfa
 //	 }
 //	 assert.EqualExportedValues(t, S{1, 2}, S{1, 3}) => true
 //	 assert.EqualExportedValues(t, S{1, 2}, S{2, 3}) => false
-func EqualExportedValues(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool {
+func EqualExportedValues(t TestingT, expected, actual any, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -687,7 +687,7 @@ func EqualExportedValues(t TestingT, expected, actual interface{}, msgAndArgs ..
 // Exactly asserts that two objects are equal in value and type.
 //
 //	assert.Exactly(t, int32(123), int64(123))
-func Exactly(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool {
+func Exactly(t TestingT, expected, actual any, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -705,7 +705,7 @@ func Exactly(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}
 // NotNil asserts that the specified object is not nil.
 //
 //	assert.NotNil(t, err)
-func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
+func NotNil(t TestingT, object any, msgAndArgs ...any) bool {
 	if !isNil(object) {
 		return true
 	}
@@ -716,7 +716,7 @@ func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
 }
 
 // isNil checks if a specified object is nil or not, without Failing.
-func isNil(object interface{}) bool {
+func isNil(object any) bool {
 	if object == nil {
 		return true
 	}
@@ -737,7 +737,7 @@ func isNil(object interface{}) bool {
 // Nil asserts that the specified object is nil.
 //
 //	assert.Nil(t, err)
-func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
+func Nil(t TestingT, object any, msgAndArgs ...any) bool {
 	if isNil(object) {
 		return true
 	}
@@ -748,7 +748,7 @@ func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
 }
 
 // isEmpty gets whether the specified object is considered empty or not.
-func isEmpty(object interface{}) bool {
+func isEmpty(object any) bool {
 	// get nil case out of the way
 	if object == nil {
 		return true
@@ -788,7 +788,7 @@ func isEmptyValue(objValue reflect.Value) bool {
 //	assert.Empty(t, obj)
 //
 // [Zero values]: https://go.dev/ref/spec#The_zero_value
-func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
+func Empty(t TestingT, object any, msgAndArgs ...any) bool {
 	pass := isEmpty(object)
 	if !pass {
 		if h, ok := t.(tHelper); ok {
@@ -805,7 +805,7 @@ func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
 //	if assert.NotEmpty(t, obj) {
 //	  assert.Equal(t, "two", obj[1])
 //	}
-func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
+func NotEmpty(t TestingT, object any, msgAndArgs ...any) bool {
 	pass := !isEmpty(object)
 	if !pass {
 		if h, ok := t.(tHelper); ok {
@@ -819,7 +819,7 @@ func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
 
 // getLen tries to get the length of an object.
 // It returns (0, false) if impossible.
-func getLen(x interface{}) (length int, ok bool) {
+func getLen(x any) (length int, ok bool) {
 	v := reflect.ValueOf(x)
 	defer func() {
 		ok = recover() == nil
@@ -831,7 +831,7 @@ func getLen(x interface{}) (length int, ok bool) {
 // Len also fails if the object has a type that len() not accept.
 //
 //	assert.Len(t, mySlice, 3)
-func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) bool {
+func Len(t TestingT, object any, length int, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -849,7 +849,7 @@ func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) 
 // True asserts that the specified value is true.
 //
 //	assert.True(t, myBool)
-func True(t TestingT, value bool, msgAndArgs ...interface{}) bool {
+func True(t TestingT, value bool, msgAndArgs ...any) bool {
 	if !value {
 		if h, ok := t.(tHelper); ok {
 			h.Helper()
@@ -863,7 +863,7 @@ func True(t TestingT, value bool, msgAndArgs ...interface{}) bool {
 // False asserts that the specified value is false.
 //
 //	assert.False(t, myBool)
-func False(t TestingT, value bool, msgAndArgs ...interface{}) bool {
+func False(t TestingT, value bool, msgAndArgs ...any) bool {
 	if value {
 		if h, ok := t.(tHelper); ok {
 			h.Helper()
@@ -880,7 +880,7 @@ func False(t TestingT, value bool, msgAndArgs ...interface{}) bool {
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
-func NotEqual(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool {
+func NotEqual(t TestingT, expected, actual any, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -899,7 +899,7 @@ func NotEqual(t TestingT, expected, actual interface{}, msgAndArgs ...interface{
 // NotEqualValues asserts that two objects are not equal even when converted to the same type
 //
 //	assert.NotEqualValues(t, obj1, obj2)
-func NotEqualValues(t TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool {
+func NotEqualValues(t TestingT, expected, actual any, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -915,7 +915,7 @@ func NotEqualValues(t TestingT, expected, actual interface{}, msgAndArgs ...inte
 // return (false, false) if impossible.
 // return (true, false) if element was not found.
 // return (true, true) if element was found.
-func containsElement(list interface{}, element interface{}) (ok, found bool) {
+func containsElement(list any, element any) (ok, found bool) {
 	listValue := reflect.ValueOf(list)
 	listType := reflect.TypeOf(list)
 	if listType == nil {
@@ -958,7 +958,7 @@ func containsElement(list interface{}, element interface{}) (ok, found bool) {
 //	assert.Contains(t, "Hello World", "World")
 //	assert.Contains(t, ["Hello", "World"], "World")
 //	assert.Contains(t, {"Hello": "World"}, "Hello")
-func Contains(t TestingT, s, contains interface{}, msgAndArgs ...interface{}) bool {
+func Contains(t TestingT, s, contains any, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -980,7 +980,7 @@ func Contains(t TestingT, s, contains interface{}, msgAndArgs ...interface{}) bo
 //	assert.NotContains(t, "Hello World", "Earth")
 //	assert.NotContains(t, ["Hello", "World"], "Earth")
 //	assert.NotContains(t, {"Hello": "World"}, "Earth")
-func NotContains(t TestingT, s, contains interface{}, msgAndArgs ...interface{}) bool {
+func NotContains(t TestingT, s, contains any, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1005,7 +1005,7 @@ func NotContains(t TestingT, s, contains interface{}, msgAndArgs ...interface{})
 //	assert.Subset(t, {"x": 1, "y": 2}, {"x": 1})
 //	assert.Subset(t, [1, 2, 3], {1: "one", 2: "two"})
 //	assert.Subset(t, {"x": 1, "y": 2}, ["x"])
-func Subset(t TestingT, list, subset interface{}, msgAndArgs ...interface{}) (ok bool) {
+func Subset(t TestingT, list, subset any, msgAndArgs ...any) (ok bool) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1044,7 +1044,7 @@ func Subset(t TestingT, list, subset interface{}, msgAndArgs ...interface{}) (ok
 
 	subsetList := reflect.ValueOf(subset)
 	if subsetKind == reflect.Map {
-		keys := make([]interface{}, subsetList.Len())
+		keys := make([]any, subsetList.Len())
 		for idx, key := range subsetList.MapKeys() {
 			keys[idx] = key.Interface()
 		}
@@ -1073,7 +1073,7 @@ func Subset(t TestingT, list, subset interface{}, msgAndArgs ...interface{}) (ok
 //	assert.NotSubset(t, {"x": 1, "y": 2}, {"z": 3})
 //	assert.NotSubset(t, [1, 3, 4], {1: "one", 2: "two"})
 //	assert.NotSubset(t, {"x": 1, "y": 2}, ["z"])
-func NotSubset(t TestingT, list, subset interface{}, msgAndArgs ...interface{}) (ok bool) {
+func NotSubset(t TestingT, list, subset any, msgAndArgs ...any) (ok bool) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1112,7 +1112,7 @@ func NotSubset(t TestingT, list, subset interface{}, msgAndArgs ...interface{}) 
 
 	subsetList := reflect.ValueOf(subset)
 	if subsetKind == reflect.Map {
-		keys := make([]interface{}, subsetList.Len())
+		keys := make([]any, subsetList.Len())
 		for idx, key := range subsetList.MapKeys() {
 			keys[idx] = key.Interface()
 		}
@@ -1137,7 +1137,7 @@ func NotSubset(t TestingT, list, subset interface{}, msgAndArgs ...interface{}) 
 // the number of appearances of each of them in both lists should match.
 //
 // assert.ElementsMatch(t, [1, 3, 2, 3], [1, 3, 3, 2])
-func ElementsMatch(t TestingT, listA, listB interface{}, msgAndArgs ...interface{}) (ok bool) {
+func ElementsMatch(t TestingT, listA, listB any, msgAndArgs ...any) (ok bool) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1159,7 +1159,7 @@ func ElementsMatch(t TestingT, listA, listB interface{}, msgAndArgs ...interface
 }
 
 // isList checks that the provided value is array or slice.
-func isList(t TestingT, list interface{}, msgAndArgs ...interface{}) (ok bool) {
+func isList(t TestingT, list any, msgAndArgs ...any) (ok bool) {
 	kind := reflect.TypeOf(list).Kind()
 	if kind != reflect.Array && kind != reflect.Slice {
 		return Fail(t, fmt.Sprintf("%q has an unsupported type %s, expecting array or slice", list, kind),
@@ -1171,7 +1171,7 @@ func isList(t TestingT, list interface{}, msgAndArgs ...interface{}) (ok bool) {
 // diffLists diffs two arrays/slices and returns slices of elements that are only in A and only in B.
 // If some element is present multiple times, each instance is counted separately (e.g. if something is 2x in A and
 // 5x in B, it will be 0x in extraA and 3x in extraB). The order of items in both lists is ignored.
-func diffLists(listA, listB interface{}) (extraA, extraB []interface{}) {
+func diffLists(listA, listB any) (extraA, extraB []any) {
 	aValue := reflect.ValueOf(listA)
 	bValue := reflect.ValueOf(listB)
 
@@ -1208,7 +1208,7 @@ func diffLists(listA, listB interface{}) (extraA, extraB []interface{}) {
 	return
 }
 
-func formatListDiff(listA, listB interface{}, extraA, extraB []interface{}) string {
+func formatListDiff(listA, listB any, extraA, extraB []any) string {
 	var msg bytes.Buffer
 
 	msg.WriteString("elements differ")
@@ -1238,7 +1238,7 @@ func formatListDiff(listA, listB interface{}, extraA, extraB []interface{}) stri
 // assert.NotElementsMatch(t, [1, 1, 2, 3], [1, 2, 3]) -> true
 //
 // assert.NotElementsMatch(t, [1, 2, 3], [1, 2, 4]) -> true
-func NotElementsMatch(t TestingT, listA, listB interface{}, msgAndArgs ...interface{}) (ok bool) {
+func NotElementsMatch(t TestingT, listA, listB any, msgAndArgs ...any) (ok bool) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1262,7 +1262,7 @@ func NotElementsMatch(t TestingT, listA, listB interface{}, msgAndArgs ...interf
 }
 
 // Condition uses a Comparison to assert a complex condition.
-func Condition(t TestingT, comp Comparison, msgAndArgs ...interface{}) bool {
+func Condition(t TestingT, comp Comparison, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1278,7 +1278,7 @@ func Condition(t TestingT, comp Comparison, msgAndArgs ...interface{}) bool {
 type PanicTestFunc func()
 
 // didPanic returns true if the function passed to it panics. Otherwise, it returns false.
-func didPanic(f PanicTestFunc) (didPanic bool, message interface{}, stack string) {
+func didPanic(f PanicTestFunc) (didPanic bool, message any, stack string) {
 	didPanic = true
 
 	defer func() {
@@ -1298,7 +1298,7 @@ func didPanic(f PanicTestFunc) (didPanic bool, message interface{}, stack string
 // Panics asserts that the code inside the specified PanicTestFunc panics.
 //
 //	assert.Panics(t, func(){ GoCrazy() })
-func Panics(t TestingT, f PanicTestFunc, msgAndArgs ...interface{}) bool {
+func Panics(t TestingT, f PanicTestFunc, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1314,7 +1314,7 @@ func Panics(t TestingT, f PanicTestFunc, msgAndArgs ...interface{}) bool {
 // the recovered panic value equals the expected panic value.
 //
 //	assert.PanicsWithValue(t, "crazy error", func(){ GoCrazy() })
-func PanicsWithValue(t TestingT, expected interface{}, f PanicTestFunc, msgAndArgs ...interface{}) bool {
+func PanicsWithValue(t TestingT, expected any, f PanicTestFunc, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1335,7 +1335,7 @@ func PanicsWithValue(t TestingT, expected interface{}, f PanicTestFunc, msgAndAr
 // EqualError comparison.
 //
 //	assert.PanicsWithError(t, "crazy error", func(){ GoCrazy() })
-func PanicsWithError(t TestingT, errString string, f PanicTestFunc, msgAndArgs ...interface{}) bool {
+func PanicsWithError(t TestingT, errString string, f PanicTestFunc, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1361,7 +1361,7 @@ func PanicsWithError(t TestingT, errString string, f PanicTestFunc, msgAndArgs .
 // NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
 //
 //	assert.NotPanics(t, func(){ RemainCalm() })
-func NotPanics(t TestingT, f PanicTestFunc, msgAndArgs ...interface{}) bool {
+func NotPanics(t TestingT, f PanicTestFunc, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1376,7 +1376,7 @@ func NotPanics(t TestingT, f PanicTestFunc, msgAndArgs ...interface{}) bool {
 // WithinDuration asserts that the two times are within duration delta of each other.
 //
 //	assert.WithinDuration(t, time.Now(), time.Now(), 10*time.Second)
-func WithinDuration(t TestingT, expected, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) bool {
+func WithinDuration(t TestingT, expected, actual time.Time, delta time.Duration, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1392,7 +1392,7 @@ func WithinDuration(t TestingT, expected, actual time.Time, delta time.Duration,
 // WithinRange asserts that a time is within a time range (inclusive).
 //
 //	assert.WithinRange(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second))
-func WithinRange(t TestingT, actual, start, end time.Time, msgAndArgs ...interface{}) bool {
+func WithinRange(t TestingT, actual, start, end time.Time, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1410,7 +1410,7 @@ func WithinRange(t TestingT, actual, start, end time.Time, msgAndArgs ...interfa
 	return true
 }
 
-func toFloat(x interface{}) (float64, bool) {
+func toFloat(x any) (float64, bool) {
 	var xf float64
 	xok := true
 
@@ -1451,7 +1451,7 @@ func toFloat(x interface{}) (float64, bool) {
 // InDelta asserts that the two numerals are within delta of each other.
 //
 //	assert.InDelta(t, math.Pi, 22/7.0, 0.01)
-func InDelta(t TestingT, expected, actual interface{}, delta float64, msgAndArgs ...interface{}) bool {
+func InDelta(t TestingT, expected, actual any, delta float64, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1484,7 +1484,7 @@ func InDelta(t TestingT, expected, actual interface{}, delta float64, msgAndArgs
 }
 
 // InDeltaSlice is the same as InDelta, except it compares two slices.
-func InDeltaSlice(t TestingT, expected, actual interface{}, delta float64, msgAndArgs ...interface{}) bool {
+func InDeltaSlice(t TestingT, expected, actual any, delta float64, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1508,7 +1508,7 @@ func InDeltaSlice(t TestingT, expected, actual interface{}, delta float64, msgAn
 }
 
 // InDeltaMapValues is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
-func InDeltaMapValues(t TestingT, expected, actual interface{}, delta float64, msgAndArgs ...interface{}) bool {
+func InDeltaMapValues(t TestingT, expected, actual any, delta float64, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1551,7 +1551,7 @@ func InDeltaMapValues(t TestingT, expected, actual interface{}, delta float64, m
 	return true
 }
 
-func calcRelativeError(expected, actual interface{}) (float64, error) {
+func calcRelativeError(expected, actual any) (float64, error) {
 	af, aok := toFloat(expected)
 	bf, bok := toFloat(actual)
 	if !aok || !bok {
@@ -1574,7 +1574,7 @@ func calcRelativeError(expected, actual interface{}) (float64, error) {
 }
 
 // InEpsilon asserts that expected and actual have a relative error less than epsilon
-func InEpsilon(t TestingT, expected, actual interface{}, epsilon float64, msgAndArgs ...interface{}) bool {
+func InEpsilon(t TestingT, expected, actual any, epsilon float64, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1597,7 +1597,7 @@ func InEpsilon(t TestingT, expected, actual interface{}, epsilon float64, msgAnd
 }
 
 // InEpsilonSlice is the same as InEpsilon, except it compares each value from two slices.
-func InEpsilonSlice(t TestingT, expected, actual interface{}, epsilon float64, msgAndArgs ...interface{}) bool {
+func InEpsilonSlice(t TestingT, expected, actual any, epsilon float64, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1637,7 +1637,7 @@ func InEpsilonSlice(t TestingT, expected, actual interface{}, epsilon float64, m
 //	  if assert.NoError(t, err) {
 //		   assert.Equal(t, expectedObj, actualObj)
 //	  }
-func NoError(t TestingT, err error, msgAndArgs ...interface{}) bool {
+func NoError(t TestingT, err error, msgAndArgs ...any) bool {
 	if err != nil {
 		if h, ok := t.(tHelper); ok {
 			h.Helper()
@@ -1652,7 +1652,7 @@ func NoError(t TestingT, err error, msgAndArgs ...interface{}) bool {
 //
 //	actualObj, err := SomeFunction()
 //	assert.Error(t, err)
-func Error(t TestingT, err error, msgAndArgs ...interface{}) bool {
+func Error(t TestingT, err error, msgAndArgs ...any) bool {
 	if err == nil {
 		if h, ok := t.(tHelper); ok {
 			h.Helper()
@@ -1668,7 +1668,7 @@ func Error(t TestingT, err error, msgAndArgs ...interface{}) bool {
 //
 //	actualObj, err := SomeFunction()
 //	assert.EqualError(t, err,  expectedErrorString)
-func EqualError(t TestingT, theError error, errString string, msgAndArgs ...interface{}) bool {
+func EqualError(t TestingT, theError error, errString string, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1691,7 +1691,7 @@ func EqualError(t TestingT, theError error, errString string, msgAndArgs ...inte
 //
 //	actualObj, err := SomeFunction()
 //	assert.ErrorContains(t, err,  expectedErrorSubString)
-func ErrorContains(t TestingT, theError error, contains string, msgAndArgs ...interface{}) bool {
+func ErrorContains(t TestingT, theError error, contains string, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1708,7 +1708,7 @@ func ErrorContains(t TestingT, theError error, contains string, msgAndArgs ...in
 }
 
 // matchRegexp return true if a specified regexp matches a string.
-func matchRegexp(rx interface{}, str interface{}) bool {
+func matchRegexp(rx any, str any) bool {
 	var r *regexp.Regexp
 	if rr, ok := rx.(*regexp.Regexp); ok {
 		r = rr
@@ -1730,7 +1730,7 @@ func matchRegexp(rx interface{}, str interface{}) bool {
 //
 //	assert.Regexp(t, regexp.MustCompile("start"), "it's starting")
 //	assert.Regexp(t, "start...$", "it's not starting")
-func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) bool {
+func Regexp(t TestingT, rx any, str any, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1748,7 +1748,7 @@ func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface
 //
 //	assert.NotRegexp(t, regexp.MustCompile("starts"), "it's starting")
 //	assert.NotRegexp(t, "^start", "it's not starting")
-func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) bool {
+func NotRegexp(t TestingT, rx any, str any, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1762,7 +1762,7 @@ func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interf
 }
 
 // Zero asserts that i is the zero value for its type.
-func Zero(t TestingT, i interface{}, msgAndArgs ...interface{}) bool {
+func Zero(t TestingT, i any, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1773,7 +1773,7 @@ func Zero(t TestingT, i interface{}, msgAndArgs ...interface{}) bool {
 }
 
 // NotZero asserts that i is not the zero value for its type.
-func NotZero(t TestingT, i interface{}, msgAndArgs ...interface{}) bool {
+func NotZero(t TestingT, i any, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1785,7 +1785,7 @@ func NotZero(t TestingT, i interface{}, msgAndArgs ...interface{}) bool {
 
 // FileExists checks whether a file exists in the given path. It also fails if
 // the path points to a directory or there is an error when trying to check the file.
-func FileExists(t TestingT, path string, msgAndArgs ...interface{}) bool {
+func FileExists(t TestingT, path string, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1804,7 +1804,7 @@ func FileExists(t TestingT, path string, msgAndArgs ...interface{}) bool {
 
 // NoFileExists checks whether a file does not exist in a given path. It fails
 // if the path points to an existing _file_ only.
-func NoFileExists(t TestingT, path string, msgAndArgs ...interface{}) bool {
+func NoFileExists(t TestingT, path string, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1820,7 +1820,7 @@ func NoFileExists(t TestingT, path string, msgAndArgs ...interface{}) bool {
 
 // DirExists checks whether a directory exists in the given path. It also fails
 // if the path is a file rather a directory or there is an error checking whether it exists.
-func DirExists(t TestingT, path string, msgAndArgs ...interface{}) bool {
+func DirExists(t TestingT, path string, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1839,7 +1839,7 @@ func DirExists(t TestingT, path string, msgAndArgs ...interface{}) bool {
 
 // NoDirExists checks whether a directory does not exist in the given path.
 // It fails if the path points to an existing _directory_ only.
-func NoDirExists(t TestingT, path string, msgAndArgs ...interface{}) bool {
+func NoDirExists(t TestingT, path string, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1859,11 +1859,11 @@ func NoDirExists(t TestingT, path string, msgAndArgs ...interface{}) bool {
 // JSONEq asserts that two JSON strings are equivalent.
 //
 //	assert.JSONEq(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
-func JSONEq(t TestingT, expected string, actual string, msgAndArgs ...interface{}) bool {
+func JSONEq(t TestingT, expected string, actual string, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	var expectedJSONAsInterface, actualJSONAsInterface interface{}
+	var expectedJSONAsInterface, actualJSONAsInterface any
 
 	if err := json.Unmarshal([]byte(expected), &expectedJSONAsInterface); err != nil {
 		return Fail(t, fmt.Sprintf("Expected value ('%s') is not valid json.\nJSON parsing error: '%s'", expected, err.Error()), msgAndArgs...)
@@ -1894,11 +1894,11 @@ func JSONEq(t TestingT, expected string, actual string, msgAndArgs ...interface{
 //	key: this is a subsequent document, it is not evaluated
 //	`
 //	assert.YAMLEq(t, expected, actual)
-func YAMLEq(t TestingT, expected string, actual string, msgAndArgs ...interface{}) bool {
+func YAMLEq(t TestingT, expected string, actual string, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	var expectedYAMLAsInterface, actualYAMLAsInterface interface{}
+	var expectedYAMLAsInterface, actualYAMLAsInterface any
 
 	if err := yaml.Unmarshal([]byte(expected), &expectedYAMLAsInterface); err != nil {
 		return Fail(t, fmt.Sprintf("Expected value ('%s') is not valid yaml.\nYAML parsing error: '%s'", expected, err.Error()), msgAndArgs...)
@@ -1916,7 +1916,7 @@ func YAMLEq(t TestingT, expected string, actual string, msgAndArgs ...interface{
 	return Equal(t, expectedYAMLAsInterface, actualYAMLAsInterface, msgAndArgs...)
 }
 
-func typeAndKind(v interface{}) (reflect.Type, reflect.Kind) {
+func typeAndKind(v any) (reflect.Type, reflect.Kind) {
 	t := reflect.TypeOf(v)
 	k := t.Kind()
 
@@ -1929,7 +1929,7 @@ func typeAndKind(v interface{}) (reflect.Type, reflect.Kind) {
 
 // diff returns a diff of both values as long as both are of the same type and
 // are a struct, map, slice, array or string. Otherwise it returns an empty string.
-func diff(expected interface{}, actual interface{}) string {
+func diff(expected any, actual any) string {
 	if expected == nil || actual == nil {
 		return ""
 	}
@@ -1972,7 +1972,7 @@ func diff(expected interface{}, actual interface{}) string {
 	return "\n\nDiff:\n" + diff
 }
 
-func isFunction(arg interface{}) bool {
+func isFunction(arg any) bool {
 	if arg == nil {
 		return false
 	}
@@ -2004,7 +2004,7 @@ type tHelper = interface {
 // periodically checking target function each tick.
 //
 //	assert.Eventually(t, func() bool { return true; }, time.Second, 10*time.Millisecond)
-func Eventually(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) bool {
+func Eventually(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -2051,7 +2051,7 @@ type CollectT struct {
 func (CollectT) Helper() {}
 
 // Errorf collects the error.
-func (c *CollectT) Errorf(format string, args ...interface{}) {
+func (c *CollectT) Errorf(format string, args ...any) {
 	c.errors = append(c.errors, fmt.Errorf(format, args...))
 }
 
@@ -2099,7 +2099,7 @@ func (c *CollectT) failed() bool {
 //		// add assertions as needed; any assertion failure will fail the current tick
 //		assert.True(c, externalValue, "expected 'externalValue' to be true")
 //	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
-func EventuallyWithT(t TestingT, condition func(collect *CollectT), waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) bool {
+func EventuallyWithT(t TestingT, condition func(collect *CollectT), waitFor time.Duration, tick time.Duration, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -2151,7 +2151,7 @@ func EventuallyWithT(t TestingT, condition func(collect *CollectT), waitFor time
 // periodically checking the target function each tick.
 //
 //	assert.Never(t, func() bool { return false; }, time.Second, 10*time.Millisecond)
-func Never(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) bool {
+func Never(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -2188,7 +2188,7 @@ func Never(t TestingT, condition func() bool, waitFor time.Duration, tick time.D
 
 // ErrorIs asserts that at least one of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
-func ErrorIs(t TestingT, err, target error, msgAndArgs ...interface{}) bool {
+func ErrorIs(t TestingT, err, target error, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -2214,7 +2214,7 @@ func ErrorIs(t TestingT, err, target error, msgAndArgs ...interface{}) bool {
 
 // NotErrorIs asserts that none of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
-func NotErrorIs(t TestingT, err, target error, msgAndArgs ...interface{}) bool {
+func NotErrorIs(t TestingT, err, target error, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -2237,7 +2237,7 @@ func NotErrorIs(t TestingT, err, target error, msgAndArgs ...interface{}) bool {
 
 // ErrorAs asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
 // This is a wrapper for errors.As.
-func ErrorAs(t TestingT, err error, target interface{}, msgAndArgs ...interface{}) bool {
+func ErrorAs(t TestingT, err error, target any, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -2261,7 +2261,7 @@ func ErrorAs(t TestingT, err error, target interface{}, msgAndArgs ...interface{
 
 // NotErrorAs asserts that none of the errors in err's chain matches target,
 // but if so, sets target to that error value.
-func NotErrorAs(t TestingT, err error, target interface{}, msgAndArgs ...interface{}) bool {
+func NotErrorAs(t TestingT, err error, target any, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -19,8 +19,8 @@ import (
 )
 
 var (
-	i     interface{}
-	zeros = []interface{}{
+	i     any
+	zeros = []any{
 		false,
 		byte(0),
 		complex64(0),
@@ -40,19 +40,19 @@ var (
 		uint64(0),
 		uintptr(0),
 		"",
-		[0]interface{}{},
-		[]interface{}(nil),
+		[0]any{},
+		[]any(nil),
 		struct{ x int }{},
-		(*interface{})(nil),
+		(*any)(nil),
 		(func())(nil),
 		nil,
-		interface{}(nil),
-		map[interface{}]interface{}(nil),
-		(chan interface{})(nil),
-		(<-chan interface{})(nil),
-		(chan<- interface{})(nil),
+		any(nil),
+		map[any]any(nil),
+		(chan any)(nil),
+		(<-chan any)(nil),
+		(chan<- any)(nil),
 	}
-	nonZeros = []interface{}{
+	nonZeros = []any{
 		true,
 		byte(1),
 		complex64(1),
@@ -72,16 +72,16 @@ var (
 		uint64(1),
 		uintptr(1),
 		"s",
-		[1]interface{}{1},
-		[]interface{}{},
+		[1]any{1},
+		[]any{},
 		struct{ x int }{1},
 		(&i),
 		(func() {}),
-		interface{}(1),
-		map[interface{}]interface{}{},
-		(make(chan interface{})),
-		(<-chan interface{})(make(chan interface{})),
-		(chan<- interface{})(make(chan interface{})),
+		any(1),
+		map[any]any{},
+		(make(chan any)),
+		(<-chan any)(make(chan any)),
+		(chan<- any)(make(chan any)),
 	}
 )
 
@@ -103,8 +103,8 @@ func TestObjectsAreEqual(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		expected interface{}
-		actual   interface{}
+		expected any
+		actual   any
 		result   bool
 	}{
 		// cases that are expected to be equal
@@ -142,8 +142,8 @@ func TestObjectsAreEqualValues(t *testing.T) {
 	now := time.Now()
 
 	cases := []struct {
-		expected interface{}
-		actual   interface{}
+		expected any
+		actual   any
 		result   bool
 	}{
 		{uint32(10), int32(10), true},
@@ -175,19 +175,19 @@ func TestObjectsAreEqualValues(t *testing.T) {
 }
 
 type Nested struct {
-	Exported    interface{}
-	notExported interface{}
+	Exported    any
+	notExported any
 }
 
 type S struct {
-	Exported1    interface{}
+	Exported1    any
 	Exported2    Nested
-	notExported1 interface{}
+	notExported1 any
 	notExported2 Nested
 }
 
 type S2 struct {
-	foo interface{}
+	foo any
 }
 
 type S3 struct {
@@ -214,8 +214,8 @@ func TestObjectsExportedFieldsAreEqual(t *testing.T) {
 	intValue := 1
 
 	cases := []struct {
-		expected interface{}
-		actual   interface{}
+		expected any
+		actual   any
 		result   bool
 	}{
 		{S{1, Nested{2, 3}, 4, Nested{5, 6}}, S{1, Nested{2, 3}, 4, Nested{5, 6}}, true},
@@ -246,28 +246,28 @@ func TestObjectsExportedFieldsAreEqual(t *testing.T) {
 		{Nested{&Nested{1, 2}, 3}, Nested{nil, 3}, false},
 
 		{
-			Nested{map[interface{}]*Nested{nil: nil}, 2},
-			Nested{map[interface{}]*Nested{nil: nil}, 2},
+			Nested{map[any]*Nested{nil: nil}, 2},
+			Nested{map[any]*Nested{nil: nil}, 2},
 			true,
 		},
 		{
-			Nested{map[interface{}]*Nested{"a": nil}, 2},
-			Nested{map[interface{}]*Nested{"a": nil}, 2},
+			Nested{map[any]*Nested{"a": nil}, 2},
+			Nested{map[any]*Nested{"a": nil}, 2},
 			true,
 		},
 		{
-			Nested{map[interface{}]*Nested{"a": nil}, 2},
-			Nested{map[interface{}]*Nested{"a": {1, 2}}, 2},
+			Nested{map[any]*Nested{"a": nil}, 2},
+			Nested{map[any]*Nested{"a": {1, 2}}, 2},
 			false,
 		},
 		{
-			Nested{map[interface{}]Nested{"a": {1, 2}, "b": {3, 4}}, 2},
-			Nested{map[interface{}]Nested{"a": {1, 5}, "b": {3, 7}}, 2},
+			Nested{map[any]Nested{"a": {1, 2}, "b": {3, 4}}, 2},
+			Nested{map[any]Nested{"a": {1, 5}, "b": {3, 7}}, 2},
 			true,
 		},
 		{
-			Nested{map[interface{}]Nested{"a": {1, 2}, "b": {3, 4}}, 2},
-			Nested{map[interface{}]Nested{"a": {2, 2}, "b": {3, 4}}, 2},
+			Nested{map[any]Nested{"a": {1, 2}, "b": {3, 4}}, 2},
+			Nested{map[any]Nested{"a": {2, 2}, "b": {3, 4}}, 2},
 			false,
 		},
 	}
@@ -289,8 +289,8 @@ func TestCopyExportedFields(t *testing.T) {
 	intValue := 1
 
 	cases := []struct {
-		input    interface{}
-		expected interface{}
+		input    any
+		expected any
 	}{
 		{
 			input:    Nested{"a", "b"},
@@ -376,8 +376,8 @@ func TestEqualExportedValues(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		value1        interface{}
-		value2        interface{}
+		value1        any
+		value2        any
 		expectedEqual bool
 		expectedFail  string
 	}{
@@ -591,11 +591,11 @@ func TestEqual(t *testing.T) {
 	type myType string
 
 	mockT := new(testing.T)
-	var m map[string]interface{}
+	var m map[string]any
 
 	cases := []struct {
-		expected interface{}
-		actual   interface{}
+		expected any
+		actual   any
 		result   bool
 		remark   string
 	}{
@@ -694,8 +694,8 @@ func Test_samePointers(t *testing.T) {
 	p := ptr(2)
 
 	type args struct {
-		first  interface{}
-		second interface{}
+		first  any
+		second any
 	}
 	tests := []struct {
 		name string
@@ -764,7 +764,7 @@ type bufferT struct {
 // Helper is like [testing.T.Helper] but does nothing.
 func (bufferT) Helper() {}
 
-func (t *bufferT) Errorf(format string, args ...interface{}) {
+func (t *bufferT) Errorf(format string, args ...any) {
 	// implementation of decorate is copied from testing.T
 	decorate := func(s string) string {
 		_, file, line, ok := runtime.Caller(3) // decorate + log + public function.
@@ -806,7 +806,7 @@ func TestStringEqual(t *testing.T) {
 	for i, currCase := range []struct {
 		equalWant  string
 		equalGot   string
-		msgAndArgs []interface{}
+		msgAndArgs []any
 		want       string
 	}{
 		{equalWant: "hi, \nmy name is", equalGot: "what,\nmy name is", want: "\tassertions.go:\\d+: \n\t+Error Trace:\t\n\t+Error:\\s+Not equal:\\s+\n\\s+expected: \"hi, \\\\nmy name is\"\n\\s+actual\\s+: \"what,\\\\nmy name is\"\n\\s+Diff:\n\\s+-+ Expected\n\\s+\\++ Actual\n\\s+@@ -1,2 \\+1,2 @@\n\\s+-hi, \n\\s+\\+what,\n\\s+my name is"},
@@ -823,13 +823,13 @@ func TestEqualFormatting(t *testing.T) {
 	for i, currCase := range []struct {
 		equalWant  string
 		equalGot   string
-		msgAndArgs []interface{}
+		msgAndArgs []any
 		want       string
 	}{
 		{equalWant: "want", equalGot: "got", want: "\tassertions.go:\\d+: \n\t+Error Trace:\t\n\t+Error:\\s+Not equal:\\s+\n\\s+expected: \"want\"\n\\s+actual\\s+: \"got\"\n\\s+Diff:\n\\s+-+ Expected\n\\s+\\++ Actual\n\\s+@@ -1 \\+1 @@\n\\s+-want\n\\s+\\+got\n"},
-		{equalWant: "want", equalGot: "got", msgAndArgs: []interface{}{"hello, %v!", "world"}, want: "\tassertions.go:[0-9]+: \n\t+Error Trace:\t\n\t+Error:\\s+Not equal:\\s+\n\\s+expected: \"want\"\n\\s+actual\\s+: \"got\"\n\\s+Diff:\n\\s+-+ Expected\n\\s+\\++ Actual\n\\s+@@ -1 \\+1 @@\n\\s+-want\n\\s+\\+got\n\\s+Messages:\\s+hello, world!\n"},
-		{equalWant: "want", equalGot: "got", msgAndArgs: []interface{}{123}, want: "\tassertions.go:[0-9]+: \n\t+Error Trace:\t\n\t+Error:\\s+Not equal:\\s+\n\\s+expected: \"want\"\n\\s+actual\\s+: \"got\"\n\\s+Diff:\n\\s+-+ Expected\n\\s+\\++ Actual\n\\s+@@ -1 \\+1 @@\n\\s+-want\n\\s+\\+got\n\\s+Messages:\\s+123\n"},
-		{equalWant: "want", equalGot: "got", msgAndArgs: []interface{}{struct{ a string }{"hello"}}, want: "\tassertions.go:[0-9]+: \n\t+Error Trace:\t\n\t+Error:\\s+Not equal:\\s+\n\\s+expected: \"want\"\n\\s+actual\\s+: \"got\"\n\\s+Diff:\n\\s+-+ Expected\n\\s+\\++ Actual\n\\s+@@ -1 \\+1 @@\n\\s+-want\n\\s+\\+got\n\\s+Messages:\\s+{a:hello}\n"},
+		{equalWant: "want", equalGot: "got", msgAndArgs: []any{"hello, %v!", "world"}, want: "\tassertions.go:[0-9]+: \n\t+Error Trace:\t\n\t+Error:\\s+Not equal:\\s+\n\\s+expected: \"want\"\n\\s+actual\\s+: \"got\"\n\\s+Diff:\n\\s+-+ Expected\n\\s+\\++ Actual\n\\s+@@ -1 \\+1 @@\n\\s+-want\n\\s+\\+got\n\\s+Messages:\\s+hello, world!\n"},
+		{equalWant: "want", equalGot: "got", msgAndArgs: []any{123}, want: "\tassertions.go:[0-9]+: \n\t+Error Trace:\t\n\t+Error:\\s+Not equal:\\s+\n\\s+expected: \"want\"\n\\s+actual\\s+: \"got\"\n\\s+Diff:\n\\s+-+ Expected\n\\s+\\++ Actual\n\\s+@@ -1 \\+1 @@\n\\s+-want\n\\s+\\+got\n\\s+Messages:\\s+123\n"},
+		{equalWant: "want", equalGot: "got", msgAndArgs: []any{struct{ a string }{"hello"}}, want: "\tassertions.go:[0-9]+: \n\t+Error Trace:\t\n\t+Error:\\s+Not equal:\\s+\n\\s+expected: \"want\"\n\\s+actual\\s+: \"got\"\n\\s+Diff:\n\\s+-+ Expected\n\\s+\\++ Actual\n\\s+@@ -1 \\+1 @@\n\\s+-want\n\\s+\\+got\n\\s+Messages:\\s+{a:hello}\n"},
 	} {
 		mockT := &bufferT{}
 		Equal(mockT, currCase.equalWant, currCase.equalGot, currCase.msgAndArgs...)
@@ -932,8 +932,8 @@ func TestExactly(t *testing.T) {
 	c := float32(1)
 	d := float32(2)
 	cases := []struct {
-		expected interface{}
-		actual   interface{}
+		expected any
+		actual   any
 		result   bool
 	}{
 		{a, b, false},
@@ -959,8 +959,8 @@ func TestNotEqual(t *testing.T) {
 	mockT := new(testing.T)
 
 	cases := []struct {
-		expected interface{}
-		actual   interface{}
+		expected any
+		actual   any
 		result   bool
 	}{
 		// cases that are expected not to match
@@ -1000,8 +1000,8 @@ func TestEqualValuesAndNotEqualValues(t *testing.T) {
 	mockT := new(testing.T)
 
 	cases := []struct {
-		expected       interface{}
-		actual         interface{}
+		expected       any
+		actual         any
 		notEqualResult bool // result for NotEqualValues
 	}{
 		// cases that are expected not to match
@@ -1064,12 +1064,12 @@ func TestContainsNotContains(t *testing.T) {
 		{"g", "h"},
 		{"j", "k"},
 	}
-	simpleMap := map[interface{}]interface{}{"Foo": "Bar"}
-	var zeroMap map[interface{}]interface{}
+	simpleMap := map[any]any{"Foo": "Bar"}
+	var zeroMap map[any]any
 
 	cases := []struct {
-		expected interface{}
-		actual   interface{}
+		expected any
+		actual   any
 		result   bool
 	}{
 		{"Hello World", "Hello", true},
@@ -1125,9 +1125,9 @@ func TestContainsNotContainsFailMessage(t *testing.T) {
 	}
 
 	cases := []struct {
-		assertion func(t TestingT, s, contains interface{}, msgAndArgs ...interface{}) bool
-		container interface{}
-		instance  interface{}
+		assertion func(t TestingT, s, contains any, msgAndArgs ...any) bool
+		container any
+		instance  any
 		expected  string
 	}{
 		{
@@ -1195,8 +1195,8 @@ func TestSubsetNotSubset(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		list    interface{}
-		subset  interface{}
+		list    any
+		subset  any
 		result  bool
 		message string
 	}{
@@ -1293,7 +1293,7 @@ func Test_containsElement(t *testing.T) {
 
 	list1 := []string{"Foo", "Bar"}
 	list2 := []int{1, 2}
-	simpleMap := map[interface{}]interface{}{"Foo": "Bar"}
+	simpleMap := map[any]any{"Foo": "Bar"}
 
 	ok, found := containsElement("Hello World", "World")
 	True(t, ok)
@@ -1346,8 +1346,8 @@ func TestElementsMatch(t *testing.T) {
 	mockT := new(testing.T)
 
 	cases := []struct {
-		expected interface{}
-		actual   interface{}
+		expected any
+		actual   any
 		result   bool
 	}{
 		// matching
@@ -1388,10 +1388,10 @@ func TestDiffLists(t *testing.T) {
 
 	tests := []struct {
 		name   string
-		listA  interface{}
-		listB  interface{}
-		extraA []interface{}
-		extraB []interface{}
+		listA  any
+		listB  any
+		extraA []any
+		extraB []any
 	}{
 		{
 			name:   "equal empty",
@@ -1418,14 +1418,14 @@ func TestDiffLists(t *testing.T) {
 			name:   "extra A",
 			listA:  []string{"hello", "hello", "world"},
 			listB:  []string{"hello", "world"},
-			extraA: []interface{}{"hello"},
+			extraA: []any{"hello"},
 			extraB: nil,
 		},
 		{
 			name:   "extra A twice",
 			listA:  []string{"hello", "hello", "hello", "world"},
 			listB:  []string{"hello", "world"},
-			extraA: []interface{}{"hello", "hello"},
+			extraA: []any{"hello", "hello"},
 			extraB: nil,
 		},
 		{
@@ -1433,14 +1433,14 @@ func TestDiffLists(t *testing.T) {
 			listA:  []string{"hello", "world"},
 			listB:  []string{"hello", "hello", "world"},
 			extraA: nil,
-			extraB: []interface{}{"hello"},
+			extraB: []any{"hello"},
 		},
 		{
 			name:   "extra B twice",
 			listA:  []string{"hello", "world"},
 			listB:  []string{"hello", "hello", "world", "hello"},
 			extraA: nil,
-			extraB: []interface{}{"hello", "hello"},
+			extraB: []any{"hello", "hello"},
 		},
 		{
 			name:   "integers 1",
@@ -1453,8 +1453,8 @@ func TestDiffLists(t *testing.T) {
 			name:   "integers 2",
 			listA:  []int{1, 2, 1, 2, 1},
 			listB:  []int{2, 1, 2, 1, 2},
-			extraA: []interface{}{1},
-			extraB: []interface{}{2},
+			extraA: []any{1},
+			extraB: []any{2},
 		},
 	}
 	for _, test := range tests {
@@ -1475,8 +1475,8 @@ func TestNotElementsMatch(t *testing.T) {
 	mockT := new(testing.T)
 
 	cases := []struct {
-		expected interface{}
-		actual   interface{}
+		expected any
+		actual   any
 		result   bool
 	}{
 		// not matching
@@ -1779,8 +1779,8 @@ func Test_isEmpty(t *testing.T) {
 	True(t, isEmpty([]byte("")))
 	True(t, isEmpty([]bool(nil)))
 	True(t, isEmpty([]bool{}))
-	True(t, isEmpty([]interface{}(nil)))
-	True(t, isEmpty([]interface{}{}))
+	True(t, isEmpty([]any(nil)))
+	True(t, isEmpty([]any{}))
 	True(t, isEmpty(struct{}{}))
 	True(t, isEmpty(&struct{}{}))
 	True(t, isEmpty(struct{ A int }{A: 0}))
@@ -1944,7 +1944,7 @@ func TestEmpty(t *testing.T) {
 	// error messages validation
 	tests := []struct {
 		name           string
-		value          interface{}
+		value          any
 		expectedResult bool
 		expectedErrMsg string
 	}{
@@ -2104,7 +2104,7 @@ func TestNotEmpty(t *testing.T) {
 	// error messages validation
 	tests := []struct {
 		name           string
-		value          interface{}
+		value          any
 		expectedResult bool
 		expectedErrMsg string
 	}{
@@ -2167,7 +2167,7 @@ func TestNotEmpty(t *testing.T) {
 func Test_getLen(t *testing.T) {
 	t.Parallel()
 
-	falseCases := []interface{}{
+	falseCases := []any{
 		nil,
 		0,
 		true,
@@ -2186,7 +2186,7 @@ func Test_getLen(t *testing.T) {
 	ch <- 2
 	ch <- 3
 	trueCases := []struct {
-		v interface{}
+		v any
 		l int
 	}{
 		{[]int{1, 2, 3}, 3},
@@ -2229,7 +2229,7 @@ func TestLen(t *testing.T) {
 	ch <- 3
 
 	cases := []struct {
-		v               interface{}
+		v               any
 		l               int
 		expected1234567 string // message when expecting 1234567 items
 	}{
@@ -2315,7 +2315,7 @@ func TestInDelta(t *testing.T) {
 	True(t, InDelta(mockT, math.NaN(), math.NaN(), 0.01), "Expected NaN for both to pass")
 
 	cases := []struct {
-		a, b  interface{}
+		a, b  any
 		delta float64
 	}{
 		{uint(2), uint(1), 1},
@@ -2369,9 +2369,9 @@ func TestInDeltaMapValues(t *testing.T) {
 
 	for _, tc := range []struct {
 		title  string
-		expect interface{}
-		actual interface{}
-		f      func(TestingT, bool, ...interface{}) bool
+		expect any
+		actual any
+		f      func(TestingT, bool, ...any) bool
 		delta  float64
 	}{
 		{
@@ -2448,7 +2448,7 @@ func TestInEpsilon(t *testing.T) {
 	mockT := new(testing.T)
 
 	cases := []struct {
-		a, b    interface{}
+		a, b    any
 		epsilon float64
 	}{
 		{uint8(2), uint16(2), .001},
@@ -2468,7 +2468,7 @@ func TestInEpsilon(t *testing.T) {
 	}
 
 	cases = []struct {
-		a, b    interface{}
+		a, b    any
 		epsilon float64
 	}{
 		{uint8(2), int16(-2), .001},
@@ -3096,7 +3096,7 @@ func TestDiffRace(t *testing.T) {
 
 type mockTestingT struct {
 	errorFmt string
-	args     []interface{}
+	args     []any
 }
 
 // Helper is like [testing.T.Helper] but does nothing.
@@ -3106,7 +3106,7 @@ func (m *mockTestingT) errorString() string {
 	return fmt.Sprintf(m.errorFmt, m.args...)
 }
 
-func (m *mockTestingT) Errorf(format string, args ...interface{}) {
+func (m *mockTestingT) Errorf(format string, args ...any) {
 	m.errorFmt = format
 	m.args = args
 }
@@ -3130,7 +3130,7 @@ type mockFailNowTestingT struct{}
 // Helper is like [testing.T.Helper] but does nothing.
 func (mockFailNowTestingT) Helper() {}
 
-func (m *mockFailNowTestingT) Errorf(format string, args ...interface{}) {}
+func (m *mockFailNowTestingT) Errorf(format string, args ...any) {}
 
 func (m *mockFailNowTestingT) FailNow() {}
 
@@ -3220,8 +3220,8 @@ func TestComparisonAssertionFunc(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		expect    interface{}
-		got       interface{}
+		expect    any
+		got       any
 		assertion ComparisonAssertionFunc
 	}{
 		{"implements", (*iface)(nil), t, Implements},
@@ -3249,8 +3249,8 @@ func TestComparisonAssertionFunc(t *testing.T) {
 func ExampleValueAssertionFunc() {
 	t := &testing.T{} // provided by test
 
-	dumbParse := func(input string) interface{} {
-		var x interface{}
+	dumbParse := func(input string) any {
+		var x any
 		_ = json.Unmarshal([]byte(input), &x)
 		return x
 	}
@@ -3279,7 +3279,7 @@ func TestValueAssertionFunc(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		value     interface{}
+		value     any
 		assertion ValueAssertionFunc
 	}{
 		{"notNil", true, NotNil},
@@ -3344,7 +3344,7 @@ func TestBoolAssertionFunc(t *testing.T) {
 func ExampleErrorAssertionFunc() {
 	t := &testing.T{} // provided by test
 
-	dumbParseNum := func(input string, v interface{}) error {
+	dumbParseNum := func(input string, v any) error {
 		return json.Unmarshal([]byte(input), v)
 	}
 
@@ -3458,7 +3458,7 @@ type errorsCapturingT struct {
 // Helper is like [testing.T.Helper] but does nothing.
 func (errorsCapturingT) Helper() {}
 
-func (t *errorsCapturingT) Errorf(format string, args ...interface{}) {
+func (t *errorsCapturingT) Errorf(format string, args ...any) {
 	t.errors = append(t.errors, fmt.Errorf(format, args...))
 }
 
@@ -3711,7 +3711,7 @@ type captureTestingT struct {
 // Helper is like [testing.T.Helper] but does nothing.
 func (captureTestingT) Helper() {}
 
-func (ctt *captureTestingT) Errorf(format string, args ...interface{}) {
+func (ctt *captureTestingT) Errorf(format string, args ...any) {
 	ctt.msg = fmt.Sprintf(format, args...)
 	ctt.failed = true
 }

--- a/assert/forward_assertions_test.go
+++ b/assert/forward_assertions_test.go
@@ -444,7 +444,7 @@ func TestLenWrapper(t *testing.T) {
 	ch <- 3
 
 	cases := []struct {
-		v interface{}
+		v any
 		l int
 	}{
 		{[]int{1, 2, 3}, 3},
@@ -501,7 +501,7 @@ func TestInDeltaWrapper(t *testing.T) {
 	False(t, assert.InDelta("", nil, 1), "Expected non numerals to fail")
 
 	cases := []struct {
-		a, b  interface{}
+		a, b  any
 		delta float64
 	}{
 		{uint8(2), uint8(1), 1},
@@ -530,7 +530,7 @@ func TestInEpsilonWrapper(t *testing.T) {
 	assert := New(new(testing.T))
 
 	cases := []struct {
-		a, b    interface{}
+		a, b    any
 		epsilon float64
 	}{
 		{uint8(2), uint16(2), .001},
@@ -547,7 +547,7 @@ func TestInEpsilonWrapper(t *testing.T) {
 	}
 
 	cases = []struct {
-		a, b    interface{}
+		a, b    any
 		epsilon float64
 	}{
 		{uint8(2), int16(-2), .001},

--- a/assert/http_assertions.go
+++ b/assert/http_assertions.go
@@ -26,7 +26,7 @@ func httpCode(handler http.HandlerFunc, method, url string, values url.Values) (
 //	assert.HTTPSuccess(t, myHandler, "POST", "http://www.google.com", nil)
 //
 // Returns whether the assertion was successful (true) or not (false).
-func HTTPSuccess(t TestingT, handler http.HandlerFunc, method, url string, values url.Values, msgAndArgs ...interface{}) bool {
+func HTTPSuccess(t TestingT, handler http.HandlerFunc, method, url string, values url.Values, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -48,7 +48,7 @@ func HTTPSuccess(t TestingT, handler http.HandlerFunc, method, url string, value
 //	assert.HTTPRedirect(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
-func HTTPRedirect(t TestingT, handler http.HandlerFunc, method, url string, values url.Values, msgAndArgs ...interface{}) bool {
+func HTTPRedirect(t TestingT, handler http.HandlerFunc, method, url string, values url.Values, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -70,7 +70,7 @@ func HTTPRedirect(t TestingT, handler http.HandlerFunc, method, url string, valu
 //	assert.HTTPError(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
 //
 // Returns whether the assertion was successful (true) or not (false).
-func HTTPError(t TestingT, handler http.HandlerFunc, method, url string, values url.Values, msgAndArgs ...interface{}) bool {
+func HTTPError(t TestingT, handler http.HandlerFunc, method, url string, values url.Values, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -92,7 +92,7 @@ func HTTPError(t TestingT, handler http.HandlerFunc, method, url string, values 
 //	assert.HTTPStatusCode(t, myHandler, "GET", "/notImplemented", nil, 501)
 //
 // Returns whether the assertion was successful (true) or not (false).
-func HTTPStatusCode(t TestingT, handler http.HandlerFunc, method, url string, values url.Values, statuscode int, msgAndArgs ...interface{}) bool {
+func HTTPStatusCode(t TestingT, handler http.HandlerFunc, method, url string, values url.Values, statuscode int, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -130,7 +130,7 @@ func HTTPBody(handler http.HandlerFunc, method, url string, values url.Values) s
 //	assert.HTTPBodyContains(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
 //
 // Returns whether the assertion was successful (true) or not (false).
-func HTTPBodyContains(t TestingT, handler http.HandlerFunc, method, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) bool {
+func HTTPBodyContains(t TestingT, handler http.HandlerFunc, method, url string, values url.Values, str any, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -150,7 +150,7 @@ func HTTPBodyContains(t TestingT, handler http.HandlerFunc, method, url string, 
 //	assert.HTTPBodyNotContains(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
 //
 // Returns whether the assertion was successful (true) or not (false).
-func HTTPBodyNotContains(t TestingT, handler http.HandlerFunc, method, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) bool {
+func HTTPBodyNotContains(t TestingT, handler http.HandlerFunc, method, url string, values url.Values, str any, msgAndArgs ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}

--- a/assert/internal/unsafetests/unsafetests_test.go
+++ b/assert/internal/unsafetests/unsafetests_test.go
@@ -14,7 +14,7 @@ var _ assert.TestingT = ignoreTestingT{}
 
 func (ignoreTestingT) Helper() {}
 
-func (ignoreTestingT) Errorf(format string, args ...interface{}) {
+func (ignoreTestingT) Errorf(format string, args ...any) {
 	// Run the formatting, but ignore the result
 	msg := fmt.Sprintf(format, args...)
 	_ = msg

--- a/assert/yaml/yaml_default.go
+++ b/assert/yaml/yaml_default.go
@@ -31,6 +31,6 @@ package yaml
 import goyaml "gopkg.in/yaml.v3"
 
 // Unmarshal is just a wrapper of [gopkg.in/yaml.v3.Unmarshal].
-func Unmarshal(in []byte, out interface{}) error {
+func Unmarshal(in []byte, out any) error {
 	return goyaml.Unmarshal(in, out)
 }

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/stretchr/testify
 
 // This should match the minimum supported version that is tested in
 // .github/workflows/main.yml
-go 1.17
+go 1.18
 
 require (
 	github.com/stretchr/objx v0.5.3

--- a/internal/difflib/difflib.go
+++ b/internal/difflib/difflib.go
@@ -490,7 +490,7 @@ type UnifiedDiff struct {
 func WriteUnifiedDiff(writer io.Writer, diff UnifiedDiff) error {
 	buf := bufio.NewWriter(writer)
 	defer buf.Flush()
-	wf := func(format string, args ...interface{}) error {
+	wf := func(format string, args ...any) error {
 		_, err := buf.WriteString(fmt.Sprintf(format, args...))
 		return err
 	}

--- a/internal/difflib/difflib_test.go
+++ b/internal/difflib/difflib_test.go
@@ -15,7 +15,7 @@ func assertAlmostEqual(t *testing.T, a, b float64, places int) {
 	}
 }
 
-func assertEqual(t *testing.T, a, b interface{}) {
+func assertEqual(t *testing.T, a, b any) {
 	if !reflect.DeepEqual(a, b) {
 		t.Errorf("%v != %v", a, b)
 	}

--- a/internal/spew/common_test.go
+++ b/internal/spew/common_test.go
@@ -132,8 +132,8 @@ type sortTestCase struct {
 }
 
 func helpTestSortValues(tests []sortTestCase, cs *spew.ConfigState, t *testing.T) {
-	getInterfaces := func(values []reflect.Value) []interface{} {
-		interfaces := []interface{}{}
+	getInterfaces := func(values []reflect.Value) []any {
+		interfaces := []any{}
 		for _, v := range values {
 			interfaces = append(interfaces, v.Interface())
 		}

--- a/internal/spew/config.go
+++ b/internal/spew/config.go
@@ -112,7 +112,7 @@ var Config = ConfigState{Indent: " "}
 // This function is shorthand for the following syntax:
 //
 //	fmt.Errorf(format, c.NewFormatter(a), c.NewFormatter(b))
-func (c *ConfigState) Errorf(format string, a ...interface{}) (err error) {
+func (c *ConfigState) Errorf(format string, a ...any) (err error) {
 	return fmt.Errorf(format, c.convertArgs(a)...)
 }
 
@@ -124,7 +124,7 @@ func (c *ConfigState) Errorf(format string, a ...interface{}) (err error) {
 // This function is shorthand for the following syntax:
 //
 //	fmt.Fprint(w, c.NewFormatter(a), c.NewFormatter(b))
-func (c *ConfigState) Fprint(w io.Writer, a ...interface{}) (n int, err error) {
+func (c *ConfigState) Fprint(w io.Writer, a ...any) (n int, err error) {
 	return fmt.Fprint(w, c.convertArgs(a)...)
 }
 
@@ -136,7 +136,7 @@ func (c *ConfigState) Fprint(w io.Writer, a ...interface{}) (n int, err error) {
 // This function is shorthand for the following syntax:
 //
 //	fmt.Fprintf(w, format, c.NewFormatter(a), c.NewFormatter(b))
-func (c *ConfigState) Fprintf(w io.Writer, format string, a ...interface{}) (n int, err error) {
+func (c *ConfigState) Fprintf(w io.Writer, format string, a ...any) (n int, err error) {
 	return fmt.Fprintf(w, format, c.convertArgs(a)...)
 }
 
@@ -147,7 +147,7 @@ func (c *ConfigState) Fprintf(w io.Writer, format string, a ...interface{}) (n i
 // This function is shorthand for the following syntax:
 //
 //	fmt.Fprintln(w, c.NewFormatter(a), c.NewFormatter(b))
-func (c *ConfigState) Fprintln(w io.Writer, a ...interface{}) (n int, err error) {
+func (c *ConfigState) Fprintln(w io.Writer, a ...any) (n int, err error) {
 	return fmt.Fprintln(w, c.convertArgs(a)...)
 }
 
@@ -159,7 +159,7 @@ func (c *ConfigState) Fprintln(w io.Writer, a ...interface{}) (n int, err error)
 // This function is shorthand for the following syntax:
 //
 //	fmt.Print(c.NewFormatter(a), c.NewFormatter(b))
-func (c *ConfigState) Print(a ...interface{}) (n int, err error) {
+func (c *ConfigState) Print(a ...any) (n int, err error) {
 	return fmt.Print(c.convertArgs(a)...)
 }
 
@@ -171,7 +171,7 @@ func (c *ConfigState) Print(a ...interface{}) (n int, err error) {
 // This function is shorthand for the following syntax:
 //
 //	fmt.Printf(format, c.NewFormatter(a), c.NewFormatter(b))
-func (c *ConfigState) Printf(format string, a ...interface{}) (n int, err error) {
+func (c *ConfigState) Printf(format string, a ...any) (n int, err error) {
 	return fmt.Printf(format, c.convertArgs(a)...)
 }
 
@@ -183,7 +183,7 @@ func (c *ConfigState) Printf(format string, a ...interface{}) (n int, err error)
 // This function is shorthand for the following syntax:
 //
 //	fmt.Println(c.NewFormatter(a), c.NewFormatter(b))
-func (c *ConfigState) Println(a ...interface{}) (n int, err error) {
+func (c *ConfigState) Println(a ...any) (n int, err error) {
 	return fmt.Println(c.convertArgs(a)...)
 }
 
@@ -194,7 +194,7 @@ func (c *ConfigState) Println(a ...interface{}) (n int, err error) {
 // This function is shorthand for the following syntax:
 //
 //	fmt.Sprint(c.NewFormatter(a), c.NewFormatter(b))
-func (c *ConfigState) Sprint(a ...interface{}) string {
+func (c *ConfigState) Sprint(a ...any) string {
 	return fmt.Sprint(c.convertArgs(a)...)
 }
 
@@ -205,7 +205,7 @@ func (c *ConfigState) Sprint(a ...interface{}) string {
 // This function is shorthand for the following syntax:
 //
 //	fmt.Sprintf(format, c.NewFormatter(a), c.NewFormatter(b))
-func (c *ConfigState) Sprintf(format string, a ...interface{}) string {
+func (c *ConfigState) Sprintf(format string, a ...any) string {
 	return fmt.Sprintf(format, c.convertArgs(a)...)
 }
 
@@ -216,7 +216,7 @@ func (c *ConfigState) Sprintf(format string, a ...interface{}) string {
 // This function is shorthand for the following syntax:
 //
 //	fmt.Sprintln(c.NewFormatter(a), c.NewFormatter(b))
-func (c *ConfigState) Sprintln(a ...interface{}) string {
+func (c *ConfigState) Sprintln(a ...any) string {
 	return fmt.Sprintln(c.convertArgs(a)...)
 }
 
@@ -237,13 +237,13 @@ Typically this function shouldn't be called directly.  It is much easier to make
 use of the custom formatter by calling one of the convenience functions such as
 c.Printf, c.Println, or c.Printf.
 */
-func (c *ConfigState) NewFormatter(v interface{}) fmt.Formatter {
+func (c *ConfigState) NewFormatter(v any) fmt.Formatter {
 	return newFormatter(c, v)
 }
 
 // Fdump formats and displays the passed arguments to io.Writer w.  It formats
 // exactly the same as Dump.
-func (c *ConfigState) Fdump(w io.Writer, a ...interface{}) {
+func (c *ConfigState) Fdump(w io.Writer, a ...any) {
 	fdump(c, w, a...)
 }
 
@@ -270,13 +270,13 @@ of c.  See ConfigState for options documentation.
 See Fdump if you would prefer dumping to an arbitrary io.Writer or Sdump to
 get the formatted result as a string.
 */
-func (c *ConfigState) Dump(a ...interface{}) {
+func (c *ConfigState) Dump(a ...any) {
 	fdump(c, os.Stdout, a...)
 }
 
 // Sdump returns a string with the passed arguments formatted exactly the same
 // as Dump.
-func (c *ConfigState) Sdump(a ...interface{}) string {
+func (c *ConfigState) Sdump(a ...any) string {
 	var buf bytes.Buffer
 	fdump(c, &buf, a...)
 	return buf.String()
@@ -285,8 +285,8 @@ func (c *ConfigState) Sdump(a ...interface{}) string {
 // convertArgs accepts a slice of arguments and returns a slice of the same
 // length with each argument converted to a spew Formatter interface using
 // the ConfigState associated with s.
-func (c *ConfigState) convertArgs(args []interface{}) (formatters []interface{}) {
-	formatters = make([]interface{}, len(args))
+func (c *ConfigState) convertArgs(args []any) (formatters []any) {
+	formatters = make([]any, len(args))
 	for index, arg := range args {
 		formatters[index] = newFormatter(c, arg)
 	}

--- a/internal/spew/dump.go
+++ b/internal/spew/dump.go
@@ -450,7 +450,7 @@ func (d *dumpState) dump(v reflect.Value) {
 
 // fdump is a helper function to consolidate the logic from the various public
 // methods which take varying writers and config states.
-func fdump(cs *ConfigState, w io.Writer, a ...interface{}) {
+func fdump(cs *ConfigState, w io.Writer, a ...any) {
 	for _, arg := range a {
 		if arg == nil {
 			w.Write(interfaceBytes)
@@ -469,13 +469,13 @@ func fdump(cs *ConfigState, w io.Writer, a ...interface{}) {
 
 // Fdump formats and displays the passed arguments to io.Writer w.  It formats
 // exactly the same as Dump.
-func Fdump(w io.Writer, a ...interface{}) {
+func Fdump(w io.Writer, a ...any) {
 	fdump(&Config, w, a...)
 }
 
 // Sdump returns a string with the passed arguments formatted exactly the same
 // as Dump.
-func Sdump(a ...interface{}) string {
+func Sdump(a ...any) string {
 	var buf bytes.Buffer
 	fdump(&Config, &buf, a...)
 	return buf.String()
@@ -504,6 +504,6 @@ spew.Config.  See ConfigState for options documentation.
 See Fdump if you would prefer dumping to an arbitrary io.Writer or Sdump to
 get the formatted result as a string.
 */
-func Dump(a ...interface{}) {
+func Dump(a ...any) {
 	fdump(&Config, os.Stdout, a...)
 }

--- a/internal/spew/dump_test.go
+++ b/internal/spew/dump_test.go
@@ -72,7 +72,7 @@ import (
 
 // dumpTest is used to describe a test to be performed against the Dump method.
 type dumpTest struct {
-	in    interface{}
+	in    any
 	wants []string
 }
 
@@ -81,7 +81,7 @@ var dumpTests = make([]dumpTest, 0)
 
 // addDumpTest is a helper method to append the passed input and desired result
 // to dumpTests
-func addDumpTest(in interface{}, wants ...string) {
+func addDumpTest(in any, wants ...string) {
 	test := dumpTest{in, wants}
 	dumpTests = append(dumpTests, test)
 }
@@ -352,11 +352,11 @@ func addArrayDumpTests() {
 
 	// Array containing interfaces.
 	v3i0 := "one"
-	v3 := [3]interface{}{v3i0, int(2), uint(3)}
+	v3 := [3]any{v3i0, int(2), uint(3)}
 	v3i0Len := fmt.Sprintf("%d", len(v3i0))
 	v3Len := fmt.Sprintf("%d", len(v3))
 	v3Cap := fmt.Sprintf("%d", cap(v3))
-	nv3 := (*[3]interface{})(nil)
+	nv3 := (*[3]any)(nil)
 	pv3 := &v3
 	v3Addr := fmt.Sprintf("%p", pv3)
 	pv3Addr := fmt.Sprintf("%p", &pv3)
@@ -443,11 +443,11 @@ func addSliceDumpTests() {
 
 	// Slice containing interfaces.
 	v3i0 := "one"
-	v3 := []interface{}{v3i0, int(2), uint(3), nil}
+	v3 := []any{v3i0, int(2), uint(3), nil}
 	v3i0Len := fmt.Sprintf("%d", len(v3i0))
 	v3Len := fmt.Sprintf("%d", len(v3))
 	v3Cap := fmt.Sprintf("%d", cap(v3))
-	nv3 := (*[]interface{})(nil)
+	nv3 := (*[]any)(nil)
 	pv3 := &v3
 	v3Addr := fmt.Sprintf("%p", pv3)
 	pv3Addr := fmt.Sprintf("%p", &pv3)
@@ -523,8 +523,8 @@ func addStringDumpTests() {
 
 func addInterfaceDumpTests() {
 	// Nil interface.
-	var v interface{}
-	nv := (*interface{})(nil)
+	var v any
+	nv := (*any)(nil)
 	pv := &v
 	vAddr := fmt.Sprintf("%p", pv)
 	pvAddr := fmt.Sprintf("%p", &pv)
@@ -536,7 +536,7 @@ func addInterfaceDumpTests() {
 	addDumpTest(nv, "(*"+vt+")(<nil>)\n")
 
 	// Sub-interface.
-	v2 := interface{}(uint16(65535))
+	v2 := any(uint16(65535))
 	pv2 := &v2
 	v2Addr := fmt.Sprintf("%p", pv2)
 	pv2Addr := fmt.Sprintf("%p", &pv2)
@@ -608,10 +608,10 @@ func addMapDumpTests() {
 	// Map with interface keys and values.
 	k3 := "one"
 	k3Len := fmt.Sprintf("%d", len(k3))
-	m3 := map[interface{}]interface{}{k3: 1}
+	m3 := map[any]any{k3: 1}
 	m3Len := fmt.Sprintf("%d", len(m3))
-	nilMap3 := map[interface{}]interface{}(nil)
-	nm3 := (*map[interface{}]interface{})(nil)
+	nilMap3 := map[any]any(nil)
+	nm3 := (*map[any]any)(nil)
 	pm3 := &m3
 	m3Addr := fmt.Sprintf("%p", pm3)
 	pm3Addr := fmt.Sprintf("%p", &pm3)
@@ -629,10 +629,10 @@ func addMapDumpTests() {
 	// Map with nil interface value.
 	k4 := "nil"
 	k4Len := fmt.Sprintf("%d", len(k4))
-	m4 := map[string]interface{}{k4: nil}
+	m4 := map[string]any{k4: nil}
 	m4Len := fmt.Sprintf("%d", len(m4))
-	nilMap4 := map[string]interface{}(nil)
-	nm4 := (*map[string]interface{})(nil)
+	nilMap4 := map[string]any(nil)
+	nm4 := (*map[string]any)(nil)
 	pm4 := &m4
 	m4Addr := fmt.Sprintf("%p", pm4)
 	pm4Addr := fmt.Sprintf("%p", &pm4)

--- a/internal/spew/format.go
+++ b/internal/spew/format.go
@@ -32,7 +32,7 @@ const supportedFlags = "0-+# "
 // be used to get a new Formatter which can be used directly as arguments
 // in standard fmt package printing calls.
 type formatState struct {
-	value          interface{}
+	value          any
 	fs             fmt.State
 	depth          int
 	pointers       map[uintptr]int
@@ -391,7 +391,7 @@ func (f *formatState) Format(fs fmt.State, verb rune) {
 
 // newFormatter is a helper function to consolidate the logic from the various
 // public methods which take varying config states.
-func newFormatter(cs *ConfigState, v interface{}) fmt.Formatter {
+func newFormatter(cs *ConfigState, v any) fmt.Formatter {
 	fs := &formatState{value: v, cs: cs}
 	fs.pointers = make(map[uintptr]int)
 	return fs
@@ -414,6 +414,6 @@ Typically this function shouldn't be called directly.  It is much easier to make
 use of the custom formatter by calling one of the convenience functions such as
 Printf, Println, or Fprintf.
 */
-func NewFormatter(v interface{}) fmt.Formatter {
+func NewFormatter(v any) fmt.Formatter {
 	return newFormatter(&Config, v)
 }

--- a/internal/spew/format_test.go
+++ b/internal/spew/format_test.go
@@ -78,7 +78,7 @@ import (
 // formatterTest is used to describe a test to be performed against NewFormatter.
 type formatterTest struct {
 	format string
-	in     interface{}
+	in     any
 	wants  []string
 }
 
@@ -87,7 +87,7 @@ var formatterTests = make([]formatterTest, 0)
 
 // addFormatterTest is a helper method to append the passed input and desired
 // result to formatterTests.
-func addFormatterTest(format string, in interface{}, wants ...string) {
+func addFormatterTest(format string, in any, wants ...string) {
 	test := formatterTest{format, in, wants}
 	formatterTests = append(formatterTests, test)
 }
@@ -553,8 +553,8 @@ func addArrayFormatterTests() {
 	addFormatterTest("%#+v", nv2, "(*"+v2t+")"+"<nil>")
 
 	// Array containing interfaces.
-	v3 := [3]interface{}{"one", int(2), uint(3)}
-	nv3 := (*[3]interface{})(nil)
+	v3 := [3]any{"one", int(2), uint(3)}
+	nv3 := (*[3]any)(nil)
 	pv3 := &v3
 	v3Addr := fmt.Sprintf("%p", pv3)
 	pv3Addr := fmt.Sprintf("%p", &pv3)
@@ -634,8 +634,8 @@ func addSliceFormatterTests() {
 	addFormatterTest("%#+v", nv2, "(*"+v2t+")"+"<nil>")
 
 	// Slice containing interfaces.
-	v3 := []interface{}{"one", int(2), uint(3), nil}
-	nv3 := (*[]interface{})(nil)
+	v3 := []any{"one", int(2), uint(3), nil}
+	nv3 := (*[]any)(nil)
 	pv3 := &v3
 	v3Addr := fmt.Sprintf("%p", pv3)
 	pv3Addr := fmt.Sprintf("%p", &pv3)
@@ -719,8 +719,8 @@ func addStringFormatterTests() {
 
 func addInterfaceFormatterTests() {
 	// Nil interface.
-	var v interface{}
-	nv := (*interface{})(nil)
+	var v any
+	nv := (*any)(nil)
 	pv := &v
 	vAddr := fmt.Sprintf("%p", pv)
 	pvAddr := fmt.Sprintf("%p", &pv)
@@ -744,7 +744,7 @@ func addInterfaceFormatterTests() {
 	addFormatterTest("%#+v", nv, "(*"+vt+")"+"<nil>")
 
 	// Sub-interface.
-	v2 := interface{}(uint16(65535))
+	v2 := any(uint16(65535))
 	pv2 := &v2
 	v2Addr := fmt.Sprintf("%p", pv2)
 	pv2Addr := fmt.Sprintf("%p", &pv2)
@@ -828,8 +828,8 @@ func addMapFormatterTests() {
 	addFormatterTest("%#+v", nv2, "(*"+v2t+")"+"<nil>")
 
 	// Map with interface keys and values.
-	v3 := map[interface{}]interface{}{"one": 1}
-	nv3 := (*map[interface{}]interface{})(nil)
+	v3 := map[any]any{"one": 1}
+	nv3 := (*map[any]any)(nil)
 	pv3 := &v3
 	v3Addr := fmt.Sprintf("%p", pv3)
 	pv3Addr := fmt.Sprintf("%p", &pv3)
@@ -856,8 +856,8 @@ func addMapFormatterTests() {
 	addFormatterTest("%#+v", nv3, "(*"+v3t+")"+"<nil>")
 
 	// Map with nil interface value
-	v4 := map[string]interface{}{"nil": nil}
-	nv4 := (*map[string]interface{})(nil)
+	v4 := map[string]any{"nil": nil}
+	nv4 := (*map[string]any)(nil)
 	pv4 := &v4
 	v4Addr := fmt.Sprintf("%p", pv4)
 	pv4Addr := fmt.Sprintf("%p", &pv4)

--- a/internal/spew/spew.go
+++ b/internal/spew/spew.go
@@ -29,7 +29,7 @@ import (
 // This function is shorthand for the following syntax:
 //
 //	fmt.Errorf(format, spew.NewFormatter(a), spew.NewFormatter(b))
-func Errorf(format string, a ...interface{}) (err error) {
+func Errorf(format string, a ...any) (err error) {
 	return fmt.Errorf(format, convertArgs(a)...)
 }
 
@@ -41,7 +41,7 @@ func Errorf(format string, a ...interface{}) (err error) {
 // This function is shorthand for the following syntax:
 //
 //	fmt.Fprint(w, spew.NewFormatter(a), spew.NewFormatter(b))
-func Fprint(w io.Writer, a ...interface{}) (n int, err error) {
+func Fprint(w io.Writer, a ...any) (n int, err error) {
 	return fmt.Fprint(w, convertArgs(a)...)
 }
 
@@ -53,7 +53,7 @@ func Fprint(w io.Writer, a ...interface{}) (n int, err error) {
 // This function is shorthand for the following syntax:
 //
 //	fmt.Fprintf(w, format, spew.NewFormatter(a), spew.NewFormatter(b))
-func Fprintf(w io.Writer, format string, a ...interface{}) (n int, err error) {
+func Fprintf(w io.Writer, format string, a ...any) (n int, err error) {
 	return fmt.Fprintf(w, format, convertArgs(a)...)
 }
 
@@ -64,7 +64,7 @@ func Fprintf(w io.Writer, format string, a ...interface{}) (n int, err error) {
 // This function is shorthand for the following syntax:
 //
 //	fmt.Fprintln(w, spew.NewFormatter(a), spew.NewFormatter(b))
-func Fprintln(w io.Writer, a ...interface{}) (n int, err error) {
+func Fprintln(w io.Writer, a ...any) (n int, err error) {
 	return fmt.Fprintln(w, convertArgs(a)...)
 }
 
@@ -76,7 +76,7 @@ func Fprintln(w io.Writer, a ...interface{}) (n int, err error) {
 // This function is shorthand for the following syntax:
 //
 //	fmt.Print(spew.NewFormatter(a), spew.NewFormatter(b))
-func Print(a ...interface{}) (n int, err error) {
+func Print(a ...any) (n int, err error) {
 	return fmt.Print(convertArgs(a)...)
 }
 
@@ -88,7 +88,7 @@ func Print(a ...interface{}) (n int, err error) {
 // This function is shorthand for the following syntax:
 //
 //	fmt.Printf(format, spew.NewFormatter(a), spew.NewFormatter(b))
-func Printf(format string, a ...interface{}) (n int, err error) {
+func Printf(format string, a ...any) (n int, err error) {
 	return fmt.Printf(format, convertArgs(a)...)
 }
 
@@ -100,7 +100,7 @@ func Printf(format string, a ...interface{}) (n int, err error) {
 // This function is shorthand for the following syntax:
 //
 //	fmt.Println(spew.NewFormatter(a), spew.NewFormatter(b))
-func Println(a ...interface{}) (n int, err error) {
+func Println(a ...any) (n int, err error) {
 	return fmt.Println(convertArgs(a)...)
 }
 
@@ -111,7 +111,7 @@ func Println(a ...interface{}) (n int, err error) {
 // This function is shorthand for the following syntax:
 //
 //	fmt.Sprint(spew.NewFormatter(a), spew.NewFormatter(b))
-func Sprint(a ...interface{}) string {
+func Sprint(a ...any) string {
 	return fmt.Sprint(convertArgs(a)...)
 }
 
@@ -122,7 +122,7 @@ func Sprint(a ...interface{}) string {
 // This function is shorthand for the following syntax:
 //
 //	fmt.Sprintf(format, spew.NewFormatter(a), spew.NewFormatter(b))
-func Sprintf(format string, a ...interface{}) string {
+func Sprintf(format string, a ...any) string {
 	return fmt.Sprintf(format, convertArgs(a)...)
 }
 
@@ -133,14 +133,14 @@ func Sprintf(format string, a ...interface{}) string {
 // This function is shorthand for the following syntax:
 //
 //	fmt.Sprintln(spew.NewFormatter(a), spew.NewFormatter(b))
-func Sprintln(a ...interface{}) string {
+func Sprintln(a ...any) string {
 	return fmt.Sprintln(convertArgs(a)...)
 }
 
 // convertArgs accepts a slice of arguments and returns a slice of the same
 // length with each argument converted to a default spew Formatter interface.
-func convertArgs(args []interface{}) (formatters []interface{}) {
-	formatters = make([]interface{}, len(args))
+func convertArgs(args []any) (formatters []any) {
+	formatters = make([]any, len(args))
 	for index, arg := range args {
 		formatters[index] = NewFormatter(arg)
 	}

--- a/internal/spew/spew_test.go
+++ b/internal/spew/spew_test.go
@@ -92,7 +92,7 @@ type spewTest struct {
 	cs     *spew.ConfigState
 	f      spewFunc
 	format string
-	in     interface{}
+	in     any
 	want   string
 }
 

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -23,8 +23,8 @@ var gccgoRE = regexp.MustCompile(`\.pN\d+_`)
 
 // TestingT is an interface wrapper around *testing.T
 type TestingT interface {
-	Logf(format string, args ...interface{})
-	Errorf(format string, args ...interface{})
+	Logf(format string, args ...any)
+	Errorf(format string, args ...any)
 	FailNow()
 }
 
@@ -105,7 +105,7 @@ func (c *Call) unlock() {
 // Return specifies the return arguments for the expectation.
 //
 //	Mock.On("DoSomething").Return(errors.New("failed"))
-func (c *Call) Return(returnArguments ...interface{}) *Call {
+func (c *Call) Return(returnArguments ...any) *Call {
 	c.lock()
 	defer c.unlock()
 
@@ -204,7 +204,7 @@ func (c *Call) Maybe() *Call {
 //	   On("MyOtherMethod", 'a', 'b', 'c').Return(errors.New("Some Error"))
 //
 //go:noinline
-func (c *Call) On(methodName string, arguments ...interface{}) *Call {
+func (c *Call) On(methodName string, arguments ...any) *Call {
 	return c.Parent.On(methodName, arguments...)
 }
 
@@ -351,7 +351,7 @@ func (m *Mock) Test(t TestingT) {
 // fail fails the current test with the given formatted format and args.
 // In case that a test was defined, it uses the test APIs for failing a test,
 // otherwise it uses panic.
-func (m *Mock) fail(format string, args ...interface{}) {
+func (m *Mock) fail(format string, args ...any) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
@@ -366,7 +366,7 @@ func (m *Mock) fail(format string, args ...interface{}) {
 // being called.
 //
 //	Mock.On("MyMethod", arg1, arg2)
-func (m *Mock) On(methodName string, arguments ...interface{}) *Call {
+func (m *Mock) On(methodName string, arguments ...any) *Call {
 	for _, arg := range arguments {
 		if v := reflect.ValueOf(arg); v.Kind() == reflect.Func {
 			panic(fmt.Sprintf("cannot use Func in expectations. Use mock.AnythingOfType(\"%T\")", arg))
@@ -376,7 +376,7 @@ func (m *Mock) On(methodName string, arguments ...interface{}) *Call {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
-	c := newCall(m, methodName, assert.CallerInfo(), arguments, make([]interface{}, 0))
+	c := newCall(m, methodName, assert.CallerInfo(), arguments, make([]any, 0))
 	m.ExpectedCalls = append(m.ExpectedCalls, c)
 	return c
 }
@@ -385,7 +385,7 @@ func (m *Mock) On(methodName string, arguments ...interface{}) *Call {
 // 	Recording and responding to activity
 // */
 
-func (m *Mock) findExpectedCall(method string, arguments ...interface{}) (int, *Call) {
+func (m *Mock) findExpectedCall(method string, arguments ...any) (int, *Call) {
 	var expectedCall *Call
 
 	for i, call := range m.ExpectedCalls {
@@ -430,7 +430,7 @@ func (c matchCandidate) isBetterMatchThan(other matchCandidate) bool {
 	return false
 }
 
-func (m *Mock) findClosestCall(method string, arguments ...interface{}) (*Call, string) {
+func (m *Mock) findClosestCall(method string, arguments ...any) (*Call, string) {
 	var bestMatch matchCandidate
 
 	for _, call := range m.expectedCalls() {
@@ -472,7 +472,7 @@ func callString(method string, arguments Arguments, includeArgumentValues bool) 
 // of arguments to return.  Panics if the call is unexpected (i.e. not preceded by
 // appropriate .On .Return() calls)
 // If Call.WaitFor is set, blocks until the channel is closed or receives a message.
-func (m *Mock) Called(arguments ...interface{}) Arguments {
+func (m *Mock) Called(arguments ...any) Arguments {
 	// get the calling function's name
 	pc, _, _, ok := runtime.Caller(1)
 	if !ok {
@@ -495,7 +495,7 @@ func (m *Mock) Called(arguments ...interface{}) Arguments {
 // an array of arguments to return. Panics if the call is unexpected (i.e. not preceded
 // by appropriate .On .Return() calls)
 // If Call.WaitFor is set, blocks until the channel is closed or receives a message.
-func (m *Mock) MethodCalled(methodName string, arguments ...interface{}) Arguments {
+func (m *Mock) MethodCalled(methodName string, arguments ...any) Arguments {
 	m.mutex.Lock()
 	// TODO: could combine expected and closes in single loop
 	found, call := m.findExpectedCall(methodName, arguments...)
@@ -599,7 +599,7 @@ type assertExpectationiser interface {
 // of the specified objects was in fact called as expected.
 //
 // Calls may have occurred in any order.
-func AssertExpectationsForObjects(t TestingT, testObjects ...interface{}) bool {
+func AssertExpectationsForObjects(t TestingT, testObjects ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -677,7 +677,7 @@ func (m *Mock) AssertNumberOfCalls(t TestingT, methodName string, expectedCalls 
 
 // AssertCalled asserts that the method was called.
 // It can produce a false result when an argument is a pointer type and the underlying value changed after calling the mocked method.
-func (m *Mock) AssertCalled(t TestingT, methodName string, arguments ...interface{}) bool {
+func (m *Mock) AssertCalled(t TestingT, methodName string, arguments ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -700,7 +700,7 @@ func (m *Mock) AssertCalled(t TestingT, methodName string, arguments ...interfac
 
 // AssertNotCalled asserts that the method was not called.
 // It can produce a false result when an argument is a pointer type and the underlying value changed after calling the mocked method.
-func (m *Mock) AssertNotCalled(t TestingT, methodName string, arguments ...interface{}) bool {
+func (m *Mock) AssertNotCalled(t TestingT, methodName string, arguments ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -715,7 +715,7 @@ func (m *Mock) AssertNotCalled(t TestingT, methodName string, arguments ...inter
 
 // IsMethodCallable returns true if given methodName and arguments have an
 // unsatisfied expected call registered in the Mock.
-func (m *Mock) IsMethodCallable(t TestingT, methodName string, arguments ...interface{}) bool {
+func (m *Mock) IsMethodCallable(t TestingT, methodName string, arguments ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -740,7 +740,7 @@ func (m *Mock) IsMethodCallable(t TestingT, methodName string, arguments ...inte
 }
 
 // isArgsEqual compares arguments
-func isArgsEqual(expected Arguments, args []interface{}) bool {
+func isArgsEqual(expected Arguments, args []any) bool {
 	if len(expected) != len(args) {
 		return false
 	}
@@ -752,7 +752,7 @@ func isArgsEqual(expected Arguments, args []interface{}) bool {
 	return true
 }
 
-func (m *Mock) methodWasCalled(methodName string, expected []interface{}) bool {
+func (m *Mock) methodWasCalled(methodName string, expected []any) bool {
 	for _, call := range m.calls() {
 		if call.Method == methodName {
 
@@ -782,7 +782,7 @@ func (m *Mock) calls() []Call {
 */
 
 // Arguments holds an array of method arguments or return values.
-type Arguments []interface{}
+type Arguments []any
 
 const (
 	// Anything is used in Diff and Assert when the argument being tested
@@ -838,14 +838,14 @@ type IsTypeArgument struct {
 // Mock cannot match interface types because the contained type will be  passed
 // to both IsType and Mock.Called, for the zero value of all interfaces this
 // will be <nil> type.
-func IsType(t interface{}) *IsTypeArgument {
+func IsType(t any) *IsTypeArgument {
 	return &IsTypeArgument{t: reflect.TypeOf(t)}
 }
 
 // FunctionalOptionsArgument contains a list of functional options arguments
 // expected for use when matching a list of arguments.
 type FunctionalOptionsArgument struct {
-	values []interface{}
+	values []any
 }
 
 // String returns the string representation of FunctionalOptionsArgument
@@ -864,7 +864,7 @@ func (f *FunctionalOptionsArgument) String() string {
 // For example:
 //
 //	args.Assert(t, FunctionalOptions(foo.Opt1("strValue"), foo.Opt2(613)))
-func FunctionalOptions(values ...interface{}) *FunctionalOptionsArgument {
+func FunctionalOptions(values ...any) *FunctionalOptionsArgument {
 	return &FunctionalOptionsArgument{
 		values: values,
 	}
@@ -877,7 +877,7 @@ type argumentMatcher struct {
 	fn reflect.Value
 }
 
-func (f argumentMatcher) Matches(argument interface{}) bool {
+func (f argumentMatcher) Matches(argument any) bool {
 	expectType := f.fn.Type().In(0)
 	expectTypeNilSupported := false
 	switch expectType.Kind() {
@@ -919,7 +919,7 @@ func (f argumentMatcher) String() string {
 // fn must be a function accepting a single argument (of the expected type)
 // which returns a bool. If fn doesn't match the required signature,
 // MatchedBy() panics.
-func MatchedBy(fn interface{}) argumentMatcher {
+func MatchedBy(fn any) argumentMatcher {
 	fnType := reflect.TypeOf(fn)
 
 	if fnType.Kind() != reflect.Func {
@@ -936,7 +936,7 @@ func MatchedBy(fn interface{}) argumentMatcher {
 }
 
 // Get Returns the argument at the specified index.
-func (args Arguments) Get(index int) interface{} {
+func (args Arguments) Get(index int) any {
 	if index+1 > len(args) {
 		panic(fmt.Sprintf("assert: arguments: Cannot call Get(%d) because there are %d argument(s).", index, len(args)))
 	}
@@ -944,7 +944,7 @@ func (args Arguments) Get(index int) interface{} {
 }
 
 // Is gets whether the objects match the arguments specified.
-func (args Arguments) Is(objects ...interface{}) bool {
+func (args Arguments) Is(objects ...any) bool {
 	for i, obj := range args {
 		if obj != objects[i] {
 			return false
@@ -957,7 +957,7 @@ func (args Arguments) Is(objects ...interface{}) bool {
 // and the specified objects.
 //
 // Returns the diff string and number of differences found.
-func (args Arguments) Diff(objects []interface{}) (string, int) {
+func (args Arguments) Diff(objects []any) (string, int) {
 	// TODO: could return string as error and nil for No difference
 
 	output := "\n"
@@ -969,7 +969,7 @@ func (args Arguments) Diff(objects []interface{}) (string, int) {
 	}
 
 	for i := 0; i < maxArgCount; i++ {
-		var actual, expected interface{}
+		var actual, expected any
 		var actualFmt, expectedFmt string
 
 		if len(objects) <= i {
@@ -1063,7 +1063,7 @@ func (args Arguments) Diff(objects []interface{}) (string, int) {
 
 // Assert compares the arguments with the specified objects and fails if
 // they do not exactly match.
-func (args Arguments) Assert(t TestingT, objects ...interface{}) bool {
+func (args Arguments) Assert(t TestingT, objects ...any) bool {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1155,7 +1155,7 @@ func safeTypeName(t reflect.Type) string {
 	return t.Name()
 }
 
-func typeAndKind(v interface{}) (reflect.Type, reflect.Kind) {
+func typeAndKind(v any) (reflect.Type, reflect.Kind) {
 	t := reflect.TypeOf(v)
 	k := t.Kind()
 
@@ -1182,7 +1182,7 @@ func diffArguments(expected Arguments, actual Arguments) string {
 
 // diff returns a diff of both values as long as both are of the same type and
 // are a struct, map, slice or array. Otherwise it returns an empty string.
-func diff(expected interface{}, actual interface{}) string {
+func diff(expected any, actual any) string {
 	if expected == nil || actual == nil {
 		return ""
 	}
@@ -1225,7 +1225,7 @@ type tHelper interface {
 	Helper()
 }
 
-func assertOpts(expected, actual interface{}) (expectedFmt, actualFmt string) {
+func assertOpts(expected, actual any) (expectedFmt, actualFmt string) {
 	expectedOpts := reflect.ValueOf(expected)
 	actualOpts := reflect.ValueOf(actual)
 
@@ -1288,7 +1288,7 @@ func assertOpts(expected, actual interface{}) (expectedFmt, actualFmt string) {
 	return "", ""
 }
 
-func runtimeFunc(opt interface{}) *runtime.Func {
+func runtimeFunc(opt any) *runtime.Func {
 	return runtime.FuncForPC(reflect.ValueOf(opt).Pointer())
 }
 

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -112,7 +112,7 @@ func (i *TestExampleImplementation) TheExampleMethodVariadic(a ...int) error {
 	return args.Error(0)
 }
 
-func (i *TestExampleImplementation) TheExampleMethodVariadicInterface(a ...interface{}) error {
+func (i *TestExampleImplementation) TheExampleMethodVariadicInterface(a ...any) error {
 	args := i.Called(a)
 	return args.Error(0)
 }
@@ -139,11 +139,11 @@ func (MockTestingT) Helper() {}
 
 const mockTestingTFailNowCalled = "FailNow was called"
 
-func (m *MockTestingT) Logf(string, ...interface{}) {
+func (m *MockTestingT) Logf(string, ...any) {
 	m.logfCount++
 }
 
-func (m *MockTestingT) Errorf(string, ...interface{}) {
+func (m *MockTestingT) Errorf(string, ...any) {
 	m.errorfCount++
 }
 
@@ -205,15 +205,15 @@ func Test_Mock_Chained_On(t *testing.T) {
 		{
 			Parent:          &mockedService.Mock,
 			Method:          "TheExampleMethod",
-			Arguments:       []interface{}{1, 2, 3},
-			ReturnArguments: []interface{}{0},
+			Arguments:       []any{1, 2, 3},
+			ReturnArguments: []any{0},
 			callerInfo:      []string{fmt.Sprintf("%s:%d", filename, line+2)},
 		},
 		{
 			Parent:          &mockedService.Mock,
 			Method:          "TheExampleMethod3",
-			Arguments:       []interface{}{AnythingOfType("*mock.ExampleType")},
-			ReturnArguments: []interface{}{nil},
+			Arguments:       []any{AnythingOfType("*mock.ExampleType")},
+			ReturnArguments: []any{nil},
 			callerInfo:      []string{fmt.Sprintf("%s:%d", filename, line+4)},
 		},
 	}
@@ -285,7 +285,7 @@ func Test_Mock_On_WithArgMatcherThatPanics(t *testing.T) {
 
 	var mockedService TestExampleImplementation
 
-	mockedService.On("TheExampleMethod2", MatchedBy(func(_ interface{}) bool {
+	mockedService.On("TheExampleMethod2", MatchedBy(func(_ any) bool {
 		panic("try to lock mockedService")
 	})).Return()
 
@@ -487,12 +487,12 @@ func Test_Mock_On_WithVariadicFuncWithInterface(t *testing.T) {
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
 
-	c := mockedService.On("TheExampleMethodVariadicInterface", []interface{}{1, 2, 3}).
+	c := mockedService.On("TheExampleMethodVariadicInterface", []any{1, 2, 3}).
 		Return(nil)
 
 	assert.Equal(t, []*Call{c}, mockedService.ExpectedCalls)
 	assert.Equal(t, 1, len(c.Arguments))
-	assert.Equal(t, []interface{}{1, 2, 3}, c.Arguments[0])
+	assert.Equal(t, []any{1, 2, 3}, c.Arguments[0])
 
 	assert.NotPanics(t, func() {
 		mockedService.TheExampleMethodVariadicInterface(1, 2, 3)
@@ -509,7 +509,7 @@ func Test_Mock_On_WithVariadicFuncWithEmptyInterfaceArray(t *testing.T) {
 	// make a test impl object
 	var mockedService = new(TestExampleImplementation)
 
-	var expected []interface{}
+	var expected []any
 	c := mockedService.
 		On("TheExampleMethodVariadicInterface", expected).
 		Return(nil)
@@ -608,15 +608,15 @@ func Test_Mock_Chained_UnsetOnlyUnsetsLastCall(t *testing.T) {
 		{
 			Parent:          &mockedService.Mock,
 			Method:          "TheExampleMethod1",
-			Arguments:       []interface{}{1, 1},
-			ReturnArguments: []interface{}{0},
+			Arguments:       []any{1, 1},
+			ReturnArguments: []any{0},
 			callerInfo:      []string{fmt.Sprintf("%s:%d", filename, line+2)},
 		},
 		{
 			Parent:          &mockedService.Mock,
 			Method:          "TheExampleMethod2",
-			Arguments:       []interface{}{2, 2},
-			ReturnArguments: []interface{}{},
+			Arguments:       []any{2, 2},
+			ReturnArguments: []any{},
 			callerInfo:      []string{fmt.Sprintf("%s:%d", filename, line+4)},
 		},
 	}
@@ -695,15 +695,15 @@ func Test_Mock_UnsetByOnMethodSpecAmongOthers(t *testing.T) {
 			Parent:          &mockedService.Mock,
 			Method:          "TheExampleMethodVariadic",
 			Repeatability:   1,
-			Arguments:       []interface{}{1, 2, 3, 4, 5},
-			ReturnArguments: []interface{}{nil},
+			Arguments:       []any{1, 2, 3, 4, 5},
+			ReturnArguments: []any{nil},
 			callerInfo:      []string{fmt.Sprintf("%s:%d", filename, line+4)},
 		},
 		{
 			Parent:          &mockedService.Mock,
 			Method:          "TheExampleMethodFuncType",
-			Arguments:       []interface{}{Anything},
-			ReturnArguments: []interface{}{nil},
+			Arguments:       []any{Anything},
+			ReturnArguments: []any{nil},
 			callerInfo:      []string{fmt.Sprintf("%s:%d", filename, line+7)},
 		},
 	}
@@ -1312,8 +1312,8 @@ func Test_Mock_findExpectedCall_Respects_Repeatability(t *testing.T) {
 func Test_callString(t *testing.T) {
 	t.Parallel()
 
-	assert.Equal(t, `Method(int,bool,string)`, callString("Method", []interface{}{1, true, "something"}, false))
-	assert.Equal(t, `Method(<nil>)`, callString("Method", []interface{}{nil}, false))
+	assert.Equal(t, `Method(int,bool,string)`, callString("Method", []any{1, true, "something"}, false))
+	assert.Equal(t, `Method(<nil>)`, callString("Method", []any{nil}, false))
 
 }
 
@@ -1845,12 +1845,12 @@ func TestIsArgsEqual(t *testing.T) {
 	var expected = Arguments{5, 3, 4, 6, 7, 2}
 
 	// Copy elements 1 to 5
-	args := append(([]interface{})(nil), expected[1:]...)
+	args := append(([]any)(nil), expected[1:]...)
 	args[2] = expected[1]
 	assert.False(t, isArgsEqual(expected, args))
 
 	// Clone
-	arr := append(([]interface{})(nil), expected...)
+	arr := append(([]any)(nil), expected...)
 	assert.True(t, isArgsEqual(expected, arr))
 }
 
@@ -1887,7 +1887,7 @@ Arguments helper methods
 func Test_Arguments_Get(t *testing.T) {
 	t.Parallel()
 
-	var args = Arguments([]interface{}{"string", 123, true})
+	var args = Arguments([]any{"string", 123, true})
 
 	assert.Equal(t, "string", args.Get(0).(string))
 	assert.Equal(t, 123, args.Get(1).(int))
@@ -1898,7 +1898,7 @@ func Test_Arguments_Get(t *testing.T) {
 func Test_Arguments_Is(t *testing.T) {
 	t.Parallel()
 
-	var args = Arguments([]interface{}{"string", 123, true})
+	var args = Arguments([]any{"string", 123, true})
 
 	assert.True(t, args.Is("string", 123, true))
 	assert.False(t, args.Is("wrong", 456, false))
@@ -1908,10 +1908,10 @@ func Test_Arguments_Is(t *testing.T) {
 func Test_Arguments_Diff(t *testing.T) {
 	t.Parallel()
 
-	var args = Arguments([]interface{}{"Hello World", 123, true})
+	var args = Arguments([]any{"Hello World", 123, true})
 	var diff string
 	var count int
-	diff, count = args.Diff([]interface{}{"Hello World", 456, "false"})
+	diff, count = args.Diff([]any{"Hello World", 456, "false"})
 
 	assert.Equal(t, 2, count)
 	assert.Contains(t, diff, `(int=456) != (int=123)`)
@@ -1922,10 +1922,10 @@ func Test_Arguments_Diff(t *testing.T) {
 func Test_Arguments_Diff_DifferentNumberOfArgs(t *testing.T) {
 	t.Parallel()
 
-	var args = Arguments([]interface{}{"string", 123, true})
+	var args = Arguments([]any{"string", 123, true})
 	var diff string
 	var count int
-	diff, count = args.Diff([]interface{}{"string", 456, "false", "extra"})
+	diff, count = args.Diff([]any{"string", 456, "false", "extra"})
 
 	assert.Equal(t, 3, count)
 	assert.Contains(t, diff, `(string=extra) != (Missing)`)
@@ -1935,9 +1935,9 @@ func Test_Arguments_Diff_DifferentNumberOfArgs(t *testing.T) {
 func Test_Arguments_Diff_WithAnythingArgument(t *testing.T) {
 	t.Parallel()
 
-	var args = Arguments([]interface{}{"string", 123, true})
+	var args = Arguments([]any{"string", 123, true})
 	var count int
-	_, count = args.Diff([]interface{}{"string", Anything, true})
+	_, count = args.Diff([]any{"string", Anything, true})
 
 	assert.Equal(t, 0, count)
 
@@ -1946,9 +1946,9 @@ func Test_Arguments_Diff_WithAnythingArgument(t *testing.T) {
 func Test_Arguments_Diff_WithAnythingArgument_InActualToo(t *testing.T) {
 	t.Parallel()
 
-	var args = Arguments([]interface{}{"string", Anything, true})
+	var args = Arguments([]any{"string", Anything, true})
 	var count int
-	_, count = args.Diff([]interface{}{"string", 123, true})
+	_, count = args.Diff([]any{"string", 123, true})
 
 	assert.Equal(t, 0, count)
 
@@ -1957,9 +1957,9 @@ func Test_Arguments_Diff_WithAnythingArgument_InActualToo(t *testing.T) {
 func Test_Arguments_Diff_WithAnythingOfTypeArgument(t *testing.T) {
 	t.Parallel()
 
-	var args = Arguments([]interface{}{"string", AnythingOfType("int"), true})
+	var args = Arguments([]any{"string", AnythingOfType("int"), true})
 	var count int
-	_, count = args.Diff([]interface{}{"string", 123, true})
+	_, count = args.Diff([]any{"string", 123, true})
 
 	assert.Equal(t, 0, count)
 
@@ -1968,10 +1968,10 @@ func Test_Arguments_Diff_WithAnythingOfTypeArgument(t *testing.T) {
 func Test_Arguments_Diff_WithAnythingOfTypeArgument_Failing(t *testing.T) {
 	t.Parallel()
 
-	var args = Arguments([]interface{}{"string", AnythingOfType("string"), true})
+	var args = Arguments([]any{"string", AnythingOfType("string"), true})
 	var count int
 	var diff string
-	diff, count = args.Diff([]interface{}{"string", 123, true})
+	diff, count = args.Diff([]any{"string", 123, true})
 
 	assert.Equal(t, 1, count)
 	assert.Contains(t, diff, `string != type int - (int=123)`)
@@ -1981,9 +1981,9 @@ func Test_Arguments_Diff_WithAnythingOfTypeArgument_Failing(t *testing.T) {
 func Test_Arguments_Diff_WithIsTypeArgument(t *testing.T) {
 	t.Parallel()
 
-	var args = Arguments([]interface{}{"string", IsType(0), true})
+	var args = Arguments([]any{"string", IsType(0), true})
 	var count int
-	_, count = args.Diff([]interface{}{"string", 123, true})
+	_, count = args.Diff([]any{"string", 123, true})
 
 	assert.Equal(t, 0, count)
 }
@@ -1991,10 +1991,10 @@ func Test_Arguments_Diff_WithIsTypeArgument(t *testing.T) {
 func Test_Arguments_Diff_WithIsTypeArgument_Failing(t *testing.T) {
 	t.Parallel()
 
-	var args = Arguments([]interface{}{"string", IsType(""), true})
+	var args = Arguments([]any{"string", IsType(""), true})
 	var count int
 	var diff string
-	diff, count = args.Diff([]interface{}{"string", 123, true})
+	diff, count = args.Diff([]any{"string", 123, true})
 
 	assert.Equal(t, 1, count)
 	assert.Contains(t, diff, `string != type int - (int=123)`)
@@ -2003,8 +2003,8 @@ func Test_Arguments_Diff_WithIsTypeArgument_Failing(t *testing.T) {
 func Test_Arguments_Diff_WithIsTypeArgument_InterfaceType(t *testing.T) {
 	t.Parallel()
 	var ctx = context.Background()
-	args := Arguments([]interface{}{IsType(ctx)})
-	_, count := args.Diff([]interface{}{context.Background()})
+	args := Arguments([]any{IsType(ctx)})
+	_, count := args.Diff([]any{context.Background()})
 	assert.Equal(t, 0, count)
 }
 
@@ -2012,8 +2012,8 @@ func Test_Arguments_Diff_WithIsTypeArgument_InterfaceType_Failing(t *testing.T) 
 	t.Parallel()
 
 	var ctx context.Context
-	var args = Arguments([]interface{}{IsType(ctx)})
-	diff, count := args.Diff([]interface{}{context.Background()})
+	var args = Arguments([]any{IsType(ctx)})
+	diff, count := args.Diff([]any{context.Background()})
 	assert.Equal(t, 1, count)
 	assert.Contains(t, diff, `type <nil> != type `)
 
@@ -2025,21 +2025,21 @@ func Test_Arguments_Diff_WithArgMatcher(t *testing.T) {
 	matchFn := func(a int) bool {
 		return a == 123
 	}
-	var args = Arguments([]interface{}{"string", MatchedBy(matchFn), true})
+	var args = Arguments([]any{"string", MatchedBy(matchFn), true})
 
-	diff, count := args.Diff([]interface{}{"string", 124, true})
+	diff, count := args.Diff([]any{"string", 124, true})
 	assert.Equal(t, 1, count)
 	assert.Contains(t, diff, `(int=124) not matched by func(int) bool`)
 
-	diff, count = args.Diff([]interface{}{"string", false, true})
+	diff, count = args.Diff([]any{"string", false, true})
 	assert.Equal(t, 1, count)
 	assert.Contains(t, diff, `(bool=false) not matched by func(int) bool`)
 
-	diff, count = args.Diff([]interface{}{"string", 123, false})
+	diff, count = args.Diff([]any{"string", 123, false})
 	assert.Equal(t, 1, count)
 	assert.Contains(t, diff, `(int=123) matched by func(int) bool`)
 
-	diff, count = args.Diff([]interface{}{"string", 123, true})
+	diff, count = args.Diff([]any{"string", 123, true})
 	assert.Equal(t, 0, count)
 	assert.Contains(t, diff, `No differences.`)
 }
@@ -2047,7 +2047,7 @@ func Test_Arguments_Diff_WithArgMatcher(t *testing.T) {
 func Test_Arguments_Assert(t *testing.T) {
 	t.Parallel()
 
-	var args = Arguments([]interface{}{"string", 123, true})
+	var args = Arguments([]any{"string", 123, true})
 
 	assert.True(t, args.Assert(t, "string", 123, true))
 
@@ -2056,7 +2056,7 @@ func Test_Arguments_Assert(t *testing.T) {
 func Test_Arguments_String_Representation(t *testing.T) {
 	t.Parallel()
 
-	var args = Arguments([]interface{}{"string", 123, true})
+	var args = Arguments([]any{"string", 123, true})
 	assert.Equal(t, `string,int,bool`, args.String())
 
 }
@@ -2064,7 +2064,7 @@ func Test_Arguments_String_Representation(t *testing.T) {
 func Test_Arguments_String(t *testing.T) {
 	t.Parallel()
 
-	var args = Arguments([]interface{}{"string", 123, true})
+	var args = Arguments([]any{"string", 123, true})
 	assert.Equal(t, "string", args.String(0))
 
 }
@@ -2073,7 +2073,7 @@ func Test_Arguments_Error(t *testing.T) {
 	t.Parallel()
 
 	var err = errors.New("An Error")
-	var args = Arguments([]interface{}{"string", 123, true, err})
+	var args = Arguments([]any{"string", 123, true, err})
 	assert.Equal(t, err, args.Error(3))
 
 }
@@ -2081,7 +2081,7 @@ func Test_Arguments_Error(t *testing.T) {
 func Test_Arguments_Error_Nil(t *testing.T) {
 	t.Parallel()
 
-	var args = Arguments([]interface{}{"string", 123, true, nil})
+	var args = Arguments([]any{"string", 123, true, nil})
 	assert.Equal(t, nil, args.Error(3))
 
 }
@@ -2089,7 +2089,7 @@ func Test_Arguments_Error_Nil(t *testing.T) {
 func Test_Arguments_Int(t *testing.T) {
 	t.Parallel()
 
-	var args = Arguments([]interface{}{"string", 123, true})
+	var args = Arguments([]any{"string", 123, true})
 	assert.Equal(t, 123, args.Int(1))
 
 }
@@ -2097,7 +2097,7 @@ func Test_Arguments_Int(t *testing.T) {
 func Test_Arguments_Bool(t *testing.T) {
 	t.Parallel()
 
-	var args = Arguments([]interface{}{"string", 123, true})
+	var args = Arguments([]any{"string", 123, true})
 	assert.Equal(t, true, args.Bool(2))
 
 }
@@ -2193,12 +2193,12 @@ type tCustomLogger struct {
 	errs []string
 }
 
-func (tc *tCustomLogger) Logf(format string, args ...interface{}) {
+func (tc *tCustomLogger) Logf(format string, args ...any) {
 	tc.T.Logf(format, args...)
 	tc.logs = append(tc.logs, fmt.Sprintf(format, args...))
 }
 
-func (tc *tCustomLogger) Errorf(format string, args ...interface{}) {
+func (tc *tCustomLogger) Errorf(format string, args ...any) {
 	tc.errs = append(tc.errs, fmt.Sprintf(format, args...))
 }
 

--- a/require/require.go
+++ b/require/require.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Condition uses a Comparison to assert a complex condition.
-func Condition(t TestingT, comp assert.Comparison, msgAndArgs ...interface{}) {
+func Condition(t TestingT, comp assert.Comparison, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -21,7 +21,7 @@ func Condition(t TestingT, comp assert.Comparison, msgAndArgs ...interface{}) {
 }
 
 // Conditionf uses a Comparison to assert a complex condition.
-func Conditionf(t TestingT, comp assert.Comparison, msg string, args ...interface{}) {
+func Conditionf(t TestingT, comp assert.Comparison, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -37,7 +37,7 @@ func Conditionf(t TestingT, comp assert.Comparison, msg string, args ...interfac
 //	require.Contains(t, "Hello World", "World")
 //	require.Contains(t, ["Hello", "World"], "World")
 //	require.Contains(t, {"Hello": "World"}, "Hello")
-func Contains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
+func Contains(t TestingT, s any, contains any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -53,7 +53,7 @@ func Contains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...int
 //	require.Containsf(t, "Hello World", "World", "error message %s", "formatted")
 //	require.Containsf(t, ["Hello", "World"], "World", "error message %s", "formatted")
 //	require.Containsf(t, {"Hello": "World"}, "Hello", "error message %s", "formatted")
-func Containsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) {
+func Containsf(t TestingT, s any, contains any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -65,7 +65,7 @@ func Containsf(t TestingT, s interface{}, contains interface{}, msg string, args
 
 // DirExists checks whether a directory exists in the given path. It also fails
 // if the path is a file rather a directory or there is an error checking whether it exists.
-func DirExists(t TestingT, path string, msgAndArgs ...interface{}) {
+func DirExists(t TestingT, path string, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -77,7 +77,7 @@ func DirExists(t TestingT, path string, msgAndArgs ...interface{}) {
 
 // DirExistsf checks whether a directory exists in the given path. It also fails
 // if the path is a file rather a directory or there is an error checking whether it exists.
-func DirExistsf(t TestingT, path string, msg string, args ...interface{}) {
+func DirExistsf(t TestingT, path string, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -92,7 +92,7 @@ func DirExistsf(t TestingT, path string, msg string, args ...interface{}) {
 // the number of appearances of each of them in both lists should match.
 //
 // require.ElementsMatch(t, [1, 3, 2, 3], [1, 3, 3, 2])
-func ElementsMatch(t TestingT, listA interface{}, listB interface{}, msgAndArgs ...interface{}) {
+func ElementsMatch(t TestingT, listA any, listB any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -107,7 +107,7 @@ func ElementsMatch(t TestingT, listA interface{}, listB interface{}, msgAndArgs 
 // the number of appearances of each of them in both lists should match.
 //
 // require.ElementsMatchf(t, [1, 3, 2, 3], [1, 3, 3, 2], "error message %s", "formatted")
-func ElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string, args ...interface{}) {
+func ElementsMatchf(t TestingT, listA any, listB any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -130,7 +130,7 @@ func ElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string
 //	require.Empty(t, obj)
 //
 // [Zero values]: https://go.dev/ref/spec#The_zero_value
-func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+func Empty(t TestingT, object any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -153,7 +153,7 @@ func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 //	require.Emptyf(t, obj, "error message %s", "formatted")
 //
 // [Zero values]: https://go.dev/ref/spec#The_zero_value
-func Emptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
+func Emptyf(t TestingT, object any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -170,7 +170,7 @@ func Emptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses). Function equality
 // cannot be determined and will always fail.
-func Equal(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+func Equal(t TestingT, expected any, actual any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -185,7 +185,7 @@ func Equal(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...i
 //
 //	actualObj, err := SomeFunction()
 //	require.EqualError(t, err,  expectedErrorString)
-func EqualError(t TestingT, theError error, errString string, msgAndArgs ...interface{}) {
+func EqualError(t TestingT, theError error, errString string, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -200,7 +200,7 @@ func EqualError(t TestingT, theError error, errString string, msgAndArgs ...inte
 //
 //	actualObj, err := SomeFunction()
 //	require.EqualErrorf(t, err,  expectedErrorString, "error message %s", "formatted")
-func EqualErrorf(t TestingT, theError error, errString string, msg string, args ...interface{}) {
+func EqualErrorf(t TestingT, theError error, errString string, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -220,7 +220,7 @@ func EqualErrorf(t TestingT, theError error, errString string, msg string, args 
 //	 }
 //	 require.EqualExportedValues(t, S{1, 2}, S{1, 3}) => true
 //	 require.EqualExportedValues(t, S{1, 2}, S{2, 3}) => false
-func EqualExportedValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+func EqualExportedValues(t TestingT, expected any, actual any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -240,7 +240,7 @@ func EqualExportedValues(t TestingT, expected interface{}, actual interface{}, m
 //	 }
 //	 require.EqualExportedValuesf(t, S{1, 2}, S{1, 3}, "error message %s", "formatted") => true
 //	 require.EqualExportedValuesf(t, S{1, 2}, S{2, 3}, "error message %s", "formatted") => false
-func EqualExportedValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+func EqualExportedValuesf(t TestingT, expected any, actual any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -254,7 +254,7 @@ func EqualExportedValuesf(t TestingT, expected interface{}, actual interface{}, 
 // type and equal.
 //
 //	require.EqualValues(t, uint32(123), int32(123))
-func EqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+func EqualValues(t TestingT, expected any, actual any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -268,7 +268,7 @@ func EqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArg
 // type and equal.
 //
 //	require.EqualValuesf(t, uint32(123), int32(123), "error message %s", "formatted")
-func EqualValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+func EqualValuesf(t TestingT, expected any, actual any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -285,7 +285,7 @@ func EqualValuesf(t TestingT, expected interface{}, actual interface{}, msg stri
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses). Function equality
 // cannot be determined and will always fail.
-func Equalf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+func Equalf(t TestingT, expected any, actual any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -299,7 +299,7 @@ func Equalf(t TestingT, expected interface{}, actual interface{}, msg string, ar
 //
 //	actualObj, err := SomeFunction()
 //	require.Error(t, err)
-func Error(t TestingT, err error, msgAndArgs ...interface{}) {
+func Error(t TestingT, err error, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -311,7 +311,7 @@ func Error(t TestingT, err error, msgAndArgs ...interface{}) {
 
 // ErrorAs asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
 // This is a wrapper for errors.As.
-func ErrorAs(t TestingT, err error, target interface{}, msgAndArgs ...interface{}) {
+func ErrorAs(t TestingT, err error, target any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -323,7 +323,7 @@ func ErrorAs(t TestingT, err error, target interface{}, msgAndArgs ...interface{
 
 // ErrorAsf asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
 // This is a wrapper for errors.As.
-func ErrorAsf(t TestingT, err error, target interface{}, msg string, args ...interface{}) {
+func ErrorAsf(t TestingT, err error, target any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -338,7 +338,7 @@ func ErrorAsf(t TestingT, err error, target interface{}, msg string, args ...int
 //
 //	actualObj, err := SomeFunction()
 //	require.ErrorContains(t, err,  expectedErrorSubString)
-func ErrorContains(t TestingT, theError error, contains string, msgAndArgs ...interface{}) {
+func ErrorContains(t TestingT, theError error, contains string, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -353,7 +353,7 @@ func ErrorContains(t TestingT, theError error, contains string, msgAndArgs ...in
 //
 //	actualObj, err := SomeFunction()
 //	require.ErrorContainsf(t, err,  expectedErrorSubString, "error message %s", "formatted")
-func ErrorContainsf(t TestingT, theError error, contains string, msg string, args ...interface{}) {
+func ErrorContainsf(t TestingT, theError error, contains string, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -365,7 +365,7 @@ func ErrorContainsf(t TestingT, theError error, contains string, msg string, arg
 
 // ErrorIs asserts that at least one of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
-func ErrorIs(t TestingT, err error, target error, msgAndArgs ...interface{}) {
+func ErrorIs(t TestingT, err error, target error, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -377,7 +377,7 @@ func ErrorIs(t TestingT, err error, target error, msgAndArgs ...interface{}) {
 
 // ErrorIsf asserts that at least one of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
-func ErrorIsf(t TestingT, err error, target error, msg string, args ...interface{}) {
+func ErrorIsf(t TestingT, err error, target error, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -391,7 +391,7 @@ func ErrorIsf(t TestingT, err error, target error, msg string, args ...interface
 //
 //	actualObj, err := SomeFunction()
 //	require.Errorf(t, err, "error message %s", "formatted")
-func Errorf(t TestingT, err error, msg string, args ...interface{}) {
+func Errorf(t TestingT, err error, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -405,7 +405,7 @@ func Errorf(t TestingT, err error, msg string, args ...interface{}) {
 // periodically checking target function each tick.
 //
 //	require.Eventually(t, func() bool { return true; }, time.Second, 10*time.Millisecond)
-func Eventually(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
+func Eventually(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -433,7 +433,7 @@ func Eventually(t TestingT, condition func() bool, waitFor time.Duration, tick t
 //		// add assertions as needed; any assertion failure will fail the current tick
 //		require.True(c, externalValue, "expected 'externalValue' to be true")
 //	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
-func EventuallyWithT(t TestingT, condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
+func EventuallyWithT(t TestingT, condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -461,7 +461,7 @@ func EventuallyWithT(t TestingT, condition func(collect *assert.CollectT), waitF
 //		// add assertions as needed; any assertion failure will fail the current tick
 //		require.True(c, externalValue, "expected 'externalValue' to be true")
 //	}, 10*time.Second, 1*time.Second, "error message %s", "formatted")
-func EventuallyWithTf(t TestingT, condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
+func EventuallyWithTf(t TestingT, condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -475,7 +475,7 @@ func EventuallyWithTf(t TestingT, condition func(collect *assert.CollectT), wait
 // periodically checking target function each tick.
 //
 //	require.Eventuallyf(t, func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
-func Eventuallyf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
+func Eventuallyf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -488,7 +488,7 @@ func Eventuallyf(t TestingT, condition func() bool, waitFor time.Duration, tick 
 // Exactly asserts that two objects are equal in value and type.
 //
 //	require.Exactly(t, int32(123), int64(123))
-func Exactly(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+func Exactly(t TestingT, expected any, actual any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -501,7 +501,7 @@ func Exactly(t TestingT, expected interface{}, actual interface{}, msgAndArgs ..
 // Exactlyf asserts that two objects are equal in value and type.
 //
 //	require.Exactlyf(t, int32(123), int64(123), "error message %s", "formatted")
-func Exactlyf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+func Exactlyf(t TestingT, expected any, actual any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -512,7 +512,7 @@ func Exactlyf(t TestingT, expected interface{}, actual interface{}, msg string, 
 }
 
 // Fail reports a failure through
-func Fail(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
+func Fail(t TestingT, failureMessage string, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -523,7 +523,7 @@ func Fail(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
 }
 
 // FailNow fails test
-func FailNow(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
+func FailNow(t TestingT, failureMessage string, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -534,7 +534,7 @@ func FailNow(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
 }
 
 // FailNowf fails test
-func FailNowf(t TestingT, failureMessage string, msg string, args ...interface{}) {
+func FailNowf(t TestingT, failureMessage string, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -545,7 +545,7 @@ func FailNowf(t TestingT, failureMessage string, msg string, args ...interface{}
 }
 
 // Failf reports a failure through
-func Failf(t TestingT, failureMessage string, msg string, args ...interface{}) {
+func Failf(t TestingT, failureMessage string, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -558,7 +558,7 @@ func Failf(t TestingT, failureMessage string, msg string, args ...interface{}) {
 // False asserts that the specified value is false.
 //
 //	require.False(t, myBool)
-func False(t TestingT, value bool, msgAndArgs ...interface{}) {
+func False(t TestingT, value bool, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -571,7 +571,7 @@ func False(t TestingT, value bool, msgAndArgs ...interface{}) {
 // Falsef asserts that the specified value is false.
 //
 //	require.Falsef(t, myBool, "error message %s", "formatted")
-func Falsef(t TestingT, value bool, msg string, args ...interface{}) {
+func Falsef(t TestingT, value bool, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -583,7 +583,7 @@ func Falsef(t TestingT, value bool, msg string, args ...interface{}) {
 
 // FileExists checks whether a file exists in the given path. It also fails if
 // the path points to a directory or there is an error when trying to check the file.
-func FileExists(t TestingT, path string, msgAndArgs ...interface{}) {
+func FileExists(t TestingT, path string, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -595,7 +595,7 @@ func FileExists(t TestingT, path string, msgAndArgs ...interface{}) {
 
 // FileExistsf checks whether a file exists in the given path. It also fails if
 // the path points to a directory or there is an error when trying to check the file.
-func FileExistsf(t TestingT, path string, msg string, args ...interface{}) {
+func FileExistsf(t TestingT, path string, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -610,7 +610,7 @@ func FileExistsf(t TestingT, path string, msg string, args ...interface{}) {
 //	require.Greater(t, 2, 1)
 //	require.Greater(t, float64(2), float64(1))
 //	require.Greater(t, "b", "a")
-func Greater(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+func Greater(t TestingT, e1 any, e2 any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -626,7 +626,7 @@ func Greater(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface
 //	require.GreaterOrEqual(t, 2, 2)
 //	require.GreaterOrEqual(t, "b", "a")
 //	require.GreaterOrEqual(t, "b", "b")
-func GreaterOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+func GreaterOrEqual(t TestingT, e1 any, e2 any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -642,7 +642,7 @@ func GreaterOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...in
 //	require.GreaterOrEqualf(t, 2, 2, "error message %s", "formatted")
 //	require.GreaterOrEqualf(t, "b", "a", "error message %s", "formatted")
 //	require.GreaterOrEqualf(t, "b", "b", "error message %s", "formatted")
-func GreaterOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+func GreaterOrEqualf(t TestingT, e1 any, e2 any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -657,7 +657,7 @@ func GreaterOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, arg
 //	require.Greaterf(t, 2, 1, "error message %s", "formatted")
 //	require.Greaterf(t, float64(2), float64(1), "error message %s", "formatted")
 //	require.Greaterf(t, "b", "a", "error message %s", "formatted")
-func Greaterf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+func Greaterf(t TestingT, e1 any, e2 any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -671,7 +671,7 @@ func Greaterf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...in
 // body that contains a string.
 //
 //	require.HTTPBodyContains(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
-func HTTPBodyContains(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
+func HTTPBodyContains(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -685,7 +685,7 @@ func HTTPBodyContains(t TestingT, handler http.HandlerFunc, method string, url s
 // body that contains a string.
 //
 //	require.HTTPBodyContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
-func HTTPBodyContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
+func HTTPBodyContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -699,7 +699,7 @@ func HTTPBodyContainsf(t TestingT, handler http.HandlerFunc, method string, url 
 // body that does not contain a string.
 //
 //	require.HTTPBodyNotContains(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
-func HTTPBodyNotContains(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
+func HTTPBodyNotContains(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -713,7 +713,7 @@ func HTTPBodyNotContains(t TestingT, handler http.HandlerFunc, method string, ur
 // body that does not contain a string.
 //
 //	require.HTTPBodyNotContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
-func HTTPBodyNotContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
+func HTTPBodyNotContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -726,7 +726,7 @@ func HTTPBodyNotContainsf(t TestingT, handler http.HandlerFunc, method string, u
 // HTTPError asserts that a specified handler returns an error status code.
 //
 //	require.HTTPError(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
-func HTTPError(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+func HTTPError(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -739,7 +739,7 @@ func HTTPError(t TestingT, handler http.HandlerFunc, method string, url string, 
 // HTTPErrorf asserts that a specified handler returns an error status code.
 //
 //	require.HTTPErrorf(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
-func HTTPErrorf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+func HTTPErrorf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -752,7 +752,7 @@ func HTTPErrorf(t TestingT, handler http.HandlerFunc, method string, url string,
 // HTTPRedirect asserts that a specified handler returns a redirect status code.
 //
 //	require.HTTPRedirect(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
-func HTTPRedirect(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+func HTTPRedirect(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -765,7 +765,7 @@ func HTTPRedirect(t TestingT, handler http.HandlerFunc, method string, url strin
 // HTTPRedirectf asserts that a specified handler returns a redirect status code.
 //
 //	require.HTTPRedirectf(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
-func HTTPRedirectf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+func HTTPRedirectf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -778,7 +778,7 @@ func HTTPRedirectf(t TestingT, handler http.HandlerFunc, method string, url stri
 // HTTPStatusCode asserts that a specified handler returns a specified status code.
 //
 //	require.HTTPStatusCode(t, myHandler, "GET", "/notImplemented", nil, 501)
-func HTTPStatusCode(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msgAndArgs ...interface{}) {
+func HTTPStatusCode(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -791,7 +791,7 @@ func HTTPStatusCode(t TestingT, handler http.HandlerFunc, method string, url str
 // HTTPStatusCodef asserts that a specified handler returns a specified status code.
 //
 //	require.HTTPStatusCodef(t, myHandler, "GET", "/notImplemented", nil, 501, "error message %s", "formatted")
-func HTTPStatusCodef(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msg string, args ...interface{}) {
+func HTTPStatusCodef(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -804,7 +804,7 @@ func HTTPStatusCodef(t TestingT, handler http.HandlerFunc, method string, url st
 // HTTPSuccess asserts that a specified handler returns a success status code.
 //
 //	require.HTTPSuccess(t, myHandler, "POST", "http://www.google.com", nil)
-func HTTPSuccess(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+func HTTPSuccess(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -817,7 +817,7 @@ func HTTPSuccess(t TestingT, handler http.HandlerFunc, method string, url string
 // HTTPSuccessf asserts that a specified handler returns a success status code.
 //
 //	require.HTTPSuccessf(t, myHandler, "POST", "http://www.google.com", nil, "error message %s", "formatted")
-func HTTPSuccessf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+func HTTPSuccessf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -830,7 +830,7 @@ func HTTPSuccessf(t TestingT, handler http.HandlerFunc, method string, url strin
 // Implements asserts that an object is implemented by the specified interface.
 //
 //	require.Implements(t, (*MyInterface)(nil), new(MyObject))
-func Implements(t TestingT, interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
+func Implements(t TestingT, interfaceObject any, object any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -843,7 +843,7 @@ func Implements(t TestingT, interfaceObject interface{}, object interface{}, msg
 // Implementsf asserts that an object is implemented by the specified interface.
 //
 //	require.Implementsf(t, (*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
-func Implementsf(t TestingT, interfaceObject interface{}, object interface{}, msg string, args ...interface{}) {
+func Implementsf(t TestingT, interfaceObject any, object any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -856,7 +856,7 @@ func Implementsf(t TestingT, interfaceObject interface{}, object interface{}, ms
 // InDelta asserts that the two numerals are within delta of each other.
 //
 //	require.InDelta(t, math.Pi, 22/7.0, 0.01)
-func InDelta(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+func InDelta(t TestingT, expected any, actual any, delta float64, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -867,7 +867,7 @@ func InDelta(t TestingT, expected interface{}, actual interface{}, delta float64
 }
 
 // InDeltaMapValues is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
-func InDeltaMapValues(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+func InDeltaMapValues(t TestingT, expected any, actual any, delta float64, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -878,7 +878,7 @@ func InDeltaMapValues(t TestingT, expected interface{}, actual interface{}, delt
 }
 
 // InDeltaMapValuesf is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
-func InDeltaMapValuesf(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+func InDeltaMapValuesf(t TestingT, expected any, actual any, delta float64, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -889,7 +889,7 @@ func InDeltaMapValuesf(t TestingT, expected interface{}, actual interface{}, del
 }
 
 // InDeltaSlice is the same as InDelta, except it compares two slices.
-func InDeltaSlice(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+func InDeltaSlice(t TestingT, expected any, actual any, delta float64, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -900,7 +900,7 @@ func InDeltaSlice(t TestingT, expected interface{}, actual interface{}, delta fl
 }
 
 // InDeltaSlicef is the same as InDelta, except it compares two slices.
-func InDeltaSlicef(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+func InDeltaSlicef(t TestingT, expected any, actual any, delta float64, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -913,7 +913,7 @@ func InDeltaSlicef(t TestingT, expected interface{}, actual interface{}, delta f
 // InDeltaf asserts that the two numerals are within delta of each other.
 //
 //	require.InDeltaf(t, math.Pi, 22/7.0, 0.01, "error message %s", "formatted")
-func InDeltaf(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+func InDeltaf(t TestingT, expected any, actual any, delta float64, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -924,7 +924,7 @@ func InDeltaf(t TestingT, expected interface{}, actual interface{}, delta float6
 }
 
 // InEpsilon asserts that expected and actual have a relative error less than epsilon
-func InEpsilon(t TestingT, expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
+func InEpsilon(t TestingT, expected any, actual any, epsilon float64, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -935,7 +935,7 @@ func InEpsilon(t TestingT, expected interface{}, actual interface{}, epsilon flo
 }
 
 // InEpsilonSlice is the same as InEpsilon, except it compares each value from two slices.
-func InEpsilonSlice(t TestingT, expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
+func InEpsilonSlice(t TestingT, expected any, actual any, epsilon float64, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -946,7 +946,7 @@ func InEpsilonSlice(t TestingT, expected interface{}, actual interface{}, epsilo
 }
 
 // InEpsilonSlicef is the same as InEpsilon, except it compares each value from two slices.
-func InEpsilonSlicef(t TestingT, expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
+func InEpsilonSlicef(t TestingT, expected any, actual any, epsilon float64, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -957,7 +957,7 @@ func InEpsilonSlicef(t TestingT, expected interface{}, actual interface{}, epsil
 }
 
 // InEpsilonf asserts that expected and actual have a relative error less than epsilon
-func InEpsilonf(t TestingT, expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
+func InEpsilonf(t TestingT, expected any, actual any, epsilon float64, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -972,7 +972,7 @@ func InEpsilonf(t TestingT, expected interface{}, actual interface{}, epsilon fl
 //	require.IsDecreasing(t, []int{2, 1, 0})
 //	require.IsDecreasing(t, []float{2, 1})
 //	require.IsDecreasing(t, []string{"b", "a"})
-func IsDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+func IsDecreasing(t TestingT, object any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -987,7 +987,7 @@ func IsDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 //	require.IsDecreasingf(t, []int{2, 1, 0}, "error message %s", "formatted")
 //	require.IsDecreasingf(t, []float{2, 1}, "error message %s", "formatted")
 //	require.IsDecreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
-func IsDecreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
+func IsDecreasingf(t TestingT, object any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1002,7 +1002,7 @@ func IsDecreasingf(t TestingT, object interface{}, msg string, args ...interface
 //	require.IsIncreasing(t, []int{1, 2, 3})
 //	require.IsIncreasing(t, []float{1, 2})
 //	require.IsIncreasing(t, []string{"a", "b"})
-func IsIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+func IsIncreasing(t TestingT, object any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1017,7 +1017,7 @@ func IsIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 //	require.IsIncreasingf(t, []int{1, 2, 3}, "error message %s", "formatted")
 //	require.IsIncreasingf(t, []float{1, 2}, "error message %s", "formatted")
 //	require.IsIncreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
-func IsIncreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
+func IsIncreasingf(t TestingT, object any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1032,7 +1032,7 @@ func IsIncreasingf(t TestingT, object interface{}, msg string, args ...interface
 //	require.IsNonDecreasing(t, []int{1, 1, 2})
 //	require.IsNonDecreasing(t, []float{1, 2})
 //	require.IsNonDecreasing(t, []string{"a", "b"})
-func IsNonDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+func IsNonDecreasing(t TestingT, object any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1047,7 +1047,7 @@ func IsNonDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) 
 //	require.IsNonDecreasingf(t, []int{1, 1, 2}, "error message %s", "formatted")
 //	require.IsNonDecreasingf(t, []float{1, 2}, "error message %s", "formatted")
 //	require.IsNonDecreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
-func IsNonDecreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
+func IsNonDecreasingf(t TestingT, object any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1062,7 +1062,7 @@ func IsNonDecreasingf(t TestingT, object interface{}, msg string, args ...interf
 //	require.IsNonIncreasing(t, []int{2, 1, 1})
 //	require.IsNonIncreasing(t, []float{2, 1})
 //	require.IsNonIncreasing(t, []string{"b", "a"})
-func IsNonIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+func IsNonIncreasing(t TestingT, object any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1077,7 +1077,7 @@ func IsNonIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) 
 //	require.IsNonIncreasingf(t, []int{2, 1, 1}, "error message %s", "formatted")
 //	require.IsNonIncreasingf(t, []float{2, 1}, "error message %s", "formatted")
 //	require.IsNonIncreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
-func IsNonIncreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
+func IsNonIncreasingf(t TestingT, object any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1090,7 +1090,7 @@ func IsNonIncreasingf(t TestingT, object interface{}, msg string, args ...interf
 // IsNotType asserts that the specified objects are not of the same type.
 //
 //	require.IsNotType(t, &NotMyStruct{}, &MyStruct{})
-func IsNotType(t TestingT, theType interface{}, object interface{}, msgAndArgs ...interface{}) {
+func IsNotType(t TestingT, theType any, object any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1103,7 +1103,7 @@ func IsNotType(t TestingT, theType interface{}, object interface{}, msgAndArgs .
 // IsNotTypef asserts that the specified objects are not of the same type.
 //
 //	require.IsNotTypef(t, &NotMyStruct{}, &MyStruct{}, "error message %s", "formatted")
-func IsNotTypef(t TestingT, theType interface{}, object interface{}, msg string, args ...interface{}) {
+func IsNotTypef(t TestingT, theType any, object any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1116,7 +1116,7 @@ func IsNotTypef(t TestingT, theType interface{}, object interface{}, msg string,
 // IsType asserts that the specified objects are of the same type.
 //
 //	require.IsType(t, &MyStruct{}, &MyStruct{})
-func IsType(t TestingT, expectedType interface{}, object interface{}, msgAndArgs ...interface{}) {
+func IsType(t TestingT, expectedType any, object any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1129,7 +1129,7 @@ func IsType(t TestingT, expectedType interface{}, object interface{}, msgAndArgs
 // IsTypef asserts that the specified objects are of the same type.
 //
 //	require.IsTypef(t, &MyStruct{}, &MyStruct{}, "error message %s", "formatted")
-func IsTypef(t TestingT, expectedType interface{}, object interface{}, msg string, args ...interface{}) {
+func IsTypef(t TestingT, expectedType any, object any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1142,7 +1142,7 @@ func IsTypef(t TestingT, expectedType interface{}, object interface{}, msg strin
 // JSONEq asserts that two JSON strings are equivalent.
 //
 //	require.JSONEq(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
-func JSONEq(t TestingT, expected string, actual string, msgAndArgs ...interface{}) {
+func JSONEq(t TestingT, expected string, actual string, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1155,7 +1155,7 @@ func JSONEq(t TestingT, expected string, actual string, msgAndArgs ...interface{
 // JSONEqf asserts that two JSON strings are equivalent.
 //
 //	require.JSONEqf(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
-func JSONEqf(t TestingT, expected string, actual string, msg string, args ...interface{}) {
+func JSONEqf(t TestingT, expected string, actual string, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1169,7 +1169,7 @@ func JSONEqf(t TestingT, expected string, actual string, msg string, args ...int
 // Len also fails if the object has a type that len() not accept.
 //
 //	require.Len(t, mySlice, 3)
-func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) {
+func Len(t TestingT, object any, length int, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1183,7 +1183,7 @@ func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) 
 // Lenf also fails if the object has a type that len() not accept.
 //
 //	require.Lenf(t, mySlice, 3, "error message %s", "formatted")
-func Lenf(t TestingT, object interface{}, length int, msg string, args ...interface{}) {
+func Lenf(t TestingT, object any, length int, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1198,7 +1198,7 @@ func Lenf(t TestingT, object interface{}, length int, msg string, args ...interf
 //	require.Less(t, 1, 2)
 //	require.Less(t, float64(1), float64(2))
 //	require.Less(t, "a", "b")
-func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+func Less(t TestingT, e1 any, e2 any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1214,7 +1214,7 @@ func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{})
 //	require.LessOrEqual(t, 2, 2)
 //	require.LessOrEqual(t, "a", "b")
 //	require.LessOrEqual(t, "b", "b")
-func LessOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+func LessOrEqual(t TestingT, e1 any, e2 any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1230,7 +1230,7 @@ func LessOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...inter
 //	require.LessOrEqualf(t, 2, 2, "error message %s", "formatted")
 //	require.LessOrEqualf(t, "a", "b", "error message %s", "formatted")
 //	require.LessOrEqualf(t, "b", "b", "error message %s", "formatted")
-func LessOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+func LessOrEqualf(t TestingT, e1 any, e2 any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1245,7 +1245,7 @@ func LessOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args .
 //	require.Lessf(t, 1, 2, "error message %s", "formatted")
 //	require.Lessf(t, float64(1), float64(2), "error message %s", "formatted")
 //	require.Lessf(t, "a", "b", "error message %s", "formatted")
-func Lessf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+func Lessf(t TestingT, e1 any, e2 any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1259,7 +1259,7 @@ func Lessf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...inter
 //
 //	require.Negative(t, -1)
 //	require.Negative(t, -1.23)
-func Negative(t TestingT, e interface{}, msgAndArgs ...interface{}) {
+func Negative(t TestingT, e any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1273,7 +1273,7 @@ func Negative(t TestingT, e interface{}, msgAndArgs ...interface{}) {
 //
 //	require.Negativef(t, -1, "error message %s", "formatted")
 //	require.Negativef(t, -1.23, "error message %s", "formatted")
-func Negativef(t TestingT, e interface{}, msg string, args ...interface{}) {
+func Negativef(t TestingT, e any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1287,7 +1287,7 @@ func Negativef(t TestingT, e interface{}, msg string, args ...interface{}) {
 // periodically checking the target function each tick.
 //
 //	require.Never(t, func() bool { return false; }, time.Second, 10*time.Millisecond)
-func Never(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
+func Never(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1301,7 +1301,7 @@ func Never(t TestingT, condition func() bool, waitFor time.Duration, tick time.D
 // periodically checking the target function each tick.
 //
 //	require.Neverf(t, func() bool { return false; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
-func Neverf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
+func Neverf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1314,7 +1314,7 @@ func Neverf(t TestingT, condition func() bool, waitFor time.Duration, tick time.
 // Nil asserts that the specified object is nil.
 //
 //	require.Nil(t, err)
-func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+func Nil(t TestingT, object any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1327,7 +1327,7 @@ func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 // Nilf asserts that the specified object is nil.
 //
 //	require.Nilf(t, err, "error message %s", "formatted")
-func Nilf(t TestingT, object interface{}, msg string, args ...interface{}) {
+func Nilf(t TestingT, object any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1339,7 +1339,7 @@ func Nilf(t TestingT, object interface{}, msg string, args ...interface{}) {
 
 // NoDirExists checks whether a directory does not exist in the given path.
 // It fails if the path points to an existing _directory_ only.
-func NoDirExists(t TestingT, path string, msgAndArgs ...interface{}) {
+func NoDirExists(t TestingT, path string, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1351,7 +1351,7 @@ func NoDirExists(t TestingT, path string, msgAndArgs ...interface{}) {
 
 // NoDirExistsf checks whether a directory does not exist in the given path.
 // It fails if the path points to an existing _directory_ only.
-func NoDirExistsf(t TestingT, path string, msg string, args ...interface{}) {
+func NoDirExistsf(t TestingT, path string, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1366,7 +1366,7 @@ func NoDirExistsf(t TestingT, path string, msg string, args ...interface{}) {
 //	actualObj, err := SomeFunction()
 //	require.NoError(t, err)
 //	require.Equal(t, expectedObj, actualObj)
-func NoError(t TestingT, err error, msgAndArgs ...interface{}) {
+func NoError(t TestingT, err error, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1381,7 +1381,7 @@ func NoError(t TestingT, err error, msgAndArgs ...interface{}) {
 //	actualObj, err := SomeFunction()
 //	require.NoErrorf(t, err, "error message %s", "formatted")
 //	require.Equal(t, expectedObj, actualObj)
-func NoErrorf(t TestingT, err error, msg string, args ...interface{}) {
+func NoErrorf(t TestingT, err error, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1393,7 +1393,7 @@ func NoErrorf(t TestingT, err error, msg string, args ...interface{}) {
 
 // NoFileExists checks whether a file does not exist in a given path. It fails
 // if the path points to an existing _file_ only.
-func NoFileExists(t TestingT, path string, msgAndArgs ...interface{}) {
+func NoFileExists(t TestingT, path string, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1405,7 +1405,7 @@ func NoFileExists(t TestingT, path string, msgAndArgs ...interface{}) {
 
 // NoFileExistsf checks whether a file does not exist in a given path. It fails
 // if the path points to an existing _file_ only.
-func NoFileExistsf(t TestingT, path string, msg string, args ...interface{}) {
+func NoFileExistsf(t TestingT, path string, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1421,7 +1421,7 @@ func NoFileExistsf(t TestingT, path string, msg string, args ...interface{}) {
 //	require.NotContains(t, "Hello World", "Earth")
 //	require.NotContains(t, ["Hello", "World"], "Earth")
 //	require.NotContains(t, {"Hello": "World"}, "Earth")
-func NotContains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
+func NotContains(t TestingT, s any, contains any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1437,7 +1437,7 @@ func NotContains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...
 //	require.NotContainsf(t, "Hello World", "Earth", "error message %s", "formatted")
 //	require.NotContainsf(t, ["Hello", "World"], "Earth", "error message %s", "formatted")
 //	require.NotContainsf(t, {"Hello": "World"}, "Earth", "error message %s", "formatted")
-func NotContainsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) {
+func NotContainsf(t TestingT, s any, contains any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1457,7 +1457,7 @@ func NotContainsf(t TestingT, s interface{}, contains interface{}, msg string, a
 // require.NotElementsMatch(t, [1, 1, 2, 3], [1, 2, 3]) -> true
 //
 // require.NotElementsMatch(t, [1, 2, 3], [1, 2, 4]) -> true
-func NotElementsMatch(t TestingT, listA interface{}, listB interface{}, msgAndArgs ...interface{}) {
+func NotElementsMatch(t TestingT, listA any, listB any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1477,7 +1477,7 @@ func NotElementsMatch(t TestingT, listA interface{}, listB interface{}, msgAndAr
 // require.NotElementsMatchf(t, [1, 1, 2, 3], [1, 2, 3], "error message %s", "formatted") -> true
 //
 // require.NotElementsMatchf(t, [1, 2, 3], [1, 2, 4], "error message %s", "formatted") -> true
-func NotElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string, args ...interface{}) {
+func NotElementsMatchf(t TestingT, listA any, listB any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1491,7 +1491,7 @@ func NotElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg str
 //
 //	require.NotEmpty(t, obj)
 //	require.Equal(t, "two", obj[1])
-func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+func NotEmpty(t TestingT, object any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1505,7 +1505,7 @@ func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 //
 //	require.NotEmptyf(t, obj, "error message %s", "formatted")
 //	require.Equal(t, "two", obj[1])
-func NotEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
+func NotEmptyf(t TestingT, object any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1521,7 +1521,7 @@ func NotEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) 
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
-func NotEqual(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+func NotEqual(t TestingT, expected any, actual any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1534,7 +1534,7 @@ func NotEqual(t TestingT, expected interface{}, actual interface{}, msgAndArgs .
 // NotEqualValues asserts that two objects are not equal even when converted to the same type
 //
 //	require.NotEqualValues(t, obj1, obj2)
-func NotEqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+func NotEqualValues(t TestingT, expected any, actual any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1547,7 +1547,7 @@ func NotEqualValues(t TestingT, expected interface{}, actual interface{}, msgAnd
 // NotEqualValuesf asserts that two objects are not equal even when converted to the same type
 //
 //	require.NotEqualValuesf(t, obj1, obj2, "error message %s", "formatted")
-func NotEqualValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+func NotEqualValuesf(t TestingT, expected any, actual any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1563,7 +1563,7 @@ func NotEqualValuesf(t TestingT, expected interface{}, actual interface{}, msg s
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
-func NotEqualf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+func NotEqualf(t TestingT, expected any, actual any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1575,7 +1575,7 @@ func NotEqualf(t TestingT, expected interface{}, actual interface{}, msg string,
 
 // NotErrorAs asserts that none of the errors in err's chain matches target,
 // but if so, sets target to that error value.
-func NotErrorAs(t TestingT, err error, target interface{}, msgAndArgs ...interface{}) {
+func NotErrorAs(t TestingT, err error, target any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1587,7 +1587,7 @@ func NotErrorAs(t TestingT, err error, target interface{}, msgAndArgs ...interfa
 
 // NotErrorAsf asserts that none of the errors in err's chain matches target,
 // but if so, sets target to that error value.
-func NotErrorAsf(t TestingT, err error, target interface{}, msg string, args ...interface{}) {
+func NotErrorAsf(t TestingT, err error, target any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1599,7 +1599,7 @@ func NotErrorAsf(t TestingT, err error, target interface{}, msg string, args ...
 
 // NotErrorIs asserts that none of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
-func NotErrorIs(t TestingT, err error, target error, msgAndArgs ...interface{}) {
+func NotErrorIs(t TestingT, err error, target error, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1611,7 +1611,7 @@ func NotErrorIs(t TestingT, err error, target error, msgAndArgs ...interface{}) 
 
 // NotErrorIsf asserts that none of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
-func NotErrorIsf(t TestingT, err error, target error, msg string, args ...interface{}) {
+func NotErrorIsf(t TestingT, err error, target error, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1624,7 +1624,7 @@ func NotErrorIsf(t TestingT, err error, target error, msg string, args ...interf
 // NotImplements asserts that an object does not implement the specified interface.
 //
 //	require.NotImplements(t, (*MyInterface)(nil), new(MyObject))
-func NotImplements(t TestingT, interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
+func NotImplements(t TestingT, interfaceObject any, object any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1637,7 +1637,7 @@ func NotImplements(t TestingT, interfaceObject interface{}, object interface{}, 
 // NotImplementsf asserts that an object does not implement the specified interface.
 //
 //	require.NotImplementsf(t, (*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
-func NotImplementsf(t TestingT, interfaceObject interface{}, object interface{}, msg string, args ...interface{}) {
+func NotImplementsf(t TestingT, interfaceObject any, object any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1650,7 +1650,7 @@ func NotImplementsf(t TestingT, interfaceObject interface{}, object interface{},
 // NotNil asserts that the specified object is not nil.
 //
 //	require.NotNil(t, err)
-func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+func NotNil(t TestingT, object any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1663,7 +1663,7 @@ func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
 // NotNilf asserts that the specified object is not nil.
 //
 //	require.NotNilf(t, err, "error message %s", "formatted")
-func NotNilf(t TestingT, object interface{}, msg string, args ...interface{}) {
+func NotNilf(t TestingT, object any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1676,7 +1676,7 @@ func NotNilf(t TestingT, object interface{}, msg string, args ...interface{}) {
 // NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
 //
 //	require.NotPanics(t, func(){ RemainCalm() })
-func NotPanics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+func NotPanics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1689,7 +1689,7 @@ func NotPanics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 // NotPanicsf asserts that the code inside the specified PanicTestFunc does NOT panic.
 //
 //	require.NotPanicsf(t, func(){ RemainCalm() }, "error message %s", "formatted")
-func NotPanicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}) {
+func NotPanicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1703,7 +1703,7 @@ func NotPanicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interfac
 //
 //	require.NotRegexp(t, regexp.MustCompile("starts"), "it's starting")
 //	require.NotRegexp(t, "^start", "it's not starting")
-func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+func NotRegexp(t TestingT, rx any, str any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1717,7 +1717,7 @@ func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interf
 //
 //	require.NotRegexpf(t, regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
 //	require.NotRegexpf(t, "^start", "it's not starting", "error message %s", "formatted")
-func NotRegexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) {
+func NotRegexpf(t TestingT, rx any, str any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1733,7 +1733,7 @@ func NotRegexpf(t TestingT, rx interface{}, str interface{}, msg string, args ..
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
-func NotSame(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+func NotSame(t TestingT, expected any, actual any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1749,7 +1749,7 @@ func NotSame(t TestingT, expected interface{}, actual interface{}, msgAndArgs ..
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
-func NotSamef(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+func NotSamef(t TestingT, expected any, actual any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1768,7 +1768,7 @@ func NotSamef(t TestingT, expected interface{}, actual interface{}, msg string, 
 //	require.NotSubset(t, {"x": 1, "y": 2}, {"z": 3})
 //	require.NotSubset(t, [1, 3, 4], {1: "one", 2: "two"})
 //	require.NotSubset(t, {"x": 1, "y": 2}, ["z"])
-func NotSubset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...interface{}) {
+func NotSubset(t TestingT, list any, subset any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1787,7 +1787,7 @@ func NotSubset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...i
 //	require.NotSubsetf(t, {"x": 1, "y": 2}, {"z": 3}, "error message %s", "formatted")
 //	require.NotSubsetf(t, [1, 3, 4], {1: "one", 2: "two"}, "error message %s", "formatted")
 //	require.NotSubsetf(t, {"x": 1, "y": 2}, ["z"], "error message %s", "formatted")
-func NotSubsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) {
+func NotSubsetf(t TestingT, list any, subset any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1798,7 +1798,7 @@ func NotSubsetf(t TestingT, list interface{}, subset interface{}, msg string, ar
 }
 
 // NotZero asserts that i is not the zero value for its type.
-func NotZero(t TestingT, i interface{}, msgAndArgs ...interface{}) {
+func NotZero(t TestingT, i any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1809,7 +1809,7 @@ func NotZero(t TestingT, i interface{}, msgAndArgs ...interface{}) {
 }
 
 // NotZerof asserts that i is not the zero value for its type.
-func NotZerof(t TestingT, i interface{}, msg string, args ...interface{}) {
+func NotZerof(t TestingT, i any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1822,7 +1822,7 @@ func NotZerof(t TestingT, i interface{}, msg string, args ...interface{}) {
 // Panics asserts that the code inside the specified PanicTestFunc panics.
 //
 //	require.Panics(t, func(){ GoCrazy() })
-func Panics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+func Panics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1837,7 +1837,7 @@ func Panics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 // EqualError comparison.
 //
 //	require.PanicsWithError(t, "crazy error", func(){ GoCrazy() })
-func PanicsWithError(t TestingT, errString string, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+func PanicsWithError(t TestingT, errString string, f assert.PanicTestFunc, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1852,7 +1852,7 @@ func PanicsWithError(t TestingT, errString string, f assert.PanicTestFunc, msgAn
 // EqualError comparison.
 //
 //	require.PanicsWithErrorf(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
-func PanicsWithErrorf(t TestingT, errString string, f assert.PanicTestFunc, msg string, args ...interface{}) {
+func PanicsWithErrorf(t TestingT, errString string, f assert.PanicTestFunc, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1866,7 +1866,7 @@ func PanicsWithErrorf(t TestingT, errString string, f assert.PanicTestFunc, msg 
 // the recovered panic value equals the expected panic value.
 //
 //	require.PanicsWithValue(t, "crazy error", func(){ GoCrazy() })
-func PanicsWithValue(t TestingT, expected interface{}, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+func PanicsWithValue(t TestingT, expected any, f assert.PanicTestFunc, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1880,7 +1880,7 @@ func PanicsWithValue(t TestingT, expected interface{}, f assert.PanicTestFunc, m
 // the recovered panic value equals the expected panic value.
 //
 //	require.PanicsWithValuef(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
-func PanicsWithValuef(t TestingT, expected interface{}, f assert.PanicTestFunc, msg string, args ...interface{}) {
+func PanicsWithValuef(t TestingT, expected any, f assert.PanicTestFunc, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1893,7 +1893,7 @@ func PanicsWithValuef(t TestingT, expected interface{}, f assert.PanicTestFunc, 
 // Panicsf asserts that the code inside the specified PanicTestFunc panics.
 //
 //	require.Panicsf(t, func(){ GoCrazy() }, "error message %s", "formatted")
-func Panicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}) {
+func Panicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1907,7 +1907,7 @@ func Panicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}
 //
 //	require.Positive(t, 1)
 //	require.Positive(t, 1.23)
-func Positive(t TestingT, e interface{}, msgAndArgs ...interface{}) {
+func Positive(t TestingT, e any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1921,7 +1921,7 @@ func Positive(t TestingT, e interface{}, msgAndArgs ...interface{}) {
 //
 //	require.Positivef(t, 1, "error message %s", "formatted")
 //	require.Positivef(t, 1.23, "error message %s", "formatted")
-func Positivef(t TestingT, e interface{}, msg string, args ...interface{}) {
+func Positivef(t TestingT, e any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1935,7 +1935,7 @@ func Positivef(t TestingT, e interface{}, msg string, args ...interface{}) {
 //
 //	require.Regexp(t, regexp.MustCompile("start"), "it's starting")
 //	require.Regexp(t, "start...$", "it's not starting")
-func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+func Regexp(t TestingT, rx any, str any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1949,7 +1949,7 @@ func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface
 //
 //	require.Regexpf(t, regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
 //	require.Regexpf(t, "start...$", "it's not starting", "error message %s", "formatted")
-func Regexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) {
+func Regexpf(t TestingT, rx any, str any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1965,7 +1965,7 @@ func Regexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...in
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
-func Same(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+func Same(t TestingT, expected any, actual any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1981,7 +1981,7 @@ func Same(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...in
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
-func Samef(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+func Samef(t TestingT, expected any, actual any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -2000,7 +2000,7 @@ func Samef(t TestingT, expected interface{}, actual interface{}, msg string, arg
 //	require.Subset(t, {"x": 1, "y": 2}, {"x": 1})
 //	require.Subset(t, [1, 2, 3], {1: "one", 2: "two"})
 //	require.Subset(t, {"x": 1, "y": 2}, ["x"])
-func Subset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...interface{}) {
+func Subset(t TestingT, list any, subset any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -2019,7 +2019,7 @@ func Subset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...inte
 //	require.Subsetf(t, {"x": 1, "y": 2}, {"x": 1}, "error message %s", "formatted")
 //	require.Subsetf(t, [1, 2, 3], {1: "one", 2: "two"}, "error message %s", "formatted")
 //	require.Subsetf(t, {"x": 1, "y": 2}, ["x"], "error message %s", "formatted")
-func Subsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) {
+func Subsetf(t TestingT, list any, subset any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -2032,7 +2032,7 @@ func Subsetf(t TestingT, list interface{}, subset interface{}, msg string, args 
 // True asserts that the specified value is true.
 //
 //	require.True(t, myBool)
-func True(t TestingT, value bool, msgAndArgs ...interface{}) {
+func True(t TestingT, value bool, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -2045,7 +2045,7 @@ func True(t TestingT, value bool, msgAndArgs ...interface{}) {
 // Truef asserts that the specified value is true.
 //
 //	require.Truef(t, myBool, "error message %s", "formatted")
-func Truef(t TestingT, value bool, msg string, args ...interface{}) {
+func Truef(t TestingT, value bool, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -2058,7 +2058,7 @@ func Truef(t TestingT, value bool, msg string, args ...interface{}) {
 // WithinDuration asserts that the two times are within duration delta of each other.
 //
 //	require.WithinDuration(t, time.Now(), time.Now(), 10*time.Second)
-func WithinDuration(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) {
+func WithinDuration(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -2071,7 +2071,7 @@ func WithinDuration(t TestingT, expected time.Time, actual time.Time, delta time
 // WithinDurationf asserts that the two times are within duration delta of each other.
 //
 //	require.WithinDurationf(t, time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
-func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msg string, args ...interface{}) {
+func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -2084,7 +2084,7 @@ func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta tim
 // WithinRange asserts that a time is within a time range (inclusive).
 //
 //	require.WithinRange(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second))
-func WithinRange(t TestingT, actual time.Time, start time.Time, end time.Time, msgAndArgs ...interface{}) {
+func WithinRange(t TestingT, actual time.Time, start time.Time, end time.Time, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -2097,7 +2097,7 @@ func WithinRange(t TestingT, actual time.Time, start time.Time, end time.Time, m
 // WithinRangef asserts that a time is within a time range (inclusive).
 //
 //	require.WithinRangef(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second), "error message %s", "formatted")
-func WithinRangef(t TestingT, actual time.Time, start time.Time, end time.Time, msg string, args ...interface{}) {
+func WithinRangef(t TestingT, actual time.Time, start time.Time, end time.Time, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -2120,7 +2120,7 @@ func WithinRangef(t TestingT, actual time.Time, start time.Time, end time.Time, 
 //	key: this is a subsequent document, it is not evaluated
 //	`
 //	require.YAMLEq(t, expected, actual)
-func YAMLEq(t TestingT, expected string, actual string, msgAndArgs ...interface{}) {
+func YAMLEq(t TestingT, expected string, actual string, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -2143,7 +2143,7 @@ func YAMLEq(t TestingT, expected string, actual string, msgAndArgs ...interface{
 //	key: this is a subsequent document, it is not evaluated
 //	`
 //	require.YAMLEqf(t, expected, actual, "error message %s", "formatted")
-func YAMLEqf(t TestingT, expected string, actual string, msg string, args ...interface{}) {
+func YAMLEqf(t TestingT, expected string, actual string, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -2154,7 +2154,7 @@ func YAMLEqf(t TestingT, expected string, actual string, msg string, args ...int
 }
 
 // Zero asserts that i is the zero value for its type.
-func Zero(t TestingT, i interface{}, msgAndArgs ...interface{}) {
+func Zero(t TestingT, i any, msgAndArgs ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
@@ -2165,7 +2165,7 @@ func Zero(t TestingT, i interface{}, msgAndArgs ...interface{}) {
 }
 
 // Zerof asserts that i is the zero value for its type.
-func Zerof(t TestingT, i interface{}, msg string, args ...interface{}) {
+func Zerof(t TestingT, i any, msg string, args ...any) {
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}

--- a/require/require_forward.go
+++ b/require/require_forward.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Condition uses a Comparison to assert a complex condition.
-func (a *Assertions) Condition(comp assert.Comparison, msgAndArgs ...interface{}) {
+func (a *Assertions) Condition(comp assert.Comparison, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -18,7 +18,7 @@ func (a *Assertions) Condition(comp assert.Comparison, msgAndArgs ...interface{}
 }
 
 // Conditionf uses a Comparison to assert a complex condition.
-func (a *Assertions) Conditionf(comp assert.Comparison, msg string, args ...interface{}) {
+func (a *Assertions) Conditionf(comp assert.Comparison, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -31,7 +31,7 @@ func (a *Assertions) Conditionf(comp assert.Comparison, msg string, args ...inte
 //	a.Contains("Hello World", "World")
 //	a.Contains(["Hello", "World"], "World")
 //	a.Contains({"Hello": "World"}, "Hello")
-func (a *Assertions) Contains(s interface{}, contains interface{}, msgAndArgs ...interface{}) {
+func (a *Assertions) Contains(s any, contains any, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -44,7 +44,7 @@ func (a *Assertions) Contains(s interface{}, contains interface{}, msgAndArgs ..
 //	a.Containsf("Hello World", "World", "error message %s", "formatted")
 //	a.Containsf(["Hello", "World"], "World", "error message %s", "formatted")
 //	a.Containsf({"Hello": "World"}, "Hello", "error message %s", "formatted")
-func (a *Assertions) Containsf(s interface{}, contains interface{}, msg string, args ...interface{}) {
+func (a *Assertions) Containsf(s any, contains any, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -53,7 +53,7 @@ func (a *Assertions) Containsf(s interface{}, contains interface{}, msg string, 
 
 // DirExists checks whether a directory exists in the given path. It also fails
 // if the path is a file rather a directory or there is an error checking whether it exists.
-func (a *Assertions) DirExists(path string, msgAndArgs ...interface{}) {
+func (a *Assertions) DirExists(path string, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -62,7 +62,7 @@ func (a *Assertions) DirExists(path string, msgAndArgs ...interface{}) {
 
 // DirExistsf checks whether a directory exists in the given path. It also fails
 // if the path is a file rather a directory or there is an error checking whether it exists.
-func (a *Assertions) DirExistsf(path string, msg string, args ...interface{}) {
+func (a *Assertions) DirExistsf(path string, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -74,7 +74,7 @@ func (a *Assertions) DirExistsf(path string, msg string, args ...interface{}) {
 // the number of appearances of each of them in both lists should match.
 //
 // a.ElementsMatch([1, 3, 2, 3], [1, 3, 3, 2])
-func (a *Assertions) ElementsMatch(listA interface{}, listB interface{}, msgAndArgs ...interface{}) {
+func (a *Assertions) ElementsMatch(listA any, listB any, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -86,7 +86,7 @@ func (a *Assertions) ElementsMatch(listA interface{}, listB interface{}, msgAndA
 // the number of appearances of each of them in both lists should match.
 //
 // a.ElementsMatchf([1, 3, 2, 3], [1, 3, 3, 2], "error message %s", "formatted")
-func (a *Assertions) ElementsMatchf(listA interface{}, listB interface{}, msg string, args ...interface{}) {
+func (a *Assertions) ElementsMatchf(listA any, listB any, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -106,7 +106,7 @@ func (a *Assertions) ElementsMatchf(listA interface{}, listB interface{}, msg st
 //	a.Empty(obj)
 //
 // [Zero values]: https://go.dev/ref/spec#The_zero_value
-func (a *Assertions) Empty(object interface{}, msgAndArgs ...interface{}) {
+func (a *Assertions) Empty(object any, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -126,7 +126,7 @@ func (a *Assertions) Empty(object interface{}, msgAndArgs ...interface{}) {
 //	a.Emptyf(obj, "error message %s", "formatted")
 //
 // [Zero values]: https://go.dev/ref/spec#The_zero_value
-func (a *Assertions) Emptyf(object interface{}, msg string, args ...interface{}) {
+func (a *Assertions) Emptyf(object any, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -140,7 +140,7 @@ func (a *Assertions) Emptyf(object interface{}, msg string, args ...interface{})
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses). Function equality
 // cannot be determined and will always fail.
-func (a *Assertions) Equal(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+func (a *Assertions) Equal(expected any, actual any, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -152,7 +152,7 @@ func (a *Assertions) Equal(expected interface{}, actual interface{}, msgAndArgs 
 //
 //	actualObj, err := SomeFunction()
 //	a.EqualError(err,  expectedErrorString)
-func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...interface{}) {
+func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -164,7 +164,7 @@ func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...
 //
 //	actualObj, err := SomeFunction()
 //	a.EqualErrorf(err,  expectedErrorString, "error message %s", "formatted")
-func (a *Assertions) EqualErrorf(theError error, errString string, msg string, args ...interface{}) {
+func (a *Assertions) EqualErrorf(theError error, errString string, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -181,7 +181,7 @@ func (a *Assertions) EqualErrorf(theError error, errString string, msg string, a
 //	 }
 //	 a.EqualExportedValues(S{1, 2}, S{1, 3}) => true
 //	 a.EqualExportedValues(S{1, 2}, S{2, 3}) => false
-func (a *Assertions) EqualExportedValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+func (a *Assertions) EqualExportedValues(expected any, actual any, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -198,7 +198,7 @@ func (a *Assertions) EqualExportedValues(expected interface{}, actual interface{
 //	 }
 //	 a.EqualExportedValuesf(S{1, 2}, S{1, 3}, "error message %s", "formatted") => true
 //	 a.EqualExportedValuesf(S{1, 2}, S{2, 3}, "error message %s", "formatted") => false
-func (a *Assertions) EqualExportedValuesf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+func (a *Assertions) EqualExportedValuesf(expected any, actual any, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -209,7 +209,7 @@ func (a *Assertions) EqualExportedValuesf(expected interface{}, actual interface
 // type and equal.
 //
 //	a.EqualValues(uint32(123), int32(123))
-func (a *Assertions) EqualValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+func (a *Assertions) EqualValues(expected any, actual any, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -220,7 +220,7 @@ func (a *Assertions) EqualValues(expected interface{}, actual interface{}, msgAn
 // type and equal.
 //
 //	a.EqualValuesf(uint32(123), int32(123), "error message %s", "formatted")
-func (a *Assertions) EqualValuesf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+func (a *Assertions) EqualValuesf(expected any, actual any, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -234,7 +234,7 @@ func (a *Assertions) EqualValuesf(expected interface{}, actual interface{}, msg 
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses). Function equality
 // cannot be determined and will always fail.
-func (a *Assertions) Equalf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+func (a *Assertions) Equalf(expected any, actual any, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -245,7 +245,7 @@ func (a *Assertions) Equalf(expected interface{}, actual interface{}, msg string
 //
 //	actualObj, err := SomeFunction()
 //	a.Error(err)
-func (a *Assertions) Error(err error, msgAndArgs ...interface{}) {
+func (a *Assertions) Error(err error, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -254,7 +254,7 @@ func (a *Assertions) Error(err error, msgAndArgs ...interface{}) {
 
 // ErrorAs asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
 // This is a wrapper for errors.As.
-func (a *Assertions) ErrorAs(err error, target interface{}, msgAndArgs ...interface{}) {
+func (a *Assertions) ErrorAs(err error, target any, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -263,7 +263,7 @@ func (a *Assertions) ErrorAs(err error, target interface{}, msgAndArgs ...interf
 
 // ErrorAsf asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
 // This is a wrapper for errors.As.
-func (a *Assertions) ErrorAsf(err error, target interface{}, msg string, args ...interface{}) {
+func (a *Assertions) ErrorAsf(err error, target any, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -275,7 +275,7 @@ func (a *Assertions) ErrorAsf(err error, target interface{}, msg string, args ..
 //
 //	actualObj, err := SomeFunction()
 //	a.ErrorContains(err,  expectedErrorSubString)
-func (a *Assertions) ErrorContains(theError error, contains string, msgAndArgs ...interface{}) {
+func (a *Assertions) ErrorContains(theError error, contains string, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -287,7 +287,7 @@ func (a *Assertions) ErrorContains(theError error, contains string, msgAndArgs .
 //
 //	actualObj, err := SomeFunction()
 //	a.ErrorContainsf(err,  expectedErrorSubString, "error message %s", "formatted")
-func (a *Assertions) ErrorContainsf(theError error, contains string, msg string, args ...interface{}) {
+func (a *Assertions) ErrorContainsf(theError error, contains string, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -296,7 +296,7 @@ func (a *Assertions) ErrorContainsf(theError error, contains string, msg string,
 
 // ErrorIs asserts that at least one of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
-func (a *Assertions) ErrorIs(err error, target error, msgAndArgs ...interface{}) {
+func (a *Assertions) ErrorIs(err error, target error, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -305,7 +305,7 @@ func (a *Assertions) ErrorIs(err error, target error, msgAndArgs ...interface{})
 
 // ErrorIsf asserts that at least one of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
-func (a *Assertions) ErrorIsf(err error, target error, msg string, args ...interface{}) {
+func (a *Assertions) ErrorIsf(err error, target error, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -316,7 +316,7 @@ func (a *Assertions) ErrorIsf(err error, target error, msg string, args ...inter
 //
 //	actualObj, err := SomeFunction()
 //	a.Errorf(err, "error message %s", "formatted")
-func (a *Assertions) Errorf(err error, msg string, args ...interface{}) {
+func (a *Assertions) Errorf(err error, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -327,7 +327,7 @@ func (a *Assertions) Errorf(err error, msg string, args ...interface{}) {
 // periodically checking target function each tick.
 //
 //	a.Eventually(func() bool { return true; }, time.Second, 10*time.Millisecond)
-func (a *Assertions) Eventually(condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
+func (a *Assertions) Eventually(condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -352,7 +352,7 @@ func (a *Assertions) Eventually(condition func() bool, waitFor time.Duration, ti
 //		// add assertions as needed; any assertion failure will fail the current tick
 //		assert.True(c, externalValue, "expected 'externalValue' to be true")
 //	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
-func (a *Assertions) EventuallyWithT(condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
+func (a *Assertions) EventuallyWithT(condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -377,7 +377,7 @@ func (a *Assertions) EventuallyWithT(condition func(collect *assert.CollectT), w
 //		// add assertions as needed; any assertion failure will fail the current tick
 //		assert.True(c, externalValue, "expected 'externalValue' to be true")
 //	}, 10*time.Second, 1*time.Second, "error message %s", "formatted")
-func (a *Assertions) EventuallyWithTf(condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
+func (a *Assertions) EventuallyWithTf(condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -388,7 +388,7 @@ func (a *Assertions) EventuallyWithTf(condition func(collect *assert.CollectT), 
 // periodically checking target function each tick.
 //
 //	a.Eventuallyf(func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
-func (a *Assertions) Eventuallyf(condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
+func (a *Assertions) Eventuallyf(condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -398,7 +398,7 @@ func (a *Assertions) Eventuallyf(condition func() bool, waitFor time.Duration, t
 // Exactly asserts that two objects are equal in value and type.
 //
 //	a.Exactly(int32(123), int64(123))
-func (a *Assertions) Exactly(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+func (a *Assertions) Exactly(expected any, actual any, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -408,7 +408,7 @@ func (a *Assertions) Exactly(expected interface{}, actual interface{}, msgAndArg
 // Exactlyf asserts that two objects are equal in value and type.
 //
 //	a.Exactlyf(int32(123), int64(123), "error message %s", "formatted")
-func (a *Assertions) Exactlyf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+func (a *Assertions) Exactlyf(expected any, actual any, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -416,7 +416,7 @@ func (a *Assertions) Exactlyf(expected interface{}, actual interface{}, msg stri
 }
 
 // Fail reports a failure through
-func (a *Assertions) Fail(failureMessage string, msgAndArgs ...interface{}) {
+func (a *Assertions) Fail(failureMessage string, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -424,7 +424,7 @@ func (a *Assertions) Fail(failureMessage string, msgAndArgs ...interface{}) {
 }
 
 // FailNow fails test
-func (a *Assertions) FailNow(failureMessage string, msgAndArgs ...interface{}) {
+func (a *Assertions) FailNow(failureMessage string, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -432,7 +432,7 @@ func (a *Assertions) FailNow(failureMessage string, msgAndArgs ...interface{}) {
 }
 
 // FailNowf fails test
-func (a *Assertions) FailNowf(failureMessage string, msg string, args ...interface{}) {
+func (a *Assertions) FailNowf(failureMessage string, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -440,7 +440,7 @@ func (a *Assertions) FailNowf(failureMessage string, msg string, args ...interfa
 }
 
 // Failf reports a failure through
-func (a *Assertions) Failf(failureMessage string, msg string, args ...interface{}) {
+func (a *Assertions) Failf(failureMessage string, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -450,7 +450,7 @@ func (a *Assertions) Failf(failureMessage string, msg string, args ...interface{
 // False asserts that the specified value is false.
 //
 //	a.False(myBool)
-func (a *Assertions) False(value bool, msgAndArgs ...interface{}) {
+func (a *Assertions) False(value bool, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -460,7 +460,7 @@ func (a *Assertions) False(value bool, msgAndArgs ...interface{}) {
 // Falsef asserts that the specified value is false.
 //
 //	a.Falsef(myBool, "error message %s", "formatted")
-func (a *Assertions) Falsef(value bool, msg string, args ...interface{}) {
+func (a *Assertions) Falsef(value bool, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -469,7 +469,7 @@ func (a *Assertions) Falsef(value bool, msg string, args ...interface{}) {
 
 // FileExists checks whether a file exists in the given path. It also fails if
 // the path points to a directory or there is an error when trying to check the file.
-func (a *Assertions) FileExists(path string, msgAndArgs ...interface{}) {
+func (a *Assertions) FileExists(path string, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -478,7 +478,7 @@ func (a *Assertions) FileExists(path string, msgAndArgs ...interface{}) {
 
 // FileExistsf checks whether a file exists in the given path. It also fails if
 // the path points to a directory or there is an error when trying to check the file.
-func (a *Assertions) FileExistsf(path string, msg string, args ...interface{}) {
+func (a *Assertions) FileExistsf(path string, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -490,7 +490,7 @@ func (a *Assertions) FileExistsf(path string, msg string, args ...interface{}) {
 //	a.Greater(2, 1)
 //	a.Greater(float64(2), float64(1))
 //	a.Greater("b", "a")
-func (a *Assertions) Greater(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+func (a *Assertions) Greater(e1 any, e2 any, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -503,7 +503,7 @@ func (a *Assertions) Greater(e1 interface{}, e2 interface{}, msgAndArgs ...inter
 //	a.GreaterOrEqual(2, 2)
 //	a.GreaterOrEqual("b", "a")
 //	a.GreaterOrEqual("b", "b")
-func (a *Assertions) GreaterOrEqual(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+func (a *Assertions) GreaterOrEqual(e1 any, e2 any, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -516,7 +516,7 @@ func (a *Assertions) GreaterOrEqual(e1 interface{}, e2 interface{}, msgAndArgs .
 //	a.GreaterOrEqualf(2, 2, "error message %s", "formatted")
 //	a.GreaterOrEqualf("b", "a", "error message %s", "formatted")
 //	a.GreaterOrEqualf("b", "b", "error message %s", "formatted")
-func (a *Assertions) GreaterOrEqualf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+func (a *Assertions) GreaterOrEqualf(e1 any, e2 any, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -528,7 +528,7 @@ func (a *Assertions) GreaterOrEqualf(e1 interface{}, e2 interface{}, msg string,
 //	a.Greaterf(2, 1, "error message %s", "formatted")
 //	a.Greaterf(float64(2), float64(1), "error message %s", "formatted")
 //	a.Greaterf("b", "a", "error message %s", "formatted")
-func (a *Assertions) Greaterf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+func (a *Assertions) Greaterf(e1 any, e2 any, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -539,7 +539,7 @@ func (a *Assertions) Greaterf(e1 interface{}, e2 interface{}, msg string, args .
 // body that contains a string.
 //
 //	a.HTTPBodyContains(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
-func (a *Assertions) HTTPBodyContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
+func (a *Assertions) HTTPBodyContains(handler http.HandlerFunc, method string, url string, values url.Values, str any, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -550,7 +550,7 @@ func (a *Assertions) HTTPBodyContains(handler http.HandlerFunc, method string, u
 // body that contains a string.
 //
 //	a.HTTPBodyContainsf(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
-func (a *Assertions) HTTPBodyContainsf(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
+func (a *Assertions) HTTPBodyContainsf(handler http.HandlerFunc, method string, url string, values url.Values, str any, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -561,7 +561,7 @@ func (a *Assertions) HTTPBodyContainsf(handler http.HandlerFunc, method string, 
 // body that does not contain a string.
 //
 //	a.HTTPBodyNotContains(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
-func (a *Assertions) HTTPBodyNotContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
+func (a *Assertions) HTTPBodyNotContains(handler http.HandlerFunc, method string, url string, values url.Values, str any, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -572,7 +572,7 @@ func (a *Assertions) HTTPBodyNotContains(handler http.HandlerFunc, method string
 // body that does not contain a string.
 //
 //	a.HTTPBodyNotContainsf(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
-func (a *Assertions) HTTPBodyNotContainsf(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
+func (a *Assertions) HTTPBodyNotContainsf(handler http.HandlerFunc, method string, url string, values url.Values, str any, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -582,7 +582,7 @@ func (a *Assertions) HTTPBodyNotContainsf(handler http.HandlerFunc, method strin
 // HTTPError asserts that a specified handler returns an error status code.
 //
 //	a.HTTPError(myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
-func (a *Assertions) HTTPError(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+func (a *Assertions) HTTPError(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -592,7 +592,7 @@ func (a *Assertions) HTTPError(handler http.HandlerFunc, method string, url stri
 // HTTPErrorf asserts that a specified handler returns an error status code.
 //
 //	a.HTTPErrorf(myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
-func (a *Assertions) HTTPErrorf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+func (a *Assertions) HTTPErrorf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -602,7 +602,7 @@ func (a *Assertions) HTTPErrorf(handler http.HandlerFunc, method string, url str
 // HTTPRedirect asserts that a specified handler returns a redirect status code.
 //
 //	a.HTTPRedirect(myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
-func (a *Assertions) HTTPRedirect(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+func (a *Assertions) HTTPRedirect(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -612,7 +612,7 @@ func (a *Assertions) HTTPRedirect(handler http.HandlerFunc, method string, url s
 // HTTPRedirectf asserts that a specified handler returns a redirect status code.
 //
 //	a.HTTPRedirectf(myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
-func (a *Assertions) HTTPRedirectf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+func (a *Assertions) HTTPRedirectf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -622,7 +622,7 @@ func (a *Assertions) HTTPRedirectf(handler http.HandlerFunc, method string, url 
 // HTTPStatusCode asserts that a specified handler returns a specified status code.
 //
 //	a.HTTPStatusCode(myHandler, "GET", "/notImplemented", nil, 501)
-func (a *Assertions) HTTPStatusCode(handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msgAndArgs ...interface{}) {
+func (a *Assertions) HTTPStatusCode(handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -632,7 +632,7 @@ func (a *Assertions) HTTPStatusCode(handler http.HandlerFunc, method string, url
 // HTTPStatusCodef asserts that a specified handler returns a specified status code.
 //
 //	a.HTTPStatusCodef(myHandler, "GET", "/notImplemented", nil, 501, "error message %s", "formatted")
-func (a *Assertions) HTTPStatusCodef(handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msg string, args ...interface{}) {
+func (a *Assertions) HTTPStatusCodef(handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -642,7 +642,7 @@ func (a *Assertions) HTTPStatusCodef(handler http.HandlerFunc, method string, ur
 // HTTPSuccess asserts that a specified handler returns a success status code.
 //
 //	a.HTTPSuccess(myHandler, "POST", "http://www.google.com", nil)
-func (a *Assertions) HTTPSuccess(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+func (a *Assertions) HTTPSuccess(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -652,7 +652,7 @@ func (a *Assertions) HTTPSuccess(handler http.HandlerFunc, method string, url st
 // HTTPSuccessf asserts that a specified handler returns a success status code.
 //
 //	a.HTTPSuccessf(myHandler, "POST", "http://www.google.com", nil, "error message %s", "formatted")
-func (a *Assertions) HTTPSuccessf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+func (a *Assertions) HTTPSuccessf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -662,7 +662,7 @@ func (a *Assertions) HTTPSuccessf(handler http.HandlerFunc, method string, url s
 // Implements asserts that an object is implemented by the specified interface.
 //
 //	a.Implements((*MyInterface)(nil), new(MyObject))
-func (a *Assertions) Implements(interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
+func (a *Assertions) Implements(interfaceObject any, object any, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -672,7 +672,7 @@ func (a *Assertions) Implements(interfaceObject interface{}, object interface{},
 // Implementsf asserts that an object is implemented by the specified interface.
 //
 //	a.Implementsf((*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
-func (a *Assertions) Implementsf(interfaceObject interface{}, object interface{}, msg string, args ...interface{}) {
+func (a *Assertions) Implementsf(interfaceObject any, object any, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -682,7 +682,7 @@ func (a *Assertions) Implementsf(interfaceObject interface{}, object interface{}
 // InDelta asserts that the two numerals are within delta of each other.
 //
 //	a.InDelta(math.Pi, 22/7.0, 0.01)
-func (a *Assertions) InDelta(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+func (a *Assertions) InDelta(expected any, actual any, delta float64, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -690,7 +690,7 @@ func (a *Assertions) InDelta(expected interface{}, actual interface{}, delta flo
 }
 
 // InDeltaMapValues is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
-func (a *Assertions) InDeltaMapValues(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+func (a *Assertions) InDeltaMapValues(expected any, actual any, delta float64, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -698,7 +698,7 @@ func (a *Assertions) InDeltaMapValues(expected interface{}, actual interface{}, 
 }
 
 // InDeltaMapValuesf is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
-func (a *Assertions) InDeltaMapValuesf(expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+func (a *Assertions) InDeltaMapValuesf(expected any, actual any, delta float64, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -706,7 +706,7 @@ func (a *Assertions) InDeltaMapValuesf(expected interface{}, actual interface{},
 }
 
 // InDeltaSlice is the same as InDelta, except it compares two slices.
-func (a *Assertions) InDeltaSlice(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+func (a *Assertions) InDeltaSlice(expected any, actual any, delta float64, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -714,7 +714,7 @@ func (a *Assertions) InDeltaSlice(expected interface{}, actual interface{}, delt
 }
 
 // InDeltaSlicef is the same as InDelta, except it compares two slices.
-func (a *Assertions) InDeltaSlicef(expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+func (a *Assertions) InDeltaSlicef(expected any, actual any, delta float64, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -724,7 +724,7 @@ func (a *Assertions) InDeltaSlicef(expected interface{}, actual interface{}, del
 // InDeltaf asserts that the two numerals are within delta of each other.
 //
 //	a.InDeltaf(math.Pi, 22/7.0, 0.01, "error message %s", "formatted")
-func (a *Assertions) InDeltaf(expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+func (a *Assertions) InDeltaf(expected any, actual any, delta float64, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -732,7 +732,7 @@ func (a *Assertions) InDeltaf(expected interface{}, actual interface{}, delta fl
 }
 
 // InEpsilon asserts that expected and actual have a relative error less than epsilon
-func (a *Assertions) InEpsilon(expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
+func (a *Assertions) InEpsilon(expected any, actual any, epsilon float64, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -740,7 +740,7 @@ func (a *Assertions) InEpsilon(expected interface{}, actual interface{}, epsilon
 }
 
 // InEpsilonSlice is the same as InEpsilon, except it compares each value from two slices.
-func (a *Assertions) InEpsilonSlice(expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
+func (a *Assertions) InEpsilonSlice(expected any, actual any, epsilon float64, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -748,7 +748,7 @@ func (a *Assertions) InEpsilonSlice(expected interface{}, actual interface{}, ep
 }
 
 // InEpsilonSlicef is the same as InEpsilon, except it compares each value from two slices.
-func (a *Assertions) InEpsilonSlicef(expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
+func (a *Assertions) InEpsilonSlicef(expected any, actual any, epsilon float64, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -756,7 +756,7 @@ func (a *Assertions) InEpsilonSlicef(expected interface{}, actual interface{}, e
 }
 
 // InEpsilonf asserts that expected and actual have a relative error less than epsilon
-func (a *Assertions) InEpsilonf(expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
+func (a *Assertions) InEpsilonf(expected any, actual any, epsilon float64, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -768,7 +768,7 @@ func (a *Assertions) InEpsilonf(expected interface{}, actual interface{}, epsilo
 //	a.IsDecreasing([]int{2, 1, 0})
 //	a.IsDecreasing([]float{2, 1})
 //	a.IsDecreasing([]string{"b", "a"})
-func (a *Assertions) IsDecreasing(object interface{}, msgAndArgs ...interface{}) {
+func (a *Assertions) IsDecreasing(object any, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -780,7 +780,7 @@ func (a *Assertions) IsDecreasing(object interface{}, msgAndArgs ...interface{})
 //	a.IsDecreasingf([]int{2, 1, 0}, "error message %s", "formatted")
 //	a.IsDecreasingf([]float{2, 1}, "error message %s", "formatted")
 //	a.IsDecreasingf([]string{"b", "a"}, "error message %s", "formatted")
-func (a *Assertions) IsDecreasingf(object interface{}, msg string, args ...interface{}) {
+func (a *Assertions) IsDecreasingf(object any, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -792,7 +792,7 @@ func (a *Assertions) IsDecreasingf(object interface{}, msg string, args ...inter
 //	a.IsIncreasing([]int{1, 2, 3})
 //	a.IsIncreasing([]float{1, 2})
 //	a.IsIncreasing([]string{"a", "b"})
-func (a *Assertions) IsIncreasing(object interface{}, msgAndArgs ...interface{}) {
+func (a *Assertions) IsIncreasing(object any, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -804,7 +804,7 @@ func (a *Assertions) IsIncreasing(object interface{}, msgAndArgs ...interface{})
 //	a.IsIncreasingf([]int{1, 2, 3}, "error message %s", "formatted")
 //	a.IsIncreasingf([]float{1, 2}, "error message %s", "formatted")
 //	a.IsIncreasingf([]string{"a", "b"}, "error message %s", "formatted")
-func (a *Assertions) IsIncreasingf(object interface{}, msg string, args ...interface{}) {
+func (a *Assertions) IsIncreasingf(object any, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -816,7 +816,7 @@ func (a *Assertions) IsIncreasingf(object interface{}, msg string, args ...inter
 //	a.IsNonDecreasing([]int{1, 1, 2})
 //	a.IsNonDecreasing([]float{1, 2})
 //	a.IsNonDecreasing([]string{"a", "b"})
-func (a *Assertions) IsNonDecreasing(object interface{}, msgAndArgs ...interface{}) {
+func (a *Assertions) IsNonDecreasing(object any, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -828,7 +828,7 @@ func (a *Assertions) IsNonDecreasing(object interface{}, msgAndArgs ...interface
 //	a.IsNonDecreasingf([]int{1, 1, 2}, "error message %s", "formatted")
 //	a.IsNonDecreasingf([]float{1, 2}, "error message %s", "formatted")
 //	a.IsNonDecreasingf([]string{"a", "b"}, "error message %s", "formatted")
-func (a *Assertions) IsNonDecreasingf(object interface{}, msg string, args ...interface{}) {
+func (a *Assertions) IsNonDecreasingf(object any, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -840,7 +840,7 @@ func (a *Assertions) IsNonDecreasingf(object interface{}, msg string, args ...in
 //	a.IsNonIncreasing([]int{2, 1, 1})
 //	a.IsNonIncreasing([]float{2, 1})
 //	a.IsNonIncreasing([]string{"b", "a"})
-func (a *Assertions) IsNonIncreasing(object interface{}, msgAndArgs ...interface{}) {
+func (a *Assertions) IsNonIncreasing(object any, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -852,7 +852,7 @@ func (a *Assertions) IsNonIncreasing(object interface{}, msgAndArgs ...interface
 //	a.IsNonIncreasingf([]int{2, 1, 1}, "error message %s", "formatted")
 //	a.IsNonIncreasingf([]float{2, 1}, "error message %s", "formatted")
 //	a.IsNonIncreasingf([]string{"b", "a"}, "error message %s", "formatted")
-func (a *Assertions) IsNonIncreasingf(object interface{}, msg string, args ...interface{}) {
+func (a *Assertions) IsNonIncreasingf(object any, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -862,7 +862,7 @@ func (a *Assertions) IsNonIncreasingf(object interface{}, msg string, args ...in
 // IsNotType asserts that the specified objects are not of the same type.
 //
 //	a.IsNotType(&NotMyStruct{}, &MyStruct{})
-func (a *Assertions) IsNotType(theType interface{}, object interface{}, msgAndArgs ...interface{}) {
+func (a *Assertions) IsNotType(theType any, object any, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -872,7 +872,7 @@ func (a *Assertions) IsNotType(theType interface{}, object interface{}, msgAndAr
 // IsNotTypef asserts that the specified objects are not of the same type.
 //
 //	a.IsNotTypef(&NotMyStruct{}, &MyStruct{}, "error message %s", "formatted")
-func (a *Assertions) IsNotTypef(theType interface{}, object interface{}, msg string, args ...interface{}) {
+func (a *Assertions) IsNotTypef(theType any, object any, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -882,7 +882,7 @@ func (a *Assertions) IsNotTypef(theType interface{}, object interface{}, msg str
 // IsType asserts that the specified objects are of the same type.
 //
 //	a.IsType(&MyStruct{}, &MyStruct{})
-func (a *Assertions) IsType(expectedType interface{}, object interface{}, msgAndArgs ...interface{}) {
+func (a *Assertions) IsType(expectedType any, object any, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -892,7 +892,7 @@ func (a *Assertions) IsType(expectedType interface{}, object interface{}, msgAnd
 // IsTypef asserts that the specified objects are of the same type.
 //
 //	a.IsTypef(&MyStruct{}, &MyStruct{}, "error message %s", "formatted")
-func (a *Assertions) IsTypef(expectedType interface{}, object interface{}, msg string, args ...interface{}) {
+func (a *Assertions) IsTypef(expectedType any, object any, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -902,7 +902,7 @@ func (a *Assertions) IsTypef(expectedType interface{}, object interface{}, msg s
 // JSONEq asserts that two JSON strings are equivalent.
 //
 //	a.JSONEq(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
-func (a *Assertions) JSONEq(expected string, actual string, msgAndArgs ...interface{}) {
+func (a *Assertions) JSONEq(expected string, actual string, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -912,7 +912,7 @@ func (a *Assertions) JSONEq(expected string, actual string, msgAndArgs ...interf
 // JSONEqf asserts that two JSON strings are equivalent.
 //
 //	a.JSONEqf(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
-func (a *Assertions) JSONEqf(expected string, actual string, msg string, args ...interface{}) {
+func (a *Assertions) JSONEqf(expected string, actual string, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -923,7 +923,7 @@ func (a *Assertions) JSONEqf(expected string, actual string, msg string, args ..
 // Len also fails if the object has a type that len() not accept.
 //
 //	a.Len(mySlice, 3)
-func (a *Assertions) Len(object interface{}, length int, msgAndArgs ...interface{}) {
+func (a *Assertions) Len(object any, length int, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -934,7 +934,7 @@ func (a *Assertions) Len(object interface{}, length int, msgAndArgs ...interface
 // Lenf also fails if the object has a type that len() not accept.
 //
 //	a.Lenf(mySlice, 3, "error message %s", "formatted")
-func (a *Assertions) Lenf(object interface{}, length int, msg string, args ...interface{}) {
+func (a *Assertions) Lenf(object any, length int, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -946,7 +946,7 @@ func (a *Assertions) Lenf(object interface{}, length int, msg string, args ...in
 //	a.Less(1, 2)
 //	a.Less(float64(1), float64(2))
 //	a.Less("a", "b")
-func (a *Assertions) Less(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+func (a *Assertions) Less(e1 any, e2 any, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -959,7 +959,7 @@ func (a *Assertions) Less(e1 interface{}, e2 interface{}, msgAndArgs ...interfac
 //	a.LessOrEqual(2, 2)
 //	a.LessOrEqual("a", "b")
 //	a.LessOrEqual("b", "b")
-func (a *Assertions) LessOrEqual(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+func (a *Assertions) LessOrEqual(e1 any, e2 any, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -972,7 +972,7 @@ func (a *Assertions) LessOrEqual(e1 interface{}, e2 interface{}, msgAndArgs ...i
 //	a.LessOrEqualf(2, 2, "error message %s", "formatted")
 //	a.LessOrEqualf("a", "b", "error message %s", "formatted")
 //	a.LessOrEqualf("b", "b", "error message %s", "formatted")
-func (a *Assertions) LessOrEqualf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+func (a *Assertions) LessOrEqualf(e1 any, e2 any, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -984,7 +984,7 @@ func (a *Assertions) LessOrEqualf(e1 interface{}, e2 interface{}, msg string, ar
 //	a.Lessf(1, 2, "error message %s", "formatted")
 //	a.Lessf(float64(1), float64(2), "error message %s", "formatted")
 //	a.Lessf("a", "b", "error message %s", "formatted")
-func (a *Assertions) Lessf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+func (a *Assertions) Lessf(e1 any, e2 any, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -995,7 +995,7 @@ func (a *Assertions) Lessf(e1 interface{}, e2 interface{}, msg string, args ...i
 //
 //	a.Negative(-1)
 //	a.Negative(-1.23)
-func (a *Assertions) Negative(e interface{}, msgAndArgs ...interface{}) {
+func (a *Assertions) Negative(e any, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1006,7 +1006,7 @@ func (a *Assertions) Negative(e interface{}, msgAndArgs ...interface{}) {
 //
 //	a.Negativef(-1, "error message %s", "formatted")
 //	a.Negativef(-1.23, "error message %s", "formatted")
-func (a *Assertions) Negativef(e interface{}, msg string, args ...interface{}) {
+func (a *Assertions) Negativef(e any, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1017,7 +1017,7 @@ func (a *Assertions) Negativef(e interface{}, msg string, args ...interface{}) {
 // periodically checking the target function each tick.
 //
 //	a.Never(func() bool { return false; }, time.Second, 10*time.Millisecond)
-func (a *Assertions) Never(condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
+func (a *Assertions) Never(condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1028,7 +1028,7 @@ func (a *Assertions) Never(condition func() bool, waitFor time.Duration, tick ti
 // periodically checking the target function each tick.
 //
 //	a.Neverf(func() bool { return false; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
-func (a *Assertions) Neverf(condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
+func (a *Assertions) Neverf(condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1038,7 +1038,7 @@ func (a *Assertions) Neverf(condition func() bool, waitFor time.Duration, tick t
 // Nil asserts that the specified object is nil.
 //
 //	a.Nil(err)
-func (a *Assertions) Nil(object interface{}, msgAndArgs ...interface{}) {
+func (a *Assertions) Nil(object any, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1048,7 +1048,7 @@ func (a *Assertions) Nil(object interface{}, msgAndArgs ...interface{}) {
 // Nilf asserts that the specified object is nil.
 //
 //	a.Nilf(err, "error message %s", "formatted")
-func (a *Assertions) Nilf(object interface{}, msg string, args ...interface{}) {
+func (a *Assertions) Nilf(object any, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1057,7 +1057,7 @@ func (a *Assertions) Nilf(object interface{}, msg string, args ...interface{}) {
 
 // NoDirExists checks whether a directory does not exist in the given path.
 // It fails if the path points to an existing _directory_ only.
-func (a *Assertions) NoDirExists(path string, msgAndArgs ...interface{}) {
+func (a *Assertions) NoDirExists(path string, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1066,7 +1066,7 @@ func (a *Assertions) NoDirExists(path string, msgAndArgs ...interface{}) {
 
 // NoDirExistsf checks whether a directory does not exist in the given path.
 // It fails if the path points to an existing _directory_ only.
-func (a *Assertions) NoDirExistsf(path string, msg string, args ...interface{}) {
+func (a *Assertions) NoDirExistsf(path string, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1078,7 +1078,7 @@ func (a *Assertions) NoDirExistsf(path string, msg string, args ...interface{}) 
 //	actualObj, err := SomeFunction()
 //	a.NoError(err)
 //	a.Equal(expectedObj, actualObj)
-func (a *Assertions) NoError(err error, msgAndArgs ...interface{}) {
+func (a *Assertions) NoError(err error, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1090,7 +1090,7 @@ func (a *Assertions) NoError(err error, msgAndArgs ...interface{}) {
 //	actualObj, err := SomeFunction()
 //	a.NoErrorf(err, "error message %s", "formatted")
 //	a.Equal(expectedObj, actualObj)
-func (a *Assertions) NoErrorf(err error, msg string, args ...interface{}) {
+func (a *Assertions) NoErrorf(err error, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1099,7 +1099,7 @@ func (a *Assertions) NoErrorf(err error, msg string, args ...interface{}) {
 
 // NoFileExists checks whether a file does not exist in a given path. It fails
 // if the path points to an existing _file_ only.
-func (a *Assertions) NoFileExists(path string, msgAndArgs ...interface{}) {
+func (a *Assertions) NoFileExists(path string, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1108,7 +1108,7 @@ func (a *Assertions) NoFileExists(path string, msgAndArgs ...interface{}) {
 
 // NoFileExistsf checks whether a file does not exist in a given path. It fails
 // if the path points to an existing _file_ only.
-func (a *Assertions) NoFileExistsf(path string, msg string, args ...interface{}) {
+func (a *Assertions) NoFileExistsf(path string, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1121,7 +1121,7 @@ func (a *Assertions) NoFileExistsf(path string, msg string, args ...interface{})
 //	a.NotContains("Hello World", "Earth")
 //	a.NotContains(["Hello", "World"], "Earth")
 //	a.NotContains({"Hello": "World"}, "Earth")
-func (a *Assertions) NotContains(s interface{}, contains interface{}, msgAndArgs ...interface{}) {
+func (a *Assertions) NotContains(s any, contains any, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1134,7 +1134,7 @@ func (a *Assertions) NotContains(s interface{}, contains interface{}, msgAndArgs
 //	a.NotContainsf("Hello World", "Earth", "error message %s", "formatted")
 //	a.NotContainsf(["Hello", "World"], "Earth", "error message %s", "formatted")
 //	a.NotContainsf({"Hello": "World"}, "Earth", "error message %s", "formatted")
-func (a *Assertions) NotContainsf(s interface{}, contains interface{}, msg string, args ...interface{}) {
+func (a *Assertions) NotContainsf(s any, contains any, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1151,7 +1151,7 @@ func (a *Assertions) NotContainsf(s interface{}, contains interface{}, msg strin
 // a.NotElementsMatch([1, 1, 2, 3], [1, 2, 3]) -> true
 //
 // a.NotElementsMatch([1, 2, 3], [1, 2, 4]) -> true
-func (a *Assertions) NotElementsMatch(listA interface{}, listB interface{}, msgAndArgs ...interface{}) {
+func (a *Assertions) NotElementsMatch(listA any, listB any, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1168,7 +1168,7 @@ func (a *Assertions) NotElementsMatch(listA interface{}, listB interface{}, msgA
 // a.NotElementsMatchf([1, 1, 2, 3], [1, 2, 3], "error message %s", "formatted") -> true
 //
 // a.NotElementsMatchf([1, 2, 3], [1, 2, 4], "error message %s", "formatted") -> true
-func (a *Assertions) NotElementsMatchf(listA interface{}, listB interface{}, msg string, args ...interface{}) {
+func (a *Assertions) NotElementsMatchf(listA any, listB any, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1179,7 +1179,7 @@ func (a *Assertions) NotElementsMatchf(listA interface{}, listB interface{}, msg
 //
 //	a.NotEmpty(obj)
 //	a.Equal("two", obj[1])
-func (a *Assertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) {
+func (a *Assertions) NotEmpty(object any, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1190,7 +1190,7 @@ func (a *Assertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) {
 //
 //	a.NotEmptyf(obj, "error message %s", "formatted")
 //	a.Equal("two", obj[1])
-func (a *Assertions) NotEmptyf(object interface{}, msg string, args ...interface{}) {
+func (a *Assertions) NotEmptyf(object any, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1203,7 +1203,7 @@ func (a *Assertions) NotEmptyf(object interface{}, msg string, args ...interface
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
-func (a *Assertions) NotEqual(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+func (a *Assertions) NotEqual(expected any, actual any, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1213,7 +1213,7 @@ func (a *Assertions) NotEqual(expected interface{}, actual interface{}, msgAndAr
 // NotEqualValues asserts that two objects are not equal even when converted to the same type
 //
 //	a.NotEqualValues(obj1, obj2)
-func (a *Assertions) NotEqualValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+func (a *Assertions) NotEqualValues(expected any, actual any, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1223,7 +1223,7 @@ func (a *Assertions) NotEqualValues(expected interface{}, actual interface{}, ms
 // NotEqualValuesf asserts that two objects are not equal even when converted to the same type
 //
 //	a.NotEqualValuesf(obj1, obj2, "error message %s", "formatted")
-func (a *Assertions) NotEqualValuesf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+func (a *Assertions) NotEqualValuesf(expected any, actual any, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1236,7 +1236,7 @@ func (a *Assertions) NotEqualValuesf(expected interface{}, actual interface{}, m
 //
 // Pointer variable equality is determined based on the equality of the
 // referenced values (as opposed to the memory addresses).
-func (a *Assertions) NotEqualf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+func (a *Assertions) NotEqualf(expected any, actual any, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1245,7 +1245,7 @@ func (a *Assertions) NotEqualf(expected interface{}, actual interface{}, msg str
 
 // NotErrorAs asserts that none of the errors in err's chain matches target,
 // but if so, sets target to that error value.
-func (a *Assertions) NotErrorAs(err error, target interface{}, msgAndArgs ...interface{}) {
+func (a *Assertions) NotErrorAs(err error, target any, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1254,7 +1254,7 @@ func (a *Assertions) NotErrorAs(err error, target interface{}, msgAndArgs ...int
 
 // NotErrorAsf asserts that none of the errors in err's chain matches target,
 // but if so, sets target to that error value.
-func (a *Assertions) NotErrorAsf(err error, target interface{}, msg string, args ...interface{}) {
+func (a *Assertions) NotErrorAsf(err error, target any, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1263,7 +1263,7 @@ func (a *Assertions) NotErrorAsf(err error, target interface{}, msg string, args
 
 // NotErrorIs asserts that none of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
-func (a *Assertions) NotErrorIs(err error, target error, msgAndArgs ...interface{}) {
+func (a *Assertions) NotErrorIs(err error, target error, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1272,7 +1272,7 @@ func (a *Assertions) NotErrorIs(err error, target error, msgAndArgs ...interface
 
 // NotErrorIsf asserts that none of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
-func (a *Assertions) NotErrorIsf(err error, target error, msg string, args ...interface{}) {
+func (a *Assertions) NotErrorIsf(err error, target error, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1282,7 +1282,7 @@ func (a *Assertions) NotErrorIsf(err error, target error, msg string, args ...in
 // NotImplements asserts that an object does not implement the specified interface.
 //
 //	a.NotImplements((*MyInterface)(nil), new(MyObject))
-func (a *Assertions) NotImplements(interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
+func (a *Assertions) NotImplements(interfaceObject any, object any, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1292,7 +1292,7 @@ func (a *Assertions) NotImplements(interfaceObject interface{}, object interface
 // NotImplementsf asserts that an object does not implement the specified interface.
 //
 //	a.NotImplementsf((*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
-func (a *Assertions) NotImplementsf(interfaceObject interface{}, object interface{}, msg string, args ...interface{}) {
+func (a *Assertions) NotImplementsf(interfaceObject any, object any, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1302,7 +1302,7 @@ func (a *Assertions) NotImplementsf(interfaceObject interface{}, object interfac
 // NotNil asserts that the specified object is not nil.
 //
 //	a.NotNil(err)
-func (a *Assertions) NotNil(object interface{}, msgAndArgs ...interface{}) {
+func (a *Assertions) NotNil(object any, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1312,7 +1312,7 @@ func (a *Assertions) NotNil(object interface{}, msgAndArgs ...interface{}) {
 // NotNilf asserts that the specified object is not nil.
 //
 //	a.NotNilf(err, "error message %s", "formatted")
-func (a *Assertions) NotNilf(object interface{}, msg string, args ...interface{}) {
+func (a *Assertions) NotNilf(object any, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1322,7 +1322,7 @@ func (a *Assertions) NotNilf(object interface{}, msg string, args ...interface{}
 // NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
 //
 //	a.NotPanics(func(){ RemainCalm() })
-func (a *Assertions) NotPanics(f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+func (a *Assertions) NotPanics(f assert.PanicTestFunc, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1332,7 +1332,7 @@ func (a *Assertions) NotPanics(f assert.PanicTestFunc, msgAndArgs ...interface{}
 // NotPanicsf asserts that the code inside the specified PanicTestFunc does NOT panic.
 //
 //	a.NotPanicsf(func(){ RemainCalm() }, "error message %s", "formatted")
-func (a *Assertions) NotPanicsf(f assert.PanicTestFunc, msg string, args ...interface{}) {
+func (a *Assertions) NotPanicsf(f assert.PanicTestFunc, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1343,7 +1343,7 @@ func (a *Assertions) NotPanicsf(f assert.PanicTestFunc, msg string, args ...inte
 //
 //	a.NotRegexp(regexp.MustCompile("starts"), "it's starting")
 //	a.NotRegexp("^start", "it's not starting")
-func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+func (a *Assertions) NotRegexp(rx any, str any, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1354,7 +1354,7 @@ func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...in
 //
 //	a.NotRegexpf(regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
 //	a.NotRegexpf("^start", "it's not starting", "error message %s", "formatted")
-func (a *Assertions) NotRegexpf(rx interface{}, str interface{}, msg string, args ...interface{}) {
+func (a *Assertions) NotRegexpf(rx any, str any, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1367,7 +1367,7 @@ func (a *Assertions) NotRegexpf(rx interface{}, str interface{}, msg string, arg
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
-func (a *Assertions) NotSame(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+func (a *Assertions) NotSame(expected any, actual any, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1380,7 +1380,7 @@ func (a *Assertions) NotSame(expected interface{}, actual interface{}, msgAndArg
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
-func (a *Assertions) NotSamef(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+func (a *Assertions) NotSamef(expected any, actual any, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1396,7 +1396,7 @@ func (a *Assertions) NotSamef(expected interface{}, actual interface{}, msg stri
 //	a.NotSubset({"x": 1, "y": 2}, {"z": 3})
 //	a.NotSubset([1, 3, 4], {1: "one", 2: "two"})
 //	a.NotSubset({"x": 1, "y": 2}, ["z"])
-func (a *Assertions) NotSubset(list interface{}, subset interface{}, msgAndArgs ...interface{}) {
+func (a *Assertions) NotSubset(list any, subset any, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1412,7 +1412,7 @@ func (a *Assertions) NotSubset(list interface{}, subset interface{}, msgAndArgs 
 //	a.NotSubsetf({"x": 1, "y": 2}, {"z": 3}, "error message %s", "formatted")
 //	a.NotSubsetf([1, 3, 4], {1: "one", 2: "two"}, "error message %s", "formatted")
 //	a.NotSubsetf({"x": 1, "y": 2}, ["z"], "error message %s", "formatted")
-func (a *Assertions) NotSubsetf(list interface{}, subset interface{}, msg string, args ...interface{}) {
+func (a *Assertions) NotSubsetf(list any, subset any, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1420,7 +1420,7 @@ func (a *Assertions) NotSubsetf(list interface{}, subset interface{}, msg string
 }
 
 // NotZero asserts that i is not the zero value for its type.
-func (a *Assertions) NotZero(i interface{}, msgAndArgs ...interface{}) {
+func (a *Assertions) NotZero(i any, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1428,7 +1428,7 @@ func (a *Assertions) NotZero(i interface{}, msgAndArgs ...interface{}) {
 }
 
 // NotZerof asserts that i is not the zero value for its type.
-func (a *Assertions) NotZerof(i interface{}, msg string, args ...interface{}) {
+func (a *Assertions) NotZerof(i any, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1438,7 +1438,7 @@ func (a *Assertions) NotZerof(i interface{}, msg string, args ...interface{}) {
 // Panics asserts that the code inside the specified PanicTestFunc panics.
 //
 //	a.Panics(func(){ GoCrazy() })
-func (a *Assertions) Panics(f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+func (a *Assertions) Panics(f assert.PanicTestFunc, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1450,7 +1450,7 @@ func (a *Assertions) Panics(f assert.PanicTestFunc, msgAndArgs ...interface{}) {
 // EqualError comparison.
 //
 //	a.PanicsWithError("crazy error", func(){ GoCrazy() })
-func (a *Assertions) PanicsWithError(errString string, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+func (a *Assertions) PanicsWithError(errString string, f assert.PanicTestFunc, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1462,7 +1462,7 @@ func (a *Assertions) PanicsWithError(errString string, f assert.PanicTestFunc, m
 // EqualError comparison.
 //
 //	a.PanicsWithErrorf("crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
-func (a *Assertions) PanicsWithErrorf(errString string, f assert.PanicTestFunc, msg string, args ...interface{}) {
+func (a *Assertions) PanicsWithErrorf(errString string, f assert.PanicTestFunc, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1473,7 +1473,7 @@ func (a *Assertions) PanicsWithErrorf(errString string, f assert.PanicTestFunc, 
 // the recovered panic value equals the expected panic value.
 //
 //	a.PanicsWithValue("crazy error", func(){ GoCrazy() })
-func (a *Assertions) PanicsWithValue(expected interface{}, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+func (a *Assertions) PanicsWithValue(expected any, f assert.PanicTestFunc, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1484,7 +1484,7 @@ func (a *Assertions) PanicsWithValue(expected interface{}, f assert.PanicTestFun
 // the recovered panic value equals the expected panic value.
 //
 //	a.PanicsWithValuef("crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
-func (a *Assertions) PanicsWithValuef(expected interface{}, f assert.PanicTestFunc, msg string, args ...interface{}) {
+func (a *Assertions) PanicsWithValuef(expected any, f assert.PanicTestFunc, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1494,7 +1494,7 @@ func (a *Assertions) PanicsWithValuef(expected interface{}, f assert.PanicTestFu
 // Panicsf asserts that the code inside the specified PanicTestFunc panics.
 //
 //	a.Panicsf(func(){ GoCrazy() }, "error message %s", "formatted")
-func (a *Assertions) Panicsf(f assert.PanicTestFunc, msg string, args ...interface{}) {
+func (a *Assertions) Panicsf(f assert.PanicTestFunc, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1505,7 +1505,7 @@ func (a *Assertions) Panicsf(f assert.PanicTestFunc, msg string, args ...interfa
 //
 //	a.Positive(1)
 //	a.Positive(1.23)
-func (a *Assertions) Positive(e interface{}, msgAndArgs ...interface{}) {
+func (a *Assertions) Positive(e any, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1516,7 +1516,7 @@ func (a *Assertions) Positive(e interface{}, msgAndArgs ...interface{}) {
 //
 //	a.Positivef(1, "error message %s", "formatted")
 //	a.Positivef(1.23, "error message %s", "formatted")
-func (a *Assertions) Positivef(e interface{}, msg string, args ...interface{}) {
+func (a *Assertions) Positivef(e any, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1527,7 +1527,7 @@ func (a *Assertions) Positivef(e interface{}, msg string, args ...interface{}) {
 //
 //	a.Regexp(regexp.MustCompile("start"), "it's starting")
 //	a.Regexp("start...$", "it's not starting")
-func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+func (a *Assertions) Regexp(rx any, str any, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1538,7 +1538,7 @@ func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...inter
 //
 //	a.Regexpf(regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
 //	a.Regexpf("start...$", "it's not starting", "error message %s", "formatted")
-func (a *Assertions) Regexpf(rx interface{}, str interface{}, msg string, args ...interface{}) {
+func (a *Assertions) Regexpf(rx any, str any, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1551,7 +1551,7 @@ func (a *Assertions) Regexpf(rx interface{}, str interface{}, msg string, args .
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
-func (a *Assertions) Same(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+func (a *Assertions) Same(expected any, actual any, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1564,7 +1564,7 @@ func (a *Assertions) Same(expected interface{}, actual interface{}, msgAndArgs .
 //
 // Both arguments must be pointer variables. Pointer variable sameness is
 // determined based on the equality of both type and value.
-func (a *Assertions) Samef(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+func (a *Assertions) Samef(expected any, actual any, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1580,7 +1580,7 @@ func (a *Assertions) Samef(expected interface{}, actual interface{}, msg string,
 //	a.Subset({"x": 1, "y": 2}, {"x": 1})
 //	a.Subset([1, 2, 3], {1: "one", 2: "two"})
 //	a.Subset({"x": 1, "y": 2}, ["x"])
-func (a *Assertions) Subset(list interface{}, subset interface{}, msgAndArgs ...interface{}) {
+func (a *Assertions) Subset(list any, subset any, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1596,7 +1596,7 @@ func (a *Assertions) Subset(list interface{}, subset interface{}, msgAndArgs ...
 //	a.Subsetf({"x": 1, "y": 2}, {"x": 1}, "error message %s", "formatted")
 //	a.Subsetf([1, 2, 3], {1: "one", 2: "two"}, "error message %s", "formatted")
 //	a.Subsetf({"x": 1, "y": 2}, ["x"], "error message %s", "formatted")
-func (a *Assertions) Subsetf(list interface{}, subset interface{}, msg string, args ...interface{}) {
+func (a *Assertions) Subsetf(list any, subset any, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1606,7 +1606,7 @@ func (a *Assertions) Subsetf(list interface{}, subset interface{}, msg string, a
 // True asserts that the specified value is true.
 //
 //	a.True(myBool)
-func (a *Assertions) True(value bool, msgAndArgs ...interface{}) {
+func (a *Assertions) True(value bool, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1616,7 +1616,7 @@ func (a *Assertions) True(value bool, msgAndArgs ...interface{}) {
 // Truef asserts that the specified value is true.
 //
 //	a.Truef(myBool, "error message %s", "formatted")
-func (a *Assertions) Truef(value bool, msg string, args ...interface{}) {
+func (a *Assertions) Truef(value bool, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1626,7 +1626,7 @@ func (a *Assertions) Truef(value bool, msg string, args ...interface{}) {
 // WithinDuration asserts that the two times are within duration delta of each other.
 //
 //	a.WithinDuration(time.Now(), time.Now(), 10*time.Second)
-func (a *Assertions) WithinDuration(expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) {
+func (a *Assertions) WithinDuration(expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1636,7 +1636,7 @@ func (a *Assertions) WithinDuration(expected time.Time, actual time.Time, delta 
 // WithinDurationf asserts that the two times are within duration delta of each other.
 //
 //	a.WithinDurationf(time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
-func (a *Assertions) WithinDurationf(expected time.Time, actual time.Time, delta time.Duration, msg string, args ...interface{}) {
+func (a *Assertions) WithinDurationf(expected time.Time, actual time.Time, delta time.Duration, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1646,7 +1646,7 @@ func (a *Assertions) WithinDurationf(expected time.Time, actual time.Time, delta
 // WithinRange asserts that a time is within a time range (inclusive).
 //
 //	a.WithinRange(time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second))
-func (a *Assertions) WithinRange(actual time.Time, start time.Time, end time.Time, msgAndArgs ...interface{}) {
+func (a *Assertions) WithinRange(actual time.Time, start time.Time, end time.Time, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1656,7 +1656,7 @@ func (a *Assertions) WithinRange(actual time.Time, start time.Time, end time.Tim
 // WithinRangef asserts that a time is within a time range (inclusive).
 //
 //	a.WithinRangef(time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second), "error message %s", "formatted")
-func (a *Assertions) WithinRangef(actual time.Time, start time.Time, end time.Time, msg string, args ...interface{}) {
+func (a *Assertions) WithinRangef(actual time.Time, start time.Time, end time.Time, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1676,7 +1676,7 @@ func (a *Assertions) WithinRangef(actual time.Time, start time.Time, end time.Ti
 //	key: this is a subsequent document, it is not evaluated
 //	`
 //	a.YAMLEq(expected, actual)
-func (a *Assertions) YAMLEq(expected string, actual string, msgAndArgs ...interface{}) {
+func (a *Assertions) YAMLEq(expected string, actual string, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1696,7 +1696,7 @@ func (a *Assertions) YAMLEq(expected string, actual string, msgAndArgs ...interf
 //	key: this is a subsequent document, it is not evaluated
 //	`
 //	a.YAMLEqf(expected, actual, "error message %s", "formatted")
-func (a *Assertions) YAMLEqf(expected string, actual string, msg string, args ...interface{}) {
+func (a *Assertions) YAMLEqf(expected string, actual string, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1704,7 +1704,7 @@ func (a *Assertions) YAMLEqf(expected string, actual string, msg string, args ..
 }
 
 // Zero asserts that i is the zero value for its type.
-func (a *Assertions) Zero(i interface{}, msgAndArgs ...interface{}) {
+func (a *Assertions) Zero(i any, msgAndArgs ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}
@@ -1712,7 +1712,7 @@ func (a *Assertions) Zero(i interface{}, msgAndArgs ...interface{}) {
 }
 
 // Zerof asserts that i is the zero value for its type.
-func (a *Assertions) Zerof(i interface{}, msg string, args ...interface{}) {
+func (a *Assertions) Zerof(i any, msg string, args ...any) {
 	if h, ok := a.t.(tHelper); ok {
 		h.Helper()
 	}

--- a/require/requirements.go
+++ b/require/requirements.go
@@ -2,7 +2,7 @@ package require
 
 // TestingT is an interface wrapper around *testing.T
 type TestingT interface {
-	Errorf(format string, args ...interface{})
+	Errorf(format string, args ...any)
 	FailNow()
 }
 
@@ -12,18 +12,18 @@ type tHelper = interface {
 
 // ComparisonAssertionFunc is a common function prototype when comparing two values.  Can be useful
 // for table driven tests.
-type ComparisonAssertionFunc func(TestingT, interface{}, interface{}, ...interface{})
+type ComparisonAssertionFunc func(TestingT, any, any, ...any)
 
 // ValueAssertionFunc is a common function prototype when validating a single value.  Can be useful
 // for table driven tests.
-type ValueAssertionFunc func(TestingT, interface{}, ...interface{})
+type ValueAssertionFunc func(TestingT, any, ...any)
 
 // BoolAssertionFunc is a common function prototype when validating a bool value.  Can be useful
 // for table driven tests.
-type BoolAssertionFunc func(TestingT, bool, ...interface{})
+type BoolAssertionFunc func(TestingT, bool, ...any)
 
 // ErrorAssertionFunc is a common function prototype when validating an error value.  Can be useful
 // for table driven tests.
-type ErrorAssertionFunc func(TestingT, error, ...interface{})
+type ErrorAssertionFunc func(TestingT, error, ...any)
 
 //go:generate sh -c "cd ../_codegen && go build && cd - && ../_codegen/_codegen -output-package=require -template=require.go.tmpl -include-format-funcs"

--- a/require/requirements_test.go
+++ b/require/requirements_test.go
@@ -36,7 +36,7 @@ func (t *MockT) FailNow() {
 	t.Failed = true
 }
 
-func (t *MockT) Errorf(format string, args ...interface{}) {
+func (t *MockT) Errorf(format string, args ...any) {
 	_, _ = format, args
 }
 
@@ -592,8 +592,8 @@ func TestComparisonAssertionFunc(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		expect    interface{}
-		got       interface{}
+		expect    any
+		got       any
 		assertion ComparisonAssertionFunc
 	}{
 		{"implements", (*iface)(nil), t, Implements},
@@ -621,8 +621,8 @@ func TestComparisonAssertionFunc(t *testing.T) {
 func ExampleValueAssertionFunc() {
 	t := &testing.T{} // provided by test
 
-	dumbParse := func(input string) interface{} {
-		var x interface{}
+	dumbParse := func(input string) any {
+		var x any
 		json.Unmarshal([]byte(input), &x)
 		return x
 	}
@@ -651,7 +651,7 @@ func TestValueAssertionFunc(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		value     interface{}
+		value     any
 		assertion ValueAssertionFunc
 	}{
 		{"notNil", true, NotNil},
@@ -716,7 +716,7 @@ func TestBoolAssertionFunc(t *testing.T) {
 func ExampleErrorAssertionFunc() {
 	t := &testing.T{} // provided by test
 
-	dumbParseNum := func(input string, v interface{}) error {
+	dumbParseNum := func(input string, v any) error {
 		return json.Unmarshal([]byte(input), v)
 	}
 

--- a/suite/suite.go
+++ b/suite/suite.go
@@ -87,7 +87,7 @@ func recoverAndFailOnPanic(t *testing.T) {
 	failOnPanic(t, r)
 }
 
-func failOnPanic(t *testing.T, r interface{}) {
+func failOnPanic(t *testing.T, r any) {
 	t.Helper()
 	if r != nil {
 		t.Errorf("test panicked: %v\n%s", r, debug.Stack())

--- a/suite/suite_test.go
+++ b/suite/suite_test.go
@@ -628,7 +628,7 @@ type tHelper interface {
 // matches one or more times in callOrder. This makes it compatible
 // with go test flag -count=X where X > 1.
 func callOrderAssert(t *testing.T, expect, callOrder []string) {
-	var ti interface{} = t
+	var ti any = t
 	if h, ok := ti.(tHelper); ok {
 		h.Helper()
 	}
@@ -777,7 +777,7 @@ func (s *SuiteSignatureValidationTester) TestValidSignature() {
 }
 
 // Invalid: has return value.
-func (s *SuiteSignatureValidationTester) TestInvalidSignatureReturnValue() interface{} {
+func (s *SuiteSignatureValidationTester) TestInvalidSignatureReturnValue() any {
 	s.executedTestCount++
 	return nil
 }
@@ -788,7 +788,7 @@ func (s *SuiteSignatureValidationTester) TestInvalidSignatureArg(somearg string)
 }
 
 // Invalid: both input arg and return value.
-func (s *SuiteSignatureValidationTester) TestInvalidSignatureBoth(somearg string) interface{} {
+func (s *SuiteSignatureValidationTester) TestInvalidSignatureBoth(somearg string) any {
 	s.executedTestCount++
 	return nil
 }


### PR DESCRIPTION
## Summary
Run the Go modernize tool against the codebase.

## Changes
* Update minimum Go to 1.18.
* Modernize with [`modernize`][0] tool.

## Motivation

Updates syntax to current Go style and use.

## Related issues
<!-- Put `Closes #XXXX` for each issue number this PR fixes/closes -->

[0]: https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/modernize
