### PR TITLE
assert/yaml: add use of build tag testify_no_deps

### DIFF
--- a/assert/yaml/yaml_custom.go
+++ b/assert/yaml/yaml_custom.go
@@ -1,4 +1,4 @@
-//go:build testify_yaml_custom && !testify_yaml_fail && !testify_yaml_default
+//go:build testify_yaml_custom && !testify_yaml_fail && !testify_yaml_default && !testify_no_deps
 
 // Package yaml is an implementation of YAML functions that calls a pluggable implementation.
 //

--- a/assert/yaml/yaml_default.go
+++ b/assert/yaml/yaml_default.go
@@ -1,4 +1,4 @@
-//go:build !testify_yaml_fail && !testify_yaml_custom
+//go:build !testify_yaml_fail && !testify_yaml_custom && !testify_no_deps
 
 // Package yaml is just an indirection to handle YAML deserialization.
 //
@@ -10,7 +10,7 @@
 //
 // Alternative implementations are selected using build tags:
 //
-//   - testify_yaml_fail: [Unmarshal] always fails with an error
+//   - testify_yaml_fail or testify_no_deps: [Unmarshal] always fails with an error
 //   - testify_yaml_custom: [Unmarshal] is a variable. Caller must initialize it
 //     before calling any of [github.com/stretchr/testify/assert.YAMLEq] or
 //     [github.com/stretchr/testify/assert.YAMLEqf].

--- a/assert/yaml/yaml_fail.go
+++ b/assert/yaml/yaml_fail.go
@@ -1,4 +1,4 @@
-//go:build testify_yaml_fail && !testify_yaml_custom && !testify_yaml_default
+//go:build (testify_no_deps || testify_yaml_fail) && !testify_yaml_custom && !testify_yaml_default
 
 // Package yaml is an implementation of YAML functions that always fail.
 //
@@ -6,6 +6,10 @@
 // to avoid linking with [gopkg.in/yaml.v3]:
 //
 //	go test -tags testify_yaml_fail
+//
+// or:
+//
+//	go test -tags testify_no_deps
 package yaml
 
 import "errors"


### PR DESCRIPTION
## Summary
Add use of build tag `testify_no_deps` in package `assert/yaml` like in `mock` where that tag is also used (see #1757).

## Changes
In package assert/yaml, use `testify_no_deps` that does the same as `testify_yaml_fail`.

## Motivation
A single build tag to exclude all uses of external dependencies, common with a similar exclusion for `github.com/stretchr/objx` in #1757.

## Related issues
* #1757