### PR TITLE
assert: don't crash diff() when spew panics on awkward inputs

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1929,7 +1929,7 @@ func typeAndKind(v interface{}) (reflect.Type, reflect.Kind) {
 
 // diff returns a diff of both values as long as both are of the same type and
 // are a struct, map, slice, array or string. Otherwise it returns an empty string.
-func diff(expected interface{}, actual interface{}) string {
+func diff(expected interface{}, actual interface{}) (result string) {
 	if expected == nil || actual == nil {
 		return ""
 	}
@@ -1944,6 +1944,16 @@ func diff(expected interface{}, actual interface{}) string {
 	if ek != reflect.Struct && ek != reflect.Map && ek != reflect.Slice && ek != reflect.Array && ek != reflect.String {
 		return ""
 	}
+
+	// spew can panic on inputs that hit reflect's unexported-field guard
+	// (e.g. a struct with an unexported map whose keys are arrays). The
+	// diff is informational, so swallow the panic and just skip it
+	// instead of taking down the test run.
+	defer func() {
+		if r := recover(); r != nil {
+			result = ""
+		}
+	}()
 
 	var e, a string
 

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -3038,6 +3038,21 @@ Diff:
 	Equal(t, expected, actual)
 }
 
+// TestDiffSpewPanic exercises an input that makes go-spew panic inside
+// reflect.Value.Interface (an unexported map field with array keys). The
+// diff is just decoration on the failure message, so the assertion
+// shouldn't crash the test run when the dump fails.
+func TestDiffSpewPanic(t *testing.T) {
+	t.Parallel()
+
+	type s struct {
+		m map[[1]byte]*struct{}
+	}
+	a := s{m: map[[1]byte]*struct{}{{1}: nil, {2}: nil}}
+	b := s{}
+	Equal(t, "", diff(a, b))
+}
+
 func TestTimeEqualityErrorFormatting(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
From #1813. A struct with an unexported map field whose keys are arrays panics inside `internal/spew/common.go:sortValues`, which calls `.Interface()` on array elements to dedupe map keys. Unexported `reflect.Value`s don't allow `Interface()`, so the assertion takes the test run down instead of reporting the mismatch.

Repro from the issue:

```go
type test struct {
    m map[[1]byte]*struct{}
}
a := test{map[[1]byte]*struct{}{{1}: nil, {2}: nil}}
b := test{}
assert.Equal(t, a, b)
```

The diff string is decoration on the failure message, the assertion itself is what matters. Recovering inside `diff()` and returning empty preserves the failure report and just drops the diff for inputs spew can't safely walk. That keeps the fix contained to assert without touching the spew fork.

Added a regression test that exercises exactly the repro.

Fixes #1813