### PR TITLE
Add Must & Mustf

### DIFF
--- a/require/must.go
+++ b/require/must.go
@@ -1,0 +1,37 @@
+//go:build go1.18
+
+package require
+
+import (
+	assert "github.com/stretchr/testify/assert"
+)
+
+// Must calls f and returns its value, requiring that f returned a nil error.
+// If f returns a non-nil error the test fails immediately, as with [NoError].
+//
+//	cfg := require.Must(t, func() (Config, error) { return LoadConfig(path) })
+//
+// Because the test is stopped with [testing.T.FailNow], Must must be called
+// from the goroutine running the test function.
+func Must[T any](t TestingT, f func() (T, error), msgAndArgs ...interface{}) T {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	v, err := f()
+	if !assert.NoError(t, err, msgAndArgs...) {
+		t.FailNow()
+	}
+	return v
+}
+
+// Mustf is like [Must] but uses a formatted message.
+func Mustf[T any](t TestingT, f func() (T, error), msg string, args ...interface{}) T {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	v, err := f()
+	if !assert.NoErrorf(t, err, msg, args...) {
+		t.FailNow()
+	}
+	return v
+}

--- a/require/must.go
+++ b/require/must.go
@@ -1,4 +1,8 @@
-//go:build go1.18
+// This file uses generics, which require language version go1.18 or later.
+// The go.mod go directive is go1.17 so that testify keeps building on old
+// toolchains; a //go:build constraint can only raise the language version on
+// Go 1.21 and later, so that is the lowest version this file can be gated on.
+//go:build go1.21
 
 package require
 

--- a/require/must_forward.go
+++ b/require/must_forward.go
@@ -1,0 +1,27 @@
+//go:build go1.27
+
+package require
+
+// Must calls f and returns its value, requiring that f returned a nil error.
+// If f returns a non-nil error the test fails immediately, as with
+// [Assertions.NoError].
+//
+//	a := require.New(t)
+//	cfg := a.Must(func() (Config, error) { return LoadConfig(path) })
+//
+// Because the test is stopped with [testing.T.FailNow], Must must be called
+// from the goroutine running the test function.
+func (a *Assertions) Must[T any](f func() (T, error), msgAndArgs ...interface{}) T {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Must(a.t, f, msgAndArgs...)
+}
+
+// Mustf is like [Assertions.Must] but uses a formatted message.
+func (a *Assertions) Mustf[T any](f func() (T, error), msg string, args ...interface{}) T {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return Mustf(a.t, f, msg, args...)
+}

--- a/require/must_forward_test.go
+++ b/require/must_forward_test.go
@@ -1,0 +1,47 @@
+//go:build go1.27
+
+package require
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestMustWrapper(t *testing.T) {
+	mockT := new(MockT)
+	require := New(mockT)
+
+	if v := require.Must(func() (int, error) { return 42, nil }); v != 42 {
+		t.Errorf("Must returned %d, expected 42", v)
+	}
+	if mockT.Failed {
+		t.Error("Must should not have failed the test")
+	}
+
+	// MockT.FailNow does not stop execution, so Must returns normally here.
+	mockT = new(MockT)
+	require = New(mockT)
+	require.Must(func() (int, error) { return 0, errors.New("boom") })
+	if !mockT.Failed {
+		t.Error("Must should have failed the test")
+	}
+}
+
+func TestMustfWrapper(t *testing.T) {
+	mockT := new(MockT)
+	require := New(mockT)
+
+	if v := require.Mustf(func() (string, error) { return "ok", nil }, "loading %s", "config"); v != "ok" {
+		t.Errorf("Mustf returned %q, expected \"ok\"", v)
+	}
+	if mockT.Failed {
+		t.Error("Mustf should not have failed the test")
+	}
+
+	mockT = new(MockT)
+	require = New(mockT)
+	require.Mustf(func() (string, error) { return "", errors.New("boom") }, "loading %s", "config")
+	if !mockT.Failed {
+		t.Error("Mustf should have failed the test")
+	}
+}

--- a/require/must_test.go
+++ b/require/must_test.go
@@ -1,4 +1,4 @@
-//go:build go1.18
+//go:build go1.21
 
 package require
 

--- a/require/must_test.go
+++ b/require/must_test.go
@@ -1,0 +1,43 @@
+//go:build go1.18
+
+package require
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestMust(t *testing.T) {
+	mockT := new(MockT)
+
+	if v := Must(mockT, func() (int, error) { return 42, nil }); v != 42 {
+		t.Errorf("Must returned %d, expected 42", v)
+	}
+	if mockT.Failed {
+		t.Error("Must should not have failed the test")
+	}
+
+	// MockT.FailNow does not stop execution, so Must returns normally here.
+	mockT = new(MockT)
+	Must(mockT, func() (int, error) { return 0, errors.New("boom") })
+	if !mockT.Failed {
+		t.Error("Must should have failed the test")
+	}
+}
+
+func TestMustf(t *testing.T) {
+	mockT := new(MockT)
+
+	if v := Mustf(mockT, func() (string, error) { return "ok", nil }, "loading %s", "config"); v != "ok" {
+		t.Errorf("Mustf returned %q, expected \"ok\"", v)
+	}
+	if mockT.Failed {
+		t.Error("Mustf should not have failed the test")
+	}
+
+	mockT = new(MockT)
+	Mustf(mockT, func() (string, error) { return "", errors.New("boom") }, "loading %s", "config")
+	if !mockT.Failed {
+		t.Error("Mustf should have failed the test")
+	}
+}


### PR DESCRIPTION
## Summary
Convenience methods around operations that must succeed.

## Changes
- Add `require.Must` and `require.Mustf` generic functions.
- Add corresponding require.Assertions methods.

These are usable only in Go 1.21+ and 1.27+, respectively. (The function versions would work in 1.18-1.20, but release-tag limitations in those versions prevent that.)

## Motivation
These are convenience methods. Usage looks thus:
```
func stringOrErr() (string, error) { … }

myStr := require.Must(t, stringOrErr())
assert.Equal(t, "expected", myStr)
```

It’s a bit more ergonomic than:
```
myStr, err := stringOrErr()
require.NoError(t, err)

assert.Equal(t, "expected", myStr)
```

Thank you!
