### PR TITLE
CI: retain Go 1.25 coverage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,7 @@ jobs:
           - "1.22"
           - "1.23"
           - "1.24"
+          - "1.25"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Setup Go


### PR DESCRIPTION
## Summary
Now that `stable` and `oldstable` resolve to Go 1.27 and Go 1.26, the build matrix no longer exercises Go 1.25. Add it to the old-version matrix so every supported Go release remains covered.

## Changes
Added `"1.25"` to the `go_version` matrix in `.github/workflows/main.yml`

## Motivation
Now that `stable` and oldstable resolve to Go 1.27 and Go 1.26, the build matrix no longer exercises Go 1.25 without this change.

