### PR TITLE
assert.InDeltaSlice: fix lack of length mismatch handling

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1488,23 +1488,25 @@ func InDeltaSlice(t TestingT, expected, actual interface{}, delta float64, msgAn
 	if h, ok := t.(tHelper); ok {
 		h.Helper()
 	}
-	if expected == nil || actual == nil ||
-		reflect.TypeOf(actual).Kind() != reflect.Slice ||
-		reflect.TypeOf(expected).Kind() != reflect.Slice {
+	if expected == nil || actual == nil {
 		return Fail(t, "Parameters must be slice", msgAndArgs...)
 	}
 
-	actualSlice := reflect.ValueOf(actual)
 	expectedSlice := reflect.ValueOf(expected)
+	actualSlice := reflect.ValueOf(actual)
 
-	if actualSlice.Len() != expectedSlice.Len() {
-		return Fail(t, "Arguments must have the same number of elements", msgAndArgs...)
+	if expectedSlice.Type().Kind() != reflect.Slice {
+		return Fail(t, "Expected value must be slice", msgAndArgs...)
 	}
 
-	for i := 0; i < actualSlice.Len(); i++ {
-		result := InDelta(t, actualSlice.Index(i).Interface(), expectedSlice.Index(i).Interface(), delta, msgAndArgs...)
-		if !result {
-			return result
+	expectedLen := expectedSlice.Len()
+	if !IsType(t, expected, actual) || !Len(t, actual, expectedLen) {
+		return false
+	}
+
+	for i := 0; i < expectedLen; i++ {
+		if !InDelta(t, expectedSlice.Index(i).Interface(), actualSlice.Index(i).Interface(), delta, "at index %d", i) {
+			return false
 		}
 	}
 

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -1497,6 +1497,10 @@ func InDeltaSlice(t TestingT, expected, actual interface{}, delta float64, msgAn
 	actualSlice := reflect.ValueOf(actual)
 	expectedSlice := reflect.ValueOf(expected)
 
+	if actualSlice.Len() != expectedSlice.Len() {
+		return Fail(t, "Arguments must have the same number of elements", msgAndArgs...)
+	}
+
 	for i := 0; i < actualSlice.Len(); i++ {
 		result := InDelta(t, actualSlice.Index(i).Interface(), expectedSlice.Index(i).Interface(), delta, msgAndArgs...)
 		if !result {

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -2369,6 +2369,11 @@ func TestInDeltaSlice(t *testing.T) {
 		[]float64{1, 2},
 		0.1), "Expected slices with extra actual values to fail")
 
+	False(t, InDeltaSlice(mockT,
+		[]float64{1},
+		[]int{1},
+		0.1), "Expected slices with different types to fail")
+
 	False(t, InDeltaSlice(mockT, "", nil, 1), "Expected non numeral slices to fail")
 }
 

--- a/assert/assertions_test.go
+++ b/assert/assertions_test.go
@@ -2359,6 +2359,16 @@ func TestInDeltaSlice(t *testing.T) {
 		[]float64{0, math.NaN(), 3},
 		0.1), "{1, NaN, 2} is not element-wise close to {0, NaN, 3} in delta=0.1")
 
+	False(t, InDeltaSlice(mockT,
+		[]float64{1, 2},
+		[]float64{1},
+		0.1), "Expected slices with extra expected values to fail")
+
+	False(t, InDeltaSlice(mockT,
+		[]float64{1},
+		[]float64{1, 2},
+		0.1), "Expected slices with extra actual values to fail")
+
 	False(t, InDeltaSlice(mockT, "", nil, 1), "Expected non numeral slices to fail")
 }
 


### PR DESCRIPTION
Fixes #1263.

`InDeltaSlice` already compares values by index, but it did not first verify that the two slices had the same length. That meant extra expected values were ignored, while extra actual values could panic by indexing past the expected slice.

This adds an explicit length check before the element-wise comparison. I also added regression coverage for both mismatch directions.

Verification:
- `go test ./assert -run TestInDeltaSlice -count=1` failed before the fix: the shorter actual slice passed and the longer actual slice panicked with `reflect: slice index out of range`
- `go test ./assert -run TestInDeltaSlice -count=1`
- `go test ./assert -count=1`
- `go test ./... -count=1`
- `go vet ./...`
- `gofmt -w assert/assertions.go assert/assertions_test.go`
- `git diff --check`
