### PR TITLE
CI: propagate code generation failures

### DIFF
--- a/.ci.gogenerate.sh
+++ b/.ci.gogenerate.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 # If GOMOD is defined we are running with Go Modules enabled, either
 # automatically or via the GO111MODULE=on environment variable. Codegen only
 # works with modules, so skip generation if modules is not in use.
-if [[ -z "$(go env GOMOD)" ]]; then
+gomod="$(go env GOMOD)"
+if [[ -z "$gomod" ]]; then
   echo "Skipping go generate because modules not enabled and required"
   exit 0
 fi


### PR DESCRIPTION
## Summary
CI currently tests the value of `GOMOD` if it exists, but it doesn't ensure that `go env` succeeds. 

## Changes
Update `.ci.gogenerate.sh` such that if `go env GOMOD` fails, the script fails immediately.

## Motivation
This is just fixing an edge case for a possible false positive in CI.
