### PR TITLE
CI: format generic methods with stable Go

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ jobs:
           go-version: ${{ matrix.go_version }}
       - run: ./.ci.gogenerate.sh
       - run: ./.ci.gofmt.sh
+        if: matrix.go_version == 'stable'
       - run: ./.ci.govet.sh
       - run: go test -v -race ./...
 


### PR DESCRIPTION
## Summary
Run the formatting check only with the stable Go toolchain.

## Changes
- Restrict `.ci.gofmt.sh` to the stable matrix entry.
- Continue running generation, vet, and tests with both stable and oldstable Go.

## Motivation
PR #1937 adds generic methods supported by Go 1.27.

Go 1.26 cannot parse generic methods, including those in files excluded by build constraints, causing its formatting check to fail. The stable Go 1.27 toolchain can format the complete source tree.

## Related issues
Required for #1937
