### PR TITLE
CI: detect untracked generated files

### DIFF
--- a/.ci.gofmt.sh
+++ b/.ci.gofmt.sh
@@ -11,7 +11,7 @@ fi
 go run ./_readme-gofmt/main.go
 
 go generate ./...
-if [ -n "$(git status -s -uno)" ]; then
+if [ -n "$(git status --short)" ]; then
   echo "Go generate output does not match commit."
   echo "Did you forget to run go generate ./... ?"
   exit 1

--- a/.ci.gogenerate.sh
+++ b/.ci.gogenerate.sh
@@ -9,8 +9,9 @@ if [[ -z "$(go env GOMOD)" ]]; then
 fi
 
 go generate ./...
-if [ -n "$(git diff)" ]; then
+if [ -n "$(git status --short)" ]; then
   echo "Go generate had not been run"
+  git status --short
   git diff
   exit 1
 fi


### PR DESCRIPTION
## Summary
Newly generated untracked files were being excluded from the safety check performed in CI, due to the git command being used to perform the check.

## Changes
Use the exit code from `git status --short` instead.  It check the complete working tree so generation checks cannot pass when code generation creates a new file.

## Motivation
`git diff` and `git status -uno` ignore newly generated untracked files, so the check was incomplete.

