### PR TITLE
CI: keep version coverage and checks reliable

### DIFF
--- a/.ci.ghactions.sh
+++ b/.ci.ghactions.sh
@@ -28,28 +28,40 @@
 
 set -euo pipefail
 
-declare -A seen
+seen=("")
 status=0
 
 for w in .github/workflows/*.yml
 do
-	sed -n -e '/uses: / s!^ *-\{0,1\} uses: \([^@]*\)@\([0-9a-f][0-9a-f]*\) *# *\(v.*\)$!\1 \2 \3!p' "$w" | while read -r action hash tag
+	actions="$(sed -n -e '/uses: / s!^ *-\{0,1\} uses: \([^@]*\)@\([0-9a-f][0-9a-f]*\) *# *\(v.*\)$!\1 \2 \3!p' "$w")"
+	while read -r action hash tag
 	do
-		if (( ${seen["$action-$hash-$tag"]:-0} )); then
-			printf "\e[1;32m%s: %s@%s == %s\e[m\n" "$w" "$action" "$tag" "$hash"
+		if [[ -z "$action" ]]; then
 			continue
 		fi
-		seen["$action-$hash-$tag"]=1
+		key="$action-$hash-$tag"
+		duplicate=0
+		for seen_key in "${seen[@]}"
+		do
+			if [[ "$seen_key" == "$key" ]]; then
+				duplicate=1
+				break
+			fi
+		done
+		if (( duplicate )); then
+			continue
+		fi
+		seen+=("$key")
 
-		if eval "$( curl -s -H "Accept: application/vnd.github+json" \
-			"https://api.github.com/repos/$action/commits/$tag" | jq -r '.sha == "'"$hash"'"' )"
+		if curl --fail --silent --show-error -H "Accept: application/vnd.github+json" \
+			"https://api.github.com/repos/$action/commits/$tag" | jq -e --arg hash "$hash" '.sha == $hash' >/dev/null
 		then
 			printf "\e[1;32m%s: %s@%s == %s\e[m\n" "$w" "$action" "$tag" "$hash"
 		else
 			printf "\e[1;31m%s: %s@%s != %s\e[m\n" "$w" "$action" "$tag" "$hash"
 			status=1
 		fi
-	done
+	done <<< "$actions"
 done
 
 exit $status

--- a/.ci.gofmt.sh
+++ b/.ci.gofmt.sh
@@ -2,7 +2,8 @@
 
 set -euo pipefail
 
-if [ -n "$(gofmt -l .)" ]; then
+unformatted_files="$(gofmt -l .)"
+if [ -n "$unformatted_files" ]; then
   echo "Go code is not formatted:"
   gofmt -d .
   exit 1
@@ -11,7 +12,8 @@ fi
 go run ./_readme-gofmt/main.go
 
 go generate ./...
-if [ -n "$(git status -s -uno)" ]; then
+repository_status="$(git status --short)"
+if [ -n "$repository_status" ]; then
   echo "Go generate output does not match commit."
   echo "Did you forget to run go generate ./... ?"
   exit 1

--- a/.ci.gogenerate.sh
+++ b/.ci.gogenerate.sh
@@ -1,16 +1,21 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 # If GOMOD is defined we are running with Go Modules enabled, either
 # automatically or via the GO111MODULE=on environment variable. Codegen only
 # works with modules, so skip generation if modules is not in use.
-if [[ -z "$(go env GOMOD)" ]]; then
+gomod="$(go env GOMOD)"
+if [[ -z "$gomod" ]]; then
   echo "Skipping go generate because modules not enabled and required"
   exit 0
 fi
 
 go generate ./...
-if [ -n "$(git diff)" ]; then
+repository_status="$(git status --short)"
+if [ -n "$repository_status" ]; then
   echo "Go generate had not been run"
+  git status --short
   git diff
   exit 1
 fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ jobs:
           go-version: ${{ matrix.go_version }}
       - run: ./.ci.gogenerate.sh
       - run: ./.ci.gofmt.sh
+        if: matrix.go_version == 'stable'
       - run: ./.ci.govet.sh
       - run: go test -v -race ./...
 
@@ -33,6 +34,7 @@ jobs:
           - "1.22"
           - "1.23"
           - "1.24"
+          - "1.25"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Setup Go


### PR DESCRIPTION
As stable and oldstable advance to Go 1.27 and Go 1.26, retain explicit Go 1.25 coverage so every supported release remains tested. Run language-level formatting validation with the stable toolchain because Go 1.26 cannot parse generic methods, even in files excluded by build constraints.

Several CI helpers could previously report success when their underlying commands, generation checks, or action-pin validation failed. Ensure those failures are propagated and newly generated files are detected so a green build means the checks actually completed successfully.