### PR TITLE
CI: fail incomplete action pin validation

### DIFF
--- a/.ci.ghactions.sh
+++ b/.ci.ghactions.sh
@@ -28,6 +28,9 @@
 
 set -euo pipefail
 
+# Keep the pipeline's while loop in this shell so status updates survive.
+shopt -s lastpipe
+
 declare -A seen
 status=0
 
@@ -41,8 +44,8 @@ do
 		fi
 		seen["$action-$hash-$tag"]=1
 
-		if eval "$( curl -s -H "Accept: application/vnd.github+json" \
-			"https://api.github.com/repos/$action/commits/$tag" | jq -r '.sha == "'"$hash"'"' )"
+		if curl --fail --silent --show-error -H "Accept: application/vnd.github+json" \
+			"https://api.github.com/repos/$action/commits/$tag" | jq -e --arg hash "$hash" '.sha == $hash' >/dev/null
 		then
 			printf "\e[1;32m%s: %s@%s == %s\e[m\n" "$w" "$action" "$tag" "$hash"
 		else


### PR DESCRIPTION
## Summary
Ensure the GitHub Actions pin validation check fails when validation cannot be completed successfully.

## Changes
Update `.ci.ghactions.sh`:

- Keep the validation loop in the current shell with Bash `lastpipe`.
- Require successful GitHub API requests with `curl --fail`.
- Use `jq -e` to validate the returned commit SHA without `eval`.

## Motivation
The validation loop previously ran in a pipeline subshell, so setting its failure status did not affect the script’s exit status. Empty or invalid GitHub API responses could also produce an empty `eval` command that succeeded. Together, these issues allowed action pin validation to report success without validating every pin.